### PR TITLE
Import real Civ3 terrain types

### DIFF
--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -126,13 +126,13 @@ namespace C7Engine
                             return;
                         }
 
-                        var newLoc = gameData.map.tileAt(dx + unit.location.xCoordinate, dy + unit.location.yCoordinate);
+                        Tile newLoc = gameData.map.tileAt(dx + unit.location.xCoordinate, dy + unit.location.yCoordinate);
                         if ((newLoc != null) && (unit.movementPointsRemaining > 0)) {
                             if (! unit.location.unitsOnTile.Remove(unit))
                                 throw new System.Exception("Failed to remove unit from tile it's supposed to be on");
                             newLoc.unitsOnTile.Add(unit);
                             unit.location = newLoc;
-                            unit.movementPointsRemaining -= 1;
+                            unit.movementPointsRemaining -= newLoc.overlayTerrainType.movementCost;
                             unit.isFortified = false;
                         }
 

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -8,7 +8,7 @@ namespace C7GameData
         public Random rng; // TODO: Is GameData really the place for this?
         public GameMap map {get; set;}
         public List<Player> players = new List<Player>();
-        List<TerrainType> terrainTypes = new List<TerrainType>();
+        public List<TerrainType> terrainTypes = new List<TerrainType>();
 
         public List<MapUnit> mapUnits {get;} = new List<MapUnit>();
         List<UnitPrototype> unitPrototypes = new List<UnitPrototype>();

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -26,144 +26,37 @@ namespace C7GameData
             byte[] defaultBicBytes = QueryCiv3.Util.ReadFile(defaultBicPath);
     		SavData civ3Save = new QueryCiv3.SavData(QueryCiv3.Util.ReadFile(savePath), defaultBicBytes);
 
-            // Dummy data
-            TerrainType desert = new TerrainType();
-            desert.name = "Desert";
-            desert.baseFoodProduction = 0;
-            desert.baseShieldProduction = 1;
-            desert.baseCommerceProduction = 0;
-            desert.movementCost = 1;
-
-            TerrainType grassland = new TerrainType();
-            grassland.name = "Grassland";
-            grassland.baseFoodProduction = 2;
-            grassland.baseShieldProduction = 1; //with only one terrain type, it needs to be > 0
-            grassland.baseCommerceProduction = 1;   //same as above
-            grassland.movementCost = 1;
-
-            TerrainType plains = new TerrainType();
-            plains.name = "Plains";
-            plains.baseFoodProduction = 1;
-            plains.baseShieldProduction = 2;
-            plains.baseCommerceProduction = 1;
-            plains.movementCost = 1;
-            
-            TerrainType tundra = new TerrainType();
-            tundra.name = "Tundra";
-            tundra.baseFoodProduction = 1;
-            tundra.baseShieldProduction = 0;
-            tundra.baseCommerceProduction = 0;
-            tundra.movementCost = 1;
-
-            TerrainType coast = new TerrainType();
-            coast.name = "Coast";
-            coast.baseFoodProduction = 2;
-            coast.baseShieldProduction = 0;
-            coast.baseCommerceProduction = 1;
-            coast.movementCost = 1;
-
-            TerrainType hills = new TerrainType();
-            hills.name = "Hills";
-            hills.baseFoodProduction = 0;
-            hills.baseShieldProduction = 1;
-            hills.baseCommerceProduction = 0;
-            hills.movementCost = 2;
-
-            TerrainType mountain = new TerrainType();
-            mountain.name = "Mountain";
-            mountain.baseFoodProduction = 0;
-            mountain.baseShieldProduction = 1;
-            mountain.baseCommerceProduction = 1;
-            mountain.movementCost = 3;
-            
-            TerrainType volcano = new TerrainType();
-            volcano.name = "Volcano";
-            volcano.baseFoodProduction = 0;
-            volcano.baseShieldProduction = 1;
-            volcano.baseCommerceProduction = 1;
-            volcano.movementCost = 3;
-
-            TerrainType forest = new TerrainType();
-            forest.name = "Forest";
-            forest.baseFoodProduction = 1;
-            forest.baseShieldProduction = 2;
-            forest.baseCommerceProduction = 0;
-            
-            TerrainType jungle = new TerrainType();
-            jungle.name = "Jungle";
-            jungle.baseFoodProduction = 1;
-            jungle.baseShieldProduction = 0;
-            jungle.baseCommerceProduction = 0;
-            
-            TerrainType marsh = new TerrainType();
-            marsh.name = "Marsh";
-            marsh.baseFoodProduction = 1;
-            marsh.baseShieldProduction = 0;
-            marsh.baseCommerceProduction = 0;
-
-            //Not dummy data
+            //Not dummy data.  Import Civ3 terrains.
             Console.WriteLine("Printing all terrains");
             foreach (TerrSection terrain in civ3Save.Bic.Terr) {
                 Console.WriteLine(terrain);
+                TerrainType c7TerrainType = TerrainType.ImportFromCiv3(terrain);
+                c7Save.GameData.terrainTypes.Add(c7TerrainType);
             }
 
