### PR TITLE
Load game works from main menu

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -32,6 +32,8 @@ public class Game : Node2D
 	private KinematicBody2D Player;
 
 	Stopwatch loadTimer = new Stopwatch();
+	GlobalSingleton Global;
+
 
 	public override void _EnterTree()
 	{
@@ -41,7 +43,9 @@ public class Game : Node2D
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()
 	{
-		controller = CreateGame.createGame();
+		Global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
+		controller = CreateGame.createGame(Global.LoadGamePath, Global.DefaultBicPath);
+		Global.ResetLoadGamePath();
 		var map = MapInteractions.GetWholeMap();
 		Civ3Map baseTerrainMap = new Civ3Map(map.numTilesWide, map.numTilesTall);
 		baseTerrainMap.Civ3Tiles = map.tiles;

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -41,7 +41,7 @@ public class Game : Node2D
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()
 	{
-		controller = CreateGame.createGame(genBasicTerrainNoiseMap);
+		controller = CreateGame.createGame();
 		var map = MapInteractions.GetWholeMap();
 		Civ3Map baseTerrainMap = new Civ3Map(map.numTilesWide, map.numTilesTall);
 		baseTerrainMap.Civ3Tiles = map.tiles;

--- a/C7/GlobalSingleton.cs
+++ b/C7/GlobalSingleton.cs
@@ -1,0 +1,22 @@
+using Godot;
+
+/****
+    Need to pass values from one scene to another, particularly when loading
+    a game in main menu. This script is set to auto load in project settings.
+    See https://docs.godotengine.org/en/stable/getting_started/step_by_step/singletons_autoload.html
+****/
+public class GlobalSingleton : Node
+{
+    // Will have main menu file picker set this and Game.cs pass it to C7Engine.createGame
+    // which then should blank it again to prevent reloading same if going back to main menu
+    // and back to game
+    public string LoadGamePath;
+    // For now this needs to get passed to QueryCiv3 when importing.
+    public string DefaultBicPath { get => Util.GetCiv3Path() + @"/Conquests/conquests.biq"; }
+    // This is the 'static map' used in lieu of terrain generation
+    public string DefaultGamePath { get => @"./c7-static-map-save.json"; }
+    public void ResetLoadGamePath()
+    {
+        LoadGamePath = DefaultGamePath;
+    }
+}

--- a/C7/MainMenu.cs
+++ b/C7/MainMenu.cs
@@ -9,12 +9,17 @@ public class MainMenu : Node2D
 	ImageTexture InactiveButton;
 	ImageTexture HoverButton;
 	TextureRect MainMenuBackground;
+	Util.Civ3FileDialog LoadDialog;
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()
 	{
 		GD.Print("Hello world!");
 		DisplayTitleScreen();
+		LoadDialog = new Util.Civ3FileDialog();
+		LoadDialog.RelPath = @"Conquests/Saves";
+		// LoadDialog.Connect("file_selected", this, nameof(_on_FileDialog_file_selected));
+		GetNode<CanvasLayer>("CanvasLayer").AddChild(LoadDialog);
 	}
 	
 	private void DisplayTitleScreen()
@@ -28,7 +33,7 @@ public class MainMenu : Node2D
 			AddButton("New Game", 160, "StartGame");
 			AddButton("Quick Start", 195, "StartGame");
 			AddButton("Tutorial", 230, "StartGame");
-			AddButton("Load Game", 265, "StartGame");
+			AddButton("Load Game", 265, "LoadGame");
 			AddButton("Load Scenario", 300, "StartGame");
 			AddButton("Hall of Fame", 335, "HallOfFame");
 			AddButton("Preferences", 370, "Preferences");
@@ -71,6 +76,14 @@ public class MainMenu : Node2D
 		GD.Print("Load button pressed");
 		PlayButtonPressedSound();
 		GetTree().ChangeScene("res://C7Game.tscn");
+	}
+	
+	public void LoadGame()
+	{
+		GD.Print("Real Load button pressed");
+		PlayButtonPressedSound();
+		LoadDialog.Popup_();
+		// GetTree().ChangeScene("res://C7Game.tscn");
 	}
 	
 	public void showCredits()

--- a/C7/MainMenu.cs
+++ b/C7/MainMenu.cs
@@ -10,15 +10,19 @@ public class MainMenu : Node2D
 	ImageTexture HoverButton;
 	TextureRect MainMenuBackground;
 	Util.Civ3FileDialog LoadDialog;
+	GlobalSingleton Global;
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()
 	{
 		GD.Print("Hello world!");
+		// To pass data between scenes, putting path string in a global singleton and reading it later in createGame
+		Global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
+		Global.ResetLoadGamePath();
 		DisplayTitleScreen();
 		LoadDialog = new Util.Civ3FileDialog();
 		LoadDialog.RelPath = @"Conquests/Saves";
-		// LoadDialog.Connect("file_selected", this, nameof(_on_FileDialog_file_selected));
+		LoadDialog.Connect("file_selected", this, nameof(_on_FileDialog_file_selected));
 		GetNode<CanvasLayer>("CanvasLayer").AddChild(LoadDialog);
 	}
 	
@@ -83,7 +87,6 @@ public class MainMenu : Node2D
 		GD.Print("Real Load button pressed");
 		PlayButtonPressedSound();
 		LoadDialog.Popup_();
-		// GetTree().ChangeScene("res://C7Game.tscn");
 	}
 	
 	public void showCredits()
@@ -114,5 +117,12 @@ public class MainMenu : Node2D
 		AudioStreamPlayer player = GetNode<AudioStreamPlayer>("CanvasLayer/SoundEffectPlayer");
 		player.Stream = wav;
 		player.Play();
+	}
+	private void _on_FileDialog_file_selected(string path)
+	{
+		GD.Print("Loading " + path);
+		Global.LoadGamePath = path;
+		GetTree().ChangeScene("res://C7Game.tscn");
+
 	}
 }

