### PR TITLE
114 - Lower right info box terrain updating

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -473,6 +473,8 @@ public class Game : Node2D
 					default: return; // Impossible
 					}
 					UnitInteractions.moveUnit(CurrentlySelectedUnit.guid, dir);
+					setSelectedUnit(CurrentlySelectedUnit);	//also triggers updating the lower-left info box
+
 				}
 			}
 			else if (eventKey.Scancode == (int)Godot.KeyList.G && eventKey.Control)

--- a/C7/UIElements/GameStatus/GameStatus.cs
+++ b/C7/UIElements/GameStatus/GameStatus.cs
@@ -22,7 +22,7 @@ public class GameStatus : MarginContainer
 	{
 		MapUnit newUnit = wrappedMapUnit.GetValue<MapUnit>();
 		GD.Print("Selected unit: " + newUnit + " at " + newUnit.location);
-		LowerRightInfoBox.UpdateUnitInfo(newUnit);
+		LowerRightInfoBox.UpdateUnitInfo(newUnit, newUnit.location.overlayTerrainType);
 	}
 	
 	private void OnTurnEnded()

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -147,9 +147,9 @@ public class LowerRightInfoBox : TextureRect
 		string movementPointsRemaining = NewUnit.movementPointsRemaining > 0 ? "" + NewUnit.movementPointsRemaining : "0";
 		string bombardText = "";
 		if (NewUnit.unitType.bombard > 0)
-        {
+		{
 			bombardText = $"({NewUnit.unitType.bombard})";
-        }
+		}
 		attackDefenseMovement.Text = $"{NewUnit.unitType.attack}{bombardText}.{NewUnit.unitType.defense} {movementPointsRemaining}/{NewUnit.unitType.movement}";
 		attackDefenseMovement.Visible = true;
 	}

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -138,13 +138,14 @@ public class LowerRightInfoBox : TextureRect
 		
 	}
 
-	public void UpdateUnitInfo(MapUnit NewUnit)
+	public void UpdateUnitInfo(MapUnit NewUnit, TerrainType terrain)
 	{
-		lblUnitSelected.Visible = true;
-		attackDefenseMovement.Visible = true;
+		terrainType.Text = terrain.DisplayName;
 		terrainType.Visible = true;
 		lblUnitSelected.Text = NewUnit.unitType.name;
+		lblUnitSelected.Visible = true;
 		attackDefenseMovement.Text = NewUnit.unitType.attack + "." + NewUnit.unitType.defense + " " + NewUnit.movementPointsRemaining + "/" + NewUnit.unitType.movement;
+		attackDefenseMovement.Visible = true;
 	}
 
 	///This is going to evolve a lot over time.  Probably this info box will need to keep some local state.

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -144,7 +144,13 @@ public class LowerRightInfoBox : TextureRect
 		terrainType.Visible = true;
 		lblUnitSelected.Text = NewUnit.unitType.name;
 		lblUnitSelected.Visible = true;
-		attackDefenseMovement.Text = NewUnit.unitType.attack + "." + NewUnit.unitType.defense + " " + NewUnit.movementPointsRemaining + "/" + NewUnit.unitType.movement;
+		string movementPointsRemaining = NewUnit.movementPointsRemaining > 0 ? "" + NewUnit.movementPointsRemaining : "0";
+		string bombardText = "";
+		if (NewUnit.unitType.bombard > 0)
+        {
+			bombardText = $"({NewUnit.unitType.bombard})";
+        }
+		attackDefenseMovement.Text = $"{NewUnit.unitType.attack}{bombardText}.{NewUnit.unitType.defense} {movementPointsRemaining}/{NewUnit.unitType.movement}";
 		attackDefenseMovement.Visible = true;
 	}
 


### PR DESCRIPTION
This updates the lower-right info box to display the correct terrain.  I also added bombard stats (if applicable), and updating it when a unit moves.

Remaining caveat: It only updates after unit movement if the unit was not in combat.  The logical place to have it be updated would be in AnimationTracker.cs, in the endAnimation method, but that method is never called.  I tried to trace through the animation to figure out where the logical place for that method to be called would be, and it looks like the update method, line 105, or maybe 111, might be that area.  If we convert the unit guid ("id") to the unit, we could probably call endAnimation.

But I'm not very confident at all changing the unit animation code, and would thus like a second opinion before I go changing it.