-            // Import data
+            // Import tiles
             c7Save.GameData.map.numTilesTall = civ3Save.Wrld.Width;
             c7Save.GameData.map.numTilesWide = civ3Save.Wrld.Height;
-            foreach (MapTile tile in civ3Save.Tile)
+            foreach (MapTile civ3Tile in civ3Save.Tile)
             {
                 Civ3ExtraInfo extra = new Civ3ExtraInfo
                 {
-                    BaseTerrainFileID = tile.BaseTerrainFileID,
-                    BaseTerrainImageID = tile.BaseTerrainImageID,                    
+                    BaseTerrainFileID = civ3Tile.BaseTerrainFileID,
+                    BaseTerrainImageID = civ3Tile.BaseTerrainImageID,                    
                 };
                 Tile c7Tile = new Tile
                 {
-                    xCoordinate = tile.X,
-                    yCoordinate = tile.Y,
+                    xCoordinate = civ3Tile.X,
+                    yCoordinate = civ3Tile.Y,
                     ExtraInfo = extra,
-                    // TEMP all water is coast, desert and plains are plains, grass and tundra are grass
-                    baseTerrainType = tile.BaseTerrain > 10 ? coast : tile.BaseTerrain > 1 ? grassland : plains,
+                    baseTerrainType = c7Save.GameData.terrainTypes[civ3Tile.BaseTerrain],
+                    overlayTerrainType = c7Save.GameData.terrainTypes[civ3Tile.OverlayTerrain],
                 };
-                if (tile.BaseTerrain == 3) {
-                    c7Tile.baseTerrainType = tundra;
+                if (civ3Tile.isSnowCapped) {
+                    c7Tile.isSnowCapped = true;
                 }
-                else if (tile.BaseTerrain == 2) {
-                    c7Tile.baseTerrainType = grassland;
-                }
-                else if (tile.BaseTerrain == 1) {
-                    c7Tile.baseTerrainType = plains;
-                }
-                else if (tile.BaseTerrain == 0) {
-                    c7Tile.baseTerrainType = desert;
-                }
-                //Not sure how to put this inline with the c7Tile reference, or without duplicating the base terrain logic
-                if (tile.OverlayTerrain == 6) {
-                    c7Tile.overlayTerrainType = mountain;
-                    if (tile.isSnowCapped) {
-                        c7Tile.isSnowCapped = true;
-                    }
-                }
-                else if (tile.OverlayTerrain == 5) {
-                    c7Tile.overlayTerrainType = hills;
-                }
-                else if (tile.OverlayTerrain == 7) {
-                    c7Tile.overlayTerrainType = forest;
-                    if (tile.isPineForest) {
-                        c7Tile.isPineForest = true;
-                    }
-                }
-                else if (tile.OverlayTerrain == 8) {
-                    c7Tile.overlayTerrainType = jungle;
-                }
-                else if (tile.OverlayTerrain == 9) {
-                    c7Tile.overlayTerrainType = marsh;
-                }
-                else if (tile.OverlayTerrain == 10) {
-                    c7Tile.overlayTerrainType = volcano;
-                }
-                else {
-                    c7Tile.overlayTerrainType = c7Tile.baseTerrainType;
+                if (civ3Tile.isPineForest) {
+                    c7Tile.isPineForest = true;
                 }
                 c7Save.GameData.map.tiles.Add(c7Tile);
             }

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -101,6 +101,12 @@ namespace C7GameData
             marsh.baseShieldProduction = 0;
             marsh.baseCommerceProduction = 0;
 
+            //Not dummy data
+            Console.WriteLine("Printing all terrains");
+            foreach (TerrSection terrain in civ3Save.Bic.Terr) {
+                Console.WriteLine(terrain);
+            }
+
             // Import data
             c7Save.GameData.map.numTilesTall = civ3Save.Wrld.Width;
             c7Save.GameData.map.numTilesWide = civ3Save.Wrld.Height;

--- a/C7GameData/TerrainType.cs
+++ b/C7GameData/TerrainType.cs
@@ -1,5 +1,6 @@
 namespace C7GameData
 {
+    using QueryCiv3;
     public class TerrainType
     {
         public string name {get; set; }
@@ -23,5 +24,17 @@ namespace C7GameData
         }
 
         public static TerrainType NONE = new TerrainType();
+        
+
+        public static TerrainType ImportFromCiv3(TerrSection civ3Terrain)
+        {
+            TerrainType c7Terrain = new TerrainType();
+            c7Terrain.name = civ3Terrain.terrainName;
+            c7Terrain.baseFoodProduction = civ3Terrain.food;
+            c7Terrain.baseShieldProduction = civ3Terrain.shields;
+            c7Terrain.baseCommerceProduction = civ3Terrain.commerce;
+            c7Terrain.movementCost = civ3Terrain.movementCost;
+            return c7Terrain;
+        }
     }
 }

--- a/QueryCiv3/BicSections.cs
+++ b/QueryCiv3/BicSections.cs
@@ -36,9 +36,45 @@ namespace QueryCiv3
         }
         public int terrainNameOffset { get => Offset + 4 + resourcesAllowedOnTerrain.Length; }
         public string terrainName { get => Bic.GetString(terrainNameOffset, 32); }
