### PR TITLE
Completed the remainder of the BIQ structs

### DIFF
--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -60,7 +60,7 @@ namespace C7GameData
                 c7Save.GameData.map.tiles.Add(c7Tile);
             }
             // This probably doesn't belong here, but not sure where else to put it
-            c7Save.GameData.map.RelativeModPath = civ3Save.MediaBic.RelativeModPath;
+            c7Save.GameData.map.RelativeModPath = civ3Save.MediaBic.Game[0].ScenarioSearchFolders;
             return c7Save;
         }
 

--- a/QueryCiv3/Bic.cs
+++ b/QueryCiv3/Bic.cs
@@ -99,9 +99,9 @@ namespace QueryCiv3
                     // Section data structures are stored in the BiqSections/ folder
                     // We can divide the BIQ sections into two types: static and dynamic
                     // Static have a fixed length always, which means they can be read directly memory-copied into our structs with no special logic
-                    //   The static sections are: BLDG, CTZN, CULT, DIFF, ERAS, ESPN, EXPR, GOOD, TECH, TFRM, WSIZ, WCHR, TILE, CONT, SLOC, UNIT, CLNY
+                    //   The static sections are: BLDG, CTZN, CULT, DIFF, ERAS, ESPN, EXPR, FLAV(??), GOOD, TECH, TFRM, WSIZ, WCHR, TILE, CONT, SLOC, UNIT, CLNY
                     // Dynamic sections have at least one component with varying length, and so require multiple structs and special logic
-                    //   The dynamic sections are: GOVT, RULE, PRTO, RACE, TERR, FLAV, WMAP, CITY, GAME, LEAD
+                    //   The dynamic sections are: GOVT, RULE, PRTO, RACE, TERR, WMAP, CITY, GAME, LEAD
                     switch (header) {
                         case "BLDG":
                             dataLength = count * sizeof(BLDG);
@@ -190,7 +190,18 @@ namespace QueryCiv3
                             }
                             break;
                         case "FLAV":
-                            dataLength = -7;
+                            // FLAV has two oddities compared with other sections:
+                            // 1. FLAV's count is not technically locked at 7, but is practically so. This means it can be treated as static (see FLAV.cs)
+                            count = 7;
+                            // 2. FLAV is the only section which is divided into section groups. However, the number of section groups is always 1,
+                            //   so again for practical usage, all that needs to happen is that the offset needs to be shifted an extra 4 for the extra int
+                            offset += 4;
+
+                            dataLength = count * sizeof(FLAV);
+                            Flav = new FLAV[count];
+                            fixed (void* ptr = Flav) {
+                                Buffer.MemoryCopy(bytePtr + offset, ptr, dataLength, dataLength);
+                            }
                             break;
                         case "GAME":
                             dataLength = -7;

--- a/QueryCiv3/Bic.cs
+++ b/QueryCiv3/Bic.cs
@@ -130,7 +130,11 @@ namespace QueryCiv3
                             }
                             break;
                         case "CONT":
-                            dataLength = -7;
+                            dataLength = count * sizeof(CONT);
+                            Cont = new CONT[count];
+                            fixed (void* ptr = Cont) {
+                                Buffer.MemoryCopy(bytePtr + offset, ptr, dataLength, dataLength);
+                            }
                             break;
                         case "CTZN":
                             dataLength = count * sizeof(CTZN);

--- a/QueryCiv3/Biq.cs
+++ b/QueryCiv3/Biq.cs
@@ -46,17 +46,17 @@ namespace QueryCiv3
             A jagged array means that the second dimension can vary between components eg. for RaceCityName, each civ can have a different # of Cities
         */
         public bool[,] TerrGood; // which resources are allowed on which types of terrain
-        public GOVTGOVT[,] GovtGovt; // relationships between governments
-        public RACECITYNAME[][] RaceCityName; // the list of city names for each civ
-        public RACEERA[,] RaceEra; // the file names for each era for each civ
-        public RACELEADERNAME[][] RaceGreatLeaderName; // the great leaders for each civ
-        public RACELEADERNAME[][] RaceScientificLeaderName; // the scientific leaders for each civ
+        public GOVT_GOVT[,] GovtGovt; // relationships between governments
+        public RACE_City[][] RaceCityName; // the list of city names for each civ
+        public RACE_ERAS[,] RaceEra; // the file names for each era for each civ
+        public RACE_LeaderName[][] RaceGreatLeaderName; // the great leaders for each civ
+        public RACE_LeaderName[][] RaceScientificLeaderName; // the scientific leaders for each civ
         public int[][] CityBuilding; // Building IDs in each city
         public int[][] WmapResource;
         public int[][] PrtoPrto; // Stealth unit targets per unit
-        public LEADPRTO[][] LeadPrto; // starting unit data for each leader
+        public LEAD_Unit[][] LeadPrto; // starting unit data for each leader
         public int[][] LeadTech; // starting tech data for each leader
-        public RULECULT[][] RuleCult; // culture level names per rule
+        public RULE_CULT[][] RuleCult; // culture level names per rule
         public int[][] RuleSpaceship; // spaceship quantity requirements per rule
         public int[][] GameCiv; // Playable civs for game
         public int[][] GameAlliance; // Civ alliances for game
@@ -271,8 +271,8 @@ namespace QueryCiv3
                             int govtLen = Bic.ReadInt32(offset) + 4;
                             dataLength = count * govtLen;
                             Govt = new GOVT[count];
