### PR TITLE
Unit prototype revamp

### DIFF
--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -758,7 +758,7 @@ public class CityLayer : LooseLayer {
 			smallFont.Size = 11;
 
 			String cityNameAndGrowth = city.name + " : " + city.TurnsUntilGrowth();
-			String productionDescription = city.itemBeingProduced + " : " + city.TurnsUntilProductionFinished();
+			String productionDescription = city.itemBeingProduced.name + " : " + city.TurnsUntilProductionFinished();
 
 			int cityNameAndGrowthWidth = (int)smallFont.GetStringSize(cityNameAndGrowth).x;
 			int productionDescriptionWidth = (int)smallFont.GetStringSize(productionDescription).x;

--- a/C7Engine/AI/CityProductionAI.cs
+++ b/C7Engine/AI/CityProductionAI.cs
@@ -25,7 +25,7 @@ namespace C7Engine
 		 * Maybe we'll wind up with some sort of collection of AI parameters to pass someday?  For now I'm not going to
 		 * get hung up on knowing exactly how it should be done the road.
 		 */
-		public static IProducable GetNextItemToBeProduced(City city, IProducable lastProduced)
+		public static IProducible GetNextItemToBeProduced(City city, IProducible lastProduced)
 		{
 			Dictionary<string, UnitPrototype> unitPrototypes = EngineStorage.gameData.unitPrototypes;
 			if (lastProduced == unitPrototypes["Warrior"]) {

--- a/C7Engine/AI/CityProductionAI.cs
+++ b/C7Engine/AI/CityProductionAI.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+namespace C7Engine
+{
+	using C7GameData;
+
+	/**
+	 * A simple AI for choosing what to produce next.
+	 * We probably will have a few variants of this, an interface, etc.
+	 * eventually.  For now, I just want to separate it out from the main
+	 * interaction events and make it clear that it's an AI component.
+	 */
+	public class CityProductionAI
+	{
+		
+		/**
+		 * Gets the next item to be produced in a given city.
+		 * Not a final API; it probably has the wrong parameters.  The last item in this city shouldn't
+		 * matter, unless the "always build previously build unit" option is enabled, in which case it isn't necessary
+		 * to call this method, just build the same thing.
+		 *
+		 * But what are the right parameters?  That's a tougher question.  We might want to consider a bunch of things.
+		 * If there's a war going on.  What victory condition we're going for.  If we're broke and need more marketplaces.
+		 * Maybe we'll wind up with some sort of collection of AI parameters to pass someday?  For now I'm not going to
+		 * get hung up on knowing exactly how it should be done the road.
+		 */
+		public static IProducable GetNextItemToBeProduced(City city, IProducable lastProduced)
+		{
+			Dictionary<string, UnitPrototype> unitPrototypes = EngineStorage.gameData.unitPrototypes;
+			if (lastProduced == unitPrototypes["Warrior"]) {
+				if (city.location.NeighborsCoast()) {
+					Random rng = new Random();
+					if (rng.Next(3) == 0) {
+						return unitPrototypes["Galley"];
+					}
+					else {
+						return unitPrototypes["Chariot"];
+					}
+				}
+				else {
+					return unitPrototypes["Chariot"];
+				}
+			}
+			else if (lastProduced == unitPrototypes["Chariot"]) {
+				return unitPrototypes["Settler"];
+			}
+			else  {
+				return unitPrototypes["Warrior"];
+			}
+		}
+	}
+}

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace C7Engine
 {
     using C7GameData;
@@ -11,11 +14,42 @@ namespace C7Engine
 
             Player owner = gameData.players.Find(player => player.guid == playerGuid);
 
-            City newCity = new City(x, y, owner, name);
+			Tile tileWithNewCity = MapInteractions.GetTileAt(x, y);
+			City newCity = new City(tileWithNewCity, owner, name, OnUnitCompleted, GetNextItemToBeProduced);
+			newCity.SetItemBeingProduced(gameData.unitPrototypes["Warrior"]);
             gameData.cities.Add(newCity);
 
-            Tile tileWithNewCity = MapInteractions.GetTileAt(x, y);
             tileWithNewCity.cityAtTile = newCity;
         }
+
+		public static void OnUnitCompleted(MapUnit newUnit)
+		{
+				EngineStorage.gameData.mapUnits.Add(newUnit);
+		}
+
+		public static IProducable GetNextItemToBeProduced(City city, IProducable lastProduced)
+		{
+			Dictionary<string, UnitPrototype> unitPrototypes = EngineStorage.gameData.unitPrototypes;
+			if (lastProduced == unitPrototypes["Warrior"]) {
+				if (city.location.NeighborsCoast()) {
+					Random rng = new Random();
+					if (rng.Next(3) == 0) {
+						return unitPrototypes["Galley"];
+					}
+					else {
+						return unitPrototypes["Chariot"];
+					}
+				}
+				else {
+					return unitPrototypes["Chariot"];
+				}
+			}
+			else if (lastProduced == unitPrototypes["Chariot"]) {
+				return unitPrototypes["Settler"];
+			}
+			else  {
+				return unitPrototypes["Warrior"];
+			}
+		}
     }
 }

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace C7Engine
 {
     using C7GameData;
@@ -15,41 +12,11 @@ namespace C7Engine
             Player owner = gameData.players.Find(player => player.guid == playerGuid);
 
 			Tile tileWithNewCity = MapInteractions.GetTileAt(x, y);
-			City newCity = new City(tileWithNewCity, owner, name, OnUnitCompleted, GetNextItemToBeProduced);
+			City newCity = new City(tileWithNewCity, owner, name);
 			newCity.SetItemBeingProduced(gameData.unitPrototypes["Warrior"]);
             gameData.cities.Add(newCity);
 
             tileWithNewCity.cityAtTile = newCity;
         }
-
-		public static void OnUnitCompleted(MapUnit newUnit)
-		{
-				EngineStorage.gameData.mapUnits.Add(newUnit);
-		}
-
-		public static IProducable GetNextItemToBeProduced(City city, IProducable lastProduced)
-		{
-			Dictionary<string, UnitPrototype> unitPrototypes = EngineStorage.gameData.unitPrototypes;
-			if (lastProduced == unitPrototypes["Warrior"]) {
-				if (city.location.NeighborsCoast()) {
-					Random rng = new Random();
-					if (rng.Next(3) == 0) {
-						return unitPrototypes["Galley"];
-					}
-					else {
-						return unitPrototypes["Chariot"];
-					}
-				}
-				else {
-					return unitPrototypes["Chariot"];
-				}
-			}
-			else if (lastProduced == unitPrototypes["Chariot"]) {
-				return unitPrototypes["Settler"];
-			}
-			else  {
-				return unitPrototypes["Warrior"];
-			}
-		}
     }
 }

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -18,14 +18,8 @@ namespace C7Engine
                     MapUnit newUnit = new MapUnit();
                     newUnit.location = tile;
                     newUnit.owner = gameData.players[1];    //todo: make this reliably point to the barbs