+        public string civilopediaEntry { get => Bic.GetString(terrainNameOffset + 32, 32); }
+        public int irrigationBonus { get => Bic.ReadInt32(terrainNameOffset + 64);}
+        public int miningBonus { get => Bic.ReadInt32(terrainNameOffset + 68);}
+        public int roadBonus { get => Bic.ReadInt32(terrainNameOffset + 72);}
+        public int defenseBonus { get => Bic.ReadInt32(terrainNameOffset + 76);}
+        public int movementCost { get => Bic.ReadInt32(terrainNameOffset + 80);}
+        public int food { get => Bic.ReadInt32(terrainNameOffset + 84);}
+        public int shields { get => Bic.ReadInt32(terrainNameOffset + 88);}
+        public int commerce { get => Bic.ReadInt32(terrainNameOffset + 92);}
+        //Which worker job (TFRM) can be performed on this terrain type
+        public int workerJobAllowed { get => Bic.ReadInt32(terrainNameOffset + 96);}
+        //Which Terrain this Terrain becomes if affected by pollution.  -1 = not affected.  14 = Base Terrain Type (probably 12 in Vanilla/PTW)
+        public int pollutionEffect { get => Bic.ReadInt32(terrainNameOffset + 100);}
+        public byte allowCities { get => Bic.ReadByte(terrainNameOffset + 104);}
+        public byte allowColonies { get => Bic.ReadByte(terrainNameOffset + 105);}
+        public byte impassable { get => Bic.ReadByte(terrainNameOffset + 106);}
+        public byte impassableByWheeled { get => Bic.ReadByte(terrainNameOffset + 107);}
+        public byte allowAirfields { get => Bic.ReadByte(terrainNameOffset + 108);}
+        public byte allowForts { get => Bic.ReadByte(terrainNameOffset + 109);}
+        public byte allowOutposts { get => Bic.ReadByte(terrainNameOffset + 110);}
+        public byte allowRadarTowers { get => Bic.ReadByte(terrainNameOffset + 111);}
+        public int unknownOne { get => Bic.ReadInt32(terrainNameOffset + 112);}
+        public byte landmarkEnabled { get => Bic.ReadByte(terrainNameOffset + 116);}
+        public int landmarkFood { get => Bic.ReadInt32(terrainNameOffset + 117);}
+        public int landmarkShields { get => Bic.ReadInt32(terrainNameOffset + 121);}
+        public int landmarkCommerce { get => Bic.ReadInt32(terrainNameOffset + 125);}
+        public int landmarkIrrigationBonus { get => Bic.ReadInt32(terrainNameOffset + 129);}
+        public int landmarkMiningBonus { get => Bic.ReadInt32(terrainNameOffset + 133);}
+        public int landmarkRoadBonus { get => Bic.ReadInt32(terrainNameOffset + 137);}
+        public int landmarkMovementCost { get => Bic.ReadInt32(terrainNameOffset + 141);}
+        public int landmarkDefensiveBonus { get => Bic.ReadInt32(terrainNameOffset + 145);}
+        public string landmarkName { get => Bic.GetString(terrainNameOffset + 149, 32);}
+        public string landmarkCivilopediaEntry { get => Bic.GetString(terrainNameOffset + 181, 32);}
+        public int unknownTwo { get => Bic.ReadInt32(terrainNameOffset + 213);}
+        public int terrainFlags { get => Bic.ReadInt32(terrainNameOffset + 217);}
+        public int diseaseStrength { get => Bic.ReadInt32(terrainNameOffset + 221);}
 
         public override string ToString() {
-            return "Terrain " + terrainName + " with " + numPossibleResources + " possible resources";
+            return terrainName + " (" + food + "/" + shields + "/" + commerce + "); LM name = " + landmarkName;
         }
     }
     public class WsizSection : SectionListItem {}

