### PR TITLE
Tweak the theme to match Civ3 in the ways that it hadn't been matched…

### DIFF
--- a/C7/C7Theme.tres
+++ b/C7/C7Theme.tres
@@ -8,6 +8,8 @@ expand_margin_top = 3.0
 expand_margin_bottom = 3.0
 
 [resource]
+LineEdit/colors/cursor_color = Color( 0, 0, 0, 1 )
 LineEdit/colors/font_color = Color( 0, 0, 0, 1 )
 LineEdit/colors/selection_color = Color( 0.709804, 0.807843, 0.709804, 1 )
+LineEdit/styles/focus = SubResource( 1 )
 LineEdit/styles/normal = SubResource( 1 )

--- a/C7/UIElements/Popups/BuildCityDialog.cs
+++ b/C7/UIElements/Popups/BuildCityDialog.cs
@@ -2,95 +2,103 @@ using Godot;
 
 public class BuildCityDialog : TextureRect
 {
-    
-    LineEdit cityName = new LineEdit();
-    
-    public override void _Ready()
-    {
-        base._Ready();
+	
+	LineEdit cityName = new LineEdit();
+	
+	public override void _Ready()
+	{
+		base._Ready();
 
-        //Dimensions are 530x260 (roughly).
-        //The top 110 px are for the advisor.
+		//Dimensions are 530x260 (roughly).
+		//The top 110 px are for the advisor.
 
-        //Transparent background.  Add 10 px on the right for offset.
-        ImageTexture thisTexture = new ImageTexture();
+		//Transparent background.  Add 10 px on the right for offset.
+		ImageTexture thisTexture = new ImageTexture();
 		Image image = new Image();
 		image.Create(540, 260, false, Image.Format.Rgba8);
 		image.Fill(Color.Color8(0, 0, 0, 0));
 		thisTexture.CreateFromImage(image);
 		this.Texture = thisTexture;
 
-        ImageTexture AdvisorHappy = Util.LoadTextureFromPCX("Art/SmallHeads/popupCULTURE.pcx", 1, 40, 149, 110);
+		ImageTexture AdvisorHappy = Util.LoadTextureFromPCX("Art/SmallHeads/popupCULTURE.pcx", 1, 40, 149, 110);
 		TextureRect AdvisorHead = new TextureRect();
 		AdvisorHead.Texture = AdvisorHappy;
 		//Appears at 400, 110 in game, but leftmost 25px are transparent with default graphics
 		AdvisorHead.SetPosition(new Vector2(375, 0));
 		AddChild(AdvisorHead);
 
-        TextureRect background = PopupOverlay.GetPopupBackground(530, 150);
+		TextureRect background = PopupOverlay.GetPopupBackground(530, 150);
 		background.SetPosition(new Vector2(0, 110));
 		AddChild(background);
 
-        PopupOverlay.AddHeaderToPopup(this, "Name this town?", 120);
+		PopupOverlay.AddHeaderToPopup(this, "Name this town?", 120);
 
-        HBoxContainer labelAndName = new HBoxContainer();
-        labelAndName.Alignment = BoxContainer.AlignMode.Begin;
-        labelAndName.SizeFlagsHorizontal = 3;   //fill and expand
-        labelAndName.SizeFlagsStretchRatio = 1;
-        labelAndName.AnchorLeft = 0.0f;
-        labelAndName.AnchorRight = 0.85f;
-        labelAndName.SetPosition(new Vector2(30, 170));
+		HBoxContainer labelAndName = new HBoxContainer();
+		labelAndName.Alignment = BoxContainer.AlignMode.Begin;
+		labelAndName.SizeFlagsHorizontal = 3;   //fill and expand
+		labelAndName.SizeFlagsStretchRatio = 1;
+		labelAndName.AnchorLeft = 0.0f;
+		labelAndName.AnchorRight = 0.85f;
+		labelAndName.SetPosition(new Vector2(30, 170));
 
-        Label nameLabel = new Label();
-        nameLabel.AddColorOverride("font_color", new Color(0, 0, 0));
-        nameLabel.Text = "Name: ";
-        labelAndName.AddChild(nameLabel);
+		Label nameLabel = new Label();
+		nameLabel.AddColorOverride("font_color", new Color(0, 0, 0));
+		nameLabel.Text = "Name: ";
+		labelAndName.AddChild(nameLabel);
 
-        cityName.SizeFlagsHorizontal = 3;  //fill and expand
-        cityName.SizeFlagsStretchRatio = 1;
-        cityName.Text = "Hippo Regius";
-        labelAndName.AddChild(cityName);
+		cityName.SizeFlagsHorizontal = 3;  //fill and expand
+		cityName.SizeFlagsStretchRatio = 1;
+		cityName.Text = "Hippo Regius";
+		labelAndName.AddChild(cityName);
 
-        this.AddChild(labelAndName);
+		this.AddChild(labelAndName);
 
-        cityName.SelectAll();
-        cityName.GrabFocus();
+		cityName.SelectAll();
+		cityName.GrabFocus();
 
-        cityName.Connect("text_entered", this, "OnCityNameEntered");
+		cityName.Connect("text_entered", this, "OnCityNameEntered");
 
-        //Cancel/confirm buttons.  Note the X button is thinner than the O button.
-        ImageTexture circleTexture= Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 1, 1, 19, 19);
-        ImageTexture xTexture = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 21, 1, 15, 19);
-        TextureButton confirmButton = new TextureButton();
-        confirmButton.TextureNormal = circleTexture;
-        confirmButton.SetPosition(new Vector2(475, 213));
-        AddChild(confirmButton);
-        TextureButton cancelButton = new TextureButton();
-        cancelButton.TextureNormal = xTexture;
-        cancelButton.SetPosition(new Vector2(500, 213));
-        AddChild(cancelButton);
+		//Cancel/confirm buttons.  Note the X button is thinner than the O button.
+		ImageTexture circleTexture= Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 1, 1, 19, 19);
+		ImageTexture xTexture = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 21, 1, 15, 19);
+		ImageTexture circleHover = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 37, 1, 19, 19);
+		ImageTexture xHover = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 57, 1, 15, 19);
+		ImageTexture circlePressed = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 73, 1, 19, 19);
+		ImageTexture xPressed = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 93, 1, 15, 19);
+		TextureButton confirmButton = new TextureButton();
+		confirmButton.TextureNormal = circleTexture;
+		confirmButton.TextureHover = circleHover;
+		confirmButton.TexturePressed = circlePressed;
+		confirmButton.SetPosition(new Vector2(475, 213));
+		AddChild(confirmButton);
+		TextureButton cancelButton = new TextureButton();
+		cancelButton.TextureNormal = xTexture;
+		cancelButton.TextureHover = xHover;
+		cancelButton.TexturePressed = xPressed;
+		cancelButton.SetPosition(new Vector2(500, 213));
+		AddChild(cancelButton);
 
