### PR TITLE
Fix non square maps not working.

### DIFF
--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -34,8 +34,8 @@ namespace C7GameData
             }
 
             // Import tiles
-            c7Save.GameData.map.numTilesTall = civ3Save.Wrld.Width;
-            c7Save.GameData.map.numTilesWide = civ3Save.Wrld.Height;
+            c7Save.GameData.map.numTilesTall = civ3Save.Wrld.Height;
+            c7Save.GameData.map.numTilesWide = civ3Save.Wrld.Width;
             int i = 0;
             foreach (QueryCiv3.Sav.TILE civ3Tile in civ3Save.Tile)
             {


### PR DESCRIPTION
They broke with SAV-slurping support, but it appears the root cause had been there all along - a height/width swap.  This gets them working again.