### PR TITLE
Slightly Improved AI

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -66,7 +66,8 @@ public class Game : Node2D
 
 			Toolbar = GetNode<Control>("CanvasLayer/ToolBar/MarginContainer/HBoxContainer");
 			Player = GetNode<KinematicBody2D>("KinematicBody2D");
-			GetTree().Root.Connect("size_changed", this, "_OnViewportSizeChanged");
+			//TODO: What was this supposed to do?  It throws errors and occasinally causes crashes now, because _OnViewportSizeChanged doesn't exist
+			// GetTree().Root.Connect("size_changed", this, "_OnViewportSizeChanged");
 			mapView.cameraZoom = (float)0.3;
 			// If later recreating scene, the component may already exist, hence try/catch
 			try{

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -328,6 +328,12 @@ public class Game : Node2D
 				var tile = mapView.tileOnScreenAt(eventMouseButton.Position);
 				if (tile != null) {
 					GD.Print("Clicked on (" + tile.xCoordinate.ToString() + ", " + tile.yCoordinate.ToString() + "): " + tile.overlayTerrainType.name);
+					if (tile.unitsOnTile.Count > 0) {
+						foreach (MapUnit unit in tile.unitsOnTile) {
+							GD.Print("  Unit on tile: " + unit);
+							GD.Print("  Strategy: " + unit.currentAIBehavior);
+						}
+					}
 				} else
 					GD.Print("Didn't click on any tile");
 			}

