### PR TITLE
Fixes #79 error when winreg key not present

### DIFF
--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -31,17 +31,18 @@ public class Util
 		if (path != null) return path;
 
 		// Look up in Windows registry if present
-		path = Civ3PathFromRegistry("");
-		if (path != "") return path;
+		path = Civ3PathFromRegistry();
+		if (path != null) return path;
 
 		// TODO: Maybe check an array of hard-coded paths during dev time?
 		return "/civ3/path/not/found";
 	}
 
-	static public string Civ3PathFromRegistry(string defaultPath = "D:/Civilization III")
+	static public string Civ3PathFromRegistry()
 	{
 		// Assuming 64-bit platform, get vanilla Civ3 install folder from registry
-		return (string)Microsoft.Win32.Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Infogrames Interactive\Civilization III", "install_path", defaultPath);
+		// Return null if value not present or if key not found
+		return (string)Microsoft.Win32.Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Infogrames Interactive\Civilization III", "install_path", null);
 	}
 
 	// Checks if a file exists ignoring case on the latter parts of its path. If the file is found, returns its full path re-capitalized as


### PR DESCRIPTION
I originally misunderstood the default value parameter; it only triggers when the key exists but the value doesn't, which isn't likely. So returning null for both cases of key with no value and of no key.

Tested on Windows with renamed value, renamed key, and proper entries present. Doesn't break Mac.