-                            GovtGovt = new GOVTGOVT[count, count];
-                            int govtgovtRowLength = count * sizeof(GOVTGOVT);
+                            GovtGovt = new GOVT_GOVT[count, count];
+                            int govtgovtRowLength = count * sizeof(GOVT_GOVT);
 
                             fixed (void* ptr = Govt, ptr2 = GovtGovt) {
                                 byte* govtPtr = (byte*)ptr;
@@ -292,7 +292,7 @@ namespace QueryCiv3
                         case "LEAD":
                             dataLength = 0;
                             Lead = new LEAD[count];
-                            LeadPrto = new LEADPRTO[count][];
+                            LeadPrto = new LEAD_Unit[count][];
                             LeadTech = new int[count][];
 
                             fixed (void* ptr = Lead) {
@@ -303,8 +303,8 @@ namespace QueryCiv3
                                 for (int i = 0; i < count; i++) {
                                     Buffer.MemoryCopy(dataPtr, leadPtr, LEAD_LEN_1, LEAD_LEN_1);
                                     leadPtr += LEAD_LEN_1;
-                                    LeadPrto[i] = new LEADPRTO[Lead[i].NumberOfStartUnitTypes];
-                                    rowLength = Lead[i].NumberOfStartUnitTypes * sizeof(LEADPRTO);
+                                    LeadPrto[i] = new LEAD_Unit[Lead[i].NumberOfStartUnitTypes];
+                                    rowLength = Lead[i].NumberOfStartUnitTypes * sizeof(LEAD_Unit);
                                     fixed (void* ptr2 = LeadPrto[i]) Buffer.MemoryCopy(dataPtr + LEAD_LEN_1, ptr2, rowLength, rowLength);
                                     dataPtr += LEAD_LEN_1 + rowLength;
 
@@ -349,9 +349,9 @@ namespace QueryCiv3
                         case "RACE":
                             dataLength = 0;
                             Race = new RACE[count];
-                            RaceCityName = new RACECITYNAME[count][];
-                            RaceScientificLeaderName = new RACELEADERNAME[count][];
-                            RaceGreatLeaderName = new RACELEADERNAME[count][];
+                            RaceCityName = new RACE_City[count][];
+                            RaceScientificLeaderName = new RACE_LeaderName[count][];
+                            RaceGreatLeaderName = new RACE_LeaderName[count][];
                             /*
                                 For getting dynamic race data, we need to know the number of eras as defined earlier
                                 Presumably this means that the ERAS section of BIQ will always appear before the RACE section
@@ -360,8 +360,8 @@ namespace QueryCiv3
                                   trying to get the length of an uninitialized array, which is sufficient
                             */
                             int eras = Eras.Length;
-                            RaceEra = new RACEERA[count, eras];
-                            int raceeraRowLength = eras * sizeof(RACEERA);
+                            RaceEra = new RACE_ERAS[count, eras];
+                            int raceeraRowLength = eras * sizeof(RACE_ERAS);
 
                             fixed (void* ptr = Race, ptr2 = RaceEra) {
                                 byte* racePtr = (byte*)ptr;
@@ -372,15 +372,15 @@ namespace QueryCiv3
                                 for (int i = 0; i < count; i++) {
                                     Buffer.MemoryCopy(dataPtr, racePtr, RACE_LEN_1, RACE_LEN_1);
                                     racePtr += RACE_LEN_1;
-                                    RaceCityName[i] = new RACECITYNAME[Race[i].NumberOfCities];
-                                    rowLength = Race[i].NumberOfCities * sizeof(RACECITYNAME);
+                                    RaceCityName[i] = new RACE_City[Race[i].NumberOfCities];
+                                    rowLength = Race[i].NumberOfCities * sizeof(RACE_City);
                                     fixed (void* ptr3 = RaceCityName[i]) Buffer.MemoryCopy(dataPtr + RACE_LEN_1, ptr3, rowLength, rowLength);
                                     dataPtr += RACE_LEN_1 + rowLength;
 
                                     Buffer.MemoryCopy(dataPtr, racePtr, RACE_LEN_2, RACE_LEN_2);
                                     racePtr += RACE_LEN_2;
-                                    RaceGreatLeaderName[i] = new RACELEADERNAME[Race[i].NumberOfGreatLeaders];
-                                    rowLength = Race[i].NumberOfGreatLeaders * sizeof(RACELEADERNAME);
+                                    RaceGreatLeaderName[i] = new RACE_LeaderName[Race[i].NumberOfGreatLeaders];
+                                    rowLength = Race[i].NumberOfGreatLeaders * sizeof(RACE_LeaderName);
                                     fixed (void* ptr3 = RaceGreatLeaderName[i]) Buffer.MemoryCopy(dataPtr + RACE_LEN_2, ptr3, rowLength, rowLength);
                                     dataPtr += RACE_LEN_2 + rowLength;
 
@@ -392,8 +392,8 @@ namespace QueryCiv3
 
                                     Buffer.MemoryCopy(dataPtr, racePtr, RACE_LEN_4, RACE_LEN_4);
                                     racePtr += RACE_LEN_4;
-                                    RaceScientificLeaderName[i] = new RACELEADERNAME[Race[i].NumberOfScientificLeaders];
-                                    rowLength = Race[i].NumberOfScientificLeaders * sizeof(RACELEADERNAME);
+                                    RaceScientificLeaderName[i] = new RACE_LeaderName[Race[i].NumberOfScientificLeaders];
+                                    rowLength = Race[i].NumberOfScientificLeaders * sizeof(RACE_LeaderName);
                                     fixed (void* ptr3 = RaceScientificLeaderName[i]) Buffer.MemoryCopy(dataPtr + RACE_LEN_4, ptr3, rowLength, rowLength);
                                     dataPtr += RACE_LEN_4 + rowLength;
 
@@ -405,7 +405,7 @@ namespace QueryCiv3
                         case "RULE":
                             dataLength = 0;
                             Rule = new RULE[count];
-                            RuleCult = new RULECULT[count][];
+                            RuleCult = new RULE_CULT[count][];
                             RuleSpaceship = new int[count][];
 
                             fixed (void* ptr = Rule) {
@@ -423,8 +423,8 @@ namespace QueryCiv3
 
                                     Buffer.MemoryCopy(dataPtr, rulePtr, RULE_LEN_2, RULE_LEN_2);
                                     rulePtr += RULE_LEN_2;
-                                    RuleCult[i] = new RULECULT[Rule[i].NumberOfCultureLevels];
-                                    rowLength = Rule[i].NumberOfCultureLevels * sizeof(RULECULT);
+                                    RuleCult[i] = new RULE_CULT[Rule[i].NumberOfCultureLevels];
+                                    rowLength = Rule[i].NumberOfCultureLevels * sizeof(RULE_CULT);
                                     fixed (void* ptr2 = RuleCult[i]) Buffer.MemoryCopy(dataPtr + RULE_LEN_2, ptr2, rowLength, rowLength);
                                     dataPtr += RULE_LEN_2 + rowLength;
 

--- a/QueryCiv3/BiqSections/City.cs
+++ b/QueryCiv3/BiqSections/City.cs
@@ -6,6 +6,29 @@ namespace QueryCiv3.Biq
     [StructLayout(LayoutKind.Sequential, Pack=1)]
     public unsafe struct CITY
     {
+        public int Length;
+        public byte HasWalls;
+        public byte HasPalace;
 
+        private fixed byte Text[24];
+        public string Name { get => Util.GetString(ref this, 6, 30); }
+
+        public int OwnerType; // 0: None, 1: Barb, 2: Civ, 3: Player
+        public int NumberOfBuildings;
+
+        /*
+            Dynamic length gap
+            In BIQ files, for each buildings, 4 bytes of space are used to point to building id
+            Data is instead stored in 2d array CityBuilding
+        */
+
+        public int Culture;
+        public int Owner;
+        public int Size;
+        public int X;
+        public int Y;
+        public int CityLevel;
+        public int BorderLevel;
+        public int UseAutoName;
     }
 }

--- a/QueryCiv3/BiqSections/Cont.cs
+++ b/QueryCiv3/BiqSections/Cont.cs
@@ -6,6 +6,8 @@ namespace QueryCiv3.Biq
     [StructLayout(LayoutKind.Sequential, Pack=1)]
     public unsafe struct CONT
     {
-
+        public int Length;
+        public int Type; // 0: Water, 1: Land
+        public int NumberOfTiles;
     }
 }

--- a/QueryCiv3/BiqSections/Flav.cs
+++ b/QueryCiv3/BiqSections/Flav.cs
@@ -4,8 +4,24 @@ using System.Runtime.InteropServices;
 namespace QueryCiv3.Biq
 {
     [StructLayout(LayoutKind.Sequential, Pack=1)]
+    public unsafe struct FLAVFLAV
+    {
+        private fixed int Relationships[7];
+        public int this[int index] { get => Relationships[index]; }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack=1)]
     public unsafe struct FLAV
     {
+        private fixed byte UnknownBuffer[4];
 
+        private fixed byte Text[256];
+        public string Name { get => Util.GetString(ref this, 4, 256); }
+
+        // So FLAV should be considered a dynamic section, because it has an amount of flavor relationship data determined by NumberOfFlavors
+        // However, NumberOfFlavors seems to always be 7, and it doesn't look like flavors can be added to or removed in the Civ3Editor
+        // So for now, I'm treating FLAV as static until a counterexample is discovered
+        public int NumberOfFlavors;
+        public FLAVFLAV FlavorRelationship;
     }
 }

--- a/QueryCiv3/BiqSections/Game.cs
+++ b/QueryCiv3/BiqSections/Game.cs
@@ -4,8 +4,119 @@ using System.Runtime.InteropServices;
 namespace QueryCiv3.Biq
 {
     [StructLayout(LayoutKind.Sequential, Pack=1)]
+    public unsafe struct TIMESCALE
+    {
+        private fixed int Values[7];
+        public int this[int index] { get => Values[index]; }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack=1)]
+    public unsafe struct ALLIANCE
+    {
+        private fixed byte Text[1280];
+        public string this[int i] { get => Util.GetString(ref this, i * 256, 256); }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack=1)]
+    public unsafe struct ALLIANCEWARS
+    {
+        private fixed int Values[25];
+        public int this[int i, int j] { get => Values[i * 5 + j]; }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack=1)]
     public unsafe struct GAME
     {
+        public int Length;
+        public int DefaultGameRules; // 0: don't use, 1: use
+        public int DefaultVictoryConditions; // 0: don't use, 1: use
+        public int NumberOfPlayableCivs; // 0: all playable
 
+        /*
+            Dynamic length gap
+            In BIQ files, for each playable civ, there is a 1 int long ID for that civ
+            Data is instead stored in 2d array GameCiv
+        */
+
+        private fixed byte Flags[4];
+        public bool DominationVictory           { get => Util.GetFlag(Flags[0], 0); }
+        public bool SpaceRaceVictory            { get => Util.GetFlag(Flags[0], 1); }
+        public bool DiplomaticVictory           { get => Util.GetFlag(Flags[0], 2); }
+        public bool ConquestVictory             { get => Util.GetFlag(Flags[0], 3); }
+        public bool CulturalVictory             { get => Util.GetFlag(Flags[0], 4); }
+        public bool CivSpecificAbilities        { get => Util.GetFlag(Flags[0], 5); }
+        public bool CulturallyLinkedStart       { get => Util.GetFlag(Flags[0], 6); }
+        public bool RestartPlayers              { get => Util.GetFlag(Flags[0], 7); }
+
+        public bool PreserveRandomSeed          { get => Util.GetFlag(Flags[1], 0); }
+        public bool AcceleratedProduction       { get => Util.GetFlag(Flags[1], 1); }
+        public bool Elimination                 { get => Util.GetFlag(Flags[1], 2); }
+        public bool Regicide                    { get => Util.GetFlag(Flags[1], 3); }
+        public bool MassRegicide                { get => Util.GetFlag(Flags[1], 4); }
+        public bool VictoryLocations            { get => Util.GetFlag(Flags[1], 5); }
+        public bool CaptureTheFlag              { get => Util.GetFlag(Flags[1], 6); }
+        public bool AllowCulturalConversions    { get => Util.GetFlag(Flags[1], 7); }
+
+        public int PlaceCaptureUnits;
+        public int AutoPlaceKings;
+        public int AutoPlaceVictoryLocations;
+        public int DebugMode;
+        public int UseTimeLimit;
+        public int BaseTimeUnit; // 0: Years, 1: Months, 2: Weeks
+        public int StartMonth;
+        public int StartWeek;
+        public int StartYear;
+        public int MinuteTimeLimit;
+        public int TurnTimeLimit;
+        public TIMESCALE TimescaleNumberOfTurns;
+        public TIMESCALE TurnNumberOfTimeUnits;
+
+        private fixed byte Text[5200];
+        public string ScenarioSearchFolders { get => Util.GetString(ref this, 120, 5200); }
+
+        /*
+            Dynamic length gap
+            In BIQ files, for each playable civ, there is a single int for alliance status
+            Data is instead stored in 2d array GameAlliance
+        */
+
+        public int VictoryPointLimit;
+        public int CityEliminationCount;
+        public int OneCityCultureWin;
+        public int AllCitiesCultureWin;
+        public int DominationTerrain;
+        public int DominationPopulation;
+        public int WonderCost;
+        public int DefeatingOpposingUnitCost;
+        public int AdvancementCost;
+        public int CityConquestPopulation;
+        public int VictoryPointScoring;
+        public int CapturingSpecialUnit;
+        private fixed byte UnknownBuffer[5];
+        public ALLIANCE AllianceNames;
+        public ALLIANCEWARS WarWithAlliance;
+        public int AllianceVictoryType;
+
+        private fixed byte Text3[260];
+        public string PlagueName { get => Util.GetString(ref this, 6757, 260); }
+
+        public byte PermitPlagues;
+        public int PlagueEarliestStart;
+        public int PlagueVartiation;
+        public int PlagueDuration;
+        public int PlagueStrength;
+        public int PlagueGracePeriod;
+        public int PlagueMaxOccurance;
+        private fixed byte UnknownBuffer2[264];
+        public int RespawnFlagUnits;
+        public byte CaptureAnyFlag;
+        public int GoldForCapture;
+        public byte MapVisible;
+        public byte RetainCulture;
+        private fixed byte UnknownBuffer3[4];
+        public int EruptionPeriod;
+        public int MPBasetime;
+        public int MPCityTime;
+        public int MPUnitTime;
     }
 }

