### PR TITLE
Non-Square Maps Now Openable

### DIFF
--- a/C7/project.godot
+++ b/C7/project.godot
@@ -27,13 +27,18 @@ GlobalSingleton="*res://GlobalSingleton.cs"
 
 window/size/height=768
 
+[global]
+
+limit=false
+limits=false
+
 [gui]
 
 theme/custom="res://C7Theme.tres"
 
 [network]
 
-limits/debugger_stdout/max_chars_per_second=16384
+limits/debugger_stdout/max_chars_per_second=65535
 
 [rendering]
 

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -46,7 +46,7 @@ namespace C7GameData
                 unit.hitPointsRemaining = 3;
                 return unit;
             } else
-                throw new System.Exception("Invalid tile coordinates");
+                throw new System.Exception("Invalid tile coordinates " + tileX + ", " + tileY);
         }
 
         /**

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -34,8 +34,8 @@ namespace C7GameData
             }
 
             // Import tiles
-            c7Save.GameData.map.numTilesTall = civ3Save.Wrld.Width;
-            c7Save.GameData.map.numTilesWide = civ3Save.Wrld.Height;
+            c7Save.GameData.map.numTilesWide = civ3Save.Wrld.Width;
+            c7Save.GameData.map.numTilesTall = civ3Save.Wrld.Height;
             foreach (MapTile civ3Tile in civ3Save.Tile)
             {
                 Civ3ExtraInfo extra = new Civ3ExtraInfo

--- a/C7GameData/TerrainType.cs
+++ b/C7GameData/TerrainType.cs
@@ -5,7 +5,7 @@ namespace C7GameData
 
     public class TerrainType
     {
-        public string name {get; set; }
+        public string name {get; set; } = "";
         public int baseFoodProduction {get; set; }
         public int baseShieldProduction {get; set; }
         public int baseCommerceProduction {get; set; }


### PR DESCRIPTION
1. Fix switcheroo in ImportCiv3 that resulted in non-square maps not being openable.
2. Somewhat improved logging in GameData if somehow invalid tile coordinates are passed in.
3. Non-null default for terrain name, which prevents Tile.NONE from causing a blow-up in the case that you ask whether it's hilly (could happen with hills on edge of map, will be obsolete with the key refactor).
4. Increase Godot printout support, as while debugging I hit the old limit.