### PR TITLE
Allow volume configuration via INI file

### DIFF
--- a/C7/MainMenuMusicPlayer.cs
+++ b/C7/MainMenuMusicPlayer.cs
@@ -1,9 +1,10 @@
 using Godot;
 using System;
+using C7Engine;
 
 public class MainMenuMusicPlayer : AudioStreamPlayer
 {
-	const bool musicEnabled = false;
+	private bool musicEnabled = true;
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()
@@ -19,15 +20,52 @@ public class MainMenuMusicPlayer : AudioStreamPlayer
 			long fileSize = (long)mp3File.GetLen();	//might blow up if it's > 2 GB, oh well
 			mp3.Data = mp3File.GetBuffer(fileSize);
 			mp3.Loop = true;
-
 			this.Stream = mp3;
 
+			string volume = C7Settings.GetSettingValue("audio", "musicVolume");
+			float targetVolumeOffset = GetVolumeOffset(volume);
+			//Intentionally comparing to float.MinValue.  It will match exactly if the INI volume settings is zero
+			if (targetVolumeOffset == float.MinValue) {
+				musicEnabled = false;
+			}
+
 			if (musicEnabled) {
+				GD.Print("Setting volume to " + volume + "%, which is " + targetVolumeOffset + " decibel offset");
+				int busIndex = AudioServer.GetBusIndex(this.Bus);
+				AudioServer.SetBusVolumeDb(busIndex, targetVolumeOffset);
 				this.Play();
 			}
 		}
 		catch(ApplicationException ex) {
 			GD.PrintErr("Could not load mp3 for main menu music");
+		}
+	}
+
+	/**
+	 * Godot uses a decibel offset volume system, described at https://docs.godotengine.org/en/stable/tutorials/audio/audio_buses.html
+	 * This is what audio professionals would use, but is not intuitive to end users.
+	 * In this system, a 6db difference halves or doubles the volume.
+	 * Our users are probably more used to a 0% to 100% system.
+	 * So this method converts between them.
+	 */
+	private float GetVolumeOffset(string volume)
+	{
+		if (volume == null) {
+			//First run.  Save the setting.
+			C7Settings.SetValue("audio", "musicVolume", "100");
+			C7Settings.SaveSettings();
+			return 0;
+		}
+		int userVolumeSetting = int.Parse(volume);
+		if (userVolumeSetting == 100) {
+			return 0;
+		}
+		else if (userVolumeSetting == 0) {
+			return float.MinValue;
+		}
+		else {
+			//Conversion math based on https://stackoverflow.com/a/37810295/3534605
+			return 20.0f * (float)(Math.Log10(userVolumeSetting / 100.0f));
 		}
 	}
 }

--- a/C7Engine/C7Settings.cs
+++ b/C7Engine/C7Settings.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using IniParser.Exceptions;
+
+namespace C7Engine
+{
+	using IniParser;
+	using IniParser.Model;
+	
+	public class C7Settings {
+		private const string SETTINGS_FILE_NAME = "C7.ini";
+		public static IniData settings;
+
+		public static void LoadSettings() {
+			try {
+				settings = new FileIniDataParser().ReadFile(SETTINGS_FILE_NAME);
+			}
+			catch(ParsingException ex) {
+				//First run.  The file doesn't exist.  That's okay.  We'll use sensible defaults.
+				settings = new IniData();
+				SaveSettings();
+			}
+		}
+
+		public static void SaveSettings() {
+			new FileIniDataParser().WriteFile(SETTINGS_FILE_NAME, settings);
+		}
+
+		public static void SetValue(string section, string key, string value)
+		{
+			settings[section][key] = value;
+		}
+
+		public static string GetSettingValue(string section, string key) {
+			if (settings == null) {
+				LoadSettings();
+			}
+			return settings[section][key];
+		}
+	}
+}


### PR DESCRIPTION
Valid values are 0 to infinity, although it sounds really odd due to clipping if you set it to over 9000 (it might also break your windows if you have powerful enough speakers).  I imagine we will allow 0-100 in game, although there's an argument to be made for 0-200, similar to VLC, for those with weak speakers, e.g. some business laptops.

It will create the INI file on first run, with the default value of 100.  You can then change it, with 0 disabling it entirely.

Future improvements:
 - GUI control in-game
 - Right now the main menu music is on the main audio bus.  We should give it is own bus so we can control its volume separately from everything else.  This relates to issue #32 .

To verify: That it works with a compiled/deployed system, not just within the Godot editor.