--- a/QueryCiv3/BiqSections/Govt.cs
+++ b/QueryCiv3/BiqSections/Govt.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace QueryCiv3.Biq
 {
-    public struct GOVTGOVT {
+    public struct GOVT_GOVT {
         public int CanBribe;
         public int BriberyModifier;
         public int ResistanceModifier;

--- a/QueryCiv3/BiqSections/Lead.cs
+++ b/QueryCiv3/BiqSections/Lead.cs
@@ -4,8 +4,48 @@ using System.Runtime.InteropServices;
 namespace QueryCiv3.Biq
 {
     [StructLayout(LayoutKind.Sequential, Pack=1)]
+    public unsafe struct LEADPRTO
+    {
+        public int NumberOfStartUnits;
+        public int UnitType;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack=1)]
     public unsafe struct LEAD
     {
+        public int Length;
+        public int CustomCivData; // 0: don't use, 1: use
+        public int HumanPlayer; // 0: no, 1: yes
 
+        private fixed byte Text[32];
+        public string Name { get => Util.GetString(ref this, 12, 32); }
+
+        private fixed byte UnknownBuffer[8]; // Are we sure this buffer isn't just a continuation of the text?
+        public int NumberOfStartUnitTypes;
+
+        /*
+            Dynamic length gap
+            In BIQ files, for each starting unit type, there are 2 ints: one for the amount of that unit and one for its ID
+            Data is instead stored in 2d array of LEADPRTO
+        */
+
+        public int GenderOfLeaderName;
+        public int NumberOfStartingTechnologies;
+
+        /*
+            Dynamic length gap
+            In BIQ files, for each starting tech, there is 1 int for that tech's ID
+            Data is instead stored in 2d array LeadTech
+        */
+
+        public int Difficulty;
+        public int InitialEra;
+        public int StartCash; // $$$$$$$$$$$$$$$$$
+        public int Government;
+        public int Civ; // -3: any, -2: random
+        public int Color;
+        public int SkipFirstTurn;
+        private fixed byte UnknownBuffer2[4];
+        public byte StartEmbassies;
     }
 }

--- a/QueryCiv3/BiqSections/Lead.cs
+++ b/QueryCiv3/BiqSections/Lead.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace QueryCiv3.Biq
 {
     [StructLayout(LayoutKind.Sequential, Pack=1)]
-    public unsafe struct LEADPRTO
+    public unsafe struct LEAD_Unit
     {
         public int NumberOfStartUnits;
         public int UnitType;

--- a/QueryCiv3/BiqSections/Prto.cs
+++ b/QueryCiv3/BiqSections/Prto.cs
@@ -3,9 +3,174 @@ using System.Runtime.InteropServices;
 
 namespace QueryCiv3.Biq
 {
+    // These two value-indexer helper structs help for getting repeating data
+    // For instance, to see if a unit is available to civ 5, these structs allow `bool myBool = myPrto.AvailableTo[5]`
+    // However, probably a good TODO would be generalizing these for multiple cases
+    [StructLayout(LayoutKind.Sequential, Pack=1)]
+    public unsafe struct PRTOTERR
+    {
+        // 1 byte for each section in TERR
+        // In Biq files, this is fixed at 14, so we can treat this as static instead of dynamic
+        private fixed byte Terr[14];
+        public bool this[int index] { get => Util.GetFlag(Terr[index], 0); }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack=1)]
+    public unsafe struct PRTORACE
+    {
+        private fixed byte Race[4];
+        public bool this[int index] { get => Util.GetFlag(Race[index / 8], index % 8); }
+    }
+
     [StructLayout(LayoutKind.Sequential, Pack=1)]
     public unsafe struct PRTO
     {
+        public int Length;
+        public int ZoneOfControl;
 
+        private fixed byte Text[64];
+        public string Name { get => Util.GetString(ref this, 8, 32); }
+        public string CivilopediaEntry { get => Util.GetString(ref this, 40, 32); }
+
+        public int BombardStrength;
+        public int BombardRange;
+        public int Capacity;
+        public int ShieldCost;
+        public int Defense;
+        public int IconIndex;
+        public int Attack;
+        public int OperationalRange;
+        public int PopulationCost;
+        public int RateOfFire;
+        public int Movement;
+        public int Required;
+        public int UpgradeTo;
+        public int RequiredResource1;
+        public int RequiredResource2;
+        public int RequiredResource3;
+
+        private fixed byte Flags1[8];
+        public bool Wheeled                 { get => Util.GetFlag(Flags1[0], 0); }
+        public bool FootSoldier             { get => Util.GetFlag(Flags1[0], 1); }
+        public bool Blitz                   { get => Util.GetFlag(Flags1[0], 2); }
+        public bool CruiseMissile           { get => Util.GetFlag(Flags1[0], 3); }
+        public bool AllTerrainAsRoads       { get => Util.GetFlag(Flags1[0], 4); }
+        public bool Radar                   { get => Util.GetFlag(Flags1[0], 5); }
+        public bool Amphibious              { get => Util.GetFlag(Flags1[0], 6); }
+        public bool Submarine               { get => Util.GetFlag(Flags1[0], 7); }
+
+        public bool AircraftCarrier         { get => Util.GetFlag(Flags1[1], 0); }
+        public bool Draft                   { get => Util.GetFlag(Flags1[1], 1); }
+        public bool Immobile                { get => Util.GetFlag(Flags1[1], 2); }
+        public bool SinkInSea               { get => Util.GetFlag(Flags1[1], 3); }
+        public bool SinkInOcean             { get => Util.GetFlag(Flags1[1], 4); }
+        // unused
+        public bool CarryFootUnitsOnly      { get => Util.GetFlag(Flags1[1], 6); }
+        public bool StartsGoldenAge         { get => Util.GetFlag(Flags1[1], 7); }
+
+        public bool NuclearWeapon           { get => Util.GetFlag(Flags1[2], 0); }
+        public bool HiddenNationality       { get => Util.GetFlag(Flags1[2], 1); }
+        public bool Army                    { get => Util.GetFlag(Flags1[2], 2); }
+        public bool Leader                  { get => Util.GetFlag(Flags1[2], 3); }
+        public bool ICBM                    { get => Util.GetFlag(Flags1[2], 4); }
+        public bool Stealth                 { get => Util.GetFlag(Flags1[2], 5); }
+        public bool CanSeeSubmarines        { get => Util.GetFlag(Flags1[2], 6); }
+        public bool TacticalMissile         { get => Util.GetFlag(Flags1[2], 7); }
+
+        public bool CanCarryTacticalMissiles{ get => Util.GetFlag(Flags1[3], 0); }
+        public bool RangedAttackAnimations  { get => Util.GetFlag(Flags1[3], 1); }
+        public bool TurnToAttack            { get => Util.GetFlag(Flags1[3], 2); }
+
+        public bool AIOffense               { get => Util.GetFlag(Flags1[4], 0); }
+        public bool AIDefense               { get => Util.GetFlag(Flags1[4], 1); }
+        public bool AIArtillery             { get => Util.GetFlag(Flags1[4], 2); }
+        public bool AIExplore               { get => Util.GetFlag(Flags1[4], 3); }
+        public bool AIArmy                  { get => Util.GetFlag(Flags1[4], 4); }
+        public bool AICruiseMissile         { get => Util.GetFlag(Flags1[4], 5); }
+        public bool AIAirBombard            { get => Util.GetFlag(Flags1[4], 6); }
+        public bool AIAirDefense            { get => Util.GetFlag(Flags1[4], 7); }
+
+        public bool AINavalPower            { get => Util.GetFlag(Flags1[5], 0); }
+        public bool AIAirTransport          { get => Util.GetFlag(Flags1[5], 1); }
+        public bool AINavalTransport        { get => Util.GetFlag(Flags1[5], 2); }
+        public bool AINavalCarrier          { get => Util.GetFlag(Flags1[5], 3); }
+        public bool AITerraform             { get => Util.GetFlag(Flags1[5], 4); }
+        public bool AISettle                { get => Util.GetFlag(Flags1[5], 5); }
+        public bool AILeader                { get => Util.GetFlag(Flags1[5], 6); }
+        public bool AITacticalNuke          { get => Util.GetFlag(Flags1[5], 7); }
+
+        public bool AIICBM                  { get => Util.GetFlag(Flags1[6], 0); }
+        public bool AINavalMissileTransport { get => Util.GetFlag(Flags1[6], 1); }
+
+        public PRTORACE AvailableTo; // Binary flag for each civ 0-31
+        private fixed byte Flags2[8];
+        public int Type; // 0: land, 1: sea, 2: air
+        public int OtherStrategy;
+        public int HPBonus;
+
+        private fixed byte Flags3[20];
+        public bool SkipTurn                { get => Util.GetFlag(Flags3[0], 0); }
+        public bool Wait                    { get => Util.GetFlag(Flags3[0], 1); }
+        public bool Fortify                 { get => Util.GetFlag(Flags3[0], 2); }
+        public bool Disband                 { get => Util.GetFlag(Flags3[0], 3); }
+        public bool GoTo                    { get => Util.GetFlag(Flags3[0], 4); }
+        public bool Explore                 { get => Util.GetFlag(Flags3[0], 5); }
+        public bool Sentry                  { get => Util.GetFlag(Flags3[0], 6); }
+
+        public bool Load                    { get => Util.GetFlag(Flags3[4], 0); }
+        public bool Unload                  { get => Util.GetFlag(Flags3[4], 1); }
+        public bool Airlift                 { get => Util.GetFlag(Flags3[4], 2); }
+        public bool Pillage                 { get => Util.GetFlag(Flags3[4], 3); }
+        public bool Bombard                 { get => Util.GetFlag(Flags3[4], 4); }
+        public bool Airdrop                 { get => Util.GetFlag(Flags3[4], 5); }
+        public bool BuildArmy               { get => Util.GetFlag(Flags3[4], 6); }
+        public bool FinishImprovements      { get => Util.GetFlag(Flags3[4], 7); }
+
+        public bool UpgradeUnit             { get => Util.GetFlag(Flags3[5], 0); }
+        public bool Capture                 { get => Util.GetFlag(Flags3[5], 1); }
+
+        public bool BuildColony             { get => Util.GetFlag(Flags3[8], 0); }
+        public bool BuildCity               { get => Util.GetFlag(Flags3[8], 1); }
+        public bool BuildRoad               { get => Util.GetFlag(Flags3[8], 2); }
+        public bool BuildRailroad           { get => Util.GetFlag(Flags3[8], 3); }
+        public bool BuildFortress           { get => Util.GetFlag(Flags3[8], 4); }
+        public bool BuildMine               { get => Util.GetFlag(Flags3[8], 5); }
+        public bool Irrigate                { get => Util.GetFlag(Flags3[8], 6); }
+        public bool ClearForest             { get => Util.GetFlag(Flags3[8], 7); }
+
+        public bool ClearJungle             { get => Util.GetFlag(Flags3[9], 0); }
+        public bool PlantForest             { get => Util.GetFlag(Flags3[9], 1); }
+        public bool ClearPollution          { get => Util.GetFlag(Flags3[9], 2); }
+        public bool Automate                { get => Util.GetFlag(Flags3[9], 3); }
+        public bool JoinCity                { get => Util.GetFlag(Flags3[9], 4); }
+        public bool BuildAirfield           { get => Util.GetFlag(Flags3[9], 5); }
+        public bool BuildRadarTower         { get => Util.GetFlag(Flags3[9], 6); }
+        public bool BuildOutpost            { get => Util.GetFlag(Flags3[9], 7); }
+
+        public bool Bombing                 { get => Util.GetFlag(Flags3[12], 0); }
+        public bool Recon                   { get => Util.GetFlag(Flags3[12], 1); }
+        public bool Intercept               { get => Util.GetFlag(Flags3[12], 2); }
+        public bool Rebase                  { get => Util.GetFlag(Flags3[12], 3); }
+        public bool PrecisionBombing        { get => Util.GetFlag(Flags3[12], 4); }
+
+        public int BombardEffects;
+        public PRTOTERR IgnoreMovementCost;
+        public int RequireSupport;
+        private fixed byte UnknownBuffer[16];
+        public int EnslaveResults;
+        private fixed byte UnknownBuffer2[4];
+        public int NumberOfStealthTargets;
+
+        /*
+            Dynamic length gap
+            In BIQ files, for each stealth target, there's an integer ID with its PRTO#
+            Data is instead stored in 2d array PrtoPrto
+        */
+
+        private fixed byte UnknownBuffer3[8];
+        public byte CreateCraters;
+        public float WorkerStrength;
+        private fixed byte UnknownBuffer4[4];
+        public int AirDefense;
     }
 }

--- a/QueryCiv3/BiqSections/Prto.cs
+++ b/QueryCiv3/BiqSections/Prto.cs
@@ -80,6 +80,10 @@ namespace QueryCiv3.Biq
         public bool CanCarryTacticalMissiles{ get => Util.GetFlag(Flags1[3], 0); }
         public bool RangedAttackAnimations  { get => Util.GetFlag(Flags1[3], 1); }
         public bool TurnToAttack            { get => Util.GetFlag(Flags1[3], 2); }
+        public bool LethalLandBombardment   { get => Util.GetFlag(Flags1[3], 3); }
+        public bool LethalSeaBombardment    { get => Util.GetFlag(Flags1[3], 4); }
+        public bool King                    { get => Util.GetFlag(Flags1[3], 5); }
+        public bool RequiresEscort          { get => Util.GetFlag(Flags1[3], 6); }
 
         public bool AIOffense               { get => Util.GetFlag(Flags1[4], 0); }
         public bool AIDefense               { get => Util.GetFlag(Flags1[4], 1); }
@@ -101,6 +105,8 @@ namespace QueryCiv3.Biq
 
         public bool AIICBM                  { get => Util.GetFlag(Flags1[6], 0); }
         public bool AINavalMissileTransport { get => Util.GetFlag(Flags1[6], 1); }
+        public bool AIFlag                  { get => Util.GetFlag(Flags1[6], 2); }
+        public bool AIKing                  { get => Util.GetFlag(Flags1[6], 3); }
 
         public PRTORACE AvailableTo; // Binary flag for each civ 0-31
         private fixed byte Flags2[8];
@@ -146,6 +152,8 @@ namespace QueryCiv3.Biq
         public bool BuildAirfield           { get => Util.GetFlag(Flags3[9], 5); }
         public bool BuildRadarTower         { get => Util.GetFlag(Flags3[9], 6); }
         public bool BuildOutpost            { get => Util.GetFlag(Flags3[9], 7); }
+
+        public bool BuildBarricade          { get => Util.GetFlag(Flags3[10], 0); }
 
         public bool Bombing                 { get => Util.GetFlag(Flags3[12], 0); }
         public bool Recon                   { get => Util.GetFlag(Flags3[12], 1); }

--- a/QueryCiv3/BiqSections/Race.cs
+++ b/QueryCiv3/BiqSections/Race.cs
@@ -81,6 +81,8 @@ namespace QueryCiv3.Biq
         public bool Scientific                  { get => Util.GetFlag(Flags[0], 3); }
         public bool Religious                   { get => Util.GetFlag(Flags[0], 4); }
         public bool Industrious                 { get => Util.GetFlag(Flags[0], 5); }
+        public bool Agricultural                { get => Util.GetFlag(Flags[0], 6); }
+        public bool Seafaring                   { get => Util.GetFlag(Flags[0], 7); }
 
         public bool ManageCitizens              { get => Util.GetFlag(Flags[4], 0); }
         public bool EmphasizeFood               { get => Util.GetFlag(Flags[4], 1); }

--- a/QueryCiv3/BiqSections/Race.cs
+++ b/QueryCiv3/BiqSections/Race.cs
@@ -4,21 +4,21 @@ using System.Runtime.InteropServices;
 namespace QueryCiv3.Biq
 {
     [StructLayout(LayoutKind.Sequential, Pack=1)]
-    public unsafe struct RACECITYNAME
+    public unsafe struct RACE_City
     {
         private fixed byte Text[24];
         public string Name { get => Util.GetString(ref this, 0, 24); }
     }
 
     [StructLayout(LayoutKind.Sequential, Pack=1)]
-    public unsafe struct RACELEADERNAME
+    public unsafe struct RACE_LeaderName
     {
         private fixed byte Text[32];
         public string Name { get => Util.GetString(ref this, 0, 32); }
     }
 
     [StructLayout(LayoutKind.Sequential, Pack=1)]
-    public unsafe struct RACEERA
+    public unsafe struct RACE_ERAS
     {
         private fixed byte Text[520];
         public string ForwardFilename { get => Util.GetString(ref this, 0, 260); }

--- a/QueryCiv3/BiqSections/Race.cs
+++ b/QueryCiv3/BiqSections/Race.cs
@@ -4,8 +4,135 @@ using System.Runtime.InteropServices;
 namespace QueryCiv3.Biq
 {
     [StructLayout(LayoutKind.Sequential, Pack=1)]
+    public unsafe struct RACECITYNAME
+    {
+        private fixed byte Text[24];
+        public string Name { get => Util.GetString(ref this, 0, 24); }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack=1)]
+    public unsafe struct RACELEADERNAME
+    {
+        private fixed byte Text[32];
+        public string Name { get => Util.GetString(ref this, 0, 32); }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack=1)]
+    public unsafe struct RACEERA
+    {
+        private fixed byte Text[520];
+        public string ForwardFilename { get => Util.GetString(ref this, 0, 260); }
+        public string ReverseFilename { get => Util.GetString(ref this, 260, 260); }
+
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack=1)]
     public unsafe struct RACE
     {
+        public int Length;
+        public int NumberOfCities;
 
+        /*
+            Dynamic length gap
+            In BIQ files, for each city, 24 bytes of space are used to store that city's name
+            Data is instead stored in 2d array of RACECITYNAME
+        */
+
+        public int NumberOfGreatLeaders;
+
+        /*
+            Dynamic length gap
+            In BIQ files, for each great leader, 32 bytes are used to store that leader's name
+            Data is instead stored in 2d array of RACELEADERNAME
+        */
+
+        private fixed byte Text[208];
+        public string LeaderName { get => Util.GetString(ref this, 12, 32); }
+        public string LeaderTitle { get => Util.GetString(ref this, 44, 24); }
+        public string CivilopediaEntry { get => Util.GetString(ref this, 68, 32); }
+        public string Adjective { get => Util.GetString(ref this, 100, 40); }
+        public string Name { get => Util.GetString(ref this, 140, 40); }
+        public string Noun { get => Util.GetString(ref this, 180, 40); }
+
+        /*
+            Dynamic length gap
+            In BIQ files, for each era, 520 bytes are used to store that era's forward and reverse filenames
+            Data is instead stored in 2d array of RACEERA
+        */
+
+        public int CultureGroup;
+        public int LeaderGender;
+        public int CivilizationGender;
+        public int AggressionLevel; // -2 to 2
+        public int UniqueCivilizationCounter;
+        public int ShunnedGovernment;
+        public int FavoriteGovernment;
+        public int DefaultColor;
+        public int UniqueColor;
+        public int FreeTech1;
+        public int FreeTech2;
+        public int FreeTech3;
+        public int FreeTech4;
+
+        private fixed byte Flags[16];
+        public bool Militaristic                { get => Util.GetFlag(Flags[0], 0); }
+        public bool Commercial                  { get => Util.GetFlag(Flags[0], 1); }
+        public bool Expansionist                { get => Util.GetFlag(Flags[0], 2); }
+        public bool Scientific                  { get => Util.GetFlag(Flags[0], 3); }
+        public bool Religious                   { get => Util.GetFlag(Flags[0], 4); }
+        public bool Industrious                 { get => Util.GetFlag(Flags[0], 5); }
+
+        public bool ManageCitizens              { get => Util.GetFlag(Flags[4], 0); }
+        public bool EmphasizeFood               { get => Util.GetFlag(Flags[4], 1); }
+        public bool EmphasizeShields            { get => Util.GetFlag(Flags[4], 2); }
+        public bool EmphasizeTrade              { get => Util.GetFlag(Flags[4], 3); }
+        public bool ManageProduction            { get => Util.GetFlag(Flags[4], 4); }
+        public bool NoWonders                   { get => Util.GetFlag(Flags[4], 5); }
+        public bool NoSmallWonders              { get => Util.GetFlag(Flags[4], 6); }
+
+        public bool OffensiveLandUnitsNever     { get => Util.GetFlag(Flags[8], 0); }
+        public bool DefensiveLandUnitsNever     { get => Util.GetFlag(Flags[8], 1); }
+        public bool ArtilleryLandUnitsNever     { get => Util.GetFlag(Flags[8], 2); }
+        public bool SettlersNever               { get => Util.GetFlag(Flags[8], 3); }
+        public bool WorkersNever                { get => Util.GetFlag(Flags[8], 4); }
+        public bool NavalUnitsNever             { get => Util.GetFlag(Flags[8], 5); }
+        public bool AirUnitsNever               { get => Util.GetFlag(Flags[8], 6); }
+        public bool GrowthNever                 { get => Util.GetFlag(Flags[8], 7); }
+        public bool ProductionNever             { get => Util.GetFlag(Flags[9], 0); }
+        public bool HappinessNever              { get => Util.GetFlag(Flags[9], 1); }
+        public bool ScienceNever                { get => Util.GetFlag(Flags[9], 2); }
+        public bool WealthNever                 { get => Util.GetFlag(Flags[9], 3); }
+        public bool TradeNever                  { get => Util.GetFlag(Flags[9], 4); }
+        public bool ExploreNever                { get => Util.GetFlag(Flags[9], 5); }
+        public bool CultureNever                { get => Util.GetFlag(Flags[9], 6); }
+
+        public bool OffensiveLandUnitsOften     { get => Util.GetFlag(Flags[12], 0); }
+        public bool DefensiveLandUnitsOften     { get => Util.GetFlag(Flags[12], 1); }
+        public bool ArtilleryLandUnitsOften     { get => Util.GetFlag(Flags[12], 2); }
+        public bool SettlersOften               { get => Util.GetFlag(Flags[12], 3); }
+        public bool WorkersOften                { get => Util.GetFlag(Flags[12], 4); }
+        public bool NavalUnitsOften             { get => Util.GetFlag(Flags[12], 5); }
+        public bool AirUnitsOften               { get => Util.GetFlag(Flags[12], 6); }
+        public bool GrowthOften                 { get => Util.GetFlag(Flags[12], 7); }
+        public bool ProductionOften             { get => Util.GetFlag(Flags[13], 0); }
+        public bool HappinessOften              { get => Util.GetFlag(Flags[13], 1); }
+        public bool ScienceOften                { get => Util.GetFlag(Flags[13], 2); }
+        public bool WealthOften                 { get => Util.GetFlag(Flags[13], 3); }
+        public bool TradeOften                  { get => Util.GetFlag(Flags[13], 4); }
+        public bool ExploreOften                { get => Util.GetFlag(Flags[13], 5); }
+        public bool CultureOften                { get => Util.GetFlag(Flags[13], 6); }
+
+        public int Plurality;
+        public int UnitTypeForKing;
+        public int Flavors;
+        private fixed byte UnknownBuffer[4];
+        public int DiplomacyTextIndex;
+        public int NumberOfScientificLeaders;
+
+        /*
+            Dynamic length gap
+            In BIQ files, for each scientific leader, 32 bytes are used to store that leader's name
+            Data is instead stored in 2d array of RACELEADERNAME
+        */
     }
 }

--- a/QueryCiv3/BiqSections/Rule.cs
+++ b/QueryCiv3/BiqSections/Rule.cs
@@ -4,8 +4,84 @@ using System.Runtime.InteropServices;
 namespace QueryCiv3.Biq
 {
     [StructLayout(LayoutKind.Sequential, Pack=1)]
+    public unsafe struct RULECULT
+    {
+        private fixed byte Text[64];
+        public string Name { get => Util.GetString(ref this, 0, 64); }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack=1)]
     public unsafe struct RULE
     {
+        public int Length;
 
+        private fixed byte Text[96];
+        public string CitySizeLevel1Name { get => Util.GetString(ref this, 4, 32); }
+        public string CitySizeLevel2Name { get => Util.GetString(ref this, 36, 32); }
+        public string CitySizeLevel3Name { get => Util.GetString(ref this, 68, 32); }
+
+        public int NumberOfSpaceshipParts;
+
+        /*
+            Dynamic length gap
+            In BIQ files, for each spaceship part, there is 1 int specifying the quantity of that part needed
+            Data is instead stored in 2d array RuleSpaceship
+        */
+
+        public int AdvancedBarbarianUnitType;
+        public int BasicBarbarianUnitType;
+        public int BarbarianSeaUnitType;
+        public int CitiesNeededToSupportAnArmy;
+        public int ChanceOfRioting;
+        public int TurnPenaltyForEachDraftedCitizen;
+        public int ShieldsCostPerGold;
+        public int FortressDefensiveBonus;
+        public int CitizensAffectedByEachHappyFace;
+        private fixed byte UnknownBuffer[8];
+        public int ForestValueInShields;
+        public int ShieldValueInGold;
+        public int CitizenValueInShields;
+        public int DefaultDifficultyLevel;
+        public int BattleCreatedUnit;
+        public int BuildArmyUnit;
+        public int BuildingDefensiveBonus;
+        public int CitizenDefensiveBonus;
+        public int DefaultMoneyResource;
+        public int ChanceToInterceptEnemyAirMissions;
+        public int ChanceToInterceptEnemyStealthMissions;
+        public int StartingTreasury;
+        private fixed byte UnknownBuffer2[4];
+        public int FoodConsumptionPerCitizen;
+        public int RiverDefensiveBonus;
+        public int TurnPenaltyForEachHurrySacrifice;
+        public int Scout;
+        public int Slave;
+        public int MovementAlongRoads;
+        public int StartUnitType1;
+        public int StartUnitType2;
+        public int MinimumPopulationForWeLoveTheKing;
+        public int TownDefenseBonus;
+        public int CityDefenseBonus;
+        public int MetropolisDefenseBonus;
+        public int MaximumLevel1CitySize;
+        public int MaximumLevel2CitySize;
+        private fixed byte UnknownBuffer3[4];
+        public int FortificationsDefensiveBonus;
+        public int NumberOfCultureLevels;
+
+        /*
+            Dynamic length gap
+            In BIQ files, for each culture level, there are 64 bytes for a culture level name string
+            Data is instead stored in 2d array of RULECULT
+        */
+
+        public int BorderExpansionMultiplier;
+        public int BorderFactor;
+        public int FutureTechCost;
+        public int GoldenAgeDuration;
+        public int MaximumResearchTime;
+        public int MinimumResearchTime;
+        public int FlagUnitType;
+        public int UpgradeCost;
     }
 }

--- a/QueryCiv3/BiqSections/Rule.cs
+++ b/QueryCiv3/BiqSections/Rule.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace QueryCiv3.Biq
 {
     [StructLayout(LayoutKind.Sequential, Pack=1)]
-    public unsafe struct RULECULT
+    public unsafe struct RULE_CULT
     {
         private fixed byte Text[64];
         public string Name { get => Util.GetString(ref this, 0, 64); }

--- a/QueryCiv3/BiqSections/Wmap.cs
+++ b/QueryCiv3/BiqSections/Wmap.cs
@@ -6,6 +6,27 @@ namespace QueryCiv3.Biq
     [StructLayout(LayoutKind.Sequential, Pack=1)]
     public unsafe struct WMAP
     {
+        public int Length;
+        public int NumberOfResources;
 
+        /*
+            Dynamic length gap
+            In BIQ files, for each resource, 4 bytes are used to store that resource's ID
+            Data is instead stored in 2d array WmapResource;
+        */
+
+        public int NumberOfContinents;
+        public int Height;
+        public int DistanceBetweenCivs;
+        public int NumberOfCivs;
+        private fixed byte UnknownBuffer[8];
+        public int Width;
+        private fixed byte UnknownBuffer2[128];
+        public int MapSeed;
+
+        private fixed byte Flags[4];
+        public bool XWrapping    { get => Util.GetFlag(Flags[0], 0); }
+        public bool YWrapping    { get => Util.GetFlag(Flags[0], 1); }
+        public bool PolarIceCaps { get => Util.GetFlag(Flags[0], 2); }
     }
 }


### PR DESCRIPTION
All the known, documented data for the BIQ format should now be accessible in the BiqData class, one way or another. Most of the stuff is stored in the arrays of section header structs themselves, but all dynamic data is stored in separate 2-dimensional arrays.

There's room for improvement to be made here. The code is a bit wet in places and better simplification and documentation would always be good. But for now, at least, this gets us access to all of the data in biq files. I've only tested it on the regular conquests.biq and the WWII one, but those at least work for sure.