### PR TITLE
Water 1.0

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -225,7 +225,7 @@ public class Game : Node2D
 
 	public async void ComputerSimulateTurn()
 	{
-		await ToSignal(GetTree().CreateTimer(2), "timeout");
+		await ToSignal(GetTree().CreateTimer(1), "timeout");
 		OnComputerEndTurn();
 	}
 

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -262,7 +262,7 @@ public class ForestLayer : LooseLayer {
 			int randomJungleRow = tile.yCoordinate % 2;
 			int randomJungleColumn;
 			ImageTexture jungleTexture;
-			if (tile.neighborsCoast()) {
+			if (tile.NeighborsCoast()) {
 				randomJungleColumn = tile.xCoordinate % 6;
 				jungleTexture = smallJungleTexture;
 			}
@@ -293,7 +293,7 @@ public class ForestLayer : LooseLayer {
 			}
 			else {
 				forestRow = tile.yCoordinate % 2;
-				if (tile.neighborsCoast()) {
+				if (tile.NeighborsCoast()) {
 					forestColumn = tile.xCoordinate % 5;
 					if (tile.baseTerrainType.name == "Grassland") {
 						forestTexture = smallForestTexture;
@@ -344,7 +344,7 @@ public class MarshLayer : LooseLayer {
 			int randomJungleRow = tile.yCoordinate % 2;
 			int randomMarshColumn;
 			ImageTexture marshTexture;
-			if (tile.neighborsCoast()) {
+			if (tile.NeighborsCoast()) {
 				randomMarshColumn = tile.xCoordinate % 5;
 				marshTexture = smallMarshTexture;
 			}

--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -12,10 +12,9 @@ namespace C7Engine {
                 if (unit.owner == gameData.players[1]) {
                     if (unit.location.unitsOnTile.Count > 1 || unit.location.hasBarbarianCamp == false) {
                         //Move randomly
-                        Tile newLocation = unit.location.neighbors[Tile.RandomDirection()];
+                        Tile newLocation = unit.location.RandomLandNeighbor();
                         //Because it chooses a semi-cardinal direction at random, not accounting for map, it could get none
                         //if it tries to move e.g. north from the north pole.  Hence, this check.
-                        //Longer term, we should enhance the code to only return valid destinations (which also means not water, etc.)
                         if (newLocation != Tile.NONE) {
                             Console.WriteLine("Moving barbarian at " + unit.location + " to " + newLocation);
                             unit.location.unitsOnTile.Remove(unit);

--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -12,7 +12,7 @@ namespace C7Engine {
                 if (unit.owner == gameData.players[1]) {
                     if (unit.location.unitsOnTile.Count > 1 || unit.location.hasBarbarianCamp == false) {
                         //Move randomly
-                        Tile newLocation = unit.location.RandomLandNeighbor();
+                        Tile newLocation = unit.unitType is SeaUnit ? unit.location.RandomCoastNeighbor() : unit.location.RandomLandNeighbor();
                         //Because it chooses a semi-cardinal direction at random, not accounting for map, it could get none
                         //if it tries to move e.g. north from the north pole.  Hence, this check.
                         if (newLocation != Tile.NONE) {

--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace C7Engine {
     using C7GameData;
     using System;
@@ -12,7 +14,8 @@ namespace C7Engine {
                 if (unit.owner == gameData.players[1]) {
                     if (unit.location.unitsOnTile.Count > 1 || unit.location.hasBarbarianCamp == false) {
                         //Move randomly
-                        Tile newLocation = unit.unitType is SeaUnit ? unit.location.RandomCoastNeighbor() : unit.location.RandomLandNeighbor();
+                        List<Tile> validTiles = unit.unitType is SeaUnit ? unit.location.GetCoastNeighbors() : unit.location.GetLandNeighbors();
+                        Tile newLocation = validTiles[gameData.rng.Next(validTiles.Count)];
                         //Because it chooses a semi-cardinal direction at random, not accounting for map, it could get none
                         //if it tries to move e.g. north from the north pole.  Hence, this check.
                         if (newLocation != Tile.NONE) {

--- a/C7Engine/EntryPoints/CreateGame.cs
+++ b/C7Engine/EntryPoints/CreateGame.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace C7Engine
 {
     using System.IO;
@@ -27,6 +29,11 @@ namespace C7Engine
             }
             save.GameData.PerformPostLoadActions();
             EngineStorage.setGameData(save.GameData);
+			//If we are loading from JSON and it lacks an RNG, set one
+			//This should be a temporary hack until we have a more stable C7 default rule set.
+			if (save.GameData.rng == null) {
+				save.GameData.rng = new Random();
+			}
             // possibly do something with save.Rules here when it exists
             // and maybe consider if we have any need to keep a reference to the save object handy...probably not
 

--- a/C7Engine/EntryPoints/CreateGame.cs
+++ b/C7Engine/EntryPoints/CreateGame.cs
@@ -30,7 +30,7 @@ namespace C7Engine
             // possibly do something with save.Rules here when it exists
             // and maybe consider if we have any need to keep a reference to the save object handy...probably not
 
-            var humanPlayer = save.GameData.createDummyGameData();
+            var humanPlayer = save.GameData.CreateDummyGameData();
             return humanPlayer;
         }
     }

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -24,12 +24,31 @@ namespace C7Engine
                     newUnitPrototype.defense = 1;
                     newUnitPrototype.movement = 1;
                     newUnitPrototype.iconIndex = 6;
+                    newUnit.hitPointsRemaining = 3;
                     newUnit.unitType = newUnitPrototype;
                     newUnit.isFortified = true; //todo: hack for unit selection
 
                     tile.unitsOnTile.Add(newUnit);
                     gameData.mapUnits.Add(newUnit);
                     Console.WriteLine("New barbarian added at " + tile);
+                }
+                else if (tile.NeighborsCoast() && result < 10) {
+                    MapUnit newUnit = new MapUnit();
+                    newUnit.location = tile;
+                    newUnit.owner = gameData.players[1];    //todo: make this reliably point to the barbs
+                    SeaUnit newUnitPrototype = new SeaUnit();
+                    newUnitPrototype.name = "Galley";
+                    newUnitPrototype.attack = 1;
+                    newUnitPrototype.defense = 1;
+                    newUnitPrototype.movement = 3;
+                    newUnitPrototype.iconIndex = 29;
+                    newUnit.hitPointsRemaining = 3;
+                    newUnit.unitType = newUnitPrototype;
+                    newUnit.isFortified = true; //todo: hack for unit selection
+
+                    tile.unitsOnTile.Add(newUnit);
+                    gameData.mapUnits.Add(newUnit);
+                    Console.WriteLine("New barbarian galley added at " + tile);
                 }
             }
             //Call the barbarian AI

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -8,31 +8,28 @@ namespace C7Engine
         {
             GameData gameData = EngineStorage.gameData;
             //Barbarians.  First, generate new barbarian units.
-            //We should really have a top-level list of tiles with barb camps
-            foreach (Tile tile in gameData.map.tiles)
+            foreach (Tile tile in gameData.map.barbarianCamps)
             {
-                if (tile.hasBarbarianCamp) {
-                    //7% chance of a new barbarian.  Probably should scale based on barbarian activity.  
-                    Random rnd = new Random();
-                    int result = rnd.Next(100);
-                    Console.WriteLine("Random barb result = " + result);
-                    if (result < 7) {
-                        MapUnit newUnit = new MapUnit();
-                        newUnit.location = tile;
-                        newUnit.owner = gameData.players[1];    //todo: make this reliably point to the barbs
-                        UnitPrototype newUnitPrototype = new UnitPrototype();
-                        newUnitPrototype.name = "Warrior";
-                        newUnitPrototype.attack = 1;
-                        newUnitPrototype.defense = 1;
-                        newUnitPrototype.movement = 1;
-                        newUnitPrototype.iconIndex = 6;
-                        newUnit.unitType = newUnitPrototype;
-                        newUnit.isFortified = true; //todo: hack for unit selection
+                //7% chance of a new barbarian.  Probably should scale based on barbarian activity.  
+                Random rnd = new Random();
+                int result = rnd.Next(100);
+                Console.WriteLine("Random barb result = " + result);
+                if (result < 7) {
+                    MapUnit newUnit = new MapUnit();
+                    newUnit.location = tile;
+                    newUnit.owner = gameData.players[1];    //todo: make this reliably point to the barbs
+                    UnitPrototype newUnitPrototype = new UnitPrototype();
+                    newUnitPrototype.name = "Warrior";
+                    newUnitPrototype.attack = 1;
+                    newUnitPrototype.defense = 1;
+                    newUnitPrototype.movement = 1;
+                    newUnitPrototype.iconIndex = 6;
+                    newUnit.unitType = newUnitPrototype;
+                    newUnit.isFortified = true; //todo: hack for unit selection
 
-                        tile.unitsOnTile.Add(newUnit);
-                        gameData.mapUnits.Add(newUnit);
-                        Console.WriteLine("New barbarian added at " + tile);
-                    }
+                    tile.unitsOnTile.Add(newUnit);
+                    gameData.mapUnits.Add(newUnit);
+                    Console.WriteLine("New barbarian added at " + tile);
                 }
             }
             //Call the barbarian AI

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -10,9 +10,8 @@ namespace C7Engine
             //Barbarians.  First, generate new barbarian units.
             foreach (Tile tile in gameData.map.barbarianCamps)
             {
-                //7% chance of a new barbarian.  Probably should scale based on barbarian activity.  
-                Random rnd = new Random();
-                int result = rnd.Next(100);
+                //7% chance of a new barbarian.  Probably should scale based on barbarian activity.
+                int result = gameData.rng.Next(100);
                 Console.WriteLine("Random barb result = " + result);
                 if (result < 7) {
                     MapUnit newUnit = new MapUnit();

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -115,16 +115,18 @@ namespace C7Engine
                 if (unit.guid == guid)
                 {
                     (int dx, int dy) = dir.toCoordDiff();
-                    var newLoc = gameData.map.tileAt(dx + unit.location.xCoordinate, dy + unit.location.yCoordinate);
-                    if ((newLoc != null) && (unit.movementPointsRemaining > 0)) {
-                        if (! unit.location.unitsOnTile.Remove(unit))
-                            throw new System.Exception("Failed to remove unit from tile it's supposed to be on");
-                        newLoc.unitsOnTile.Add(unit);
-                        unit.location = newLoc;
-                        unit.facingDirection = dir;
-                        unit.movementPointsRemaining -= newLoc.overlayTerrainType.movementCost;
-                        unit.isFortified = false;
-                        EngineStorage.animTracker.startAnimation(unit, MapUnit.AnimatedAction.RUN, null);
+                    Tile newLoc = gameData.map.tileAt(dx + unit.location.xCoordinate, dy + unit.location.yCoordinate);
+                    if (newLoc != null && newLoc.IsLand()) {
+                        if (unit.movementPointsRemaining > 0) {
+                            if (!unit.location.unitsOnTile.Remove(unit))
+                                throw new System.Exception("Failed to remove unit from tile it's supposed to be on");
+                            newLoc.unitsOnTile.Add(unit);
+                            unit.location = newLoc;
+                            unit.facingDirection = dir;
+                            unit.movementPointsRemaining -= newLoc.overlayTerrainType.movementCost;
+                            unit.isFortified = false;
+                            EngineStorage.animTracker.startAnimation(unit, MapUnit.AnimatedAction.RUN, null);
+                        }
                     }
 
                     break;

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -5,7 +5,7 @@ namespace C7GameData
     public class GameData
     {
         public int turn {get; set;}
-        private Random rng; // TODO: Is GameData really the place for this?
+        public Random rng; // TODO: Is GameData really the place for this?
         public GameMap map {get; set;}
         public List<Player> players = new List<Player>();
         public List<TerrainType> terrainTypes = new List<TerrainType>();
@@ -13,6 +13,11 @@ namespace C7GameData
         public List<MapUnit> mapUnits {get;} = new List<MapUnit>();
         List<UnitPrototype> unitPrototypes = new List<UnitPrototype>();
         public List<City> cities = new List<City>();
+
+        public GameData()
+        {
+	        rng = new Random();
+        }
 
         /**
          * This is intended as a place to set up post-load actions on the save, regardless of
@@ -64,7 +69,6 @@ namespace C7GameData
         public Player CreateDummyGameData()
         {
             this.turn = 0;
-            this.rng = new Random();
 
             int blue = 0x4040FFFF; // R:64, G:64, B:255, A:255
             Player humanPlayer = new Player(blue);
@@ -85,9 +89,8 @@ namespace C7GameData
             warrior.defense = 1;
             warrior.movement = 1;
             warrior.iconIndex = 6;
-
+            
             CreateStartingDummyUnits(humanPlayer);
-
             List<Tile> barbarianCamps = map.generateStartingLocations(rng, 10, 10);
             foreach (Tile barbCampLocation in barbarianCamps) {
                 if (barbCampLocation.unitsOnTile.Count == 0) { // in case a starting location is under one of the human player's units

--- a/C7GameData/GameMap.cs
+++ b/C7GameData/GameMap.cs
@@ -141,7 +141,7 @@ namespace C7GameData
                 bool foundOne = false;
                 for (int numTries = 0; (! foundOne) && (numTries < 100); numTries++) {
                     var randTile = tiles[rng.Next(0, tiles.Count)];
-                    if (randTile.baseTerrainType.name == "Coast") // TODO: Write a proper check for if tile is water
+                    if (randTile.baseTerrainType.isWater())
                         continue;
                     int distToNearestOtherLoc = Int32.MaxValue;
                     foreach (var sL in tr) {

--- a/C7GameData/GameMap.cs
+++ b/C7GameData/GameMap.cs
@@ -22,6 +22,7 @@ namespace C7GameData
 
         public List<TerrainType> terrainTypes = new List<TerrainType>();
         public List<Tile> tiles { get; set;}
+		public List<Tile> barbarianCamps = new List<Tile>();
 
         public GameMap()
         {

--- a/C7GameData/GameMap.cs
+++ b/C7GameData/GameMap.cs
@@ -194,24 +194,24 @@ namespace C7GameData
             dummyMap.numTilesTall = 80;
             dummyMap.numTilesWide = 80;
 
-	    // NOTE: The order of terrain types in this array must match the indices produced by terrainGen
-	    dummyMap.terrainTypes.Add(plains);
-	    dummyMap.terrainTypes.Add(grassland);
-	    dummyMap.terrainTypes.Add(coast);
+			// NOTE: The order of terrain types in this array must match the indices produced by terrainGen
+			dummyMap.terrainTypes.Add(plains);
+			dummyMap.terrainTypes.Add(grassland);
+			dummyMap.terrainTypes.Add(coast);
 
-	    dummyMap.terrainNoiseMap = terrainGen(rng.Next(), dummyMap.numTilesWide, dummyMap.numTilesTall);
+			dummyMap.terrainNoiseMap = terrainGen(rng.Next(), dummyMap.numTilesWide, dummyMap.numTilesTall);
 
-            for (int y = 0; y < dummyMap.numTilesTall; y++)
-		for (int x = y%2; x < dummyMap.numTilesWide; x += 2) {
-                    Tile newTile = new Tile();
-                    newTile.xCoordinate = x;
-                    newTile.yCoordinate = y;
-                    newTile.baseTerrainType = dummyMap.terrainTypes[dummyMap.terrainNoiseMap[x, y]];
-                    dummyMap.tiles.Add(newTile);
-                }
-
-            return dummyMap;
-        }
+			for (int y = 0; y < dummyMap.numTilesTall; y++) {
+				for (int x = y%2; x < dummyMap.numTilesWide; x += 2) {
+					Tile newTile = new Tile();
+					newTile.xCoordinate = x;
+					newTile.yCoordinate = y;
+					newTile.baseTerrainType = dummyMap.terrainTypes[dummyMap.terrainNoiseMap[x, y]];
+					dummyMap.tiles.Add(newTile);
+				}
+			}
+			return dummyMap;
+		}
 
         // STATUS 2021-11-26: This noise function is not currently referenced, but it is a very useful
         //  noisemap generator that we will likely use in the future once we start trying

--- a/C7GameData/SeaUnit.cs
+++ b/C7GameData/SeaUnit.cs
@@ -1,0 +1,7 @@
+namespace C7GameData
+{
+	public class SeaUnit : UnitPrototype
+	{
+		
+	}
+}

--- a/C7GameData/TerrainType.cs
+++ b/C7GameData/TerrainType.cs
@@ -20,6 +20,12 @@ namespace C7GameData
             return false;
         }
 
+		//TODO: Once we have IDs, this should *not* rely on the display name.
+		//That will be after issue 58, which will be after PR 70.
+		public bool isWater() {
+			return name.Equals("Coast") || name.Equals("Sea") || name.Equals("Ocean");
+		}
+
         public override string ToString()
         {
             return name + "(" + baseFoodProduction + ", " + baseShieldProduction + ", " + baseCommerceProduction + ")";

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -2,6 +2,7 @@ namespace C7GameData
 {
 	using System;
 	using System.Collections.Generic;
+	using System.Linq;
 	public class Tile
 	{
 		// ExtraInfo will eventually be type object and use a type descriminator in JSON to determine
@@ -73,6 +74,11 @@ namespace C7GameData
 			Random rnd = new Random();
 			int index = rnd.Next(8);
 			return (TileDirection)(Enum.GetValues(TileDirection.NORTH.GetType())).GetValue(index);
+		}
+
+		public Tile RandomLandNeighbor() {
+			List<Tile> landNeighbors = neighbors.Values.ToList().Where(tile => !tile.baseTerrainType.isWater()).ToList();
+			return landNeighbors[new Random().Next(landNeighbors.Count)];
 		}
 	}
 

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -86,6 +86,11 @@ namespace C7GameData
 			List<Tile> seaNeighbors = neighbors.Values.ToList().Where(tile => tile.baseTerrainType.name == "Coast").ToList();
 			return seaNeighbors[new Random().Next(seaNeighbors.Count)];
 		}
+
+		public bool IsLand()
+		{
+			return !baseTerrainType.isWater();
+		}
 	}
 
 	public enum TileDirection {

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -51,7 +51,7 @@ namespace C7GameData
 		
 		public static Tile NONE = new Tile();
 
-		public bool neighborsCoast() {
+		public bool NeighborsCoast() {
 			foreach (Tile neighbor in getDiagonalNeighbors()) {
 				if (neighbor.baseTerrainType.name == "Coast") {
 					return true;
@@ -79,6 +79,12 @@ namespace C7GameData
 		public Tile RandomLandNeighbor() {
 			List<Tile> landNeighbors = neighbors.Values.ToList().Where(tile => !tile.baseTerrainType.isWater()).ToList();
 			return landNeighbors[new Random().Next(landNeighbors.Count)];
+		}
+
+		public Tile RandomCoastNeighbor()
+		{
+			List<Tile> seaNeighbors = neighbors.Values.ToList().Where(tile => tile.baseTerrainType.name == "Coast").ToList();
+			return seaNeighbors[new Random().Next(seaNeighbors.Count)];
 		}
 	}
 

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -71,12 +71,12 @@ namespace C7GameData
 		}
 
 		public List<Tile> GetLandNeighbors() {
-			return neighbors.Values.ToList().Where(tile => !tile.baseTerrainType.isWater()).ToList();
+			return neighbors.Values.Where(tile => !tile.baseTerrainType.isWater()).ToList();
 		}
 
 		public List<Tile> GetCoastNeighbors()
 		{
-			return neighbors.Values.ToList().Where(tile => tile.baseTerrainType.name == "Coast").ToList();
+			return neighbors.Values.Where(tile => tile.baseTerrainType.name == "Coast").ToList();
 		}
 
 		public bool IsLand()

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -70,21 +70,13 @@ namespace C7GameData
 			return "[" + xCoordinate + ", " + yCoordinate + "] (" + overlayTerrainType.name + " on " + baseTerrainType.name + ")";
 		}
 
-		public static TileDirection RandomDirection() {
-			Random rnd = new Random();
-			int index = rnd.Next(8);
-			return (TileDirection)(Enum.GetValues(TileDirection.NORTH.GetType())).GetValue(index);
+		public List<Tile> GetLandNeighbors() {
+			return neighbors.Values.ToList().Where(tile => !tile.baseTerrainType.isWater()).ToList();
 		}
 
-		public Tile RandomLandNeighbor() {
-			List<Tile> landNeighbors = neighbors.Values.ToList().Where(tile => !tile.baseTerrainType.isWater()).ToList();
-			return landNeighbors[new Random().Next(landNeighbors.Count)];
-		}
-
-		public Tile RandomCoastNeighbor()
+		public List<Tile> GetCoastNeighbors()
 		{
-			List<Tile> seaNeighbors = neighbors.Values.ToList().Where(tile => tile.baseTerrainType.name == "Coast").ToList();
-			return seaNeighbors[new Random().Next(seaNeighbors.Count)];
+			return neighbors.Values.ToList().Where(tile => tile.baseTerrainType.name == "Coast").ToList();
 		}
 
 		public bool IsLand()


### PR DESCRIPTION
Start differentiating land from water.  Human units can only move on land (sorry, no human boats yet).  Barbarians will build galleys if they are coastal, and galleys will only move on the coast, whereas barbarian warriors will stay on land.  Barbarian camps will also always be on land instead of sometimes being on water.

Also has a few stylistic changes as identified in part with Rider.  Some of these are whitespace fixes, so if the two halves of the comparison look the same, that's probably what's going on.

Finally, changed the wait time for AI turns to 1 second from 2.  Now that there is barbarian activity, we don't really need a whole two second wait between turns.