--- a/QueryCiv3/BicSections.cs
+++ b/QueryCiv3/BicSections.cs
@@ -21,7 +21,39 @@ namespace QueryCiv3
     public class RaceSection : SectionListItem {}
     public class TechSection : SectionListItem {}
     public class TfrmSection : SectionListItem {}
-    public class TerrSection : SectionListItem {}
+    public class TerrSection : SectionListItem {
+        //TODO: This is probably not how Puppeteer intended us to fetch the data.
+        public int numPossibleResources {
+            get => BitConverter.ToInt32(RawBytes, 0);
+        }
+        //This contains one byte for each 8 resources available on the tile.
+        //Thus, if there are 0 resource, 0 bytes; 1-8 resources, 1 bytes, 9-16, 2 bytes, etc.
+        public byte[] possibleResources {
+            get {
+                int possibleResourceByteCount = (numPossibleResources + 7) /8;
+                byte[] possibleResources = new byte[possibleResourceByteCount];
+                Array.Copy(RawBytes, 4, possibleResources, 0, possibleResources.Length);
+                return possibleResources;
+            }
+        }
+        public int terrainNameOffset {
+            get {
+                return 4 + possibleResources.Length;
+            }
+        }
+        public string terrainName {
+            get {
+                byte[] terrainNameBytes = new byte[32];
+                Array.Copy(RawBytes, terrainNameOffset, terrainNameBytes, 0, terrainNameBytes.Length);
+                string terrainName = System.Text.Encoding.GetEncoding("Windows-1252").GetString(terrainNameBytes);
+                return terrainName;
+            }
+        }
+
+        public override string ToString() {
+            return "Terrain " + terrainName + " with " + numPossibleResources + " possible resources";
+        }
+    }
     public class WsizSection : SectionListItem {}
     public class FlavSection : SectionListItem {}
 

--- a/QueryCiv3/BicSections.cs
+++ b/QueryCiv3/BicSections.cs
@@ -22,33 +22,20 @@ namespace QueryCiv3
     public class TechSection : SectionListItem {}
     public class TfrmSection : SectionListItem {}
     public class TerrSection : SectionListItem {
-        //TODO: This is probably not how Puppeteer intended us to fetch the data.
-        public int numPossibleResources {
-            get => BitConverter.ToInt32(RawBytes, 0);
-        }
+        public int numPossibleResources { get => Bic.ReadInt32(Offset); }
+
         //This contains one byte for each 8 resources available on the tile.
         //Thus, if there are 0 resource, 0 bytes; 1-8 resources, 1 bytes, 9-16, 2 bytes, etc.
-        public byte[] possibleResources {
+        public byte[] resourcesAllowedOnTerrain {
             get {
-                int possibleResourceByteCount = (numPossibleResources + 7) /8;
-                byte[] possibleResources = new byte[possibleResourceByteCount];
-                Array.Copy(RawBytes, 4, possibleResources, 0, possibleResources.Length);
-                return possibleResources;
+                int bytesNeededForResources = (numPossibleResources + 7) /8;
+                byte[] byteBuffer = new byte[bytesNeededForResources];
+                Array.Copy(RawBytes, 4, byteBuffer, 0, byteBuffer.Length);
+                return byteBuffer;
             }
         }
-        public int terrainNameOffset {
-            get {
-                return 4 + possibleResources.Length;
-            }
-        }
-        public string terrainName {
-            get {
-                byte[] terrainNameBytes = new byte[32];
-                Array.Copy(RawBytes, terrainNameOffset, terrainNameBytes, 0, terrainNameBytes.Length);
-                string terrainName = System.Text.Encoding.GetEncoding("Windows-1252").GetString(terrainNameBytes);
-                return terrainName;
-            }
-        }
+        public int terrainNameOffset { get => Offset + 4 + resourcesAllowedOnTerrain.Length; }
+        public string terrainName { get => Bic.GetString(terrainNameOffset, 32); }
 
         public override string ToString() {
             return "Terrain " + terrainName + " with " + numPossibleResources + " possible resources";


### PR DESCRIPTION
This replaces the dummy terrain types with actual, imported-from-civ3 terrain types.  This means we will now have all terrain types (including flood plains, sea, and ocean, which had not been dummied out).  It also sets the stage for easily adding more terrain attributes to C7 terrain types as we're ready for them.

I went ahead and added all the Civ3 TERR attributes, although not all convenience methods we may want for them, following the Apolyton documentation, in a few cases with comments clarifying them based on code from my editor.  One notable call-out is that there is a variable-length array in TERR, whose length is based on the number of resources in-game.  This has some special handling, and subsequent attributes use an offset from the end of that array, rather than the base offset for the TERR section.