### PR TITLE
Horse taming

### DIFF
--- a/C7/MainMenu.tscn
+++ b/C7/MainMenu.tscn
@@ -89,8 +89,6 @@ window_title = "Open a File or Directory"
 resizable = true
 mode = 3
 access = 2
-current_dir = "/Development/Civ Related Projects/Prototype/C7"
-current_path = "/Development/Civ Related Projects/Prototype/C7/"
 
 [connection signal="pressed" from="CanvasLayer/SetCiv3Home" to="." method="_on_SetCiv3Home_pressed"]
 [connection signal="dir_selected" from="CanvasLayer/SetCiv3HomeDialog" to="." method="_on_SetCiv3HomeDialog_dir_selected"]

--- a/C7/MainMenu.tscn
+++ b/C7/MainMenu.tscn
@@ -89,8 +89,8 @@ window_title = "Open a File or Directory"
 resizable = true
 mode = 3
 access = 2
-current_dir = "/Users/jim/code/src/godot/Prototype/C7"
-current_path = "/Users/jim/code/src/godot/Prototype/C7/"
+current_dir = "/Development/Civ Related Projects/Prototype/C7"
+current_path = "/Development/Civ Related Projects/Prototype/C7/"
 
 [connection signal="pressed" from="CanvasLayer/SetCiv3Home" to="." method="_on_SetCiv3Home_pressed"]
 [connection signal="dir_selected" from="CanvasLayer/SetCiv3HomeDialog" to="." method="_on_SetCiv3HomeDialog_dir_selected"]

--- a/C7/Map/ResourceLayer.cs
+++ b/C7/Map/ResourceLayer.cs
@@ -20,26 +20,16 @@ namespace C7.Map
 		{
 			Resource resource = tile.Resource;
 			if (resource != Resource.NONE) {
-				if (resource.Index == -1) {
-					// GD.Print("This should be Resource.NONE " + resource);
-					if (!debugMessage) {
-						GD.Print("Resource.NONE = " + Resource.NONE);
-						GD.Print("This is " + resource);
-						debugMessage = true;
-					}
+				int resourceIcon = tile.Resource.Icon;
+				int row = resourceIcon / 6;
+				int col = resourceIcon % 6;
+				if (row > maxRow) {
+					GD.Print("Resource icon for " + resource.Name + " is too high");
+					return;
 				}
-				else {
-					int resourceIcon = tile.Resource.Icon;
-					int row = resourceIcon / 6;
-					int col = resourceIcon % 6;
-					if (row > maxRow) {
-						GD.Print("Resource icon for " + resource.Name + " is too high");
-						return;
-					}
-					Rect2 resourceRectangle = new Rect2(col * resourceSize.x, row * resourceSize.y, resourceSize);
-					Rect2 screenTarget = new Rect2(tileCenter - 0.5f * resourceSize, resourceSize);
-					looseView.DrawTextureRectRegion(resourceTexture, screenTarget, resourceRectangle);
-				}
+				Rect2 resourceRectangle = new Rect2(col * resourceSize.x, row * resourceSize.y, resourceSize);
+				Rect2 screenTarget = new Rect2(tileCenter - 0.5f * resourceSize, resourceSize);
+				looseView.DrawTextureRectRegion(resourceTexture, screenTarget, resourceRectangle);
 			}
 		}
 	}

--- a/C7/Map/ResourceLayer.cs
+++ b/C7/Map/ResourceLayer.cs
@@ -9,7 +9,6 @@ namespace C7.Map
 		private static readonly Vector2 resourceSize = new Vector2(50, 50);
 		private int maxRow;
 		private ImageTexture resourceTexture;