-                    UnitPrototype newUnitPrototype = new UnitPrototype();
-                    newUnitPrototype.name = "Warrior";
-                    newUnitPrototype.attack = 1;
-                    newUnitPrototype.defense = 1;
-                    newUnitPrototype.movement = 1;
-                    newUnitPrototype.iconIndex = 6;
+                    newUnit.unitType = gameData.unitPrototypes["Warrior"];
                     newUnit.hitPointsRemaining = 3;
-                    newUnit.unitType = newUnitPrototype;
                     newUnit.isFortified = true; //todo: hack for unit selection
 
                     tile.unitsOnTile.Add(newUnit);
@@ -36,14 +30,8 @@ namespace C7Engine
                     MapUnit newUnit = new MapUnit();
                     newUnit.location = tile;
                     newUnit.owner = gameData.players[1];    //todo: make this reliably point to the barbs
-                    SeaUnit newUnitPrototype = new SeaUnit();
-                    newUnitPrototype.name = "Galley";
-                    newUnitPrototype.attack = 1;
-                    newUnitPrototype.defense = 1;
-                    newUnitPrototype.movement = 3;
-                    newUnitPrototype.iconIndex = 29;
+                    newUnit.unitType = gameData.unitPrototypes["Galley"];
                     newUnit.hitPointsRemaining = 3;
