### PR TITLE
Make Engine Tests Runnable From CLI

### DIFF
--- a/EngineTests/EngineTests.csproj
+++ b/EngineTests/EngineTests.csproj
@@ -1,25 +1,29 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net472</TargetFramework>
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
 
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.2">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\C7Engine\C7Engine.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\C7Engine\C7Engine.csproj" />
+  </ItemGroup>
 
+  <ItemGroup>
+    <None Remove="Microsoft.TestPlatform.ObjectModel" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
On mac / unix, running xunit tests from the command line via `dotnet test` fails because `Microsoft.VisualStudio.TestPlatform.ObjectModel` cannot be found. [This issue](https://github.com/microsoft/vstest/issues/2469#issuecomment-666998302) explains the issue, and the solution which is to add the necessary package as a reference explicitly.

Fixing this makes local testing possible without Visual Studio on mac and linux, and will help with setting up CI testing on GitHub.