--- a/C7/project.godot
+++ b/C7/project.godot
@@ -19,6 +19,10 @@ run/main_scene="res://MainMenu.tscn"
 boot_splash/image="res://icon.png"
 config/icon="res://icon.png"
 
+[autoload]
+
+GlobalSingleton="*res://GlobalSingleton.cs"
+
 [display]
 
 window/size/height=768

--- a/C7Engine/EntryPoints/CreateGame.cs
+++ b/C7Engine/EntryPoints/CreateGame.cs
@@ -11,7 +11,7 @@ namespace C7Engine
          * quickly.  By keeping all the client-callable APIs in the EntryPoints folder,
          * hopefully it won't be too much of a goose hunt to refactor it later if we decide to do so.
          **/
-        public static Player createGame(string loadFilePath = @"./c7-static-map-save.json", string defaultBicPath = "")
+        public static Player createGame(string loadFilePath, string defaultBicPath)
         {
             C7SaveFormat save;
             if (loadFilePath.EndsWith("SAV", System.StringComparison.CurrentCultureIgnoreCase))

--- a/C7Engine/EntryPoints/CreateGame.cs
+++ b/C7Engine/EntryPoints/CreateGame.cs
@@ -11,11 +11,16 @@ namespace C7Engine
          * quickly.  By keeping all the client-callable APIs in the EntryPoints folder,
          * hopefully it won't be too much of a goose hunt to refactor it later if we decide to do so.
          **/
-        public static Player createGame(GameMap.TerrainNoiseMapGenerator terrainGen)
+        public static Player createGame(string loadFilePath = @"./c7-static-map-save.json", string defaultBicPath = "")
         {
-            // I think this path is relative from the C7 folder, not C7GameEngine, if that matters
-            // TODO: Unsure if this will work when exported for distribution
-            C7SaveFormat save = C7SaveFormat.Load(@"./c7-static-map-save.json");
+            C7SaveFormat save;
+            if (loadFilePath.EndsWith("SAV", System.StringComparison.CurrentCultureIgnoreCase))
+            {
+                save = ImportCiv3.ImportSav(loadFilePath, defaultBicPath);
+            }
+            else {
+                save = C7SaveFormat.Load(loadFilePath);
+            }
             EngineStorage.setGameData(save.GameData);
             // possibly do something with save.Rules here when it exists
             // and maybe consider if we have any need to keep a reference to the save object handy...probably not


### PR DESCRIPTION
I had to create a global singleton to communicate between nodes. I'm not thrilled with that, but it seems to be the Godot way.

If a .SAV file is chosen it tries to import from Civ3, elsewise it tries to load it like a text/JSON file.