-                    newUnit.unitType = newUnitPrototype;
                     newUnit.isFortified = true; //todo: hack for unit selection
 
                     tile.unitsOnTile.Add(newUnit);

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -47,7 +47,7 @@ namespace C7Engine
             //City Production
             foreach (City city in gameData.cities)
             {
-                IProducable producedItem = city.ComputeTurnProduction();
+                IProducible producedItem = city.ComputeTurnProduction();
                 if (producedItem != null) {
 					if (producedItem is UnitPrototype prototype) {
 						MapUnit newUnit = prototype.GetInstance();

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -48,42 +48,19 @@ namespace C7Engine
             //City Production
             foreach (City city in gameData.cities)
             {
-                string producedItem = city.ComputeTurnProduction();
-                if (producedItem != "") {
-	                //TODO: Cleanup
-                    MapUnit newUnit = new MapUnit();
-                    newUnit.location = city.location;
-                    newUnit.hitPointsRemaining = 3;
-                    newUnit.owner = gameData.players[0];
-                    //This should not be re-genned here
-                    UnitPrototype newUnitPrototype = new UnitPrototype();
+                IProducable producedItem = city.ComputeTurnProduction();
+                if (producedItem != null) {
+					if (producedItem is UnitPrototype prototype) {
+						MapUnit newUnit = prototype.GetInstance();
+						newUnit.owner = city.owner;
+						newUnit.location = city.location;
+						newUnit.facingDirection = TileDirection.SOUTHWEST;
 
-                    if (producedItem == "Warrior") {
-                        newUnitPrototype.name = "Warrior";
-                        newUnitPrototype.attack = 1;
-                        newUnitPrototype.defense = 1;
-                        newUnitPrototype.movement = 1;
-                        newUnitPrototype.iconIndex = 6;
-                        newUnit.unitType = newUnitPrototype;
-                    }
-                    else if (producedItem == "Chariot") {
-                        newUnitPrototype.name = "Chariot";
-                        newUnitPrototype.attack = 1;
-                        newUnitPrototype.defense = 1;
-                        newUnitPrototype.movement = 3;
-                        newUnitPrototype.iconIndex = 10;
-                        newUnit.unitType = newUnitPrototype;
-                    }
-                    else if (producedItem == "Settler") {
-                        newUnitPrototype.name = "Settler";
-                        newUnitPrototype.attack = 0;
-                        newUnitPrototype.defense = 0;
-                        newUnitPrototype.movement = 1;
-                        newUnitPrototype.iconIndex = 0;
-                        newUnit.unitType = newUnitPrototype;
-                    }
-                    newUnit.location.unitsOnTile.Add(newUnit);
-                    gameData.mapUnits.Add(newUnit);
+						city.location.unitsOnTile.Add(newUnit);
+						gameData.mapUnits.Add(newUnit);
+	                }
+					
+					city.SetItemBeingProduced(CityProductionAI.GetNextItemToBeProduced(city, producedItem));
                 }
             }
             //Reset movement points available for all units

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -50,9 +50,9 @@ namespace C7Engine
             {
                 string producedItem = city.ComputeTurnProduction();
                 if (producedItem != "") {
+	                //TODO: Cleanup
                     MapUnit newUnit = new MapUnit();
-                    //TODO: It's inconsistent that one of them stores Tile, the other stores X, Y coordinates
-                    newUnit.location = gameData.map.tileAt(city.xLocation, city.yLocation);
+                    newUnit.location = city.location;
                     newUnit.hitPointsRemaining = 3;
                     newUnit.owner = gameData.players[0];
                     //This should not be re-genned here

--- a/C7GameData/City.cs
+++ b/C7GameData/City.cs
@@ -10,7 +10,6 @@ namespace C7GameData
 
         //Temporary production code because production is fun.
         public IProducable itemBeingProduced;
-        public int shieldCost = 10;
         public int shieldsStored = 0;
         public int shieldsPerTurn = 2;
 
@@ -48,8 +47,8 @@ namespace C7GameData
         }
 
         public int TurnsUntilProductionFinished() {
-            int turnsRoundedDown = (shieldCost - shieldsStored) / shieldsPerTurn;
-            if ((shieldCost - shieldsStored) % shieldsPerTurn != 0) {
+            int turnsRoundedDown = (itemBeingProduced.shieldCost - shieldsStored) / shieldsPerTurn;
+            if ((itemBeingProduced.shieldCost - shieldsStored) % shieldsPerTurn != 0) {
                 return turnsRoundedDown++;
             }
             return turnsRoundedDown;
@@ -68,8 +67,11 @@ namespace C7GameData
             }
 
             shieldsStored+=shieldsPerTurn;
-            if (shieldsStored >= shieldCost) {
+            if (shieldsStored >= itemBeingProduced.shieldCost) {
 	            shieldsStored = 0;
+	            if (itemBeingProduced.populationCost > 0) {
+		            size -= itemBeingProduced.populationCost;
+	            }
                 return itemBeingProduced;
             }
 

--- a/C7GameData/City.cs
+++ b/C7GameData/City.cs
@@ -19,21 +19,13 @@ namespace C7GameData
         public int foodGrowthPerTurn = 2;
 
         public Player owner {get; set;}
-        
-        public delegate void OnUnitCompletedDelegate(MapUnit newUnit);
-        private OnUnitCompletedDelegate onUnitCompleted;
 
-        public delegate IProducable GetNextItemToBeProducedDelegate(City city, IProducable lastItemProduced);
-        private GetNextItemToBeProducedDelegate getNextItemToBeProduced;
-
-        public City(Tile location, Player owner, string name, OnUnitCompletedDelegate ouc, GetNextItemToBeProducedDelegate gnitbpd)
+        public City(Tile location, Player owner, string name)
         {
             guid = Guid.NewGuid().ToString();
             this.location = location;
             this.owner = owner;
             this.name = name;
-            this.onUnitCompleted = ouc;
-            getNextItemToBeProduced = gnitbpd;
         }
 
         public void SetItemBeingProduced(IProducable producable)
@@ -63,12 +55,12 @@ namespace C7GameData
             return turnsRoundedDown;
         }
 
-        //Placeholder for now.  Don't be alarmed that it ignores things like the produce-next popup
-        //Probably don't want to return a string here.  Just doing things the wrong way to add behavior quickly so Babylon is more fun.
-        public string ComputeTurnProduction()
+        /**
+         * Computes turn production.  Adjusts population if need be.  If the production queue finishes,
+         * returns the item that is built.  Otherwise, returns null.
+         */
+        public IProducable ComputeTurnProduction()
         {
-            string itemProduced = "";
-
             foodStored+=foodGrowthPerTurn;
             if (foodStored >= foodNeededToGrow) {
                 size++;
@@ -77,33 +69,12 @@ namespace C7GameData
 
             shieldsStored+=shieldsPerTurn;
             if (shieldsStored >= shieldCost) {
-				if (itemBeingProduced is UnitPrototype prototype) {
-					MapUnit newUnit = prototype.GetInstance();
-					newUnit.owner = this.owner;
-					newUnit.location = this.location;
-					newUnit.facingDirection = TileDirection.SOUTHWEST;
-					
-					location.unitsOnTile.Add(newUnit);
-					
-					//Figuring out the paradigms here.  We're sorta object-oriented,
-					//but we're also trying to not box ourselves in to not being able to
-					//be client-server.  C7GameData is a child of C7Engine, so the engine
-					//has to add the unit to the list.
-					//Probably the engine should be doing most of the other stuff, too.
-					onUnitCompleted(newUnit);
-					
-					//In reality, the human would set the next produced unit (unless it's an AI)
-					//For now I'm going to figure something out that gets a new unit, but is more
-					//engine/AI level
-					itemBeingProduced = getNextItemToBeProduced(this, prototype);
-				}
-				else {
-				    //building.  adding later
-				}
-                shieldsStored = 0;
+	            shieldsStored = 0;
+                return itemBeingProduced;
             }
 
-            return itemProduced;
+            return null;
         }
+        
     }
 }

--- a/C7GameData/City.cs
+++ b/C7GameData/City.cs
@@ -9,7 +9,7 @@ namespace C7GameData
         public int size = 1;
 
         //Temporary production code because production is fun.
-        public IProducable itemBeingProduced;
+        public IProducible itemBeingProduced;
         public int shieldsStored = 0;
         public int shieldsPerTurn = 2;
 
@@ -27,9 +27,9 @@ namespace C7GameData
             this.name = name;
         }
 
-        public void SetItemBeingProduced(IProducable producable)
+        public void SetItemBeingProduced(IProducible producible)
         {
-            this.itemBeingProduced = producable;
+            this.itemBeingProduced = producible;
         }
 
         public bool IsCapital()
@@ -58,7 +58,7 @@ namespace C7GameData
          * Computes turn production.  Adjusts population if need be.  If the production queue finishes,
          * returns the item that is built.  Otherwise, returns null.
          */
-        public IProducable ComputeTurnProduction()
+        public IProducible ComputeTurnProduction()
         {
             foodStored+=foodGrowthPerTurn;
             if (foodStored >= foodNeededToGrow) {

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -108,6 +108,7 @@ namespace C7GameData
             warrior.defense = 1;
             warrior.movement = 1;
             warrior.iconIndex = 6;
+            warrior.shieldCost = 10;
 
             UnitPrototype settler = new UnitPrototype();
             settler.name = "Settler";
@@ -116,6 +117,8 @@ namespace C7GameData
             settler.movement = 1;
             settler.iconIndex = 0;
             settler.canFoundCity = true;
+            settler.shieldCost = 30;
+            settler.populationCost = 2;
 
             UnitPrototype worker = new UnitPrototype();
             worker.name = "Worker";
@@ -124,6 +127,8 @@ namespace C7GameData
             worker.movement = 1;
             worker.iconIndex = 1;
             worker.canBuildRoads = true;
+            worker.shieldCost = 1;
+            worker.populationCost = 1;
 
             UnitPrototype chariot = new UnitPrototype();
             chariot.name = "Chariot";
@@ -131,6 +136,7 @@ namespace C7GameData
             chariot.defense = 1;
             chariot.movement = 2;
             chariot.iconIndex = 10;
+            chariot.shieldCost = 30;
 
             UnitPrototype galley = new SeaUnit();
             galley.name = "Galley";
@@ -138,6 +144,7 @@ namespace C7GameData
             galley.defense = 1;
             galley.movement = 3;
             galley.iconIndex = 29;
+            galley.shieldCost = 30;
             
             unitPrototypes["Warrior"] = warrior;
             unitPrototypes["Settler"] = settler;

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -105,55 +105,14 @@ namespace C7GameData
         }
         private void CreateDefaultUnitPrototypes()
         {
-            UnitPrototype warrior = new UnitPrototype();
-            warrior.name = "Warrior";
-            warrior.attack = 1;
-            warrior.defense = 1;
-            warrior.movement = 1;
-            warrior.iconIndex = 6;
-            warrior.shieldCost = 10;
-
-            UnitPrototype settler = new UnitPrototype();
-            settler.name = "Settler";
-            settler.attack = 0;
-            settler.defense = 0;
-            settler.movement = 1;
-            settler.iconIndex = 0;
-            settler.canFoundCity = true;
-            settler.shieldCost = 30;
-            settler.populationCost = 2;
-
-            UnitPrototype worker = new UnitPrototype();
-            worker.name = "Worker";
-            worker.attack = 0;
-            worker.defense = 0;
-            worker.movement = 1;
-            worker.iconIndex = 1;
-            worker.canBuildRoads = true;
-            worker.shieldCost = 1;
-            worker.populationCost = 1;
-
-            UnitPrototype chariot = new UnitPrototype();
-            chariot.name = "Chariot";
-            chariot.attack = 1;
-            chariot.defense = 1;
-            chariot.movement = 2;
-            chariot.iconIndex = 10;
-            chariot.shieldCost = 30;
-
-            UnitPrototype galley = new SeaUnit();
-            galley.name = "Galley";
-            galley.attack = 1;
-            galley.defense = 1;
-            galley.movement = 3;
-            galley.iconIndex = 29;
-            galley.shieldCost = 30;
-            
-            unitPrototypes["Warrior"] = warrior;
-            unitPrototypes["Settler"] = settler;
-            unitPrototypes["Worker"] = worker;
-            unitPrototypes["Chariot"] = chariot;
-            unitPrototypes["Galley"] = galley;
+			unitPrototypes = new Dictionary<string, UnitPrototype>()
+			{
+				{ "Warrior", new UnitPrototype { name = "Warrior", attack = 1, defense = 1, movement = 1, iconIndex =  6, shieldCost = 10 }},
+				{ "Settler", new UnitPrototype { name = "Settler", attack = 0, defense = 0, movement = 1, iconIndex =  0, shieldCost = 30, populationCost = 2 }},
+				{ "Worker",  new UnitPrototype { name = "Worker",  attack = 0, defense = 0, movement = 1, iconIndex =  1, shieldCost = 30, populationCost = 1 }},
+				{ "Chariot", new UnitPrototype { name = "Chariot", attack = 1, defense = 1, movement = 2, iconIndex = 10, shieldCost = 20 }},
+				{ "Galley",  new SeaUnit       { name = "Galley",  attack = 1, defense = 1, movement = 3, iconIndex = 29, shieldCost = 30 }},
+			};
         }
 
         private void CreateStartingDummyUnits(Player humanPlayer)

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -11,7 +11,7 @@ namespace C7GameData
         public List<TerrainType> terrainTypes = new List<TerrainType>();
 
         public List<MapUnit> mapUnits {get;} = new List<MapUnit>();
-        List<UnitPrototype> unitPrototypes = new List<UnitPrototype>();
+        public Dictionary<string, UnitPrototype> unitPrototypes = new Dictionary<string, UnitPrototype>();
         public List<City> cities = new List<City>();
 
         /**
@@ -79,19 +79,14 @@ namespace C7GameData
             //That is not great, but let's overlook that for now, as for now all our terrain type
             //references will be via the map.
             
-            UnitPrototype warrior = new UnitPrototype();
-            warrior.name = "Warrior";
-            warrior.attack = 1;
-            warrior.defense = 1;
-            warrior.movement = 1;
-            warrior.iconIndex = 6;
+            CreateDefaultUnitPrototypes();
 
             CreateStartingDummyUnits(humanPlayer);
 
             List<Tile> barbarianCamps = map.generateStartingLocations(rng, 10, 10);
             foreach (Tile barbCampLocation in barbarianCamps) {
                 if (barbCampLocation.unitsOnTile.Count == 0) { // in case a starting location is under one of the human player's units
-                    MapUnit barbWarrior = createDummyUnit(warrior, barbarianPlayer, barbCampLocation.xCoordinate, barbCampLocation.yCoordinate);
+                    MapUnit barbWarrior = createDummyUnit(unitPrototypes["Warrior"], barbarianPlayer, barbCampLocation.xCoordinate, barbCampLocation.yCoordinate);
                     barbWarrior.isFortified = true; // Can't do this through UnitInteractions b/c we don't have access to the engine. Really this
                     // whole procedure of generating a map should be part of the engine not the data module.
                     barbWarrior.facingDirection = TileDirection.SOUTHEAST;
@@ -105,9 +100,15 @@ namespace C7GameData
 
             return humanPlayer;
         }
-
-        private void CreateStartingDummyUnits(Player humanPlayer)
+        private void CreateDefaultUnitPrototypes()
         {
+            UnitPrototype warrior = new UnitPrototype();
+            warrior.name = "Warrior";
+            warrior.attack = 1;
+            warrior.defense = 1;
+            warrior.movement = 1;
+            warrior.iconIndex = 6;
+
             UnitPrototype settler = new UnitPrototype();
             settler.name = "Settler";
             settler.attack = 0;
@@ -115,13 +116,6 @@ namespace C7GameData
             settler.movement = 1;
             settler.iconIndex = 0;
             settler.canFoundCity = true;
-
-            UnitPrototype warrior = new UnitPrototype();
-            warrior.name = "Warrior";
-            warrior.attack = 1;
-            warrior.defense = 1;
-            warrior.movement = 1;
-            warrior.iconIndex = 6;
 
             UnitPrototype worker = new UnitPrototype();
             worker.name = "Worker";
@@ -138,10 +132,26 @@ namespace C7GameData
             chariot.movement = 2;
             chariot.iconIndex = 10;
 
-            createDummyUnit(settler, humanPlayer, 20, 26);
-            createDummyUnit(warrior, humanPlayer, 22, 26);
-            createDummyUnit(worker, humanPlayer, 24, 26);
-            createDummyUnit(chariot, humanPlayer, 26, 26);
+            UnitPrototype galley = new SeaUnit();
+            galley.name = "Galley";
+            galley.attack = 1;
+            galley.defense = 1;
+            galley.movement = 3;
+            galley.iconIndex = 29;
+            
+            unitPrototypes["Warrior"] = warrior;
+            unitPrototypes["Settler"] = settler;
+            unitPrototypes["Worker"] = worker;
+            unitPrototypes["Chariot"] = chariot;
+            unitPrototypes["Galley"] = galley;
+        }
+
+        private void CreateStartingDummyUnits(Player humanPlayer)
+        {
+            createDummyUnit(unitPrototypes["Settler"], humanPlayer, 20, 26);
+            createDummyUnit(unitPrototypes["Warrior"], humanPlayer, 22, 26);
+            createDummyUnit(unitPrototypes["Worker"], humanPlayer, 24, 26);
+            createDummyUnit(unitPrototypes["Chariot"], humanPlayer, 22, 24);
         }
     }
 }

--- a/C7GameData/IProducable.cs
+++ b/C7GameData/IProducable.cs
@@ -1,0 +1,11 @@
+namespace C7GameData
+{
+	/**
+	 * Represents something that can be produced by a city.
+	 * Known examples are Buildings and UnitPrototypes.
+	 */
+	public interface IProducable
+	{
+		string GetName();
+	}
+}

--- a/C7GameData/IProducable.cs
+++ b/C7GameData/IProducable.cs
@@ -4,8 +4,10 @@ namespace C7GameData
 	 * Represents something that can be produced by a city.
 	 * Known examples are Buildings and UnitPrototypes.
 	 */
-	public interface IProducable
+	public abstract class IProducable
 	{
-		string GetName();
+		public string name { get; set; }
+		public int shieldCost { get; set; }
+		public int populationCost { get; set; }
 	}
 }

--- a/C7GameData/IProducible.cs
+++ b/C7GameData/IProducible.cs
@@ -4,10 +4,10 @@ namespace C7GameData
 	 * Represents something that can be produced by a city.
 	 * Known examples are Buildings and UnitPrototypes.
 	 */
-	public abstract class IProducable
+	public interface IProducible
 	{
-		public string name { get; set; }
-		public int shieldCost { get; set; }
-		public int populationCost { get; set; }
+		string name { get; set; }
+		int shieldCost { get; set; }
+		int populationCost { get; set; }
 	}
 }

--- a/C7GameData/UnitPrototype.cs
+++ b/C7GameData/UnitPrototype.cs
@@ -6,7 +6,6 @@ namespace C7GameData
      **/
     public class UnitPrototype : IProducable
     {
-        public string name {get; set;}
         public int attack {get; set;}
         public int defense {get; set;}
         public int movement {get; set;}
@@ -20,10 +19,6 @@ namespace C7GameData
         public override string ToString()
         {
             return name + " (" + attack + "/" + defense + "/" + movement + ")";
-        }
-        public string GetName()
-        {
-            return name;
         }
 
         public MapUnit GetInstance()

--- a/C7GameData/UnitPrototype.cs
+++ b/C7GameData/UnitPrototype.cs
@@ -4,8 +4,11 @@ namespace C7GameData
      * The prototype for a unit, which defines the characteristics of a unit.
      * For example, a Spearman might have 1 attack, 2 defense, and 1 movement.
      **/
-    public class UnitPrototype : IProducable
+    public class UnitPrototype : IProducible
     {
+	    public string name { get; set; }
+	    public int shieldCost { get; set; }
+	    public int populationCost { get; set; }
         public int attack {get; set;}
         public int defense {get; set;}
         public int movement {get; set;}

--- a/C7GameData/UnitPrototype.cs
+++ b/C7GameData/UnitPrototype.cs
@@ -18,7 +18,7 @@ namespace C7GameData
 
         public override string ToString()
         {
-            return name + " (" + attack + "/" + defense + "/" + movement + ")";
+            return $"{name} ({attack}/{defense}/{movement})";
         }
 
         public MapUnit GetInstance()

--- a/C7GameData/UnitPrototype.cs
+++ b/C7GameData/UnitPrototype.cs
@@ -4,7 +4,7 @@ namespace C7GameData
      * The prototype for a unit, which defines the characteristics of a unit.
      * For example, a Spearman might have 1 attack, 2 defense, and 1 movement.
      **/
-    public class UnitPrototype
+    public class UnitPrototype : IProducable
     {
         public string name {get; set;}
         public int attack {get; set;}
@@ -20,6 +20,19 @@ namespace C7GameData
         public override string ToString()
         {
             return name + " (" + attack + "/" + defense + "/" + movement + ")";
+        }
+        public string GetName()
+        {
+            return name;
+        }
+
+        public MapUnit GetInstance()
+        {
+            MapUnit instance = new MapUnit();
+            instance.unitType = this;
+            instance.hitPointsRemaining = 3;    //todo: make this configurable
+            instance.movementPointsRemaining = movement;
+            return instance;
         }
     }
 }


### PR DESCRIPTION
1.  Instead of creating a new unit prototype every time we create a unit, have them be created at game start, and reference those prototypes.  This applies for initial unit spawning, barbarian unit spawning, and city production.
2. IProducable abstract class for things that can be built in cities.  Right now, only units, but that will change over time.
3. Basic city production AI is now in its own class in the AI folder.  Method interface will change, at this point the goal of the change is to have it not be stuck in the EntryPoint to the engine, but be its own component.

Note that this builds on the Water branch, so that one should be merged into Development before this one is merged into Water.  Otherwise we'll wind up with a review for Water that includes both and is twice as large.