### PR TITLE
Visual Studio 2019 Debugging Support

### DIFF
--- a/C7/C7.sln
+++ b/C7/C7.sln
@@ -15,9 +15,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QueryCiv3", "..\QueryCiv3\Q
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Blast", "..\Blast\Blast.csproj", "{C758B0EB-9F8F-45CF-9ACB-B04705CD7FEC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EngineTests", "..\EngineTests\EngineTests.csproj", "{270876A6-0DC8-4150-B374-0BC9E4CC2113}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EngineTests", "..\EngineTests\EngineTests.csproj", "{270876A6-0DC8-4150-B374-0BC9E4CC2113}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BuildDevSave", "..\_Console\BuildDevSave\BuildDevSave.csproj", "{E66928C1-157B-42D3-AEC5-88F41C7A7846}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildDevSave", "..\_Console\BuildDevSave\BuildDevSave.csproj", "{E66928C1-157B-42D3-AEC5-88F41C7A7846}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VSStub", "VSStub\VSStub.csproj", "{D420363F-5260-42D6-883A-BC1D970B39D9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -91,6 +93,14 @@ Global
 		{E66928C1-157B-42D3-AEC5-88F41C7A7846}.ExportRelease|Any CPU.Build.0 = Debug|Any CPU
 		{E66928C1-157B-42D3-AEC5-88F41C7A7846}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E66928C1-157B-42D3-AEC5-88F41C7A7846}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D420363F-5260-42D6-883A-BC1D970B39D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D420363F-5260-42D6-883A-BC1D970B39D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D420363F-5260-42D6-883A-BC1D970B39D9}.ExportDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D420363F-5260-42D6-883A-BC1D970B39D9}.ExportDebug|Any CPU.Build.0 = Debug|Any CPU
+		{D420363F-5260-42D6-883A-BC1D970B39D9}.ExportRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{D420363F-5260-42D6-883A-BC1D970B39D9}.ExportRelease|Any CPU.Build.0 = Release|Any CPU
+		{D420363F-5260-42D6-883A-BC1D970B39D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D420363F-5260-42D6-883A-BC1D970B39D9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/C7/VSStub/VSStub.csproj
+++ b/C7/VSStub/VSStub.csproj
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D420363F-5260-42D6-883A-BC1D970B39D9}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>StubProj</RootNamespace>
+    <AssemblyName>StubProj</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+    <ProjectTypeGuids>{8F3E2DF0-C35C-4265-82FC-BEA011F4A7ED};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\*.csproj">
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
See the thread at https://forums.civfanatics.com/threads/visual-studio-2019-impressions.675739/

This gets Visual Studio Community 2019 working including debugging support.

Visual Studio 2017 is not supported by the Godot extension, and on Visual Studio 2022 the extension + workaround to get it working breaks IntelliSense, so 2019 is the only version supported.