--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -18,6 +18,7 @@ namespace C7Engine {
                         //Move randomly
                         List<Tile> validTiles = unit.unitType is SeaUnit ? unit.location.GetCoastNeighbors() : unit.location.GetLandNeighbors();
                         if (validTiles.Count == 0) {
+	                        //This can happen if a barbarian galley spawns next to a 1-tile lake, moves there, and doesn't have anywhere else to go.
 	                        Console.WriteLine("WARNING: No valid tiles for barbarian to move to");
 	                        continue;
                         }

--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 
 namespace C7Engine {
     using C7GameData;
@@ -16,11 +17,15 @@ namespace C7Engine {
                     if (unit.location.unitsOnTile.Count > 1 || unit.location.hasBarbarianCamp == false) {
                         //Move randomly
                         List<Tile> validTiles = unit.unitType is SeaUnit ? unit.location.GetCoastNeighbors() : unit.location.GetLandNeighbors();
+                        if (validTiles.Count == 0) {
+	                        Console.WriteLine("WARNING: No valid tiles for barbarian to move to");
+	                        continue;
+                        }
                         Tile newLocation = validTiles[gameData.rng.Next(validTiles.Count)];
                         //Because it chooses a semi-cardinal direction at random, not accounting for map, it could get none
                         //if it tries to move e.g. north from the north pole.  Hence, this check.
                         if (newLocation != Tile.NONE) {
-                            Console.WriteLine("Moving barbarian at " + unit.location + " to " + newLocation);
+                            //Console.WriteLine("Moving barbarian at " + unit.location + " to " + newLocation);
                             unit.location.unitsOnTile.Remove(unit);
                             newLocation.unitsOnTile.Add(unit);
                             unit.location = newLocation;

--- a/C7Engine/AI/CityProductionAI.cs
+++ b/C7Engine/AI/CityProductionAI.cs
@@ -28,6 +28,9 @@ namespace C7Engine
 		public static IProducible GetNextItemToBeProduced(City city, IProducible lastProduced)
 		{
 			Dictionary<string, UnitPrototype> unitPrototypes = EngineStorage.gameData.unitPrototypes;
+			if (city.size >= 3) {
+				return unitPrototypes["Settler"];
+			}
 			if (lastProduced == unitPrototypes["Warrior"]) {
 				if (city.location.NeighborsCoast()) {
 					Random rng = new Random();
@@ -41,9 +44,6 @@ namespace C7Engine
 				else {
 					return unitPrototypes["Chariot"];
 				}
-			}
-			else if (lastProduced == unitPrototypes["Chariot"]) {
-				return unitPrototypes["Settler"];
 			}
 			else  {
 				return unitPrototypes["Warrior"];

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -17,7 +17,7 @@ namespace C7Engine
 			foreach (MapUnit unit in player.units.ToArray())
 			{
 				if (unit.currentAIBehavior == null) {
-					SetAIForUnit(unit);
+					SetAIForUnit(unit, player);
 				}
 				
 				//Now actually take actions
@@ -85,7 +85,7 @@ namespace C7Engine
 			unit.location = nextTile;
 		}
 
-		private static void SetAIForUnit(MapUnit unit) 
+		private static void SetAIForUnit(MapUnit unit, Player player) 
 		{
 			//figure out an AI behavior
 			//TODO: Use strategies, not names
@@ -97,7 +97,7 @@ namespace C7Engine
 					settlerAI.destination = unit.location;
 				}
 				else {
-					settlerAI.destination = SettlerLocationAI.findSettlerLocation(unit.location);
+					settlerAI.destination = SettlerLocationAI.findSettlerLocation(unit.location, player.cities);
 				}
 				Console.WriteLine("Set AI for unit to settler AI with destination of " + settlerAI.destination);
 				unit.currentAIBehavior = settlerAI;

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -23,7 +23,12 @@ namespace C7Engine
 				//Now actually take actions
 				//TODO: Move these into an AI method
 				if (unit.currentAIBehavior is SettlerAI settlerAi) {
-					if (unit.location == settlerAi.destination) {
+					if (settlerAi.goal == SettlerAI.SettlerGoal.JOIN_CITY && unit.location.cityAtTile != null) {
+						//TODO: Actually join the city.  Haven't added that action.
+						//For now, just get rid of the unit.  Sorry, bro.
+						UnitInteractions.disbandUnit(unit.guid);
+					}
+					else if (unit.location == settlerAi.destination) {
 						Console.WriteLine("Building city with " + unit);
 						CityInteractions.BuildCity(unit.location.xCoordinate, unit.location.yCoordinate, player.guid, unit.owner.GetNextCityName());
 						UnitInteractions.disbandUnit(unit.guid);
@@ -108,7 +113,7 @@ namespace C7Engine
 				Console.WriteLine("Set AI for unit to settler AI with destination of " + settlerAI.destination);
 				unit.currentAIBehavior = settlerAI;
 			}
-			else if (unit.location.cityAtTile != null && unit.location.unitsOnTile.Count == 0) {
+			else if (unit.location.cityAtTile != null && unit.location.unitsOnTile.Count(u => u.unitType.defense > 0 && u != unit) == 0) {
 				DefenderAI ai = new DefenderAI();
 				ai.goal = DefenderAI.DefenderGoal.DEFEND_CITY;
 				ai.destination = unit.location;

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -39,8 +39,10 @@ namespace C7Engine
 				}
 				else if (unit.currentAIBehavior is DefenderAI defenderAI) {
 					if (defenderAI.destination == unit.location) {
-						UnitInteractions.fortifyUnit(unit.guid);
-						Console.WriteLine("Fortifying " + unit + " at " + defenderAI.destination);
+						if (!unit.isFortified) {
+							UnitInteractions.fortifyUnit(unit.guid);
+							Console.WriteLine("Fortifying " + unit + " at " + defenderAI.destination);
+						}
 					}
 					else {
 						//TODO: Move towards destination

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -43,7 +43,7 @@ namespace C7Engine
 					}
 				}
 				else if (unit.currentAIBehavior is ExplorerAI explorerAi) {
-					Console.Write("Moving explorer AI for " + unit);
+					// Console.Write("Moving explorer AI for " + unit);
 					//TODO: Distinguish between types of exploration
 					//TODO: Make sure ON_A_BOAT units stay on the boat
 					//Move randomly
@@ -52,7 +52,7 @@ namespace C7Engine
 					//Because it chooses a semi-cardinal direction at random, not accounting for map, it could get none
 					//if it tries to move e.g. north from the north pole.  Hence, this check.
 					if (newLocation != Tile.NONE) {
-						Console.WriteLine("Moving unit at " + unit.location + " to " + newLocation);
+						// Console.WriteLine("Moving unit at " + unit.location + " to " + newLocation);
 						unit.location.unitsOnTile.Remove(unit);
 						newLocation.unitsOnTile.Add(unit);
 						unit.location = newLocation;
@@ -77,7 +77,7 @@ namespace C7Engine
 				if (nextTile == null) {
 					nextTile = kvp.Key;
 				}
-				Console.WriteLine("Settler could move to " + kvp.Key + " with distance value " + kvp.Value);
+				// Console.WriteLine("Settler could move to " + kvp.Key + " with distance value " + kvp.Value);
 			}
 			Console.WriteLine("Settler unit moving from " + unit.location + " to " + nextTile + " towards " + settlerAi.destination);
 			unit.location.unitsOnTile.Remove(unit);
@@ -97,7 +97,13 @@ namespace C7Engine
 					settlerAI.destination = unit.location;
 				}
 				else {
-					settlerAI.destination = SettlerLocationAI.findSettlerLocation(unit.location, player.cities);
+					settlerAI.destination = SettlerLocationAI.findSettlerLocation(unit.location, player.cities, player.units);
+					if (settlerAI.destination == Tile.NONE) {
+						//This is possible if all tiles within 4 tiles of a city are either not land, or already claimed
+						//by another colonist.  Longer-term, the AI shouldn't be building settlers if that is the case,
+						//but right now we'll just spike the football to stop the clock and avoid building immediately next to another city.
+						settlerAI.goal = SettlerAI.SettlerGoal.JOIN_CITY;
+					}
 				}
 				Console.WriteLine("Set AI for unit to settler AI with destination of " + settlerAI.destination);
 				unit.currentAIBehavior = settlerAI;

--- a/C7Engine/AI/SettlerLocationAI.cs
+++ b/C7Engine/AI/SettlerLocationAI.cs
@@ -8,8 +8,30 @@ namespace C7Engine
 	public class SettlerLocationAI
 	{
 		//Figures out where to plant Settlers
-		public static Tile findSettlerLocation(Tile start)
+		public static Tile findSettlerLocation(Tile start, List<City> playerCities)
 		{
+			HashSet<Tile> candidates = GetCandidateTiles(start);
+			foreach (City city in playerCities) {
+				HashSet<Tile> moreCandidates = GetCandidateTiles(city.location);
+				candidates.UnionWith(moreCandidates);
+			}
+			Dictionary<Tile, int> scores = AssignTileScores(start, candidates);
+
+			IOrderedEnumerable<KeyValuePair<Tile, int> > orderedScores = scores.OrderByDescending(t => t.Value);
+			//Debugging: Print out scores
+			Tile returnValue = null;
+			foreach (KeyValuePair<Tile, int> kvp in orderedScores)
+			{
+				if (returnValue == null) {
+					returnValue = kvp.Key;
+				}
+				Console.WriteLine("Tile " + kvp.Key + " scored " + kvp.Value);
+			}
+			return returnValue;
+		}
+		private static HashSet<Tile> GetCandidateTiles(Tile start)
+		{
+
 			//First approach: Swing out from the start tile, searching for valid locations.
 			//This is not going to be amazing at first, don't take this as the One True Way.
 			//ringOne = direct neighbors of start tile.  Not valid.
@@ -22,7 +44,7 @@ namespace C7Engine
 				ringTwo.UnionWith(tiles);
 			}
 			ringTwo.ExceptWith(ringOne);
-			ringTwo.Remove(start);	//start probably got added in as a neighbor of ring 1.
+			ringTwo.Remove(start); //start probably got added in as a neighbor of ring 1.
 			//Ring three is CxxC style city planning.  Potentially valid.
 			HashSet<Tile> ringThree = new HashSet<Tile>();
 			foreach (Tile t in ringTwo) {
@@ -37,26 +59,14 @@ namespace C7Engine
 			}
 			ringFour.ExceptWith(ringThree);
 			ringFour.ExceptWith(ringTwo);
-			
+
 			//Okay, we've got our rings.  Now let's try to evaluate them.
 			HashSet<Tile> candidates = new HashSet<Tile>();
 			candidates.UnionWith(ringThree);
 			candidates.UnionWith(ringFour);
-			Dictionary<Tile, int> scores = AssignTileScores(candidates);
-
-			IOrderedEnumerable<KeyValuePair<Tile, int> > orderedScores = scores.OrderByDescending(t => t.Value);
-			//Debugging: Print out scores
-			Tile returnValue = null;
-			foreach (KeyValuePair<Tile, int> kvp in orderedScores)
-			{
-				if (returnValue == null) {
-					returnValue = kvp.Key;
-				}
-				Console.WriteLine("Tile " + kvp.Key + " scored " + kvp.Value);
-			}
-			return returnValue;
+			return candidates;
 		}
-		private static Dictionary<Tile, int> AssignTileScores(HashSet<Tile> candidates)
+		private static Dictionary<Tile, int> AssignTileScores(Tile startTile, HashSet<Tile> candidates)
 		{
 
 			Dictionary<Tile, int> scores = new Dictionary<Tile, int>();
@@ -90,7 +100,16 @@ namespace C7Engine
 				if (t.NeighborsCoast()) {
 					score += 10;
 				}
-				//TODO: Exclude locations that are already settled or too close to another civ.
+				//TODO: Exclude locations that are too close to another civ.
+				
+				//Lower scores if they are far away
+				int distance = startTile.distanceToOtherTile(t);
+				if (distance > 4) {
+					score -= distance * 2;
+				}
+				
+				//TODO: Remove locations that we already have another Settler moving towards
+				
 				scores[t] = score;
 			}
 			return scores;

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -15,6 +15,7 @@ namespace C7Engine
 			City newCity = new City(tileWithNewCity, owner, name);
 			newCity.SetItemBeingProduced(gameData.unitPrototypes["Warrior"]);
             gameData.cities.Add(newCity);
+            owner.cities.Add(newCity);
 
             tileWithNewCity.cityAtTile = newCity;
         }

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -16,7 +16,7 @@ namespace C7Engine
             {
                 //7% chance of a new barbarian.  Probably should scale based on barbarian activity.
                 int result = gameData.rng.Next(100);
-                Console.WriteLine("Random barb result = " + result);
+                // Console.WriteLine("Random barb result = " + result);
                 if (result < 7) {
                     MapUnit newUnit = new MapUnit();
                     newUnit.location = tile;

--- a/C7GameData/AIData/DefenderAI.cs
+++ b/C7GameData/AIData/DefenderAI.cs
@@ -18,5 +18,11 @@ namespace C7GameData.AIData
 		
 		public DefenderGoal goal;
 		public Tile destination;
+		
+		public override string ToString()
+		{
+			string cityName = destination.cityAtTile.name;
+			return goal + " " + cityName;
+		}
 	}
 }

--- a/C7GameData/AIData/ExplorerAI.cs
+++ b/C7GameData/AIData/ExplorerAI.cs
@@ -11,5 +11,10 @@ namespace C7GameData.AIData
 			ON_A_BOAT
 		}
 		public ExplorationType type;
+		
+		public override string ToString()
+		{
+			return type + " exploration";
+		}
 	}
 }

--- a/C7GameData/AIData/SettlerAI.cs
+++ b/C7GameData/AIData/SettlerAI.cs
@@ -25,5 +25,10 @@ namespace C7GameData.AIData
 		}
 		public SettlerGoal goal;
 		public Tile destination;
+
+		public override string ToString()
+		{
+			return goal + " at " + destination;
+		}
 	}
 }

--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -17,6 +17,7 @@ public class Player
 	private int cityNameIndex = 0;
 	
 	public List<MapUnit> units = new List<MapUnit>();
+	public List<City> cities = new List<City>();
 
 	public Player(uint color)
 	{

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -23,9 +23,9 @@ namespace C7GameData
 		//of memory for pointers), but I'm inclined to go with both since it makes it easy and
 		//efficient to perform calculations, whether you need to know which unit on a tile
 		//has the best defense, or which tile a unit is on when viewing the Military Advisor.
-		public List<MapUnit> unitsOnTile;
+		public List<MapUnit> unitsOnTile = new List<MapUnit>();
 
-		public Dictionary<TileDirection, Tile> neighbors {get; set;}
+		public Dictionary<TileDirection, Tile> neighbors { get; set; } = new Dictionary<TileDirection, Tile>();
 
 		//See discussion on page 4 of the "Babylon" thread (https://forums.civfanatics.com/threads/0-1-babylon-progress-thread.673959) about sub-terrain type and Civ3 properties.
 		//We may well move these properties somewhere, whether that's Civ3ExtraInfo, a Civ3Tile child class, a Dictionary property, or something else, in the future.


### PR DESCRIPTION
Two main improvements versus BasicOpponents:
 - The AI will consider sites Settler locations near cities other than its first city, and will take into account where other Settlers are going so they don't wind up settling at the same tile or immediately next to one another.
 -  The AI will now fortify some units in its cities.  It isn't very good at this yet, but at least it's not totally random whether a city will have defenses.

This should be a significant improvement over BasicOpponents for settling, but the AI still often fails to colonize its whole continent due to the pathing being too simple, using only a greedy algorithm.  The follow-up on this, #85 , will address that problem.