### PR TITLE
Improve PCX loading and Godot conversion performance

### DIFF
--- a/C7/PCXToGodot.cs
+++ b/C7/PCXToGodot.cs
@@ -5,65 +5,98 @@ using ConvertCiv3Media;
 public class PCXToGodot : Godot.Object
 {
 	private readonly static byte CIV3_TRANSPARENCY_START = 254;
-	
-	public static ImageTexture getImageTextureFromPCX(Pcx pcx) {
-		Image ImgTxtr = ByteArrayToImage(pcx.ColorIndices, pcx.Palette, pcx.Width, pcx.Height);
+
+	public static ImageTexture getImageTextureFromImage(Image image) {
 		ImageTexture Txtr = new ImageTexture();
-		Txtr.CreateFromImage(ImgTxtr, 0);
+		Txtr.CreateFromImage(image, 0);
 		return Txtr;
 	}
 
+	public static ImageTexture getImageTextureFromPCX(Pcx pcx) {
+		Image ImgTxtr = ByteArrayToImage(pcx.ColorIndices, pcx.Palette, pcx.Width, pcx.Height);
+		return getImageTextureFromImage(ImgTxtr);
+	}
+
 	public static ImageTexture getImageTextureFromPCX(Pcx pcx, int leftStart, int topStart, int croppedWidth, int croppedHeight) {
-		Image Image = getImageFromPCX(pcx, leftStart, topStart, croppedWidth, croppedHeight);
-		ImageTexture Txtr = new ImageTexture();
-		Txtr.CreateFromImage(Image, 0);
-		return Txtr;
+		Image image = getImageFromPCX(pcx, leftStart, topStart, croppedWidth, croppedHeight);
+		return getImageTextureFromImage(image);
+	}
+
+	// BufferData should be as large as the largest PCX file needed to be loaded in pixels
+	// For now, I will assume no PCX file is larger than 4k resolution
+	public static int[] BufferData = new int[3840 * 2160];
+	public static int[] ColorData = new int[256];
+	public static int[] AlphaData = new int[256];
+
+	public static void loadPalette(byte[,] palette, bool shadows = false) {
+		int Red, Green, Blue;
+		int Alpha = 255 << 24;
+
+		for (int i = 0; i < 256; i++) {
+			Red = palette[i, 0];
+			Green = palette[i, 1];
+			Blue = palette[i, 2];
+			ColorData[i] = Red + (Green << 8) + (Blue << 16) + Alpha;
+		}
+
+		for (int i = CIV3_TRANSPARENCY_START; i < 256; i++) {
+			ColorData[i] &= 0x00ffffff;
+		}
+
+		if (shadows) {
+			for (int i = 240; i < 256; i++) {
+				ColorData[i] = ((255 - i) * 16) << 24;
+			}
+		}
+	}
+
+	public static void loadAlphaPalette(byte[,] palette) {
+		for (int i = 0; i < 256; i++) {
+			// Assumption based on menuButtonsAlpha.pcx: The palette in the alpha PCX always has the same red, green, and blue values (i.e. is grayscale).
+			// Examining it with breakpoints in my Java code, it appears it starts at 255, 255, 255, and goes down one at a time.  But this code
+			// doesn't assume that, it only assumes the grayscale aspect.  In theory, this should work for any transparency, 0 to 255.
+			AlphaData[i] = palette[i, 0] << 24;
+		}
+	}
+
+	public static Image getImageFromBufferData(int width, int height) {
+		Image image = new Image();
+		var Data = new byte[4 * width * height];
+		Buffer.BlockCopy(BufferData, 0, Data, 0, 4 * width * height);
+		image.CreateFromData(width, height, false, Image.Format.Rgba8, Data);
+		return image;
 	}
 
 	/**
 	 * This method is for cases where we want to use components of multiple PCXs in a texture, such as for the popup background.
 	 **/
 	public static Image getImageFromPCX(Pcx pcx, int leftStart, int topStart, int croppedWidth, int croppedHeight) {
-		Image image = new Image();
-		image.Create(croppedWidth, croppedHeight, false, Image.Format.Rgba8);
-		image.Lock();
-		for (int y = topStart; y < topStart + croppedHeight; y++)
-		{
-			for (int x = leftStart; x < leftStart + croppedWidth; x++)
-			{
-				byte red = pcx.Palette[pcx.ColorIndexAt(x, y), 0];
-				byte green = pcx.Palette[pcx.ColorIndexAt(x, y), 1];
-				byte blue = pcx.Palette[pcx.ColorIndexAt(x, y), 2];
-				byte alpha = pcx.ColorIndexAt(x, y) >= CIV3_TRANSPARENCY_START ? (byte)0 : (byte)255;
-				image.SetPixel(x - leftStart, y - topStart, Color.Color8(red, green, blue, alpha));
-			}
-		}
-		image.Unlock();
-		return image;
-	}
-	
-	private static Image ByteArrayToImage(byte[] colorIndices, byte[,] palette, int width, int height, int[] transparent = null, bool shadows = false) {
-		Image OutImage = new Image();
-		OutImage.Create(width, height, false, Image.Format.Rgba8);
-		OutImage.Lock();
-		for (int i = 0; i < width * height; i++)
-		{
-			if (shadows && colorIndices[i] > 239) {
-				// using black and transparency
-				OutImage.SetPixel(i % width, i / width, Color.Color8(0,0,0, (byte)((255 -colorIndices[i]) * 16)));
-				// using the palette color but adding transparency
-				// OutImage.SetPixel(i % width, i / width, Color.Color8(palette[ba[i],0], palette[ba[i],1], palette[ba[i],2], (byte)((255 -ba[i]) * 16)));
-			} else {
-				byte red = palette[colorIndices[i], 0];
-				byte green = palette[colorIndices[i], 1];
-				byte blue = palette[colorIndices[i], 2];
-				byte alpha = colorIndices[i] >= CIV3_TRANSPARENCY_START ? (byte)0 : (byte)255;
-				OutImage.SetPixel(i % width, i / width, Color.Color8(red, green, blue, alpha));
-			}
-		}
-		OutImage.Unlock();
+		loadPalette(pcx.Palette);
 
-		return OutImage;
+		int yEnd = topStart + croppedHeight;
+		int xEnd = leftStart + croppedWidth;
+		int Index;
+		int DataIndex = 0;
+
+		for (int y = topStart; y < yEnd; y++) {
+			Index = y * pcx.Width + leftStart;
+			for (int x = leftStart; x < xEnd; x++) {
+				BufferData[DataIndex++] = ColorData[pcx.ColorIndices[Index++]];
+			}
+		}
+
+		return getImageFromBufferData(croppedWidth, croppedHeight);
+	}
+
+	private static Image ByteArrayToImage(byte[] colorIndices, byte[,] palette, int width, int height, int[] transparent = null, bool shadows = false) {
+		loadPalette(palette, shadows);
+
+		int length = width * height;
+		for (int i = 0; i < length; i++) {
+			BufferData[i] = ColorData[colorIndices[i]];
+		}
+
+		return getImageFromBufferData(width, height);
 	}
 
 	public static ImageTexture getImageFromPCXWithAlphaBlend(Pcx imagePcx, Pcx alphaPcx) {
@@ -73,30 +106,24 @@ public class PCXToGodot : Godot.Object
 	//Combines two PCXs, one used for the alpha, to produce a final output image.
 	//Some files, such as Art/interface/menuButtons.pcx and Art/interface/menuButtonsAlpha.pcx, use this method.
 	public static ImageTexture getImageFromPCXWithAlphaBlend(Pcx imagePcx, Pcx alphaPcx, int leftStart, int topStart, int croppedWidth, int croppedHeight, int alphaRowOffset = 0) {
-		Image OutImage = new Image();
-		OutImage.Create(croppedWidth, croppedHeight, false, Image.Format.Rgba8);
-		OutImage.Lock();
-		for (int y = topStart; y < topStart + croppedHeight; y++)
-		{
-			for (int x = leftStart; x < leftStart + croppedWidth; x++)
-			{
-				int currentPixel = y * imagePcx.Width + x;
-				byte red = imagePcx.Palette[imagePcx.ColorIndexAt(x, y), 0];
-				byte green = imagePcx.Palette[imagePcx.ColorIndexAt(x, y), 1];
-				byte blue = imagePcx.Palette[imagePcx.ColorIndexAt(x, y), 2];
-				//Assumption based on menuButtonsAlpha.pcx: The palette in the alpha PCX always has the same red, green, and blue values (i.e. is grayscale).
-				//Examining it with breakpoints in my Java code, it appears it starts at 255, 255, 255, and goes down one at a time.  But this code
-				//doesn't assume that, it only assumes the grayscale aspect.  In theory, this should work for any transparency, 0 to 255.
-				byte alpha = alphaPcx.Palette[alphaPcx.ColorIndexAt(x, y - alphaRowOffset), 0];
-				OutImage.SetPixel(x - leftStart, y - topStart, Color.Color8(red, green, blue, alpha));
+		loadPalette(imagePcx.Palette);
+		loadAlphaPalette(alphaPcx.Palette);
+
+		int yEnd = topStart + croppedHeight;
+		int xEnd = leftStart + croppedWidth;
+		int Index;
+		int AlphaIndex;
+		int DataIndex = 0;
+
+		for (int y = topStart; y < yEnd; y++) {
+			Index = y * imagePcx.Width + leftStart;
+			AlphaIndex = (y - alphaRowOffset) * imagePcx.Width + leftStart;
+			for (int x = leftStart; x < xEnd; x++) {
+				BufferData[DataIndex++] = (ColorData[imagePcx.ColorIndices[Index++]] & 0x00ffffff) | AlphaData[alphaPcx.ColorIndices[AlphaIndex++]];
 			}
 		}
-		OutImage.Unlock();
 
-		ImageTexture Txtr = new ImageTexture();
-		Txtr.CreateFromImage(OutImage, 0);
-		return Txtr;
-
-
+		Image OutImage = getImageFromBufferData(croppedWidth, croppedHeight);
+		return getImageTextureFromImage(OutImage);
 	}
 }

--- a/ConvertCiv3Media/ReadPcx.cs
+++ b/ConvertCiv3Media/ReadPcx.cs
@@ -6,8 +6,8 @@ namespace ConvertCiv3Media
 {
     public class Pcx {
 
-        public byte[,] Palette = new byte[256,3];
-        public byte[] ColorIndices = new byte[]{};
+        public byte[,] Palette = new byte[256, 3];
+        public byte[] ColorIndices;
         public int Width = 0;
         public int Height = 0;
 
@@ -43,44 +43,48 @@ namespace ConvertCiv3Media
             int PaletteOffset = PcxBytes.Length - 768;
 
             // Populate color palette
-            for (int i = 0; i < 256; i++) {
-                this.Palette[i,0] = PcxBytes[PaletteOffset + i * 3];
-                this.Palette[i,1] = PcxBytes[PaletteOffset + i * 3 + 1];
-                this.Palette[i,2] = PcxBytes[PaletteOffset + i * 3 + 2];
-            }
+            Buffer.BlockCopy(PcxBytes, PaletteOffset, Palette, 0, 768);
 
-            // Populate image byte array
-            List<byte> ListImage = new List<byte>();
+            int Length = Width * Height;
+            ColorIndices = new byte[Length];
+
             // Encoding always have even number of bytes per line; if image width is odd, there is a junk byte in every row
             bool JunkByte = BytesPerLine > Width;
+            byte PcxData;
+
             // Loop to decode run-length-encoded image data which begins at file offset 0x80
-            for (int ImgIdx = 0, PcxIdx = 0x80, RunLen = 0, LineIdx = 0; ImgIdx < Width * Height; ) {
+            for (int ImgIdx = 0, PcxIdx = 0x80, RunLen = 0, LineIdx = 0; ImgIdx < Length; ) {
                 // if two most significant bits are 11
-                if ((PcxBytes[PcxIdx] & 0xc0) == 0xc0) {
+                PcxData = PcxBytes[PcxIdx];
+                if ((PcxData & 0xc0) == 0xc0) {
                     // then it & 0x3f is the run length of the following byte
-                    RunLen = PcxBytes[PcxIdx] & 0x3f;
+                    RunLen = PcxData & 0x3f;
                     PcxIdx++;
                     // Repeat the pixel in the image RunLen times
                     for (int j = 0; j < RunLen; j++) {
                         // Add pixel copy if it's not a junk byte
-                        if (!(JunkByte && LineIdx % BytesPerLine == BytesPerLine - 1)) {
-                            ListImage.Add(PcxBytes[PcxIdx]);
-                            ImgIdx++;
+                        if (JunkByte) {
+                            if (++LineIdx == BytesPerLine) {
+                                LineIdx = 0;
+                                ImgIdx--;
+                            }
                         }
-                        LineIdx++;
+                        ColorIndices[ImgIdx++] = PcxBytes[PcxIdx];
                     }
                     PcxIdx++;
                 } else {
                     // Add as literal pixel if it's not a junk byte
-                    if (!(JunkByte && LineIdx % BytesPerLine == BytesPerLine - 1)) {
-                        ListImage.Add(PcxBytes[PcxIdx]);
-                        ImgIdx++;
-                    }
+                    ColorIndices[ImgIdx++] = PcxData;
                     PcxIdx++;
-                    LineIdx++;
+
+                    if (JunkByte) {
+                        if (++LineIdx == BytesPerLine) {
+                            LineIdx = 0;
+                            ImgIdx--;
+                        }
+                    }
                 }
             }
-            this.ColorIndices = ListImage.ToArray();
         }
     }
 }


### PR DESCRIPTION
There were a number of small and moderate gains to be made in the speed of the code controlling PCX loading. Most of these were minor changes, like instead of calculating length as width * height in every for loop iteration, the length could be moved outside. The biggest change was replacing (relatively) expensive SetPixel function calls with a single CreateFromData call.

Further PCX performance progress can be made by moving from array indexing to pointers. Unfortunately, like in QueryCiv3, this would require unsafe code, so I've avoided making that step for now.