-        confirmButton.Connect("pressed", this, "OnConfirmButtonPressed");
-        cancelButton.Connect("pressed", GetParent(), "OnHidePopup");
-    }
+		confirmButton.Connect("pressed", this, "OnConfirmButtonPressed");
+		cancelButton.Connect("pressed", GetParent(), "OnHidePopup");
+	}
 
-    /**
-     * Need a second method b/c the LineEdit sends a param and the ConfirmButton doesn't.
-     **/
-    public void OnConfirmButtonPressed()
-    {
-        this.OnCityNameEntered(cityName.Text);
-    }
+	/**
+	 * Need a second method b/c the LineEdit sends a param and the ConfirmButton doesn't.
+	 **/
+	public void OnConfirmButtonPressed()
+	{
+		this.OnCityNameEntered(cityName.Text);
+	}
 
-    public void OnCityNameEntered(string name)
-    {
+	public void OnCityNameEntered(string name)
+	{
 		GetTree().SetInputAsHandled();
-        GD.Print("The user hit enter with a city name of " + name);
-        GetParent().EmitSignal("BuildCity", name);
-        GetParent().EmitSignal("HidePopup");
-    }
+		GD.Print("The user hit enter with a city name of " + name);
+		GetParent().EmitSignal("BuildCity", name);
+		GetParent().EmitSignal("HidePopup");
+	}
 
-    public override void _UnhandledInput(InputEvent @event)
+	public override void _UnhandledInput(InputEvent @event)
 	{
 		if (this.Visible) {
 			if (@event is InputEventKey eventKey && eventKey.Pressed)
@@ -98,7 +106,7 @@ public class BuildCityDialog : TextureRect
 				if (eventKey.Scancode == (int)Godot.KeyList.Escape)
 				{
 					GetTree().SetInputAsHandled();
-                    GetParent().EmitSignal("HidePopup");
+					GetParent().EmitSignal("HidePopup");
 				}
 			}
 		}


### PR DESCRIPTION
… yet.  Namely, get rid of the focus ring when focused, and change the color of the ibeam so you can see it again.

Also added hover/focus colors for build city buttons.  This is a common enough thing that it feels like it should not be one-off.  It is true that there are several graphics that have hover/pressed effects, and those graphics have different dimensions (and in this case, two buttons, each with different dimensions), so we'll probably still have multiple handlers.  Just, whenever we use one of those handlers, it shouldn't be coded separately of "this is how we handle this file."  I'm thinking some sort of utility class of, "hey, load this button", or perhaps better yet a Godot component that adds both buttons from a particular file.

Committing this as a branch to get in the habit of that.  Although it doesn't seem like a "going to take a bunch of commits to finish baking, needs a branch" type thing, I did notice when viewing the diffs that Godot hadn't saved the ibeam color, so that sort of thing might be caught in a PR.  We also got spaces instead of tabs in our BuildCityDialog somehow, but this commit converts them.

I'll probably merge this whenever I'm next online, if no one objects.