### PR TITLE
Default zoom and grid

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -68,7 +68,8 @@ public class Game : Node2D
 			Player = GetNode<KinematicBody2D>("KinematicBody2D");
 			//TODO: What was this supposed to do?  It throws errors and occasinally causes crashes now, because _OnViewportSizeChanged doesn't exist
 			// GetTree().Root.Connect("size_changed", this, "_OnViewportSizeChanged");
-			mapView.cameraZoom = (float)0.3;
+			mapView.cameraZoom = (float)1.0;
+			mapView.gridLayer.visible = false;
 			// If later recreating scene, the component may already exist, hence try/catch
 			try{
 				ComponentManager.Instance.AddComponent(new TurnCounterComponent());

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -396,9 +396,7 @@ public class Game : Node2D
 					}
 				}
 			}
-			// I key toggles the grid. This should be CTRL+G to match the original game but that key combination gets intercepted by the
-			// unit action handler.
-			else if (eventKey.Scancode == (int)Godot.KeyList.I)
+			else if (eventKey.Scancode == (int)Godot.KeyList.G && eventKey.Control)
 			{
 				mapView.gridLayer.visible = ! mapView.gridLayer.visible;
 			}

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -108,7 +108,7 @@ public class UnitButtons : VBoxContainer
 				foreach (UnitControlButton button in buttonMap.Values)
 				{
 					if (button.Visible == true) {
-						if (eventKey.Scancode == button.shortcutKey) {
+						if (eventKey.Scancode == button.shortcutKey && !eventKey.Shift && !eventKey.Command && !eventKey.Control && !eventKey.Alt) {
 							this.onButtonPressed(button.key);
 							GetTree().SetInputAsHandled();
 						}


### PR DESCRIPTION
1. Zoom is 100% by default, rather than 30%
2. Grid is off by default
3. Unit buttons only listen to base key press (no modifiers), which allows Ctrl+G to be used for grid.