-		private bool debugMessage = false;
 
 		public ResourceLayer()
 		{

--- a/C7/Map/ResourceLayer.cs
+++ b/C7/Map/ResourceLayer.cs
@@ -9,6 +9,7 @@ namespace C7.Map
 		private static readonly Vector2 resourceSize = new Vector2(50, 50);
 		private int maxRow;
 		private ImageTexture resourceTexture;
+		private bool debugMessage = false;
 
 		public ResourceLayer()
 		{
@@ -19,16 +20,26 @@ namespace C7.Map
 		{
 			Resource resource = tile.Resource;
 			if (resource != Resource.NONE) {
-				int resourceIcon = tile.Resource.Icon;
-				int row = resourceIcon / 6;
-				int col = resourceIcon % 6;
-				if (row > maxRow) {
-					GD.Print("Resource icon for " + resource.Name + " is too high");
-					return;
+				if (resource.Index == -1) {
+					// GD.Print("This should be Resource.NONE " + resource);
+					if (!debugMessage) {
+						GD.Print("Resource.NONE = " + Resource.NONE);
+						GD.Print("This is " + resource);
+						debugMessage = true;
+					}
 				}
-				Rect2 resourceRectangle = new Rect2(col * resourceSize.x, row * resourceSize.y, resourceSize);
-				Rect2 screenTarget = new Rect2(tileCenter - 0.5f * resourceSize, resourceSize);
-				looseView.DrawTextureRectRegion(resourceTexture, screenTarget, resourceRectangle);
+				else {
+					int resourceIcon = tile.Resource.Icon;
+					int row = resourceIcon / 6;
+					int col = resourceIcon % 6;
+					if (row > maxRow) {
+						GD.Print("Resource icon for " + resource.Name + " is too high");
+						return;
+					}
+					Rect2 resourceRectangle = new Rect2(col * resourceSize.x, row * resourceSize.y, resourceSize);
+					Rect2 screenTarget = new Rect2(tileCenter - 0.5f * resourceSize, resourceSize);
+					looseView.DrawTextureRectRegion(resourceTexture, screenTarget, resourceRectangle);
+				}
 			}
 		}
 	}

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System;
-using System.Linq;
 
 namespace C7GameData
 
@@ -8,71 +7,71 @@ namespace C7GameData
   This will read a Civ3 sav into C7 native format for immediate use or saving to native JSON save
 */
 {
-    using QueryCiv3;
-    using QueryCiv3.Biq;
+	using QueryCiv3;
+	using QueryCiv3.Biq;
 
-    // Additional parameters used to refer to specific media files and tiles in Civ3
-    public class Civ3ExtraInfo
-    {
-        public int BaseTerrainFileID;
-        public int BaseTerrainImageID;
-    }
-    public class ImportCiv3
-    {
-        public static C7SaveFormat ImportSav(string savePath, string defaultBicPath)
-        {
-            // init empty C7 save
-            C7SaveFormat c7Save = new C7SaveFormat();
+	// Additional parameters used to refer to specific media files and tiles in Civ3
+	public class Civ3ExtraInfo
+	{
+		public int BaseTerrainFileID;
+		public int BaseTerrainImageID;
+	}
+	public class ImportCiv3
+	{
+		public static C7SaveFormat ImportSav(string savePath, string defaultBicPath)
+		{
+			// init empty C7 save
+			C7SaveFormat c7Save = new C7SaveFormat();
 
-            // Get save data reader
-            byte[] defaultBicBytes = Util.ReadFile(defaultBicPath);
-    		SavData civ3Save = new SavData(Util.ReadFile(savePath), defaultBicBytes);
-            BiqData theBiq = civ3Save.Bic;
+			// Get save data reader
+			byte[] defaultBicBytes = Util.ReadFile(defaultBicPath);
+			SavData civ3Save = new SavData(Util.ReadFile(savePath), defaultBicBytes);
+			BiqData theBiq = civ3Save.Bic;
 
-            ImportCiv3TerrainTypes(theBiq, c7Save);
-            Dictionary<int, Resource> resourcesByIndex = ImportCiv3Resources(civ3Save.Bic, c7Save);
-            SetMapDimensions(civ3Save, theBiq, c7Save);
+			ImportCiv3TerrainTypes(theBiq, c7Save);
+			Dictionary<int, Resource> resourcesByIndex = ImportCiv3Resources(civ3Save.Bic, c7Save);
+			SetMapDimensions(civ3Save, theBiq, c7Save);
 
-            // Import tiles.  This is similar to, but different from the BIQ version as tile contents may have changed in-game.
-            int i = 0;
-            foreach (QueryCiv3.Sav.TILE civ3Tile in civ3Save.Tile)
-            {
-                Civ3ExtraInfo extra = new Civ3ExtraInfo
-                {
-                    BaseTerrainFileID = civ3Tile.TextureFile,
-                    BaseTerrainImageID = civ3Tile.TextureLocation,
-                };
-                int x, y;
-                (x, y) = GetMapCoordinates(i, civ3Save.Wrld.Width);
-                Tile c7Tile = new Tile
-                {
-                    xCoordinate = x,
-                    yCoordinate = y,
-                    ExtraInfo = extra,
-                    baseTerrainType = c7Save.GameData.terrainTypes[civ3Tile.BaseTerrain],
-                    overlayTerrainType = c7Save.GameData.terrainTypes[civ3Tile.OverlayTerrain],
-                };
-                if (civ3Tile.SnowCapped) {
-                    c7Tile.isSnowCapped = true;
-                }
-                if (civ3Tile.PineForest) {
-                    c7Tile.isPineForest = true;
-                }
-                c7Tile.riverNortheast = civ3Tile.RiverNortheast;
-                c7Tile.riverSoutheast = civ3Tile.RiverSoutheast;
-                c7Tile.riverSouthwest = civ3Tile.RiverSouthwest;
-                c7Tile.riverNorthwest = civ3Tile.RiverNorthwest;
-                c7Tile.Resource = resourcesByIndex[civ3Tile.ResourceID];
+			// Import tiles.  This is similar to, but different from the BIQ version as tile contents may have changed in-game.
+			int i = 0;
+			foreach (QueryCiv3.Sav.TILE civ3Tile in civ3Save.Tile)
+			{
+				Civ3ExtraInfo extra = new Civ3ExtraInfo
+				{
+					BaseTerrainFileID = civ3Tile.TextureFile,
+					BaseTerrainImageID = civ3Tile.TextureLocation,
+				};
+				int x, y;
+				(x, y) = GetMapCoordinates(i, civ3Save.Wrld.Width);
+				Tile c7Tile = new Tile
+				{
+					xCoordinate = x,
+					yCoordinate = y,
+					ExtraInfo = extra,
+					baseTerrainType = c7Save.GameData.terrainTypes[civ3Tile.BaseTerrain],
+					overlayTerrainType = c7Save.GameData.terrainTypes[civ3Tile.OverlayTerrain],
+				};
+				if (civ3Tile.SnowCapped) {
+					c7Tile.isSnowCapped = true;
+				}
+				if (civ3Tile.PineForest) {
+					c7Tile.isPineForest = true;
+				}
+				c7Tile.riverNortheast = civ3Tile.RiverNortheast;
+				c7Tile.riverSoutheast = civ3Tile.RiverSoutheast;
+				c7Tile.riverSouthwest = civ3Tile.RiverSouthwest;
+				c7Tile.riverNorthwest = civ3Tile.RiverNorthwest;
+				c7Tile.Resource = resourcesByIndex[civ3Tile.ResourceID];
 				c7Tile.ResourceKey = resourcesByIndex[civ3Tile.ResourceID].Key;
-                c7Save.GameData.map.tiles.Add(c7Tile);
-                i++;
-            }
-            // This probably doesn't belong here, but not sure where else to put it
-            // c7Save.GameData.map.RelativeModPath = civ3Save.MediaBic.Game[0].ScenarioSearchFolders;
-            return c7Save;
-        }
+				c7Save.GameData.map.tiles.Add(c7Tile);
+				i++;
+			}
+			// This probably doesn't belong here, but not sure where else to put it
+			// c7Save.GameData.map.RelativeModPath = civ3Save.MediaBic.Game[0].ScenarioSearchFolders;
+			return c7Save;
+		}
 
-        /**
+		/**
 		 * defaultBiqPath is used in case some sections (map, rules, player data) are not
 		 * present.
 		 */

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -63,6 +63,7 @@ namespace C7GameData
                 c7Tile.riverSouthwest = civ3Tile.RiverSouthwest;
                 c7Tile.riverNorthwest = civ3Tile.RiverNorthwest;
                 c7Tile.Resource = resourcesByIndex[civ3Tile.ResourceID];
+				c7Tile.ResourceKey = resourcesByIndex[civ3Tile.ResourceID].Key;
                 c7Save.GameData.map.tiles.Add(c7Tile);
                 i++;
             }
@@ -116,6 +117,7 @@ namespace C7GameData
 				c7Tile.riverSouthwest = civ3Tile.RiverConnectionSouthwest;
 				c7Tile.riverNorthwest = civ3Tile.RiverConnectionNorthwest;
 				c7Tile.Resource = resourcesByIndex[civ3Tile.Resource];
+				c7Tile.ResourceKey = resourcesByIndex[civ3Tile.Resource].Key;
 				c7Save.GameData.map.tiles.Add(c7Tile);
 				i++;
 			}
@@ -139,6 +141,7 @@ namespace C7GameData
 			foreach (GOOD good in biq.Good) {
 				Resource resource = new Resource
 				{
+					Key = good.Name,
 					Index = g,
 					Name = good.Name,
 					Icon = good.Icon,

--- a/C7GameData/Resource.cs
+++ b/C7GameData/Resource.cs
@@ -2,6 +2,7 @@ namespace C7GameData
 {
 	public class Resource
 	{
+		public string Key { get; set;}
 		public int Index { get; set; }	//used so we can wire up tiles to resources later
 		public int Icon { get; set; }
 		public int FoodBonus { get; set; }
@@ -16,6 +17,7 @@ namespace C7GameData
 
 		public static readonly Resource NONE = new Resource
 		{
+			Key = "NONE",
 			Index = -1,
 			Category = ResourceCategory.NONE
 		};

--- a/C7GameData/Resource.cs
+++ b/C7GameData/Resource.cs
@@ -19,6 +19,10 @@ namespace C7GameData
 			Index = -1,
 			Category = ResourceCategory.NONE
 		};
+
+		public override string ToString() {
+			return $"Resource {Index} named {Name} of type {Category} with bonuses {FoodBonus}, {ShieldsBonus}, {CommerceBonus}";
+		}
 	}
 
 	public enum ResourceCategory

--- a/C7GameData/SaveFormat.cs
+++ b/C7GameData/SaveFormat.cs
@@ -31,6 +31,15 @@ namespace C7GameData
         {
             string json = File.ReadAllText(path);
             C7SaveFormat save = JsonSerializer.Deserialize<C7SaveFormat>(json, JsonOptions);
+            //Inflate things that are stored by reference
+            foreach (Tile tile in save.GameData.map.tiles) {
+                if (tile.ResourceKey == "NONE") {
+                    tile.Resource = Resource.NONE;
+                }
+                else {
+                    tile.Resource = save.GameData.Resources.Find(r => r.Key == tile.ResourceKey);
+                }
+            }
             return save;
         }
         public static void Save(C7SaveFormat save, string path)

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -1,6 +1,7 @@
 namespace C7GameData
 {
 	using System;
+	using System.Text.Json.Serialization;
 	using System.Collections.Generic;
 	using System.Linq;
 	public class Tile
@@ -24,6 +25,8 @@ namespace C7GameData
 		//efficient to perform calculations, whether you need to know which unit on a tile
 		//has the best defense, or which tile a unit is on when viewing the Military Advisor.
 		public List<MapUnit> unitsOnTile = new List<MapUnit>();
+		public string ResourceKey { get; set; }
+		[JsonIgnore]
 		public Resource Resource { get; set; }
 
 		public Dictionary<TileDirection, Tile> neighbors { get; set; } = new Dictionary<TileDirection, Tile>();


### PR DESCRIPTION
This reduces horse presence to just the tiles where they are supposed to appear.

This is done by changing resources on tiles within the JSON to be a reference, rather than a whole embedded object.  The whole embedded object was problematic because object equality did not hold between each instance when loaded from the flat JSON file (it did when everything was done in-memory, which is why the problem wasn't present for loading BIQ and SAV files).

I've gone with the "key" approach rather than using the name variable as the key because Civ using the name as an identifier in many places was one of the reasons internationalization of Civ was difficult.  By having separate identifiers, I18N of a scenario will be much easier - you could simply jump in the JSON and change the names of all the resources, and everything else would keep working.  (Later on, a similar approach to units will also enable renaming them without having to rename all their folders and files)