### PR TITLE
Move units with go to button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ logs/
 # re-ignoring it so manual exports don't mess with the to-be-finely-honed settings; can manually add if needs updating
 export_presets.cfg
 mono_crash.*.json
+mono_crash.*.blob
 
 # Exports folder ignores
 C7/Exports

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -251,6 +251,11 @@ public class Game : Node2D
 	{
 		unit = UnitInteractions.UnitWithAvailableActions(unit);
 
+		if ((unit.path?.PathLength() ?? -1) > 0) {
+			GD.Print("cancelling path for " + unit);
+			unit.path = TilePath.NONE;
+		}
+
 		this.CurrentlySelectedUnit = unit;
 		this.KeepCSUWhenFortified = unit.isFortified; // If fortified, make sure the autoselector doesn't immediately skip past the unit
 

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -386,7 +386,7 @@ public class Game : Node2D
 						using (var gameDataAccess = new UIGameDataAccess()) {
 							var tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
 							if (tile != null) {
-								UnitInteractions.setUnitPath(CurrentlySelectedUnit.guid, tile);
+								new MsgSetUnitPath(CurrentlySelectedUnit.guid, tile).send();
 							}
 						}
 					}

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -15,7 +15,7 @@ public class LowerRightInfoBox : TextureRect
 	Label attackDefenseMovement = new Label();
 	Label terrainType = new Label();
 	Label yearAndGold = new Label();
-	
+
 	Timer blinkingTimer = new Timer();
 	Boolean timerStarted = false;	//This "isStopped" returns false if it's never been started.  So we need this to know if we've ever started it.
 
@@ -54,21 +54,21 @@ public class LowerRightInfoBox : TextureRect
 		lblUnitSelected.AnchorRight = 1.0f;
 		lblUnitSelected.MarginRight = -35;
 		boxRightRectangle.AddChild(lblUnitSelected);
-		
+
 		attackDefenseMovement.Text = "0.0. 1/1";
 		attackDefenseMovement.Align = Label.AlignEnum.Right;
 		attackDefenseMovement.SetPosition(new Vector2(0, 35));
 		attackDefenseMovement.AnchorRight = 1.0f;
 		attackDefenseMovement.MarginRight = -35;
 		boxRightRectangle.AddChild(attackDefenseMovement);
-		
+
 		terrainType.Text = "Grassland";
 		terrainType.Align = Label.AlignEnum.Right;
 		terrainType.SetPosition(new Vector2(0, 50));
 		terrainType.AnchorRight = 1.0f;
 		terrainType.MarginRight = -35;
 		boxRightRectangle.AddChild(terrainType);
-		
+
 		//For the centered labels, we anchor them center, with equal weight on each side.
 		//Then, when they are visible, we add a left margin that's negative and equal to half
 		//their width.
@@ -89,7 +89,7 @@ public class LowerRightInfoBox : TextureRect
 		yearAndGold.AnchorRight = 0.5f;
 		boxRightRectangle.AddChild(yearAndGold);
 		yearAndGold.MarginLeft = -1 * (yearAndGold.RectSize.x/2.0f);
-		
+
 		//Setup up, but do not start, the timer.
 		blinkingTimer.OneShot = false;
 		blinkingTimer.WaitTime = 0.6f;
@@ -103,7 +103,7 @@ public class LowerRightInfoBox : TextureRect
 		terrainType.Visible = false;
 
 		toggleEndTurnButton();
-		
+
 		if (!timerStarted) {
 			blinkingTimer.Start();
 			GD.Print("Started a timer for blinking");
@@ -135,7 +135,6 @@ public class LowerRightInfoBox : TextureRect
 	private void turnEnded() {
 		GD.Print("Emitting the blinky button pressed signal");
 		GetParent().EmitSignal("BlinkyEndTurnButtonPressed");
-		
 	}
 
 	public void UpdateUnitInfo(MapUnit NewUnit, TerrainType terrain)
@@ -164,6 +163,6 @@ public class LowerRightInfoBox : TextureRect
 //  // Called every frame. 'delta' is the elapsed time since the previous frame.
 //  public override void _Process(float delta)
 //  {
-//      
+//
 //  }
 }

--- a/C7Engine/AI/Pathing/BFSLandAlgorithm.cs
+++ b/C7Engine/AI/Pathing/BFSLandAlgorithm.cs
@@ -18,6 +18,10 @@ namespace C7Engine.Pathing
 		//N.B. This should really be static, but we can't put a static method on interfaces, so it isn't.
 		public TilePath PathFrom(Tile start, Tile destination)
 		{
+			if (start == destination) {
+				return TilePath.EmptyPath(destination);
+			}
+
 			//Distance from start to a given tile
 			Dictionary<Tile, int> distances = new Dictionary<Tile, int>();
 			//Keeps track of which tile (value) preceded a tile (key), so we can reconstruct
@@ -25,16 +29,20 @@ namespace C7Engine.Pathing
 			Dictionary<Tile, Tile> predecessors = new Dictionary<Tile, Tile>();
 			Queue<Tile> tilesToVisit = new Queue<Tile>();
 			distances[start] = 0;
-			
+
 			foreach(Tile tile in start.GetLandNeighbors()) {
 				distances[tile] = 1;
 				predecessors[tile] = start;
 				tilesToVisit.Enqueue(tile);
 			}
-			
+
 			//The core BFS algorithm.
 			while (tilesToVisit.Count > 0) {
 				Tile current = tilesToVisit.Dequeue();
+				if (current == destination) {
+					return ConstructPath(current, predecessors);
+				}
+
 				foreach (Tile tile in current.GetLandNeighbors()) {
 					if (!distances.Keys.Contains(tile)) {
 						distances[tile] = distances[current] + 1;

--- a/C7Engine/C7Settings.cs
+++ b/C7Engine/C7Settings.cs
@@ -5,7 +5,7 @@ namespace C7Engine
 {
 	using IniParser;
 	using IniParser.Model;
-	
+
 	public class C7Settings {
 		private const string SETTINGS_FILE_NAME = "C7.ini";
 		public static IniData settings;

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -64,12 +64,12 @@ namespace C7Engine
 		}
 	}
 
-	public class MsgBeginUnitMoveTo : MessageToEngine
+	public class MsgSetUnitPath : MessageToEngine
 	{
 		private string unitGUID;
 		private Tile dest;
 
-		public MsgBeginUnitMoveTo(string unitGUID, Tile dest)
+		public MsgSetUnitPath(string unitGUID, Tile dest)
 		{
 			this.unitGUID = unitGUID;
 			this.dest = dest;
@@ -78,7 +78,7 @@ namespace C7Engine
 		public override void process()
 		{
 			MapUnit unit = EngineStorage.gameData.GetUnit(unitGUID);
-			unit?.beginMoveTo(dest);
+			unit?.setUnitPath(dest);
 		}
 	}
 

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -1,149 +1,164 @@
 namespace C7Engine
 {
+	using System;
+	using C7GameData;
 
-using System;
-using C7GameData;
+	public abstract class MessageToEngine {
+		public abstract void process();
 
-public abstract class MessageToEngine {
-	public abstract void process();
-
-	public void send()
-	{
-		EngineStorage.pendingMessages.Enqueue(this);
-		EngineStorage.actionAddedToQueue.Set();
-	}
-}
-
-public class MsgShutdownEngine : MessageToEngine {
-	public override void process()
-	{
-		Console.WriteLine("Engine received shutdown message.");
-	}
-}
-
-public class MsgSetFortification : MessageToEngine
-{
-	private string unitGUID;
-	private bool fortifyElseWake;
-
-	public MsgSetFortification(string unitGUID, bool fortifyElseWake)
-	{
-		this.unitGUID = unitGUID;
-		this.fortifyElseWake = fortifyElseWake;
-	}
-
-	public override void process()
-	{
-		MapUnit unit = EngineStorage.gameData.mapUnits.Find(u => u.guid == unitGUID);
-
-		// Simply do nothing if we weren't given a valid GUID. TODO: Maybe this is an error we need to handle? In an MP game, we should reject
-		// invalid actions at the server level but at the client level an invalid action received from the server indicates a desync.
-		if (unit != null) {
-			if (fortifyElseWake)
-				unit.fortify();
-			else
-				unit.wake();
+		public void send()
+		{
+			EngineStorage.pendingMessages.Enqueue(this);
+			EngineStorage.actionAddedToQueue.Set();
 		}
 	}
-}
 
-public class MsgMoveUnit : MessageToEngine
-{
-	private string unitGUID;
-	private TileDirection dir;
-
-	public MsgMoveUnit(string unitGUID, TileDirection dir)
-	{
-		this.unitGUID = unitGUID;
-		this.dir = dir;
+	public class MsgShutdownEngine : MessageToEngine {
+		public override void process()
+		{
+			Console.WriteLine("Engine received shutdown message.");
+		}
 	}
 
-	public override void process()
+	public class MsgSetFortification : MessageToEngine
 	{
-		MapUnit unit = EngineStorage.gameData.mapUnits.Find(u => u.guid == unitGUID);
-		if (unit != null)
-			unit.move(dir);
-	}
-}
+		private string unitGUID;
+		private bool fortifyElseWake;
 
-public class MsgSkipUnitTurn : MessageToEngine
-{
-	private string unitGUID;
+		public MsgSetFortification(string unitGUID, bool fortifyElseWake)
+		{
+			this.unitGUID = unitGUID;
+			this.fortifyElseWake = fortifyElseWake;
+		}
 
-	public MsgSkipUnitTurn(string unitGUID)
-	{
-		this.unitGUID = unitGUID;
-	}
+		public override void process()
+		{
+			MapUnit unit = EngineStorage.gameData.GetUnit(unitGUID);
 
-	public override void process()
-	{
-		MapUnit unit = EngineStorage.gameData.mapUnits.Find(u => u.guid == unitGUID);
-		if (unit != null)
-			unit.skipTurn();
-	}
-}
-
-public class MsgDisbandUnit : MessageToEngine {
-	private string unitGUID;
-
-	public MsgDisbandUnit(string unitGUID)
-	{
-		this.unitGUID = unitGUID;
+			// Simply do nothing if we weren't given a valid GUID. TODO: Maybe this is an error we need to handle? In an MP game, we should reject
+			// invalid actions at the server level but at the client level an invalid action received from the server indicates a desync.
+			if (unit != null) {
+				if (fortifyElseWake)
+					unit.fortify();
+				else
+					unit.wake();
+			}
+		}
 	}
 
-	public override void process()
+	public class MsgMoveUnit : MessageToEngine
 	{
-		MapUnit unit = EngineStorage.gameData.mapUnits.Find(u => u.guid == unitGUID);
-		if (unit != null)
-			unit.disband();
-	}
-}
+		private string unitGUID;
+		private TileDirection dir;
 
-public class MsgBuildCity : MessageToEngine {
-	private string unitGUID;
-	private string cityName;
+		public MsgMoveUnit(string unitGUID, TileDirection dir)
+		{
+			this.unitGUID = unitGUID;
+			this.dir = dir;
+		}
 
-	public MsgBuildCity(string unitGUID, string cityName)
-	{
-		this.unitGUID = unitGUID;
-		this.cityName = cityName;
-	}
-
-	public override void process()
-	{
-		MapUnit unit = EngineStorage.gameData.mapUnits.Find(u => u.guid == unitGUID);
-		if (unit != null)
-			unit.buildCity(cityName);
-	}
-}
-
-public class MsgChooseProduction : MessageToEngine {
-	private string cityGUID;
-	private string producibleName;
-
-	public MsgChooseProduction(string cityGUID, string producibleName)
-	{
-		this.cityGUID = cityGUID;
-		this.producibleName = producibleName;
+		public override void process()
+		{
+			MapUnit unit = EngineStorage.gameData.GetUnit(unitGUID);
+			unit?.move(dir);
+		}
 	}
 
-	public override void process()
+	public class MsgBeginUnitMoveTo : MessageToEngine
 	{
-		City city = EngineStorage.gameData.cities.Find(c => c.guid == cityGUID);
-		if (city != null)
-			foreach (IProducible producible in city.ListProductionOptions())
-				if (producible.name == producibleName) {
-					city.SetItemBeingProduced(producible);
-					break;
+		private string unitGUID;
+		private Tile dest;
+
+		public MsgBeginUnitMoveTo(string unitGUID, Tile dest)
+		{
+			this.unitGUID = unitGUID;
+			this.dest = dest;
+		}
+
+		public override void process()
+		{
+			MapUnit unit = EngineStorage.gameData.GetUnit(unitGUID);
+			unit?.beginMoveTo(dest);
+		}
+	}
+
+	public class MsgSkipUnitTurn : MessageToEngine
+	{
+		private string unitGUID;
+
+		public MsgSkipUnitTurn(string unitGUID)
+		{
+			this.unitGUID = unitGUID;
+		}
+
+		public override void process()
+		{
+			MapUnit unit = EngineStorage.gameData.GetUnit(unitGUID);
+			unit?.skipTurn();
+		}
+	}
+
+	public class MsgDisbandUnit : MessageToEngine {
+		private string unitGUID;
+
+		public MsgDisbandUnit(string unitGUID)
+		{
+			this.unitGUID = unitGUID;
+		}
+
+		public override void process()
+		{
+			MapUnit unit = EngineStorage.gameData.GetUnit(unitGUID);
+			unit?.disband();
+		}
+	}
+
+	public class MsgBuildCity : MessageToEngine {
+		private string unitGUID;
+		private string cityName;
+
+		public MsgBuildCity(string unitGUID, string cityName)
+		{
+			this.unitGUID = unitGUID;
+			this.cityName = cityName;
+		}
+
+		public override void process()
+		{
+			MapUnit unit = EngineStorage.gameData.GetUnit(unitGUID);
+			unit?.buildCity(cityName);
+		}
+	}
+
+	public class MsgChooseProduction : MessageToEngine {
+		private string cityGUID;
+		private string producibleName;
+
+		public MsgChooseProduction(string cityGUID, string producibleName)
+		{
+			this.cityGUID = cityGUID;
+			this.producibleName = producibleName;
+		}
+
+		public override void process()
+		{
+			City city = EngineStorage.gameData.cities.Find(c => c.guid == cityGUID);
+			if (city != null) {
+				foreach (IProducible producible in city.ListProductionOptions()) {
+					if (producible.name == producibleName) {
+						city.SetItemBeingProduced(producible);
+						break;
+					}
 				}
+			}
+		}
 	}
-}
 
-public class MsgEndTurn : MessageToEngine {
-	public override void process()
-	{
-		TurnHandling.EndTurn();
+	public class MsgEndTurn : MessageToEngine {
+		public override void process()
+		{
+			TurnHandling.EndTurn();
+		}
 	}
-}
 
 }

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -67,18 +67,20 @@ namespace C7Engine
 	public class MsgSetUnitPath : MessageToEngine
 	{
 		private string unitGUID;
-		private Tile dest;
+		private int destX;
+		private int destY;
 
-		public MsgSetUnitPath(string unitGUID, Tile dest)
+		public MsgSetUnitPath(string unitGUID, Tile tile)
 		{
 			this.unitGUID = unitGUID;
-			this.dest = dest;
+			this.destX = tile.xCoordinate;
+			this.destY = tile.yCoordinate;
 		}
 
 		public override void process()
 		{
 			MapUnit unit = EngineStorage.gameData.GetUnit(unitGUID);
-			unit?.setUnitPath(dest);
+			unit?.setUnitPath(EngineStorage.gameData.map.tileAt(destX, destY));
 		}
 	}
 

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -1,45 +1,41 @@
 namespace C7Engine
 {
-using System;
-using System.Threading;
-using C7GameData;
+	using System.Threading;
+	using C7GameData;
 
-public class MessageToUI {
-	public void send()
-	{
-		EngineStorage.messagesToUI.Enqueue(this);
+	public class MessageToUI {
+		public void send()
+		{
+			EngineStorage.messagesToUI.Enqueue(this);
+		}
 	}
-}
 
-public class MsgStartUnitAnimation : MessageToUI {
-	public string unitGUID;
-	public MapUnit.AnimatedAction action;
-	public AutoResetEvent completionEvent;
-	public AnimationEnding ending;
+	public class MsgStartUnitAnimation : MessageToUI {
+		public string unitGUID;
+		public MapUnit.AnimatedAction action;
+		public AutoResetEvent completionEvent;
 
-	public MsgStartUnitAnimation(MapUnit unit, MapUnit.AnimatedAction action, AutoResetEvent completionEvent, AnimationEnding ending)
-	{
-		this.unitGUID = unit.guid;
-		this.action = action;
-		this.completionEvent = completionEvent;
-		this.ending = ending;
+		public MsgStartUnitAnimation(MapUnit unit, MapUnit.AnimatedAction action, AutoResetEvent completionEvent)
+		{
+			this.unitGUID = unit.guid;
+			this.action = action;
+			this.completionEvent = completionEvent;
+		}
 	}
-}
 
-public class MsgStartEffectAnimation : MessageToUI {
-	public int tileIndex;
-	public AnimatedEffect effect;
-	public AutoResetEvent completionEvent;
-	public AnimationEnding ending;
+	public class MsgStartEffectAnimation : MessageToUI {
+		public int tileIndex;
+		public AnimatedEffect effect;
+		public AutoResetEvent completionEvent;
 
-	public MsgStartEffectAnimation(Tile tile, AnimatedEffect effect, AutoResetEvent completionEvent, AnimationEnding ending)
-	{
-		this.tileIndex = EngineStorage.gameData.map.tileCoordsToIndex(tile.xCoordinate, tile.yCoordinate);
-		this.effect = effect;
-		this.completionEvent = completionEvent;
-		this.ending = ending;
+		public MsgStartEffectAnimation(Tile tile, AnimatedEffect effect, AutoResetEvent completionEvent)
+		{
+			this.tileIndex = EngineStorage.gameData.map.tileCoordsToIndex(tile.xCoordinate, tile.yCoordinate);
+			this.effect = effect;
+			this.completionEvent = completionEvent;
+		}
 	}
-}
 
-public class MsgStartTurn : MessageToUI {}
+	public class MsgStartTurn : MessageToUI {}
+
 }

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -14,12 +14,14 @@ namespace C7Engine
 		public string unitGUID;
 		public MapUnit.AnimatedAction action;
 		public AutoResetEvent completionEvent;
+		public AnimationEnding ending;
 
-		public MsgStartUnitAnimation(MapUnit unit, MapUnit.AnimatedAction action, AutoResetEvent completionEvent)
+		public MsgStartUnitAnimation(MapUnit unit, MapUnit.AnimatedAction action, AutoResetEvent completionEvent, AnimationEnding ending)
 		{
 			this.unitGUID = unit.guid;
 			this.action = action;
 			this.completionEvent = completionEvent;
+			this.ending = ending;
 		}
 	}
 
@@ -27,12 +29,14 @@ namespace C7Engine
 		public int tileIndex;
 		public AnimatedEffect effect;
 		public AutoResetEvent completionEvent;
+		public AnimationEnding ending;
 
-		public MsgStartEffectAnimation(Tile tile, AnimatedEffect effect, AutoResetEvent completionEvent)
+		public MsgStartEffectAnimation(Tile tile, AnimatedEffect effect, AutoResetEvent completionEvent, AnimationEnding ending)
 		{
 			this.tileIndex = EngineStorage.gameData.map.tileCoordsToIndex(tile.xCoordinate, tile.yCoordinate);
 			this.effect = effect;
 			this.completionEvent = completionEvent;
+			this.ending = ending;
 		}
 	}
 

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -12,9 +12,9 @@ namespace C7Engine
 		{
 			GameData gameData = EngineStorage.gameData;
 
-			foreach (Player player in gameData.players) {
+			foreach (Player player in gameData.GetHumanPlayers()) {
 				foreach (MapUnit unit in player.units) {
-					Console.WriteLine(unit + ", path length: " + unit.path.PathLength());
+					Console.WriteLine($"{unit}, path length: {unit.path?.PathLength() ?? 0}");
 					if (unit.path?.PathLength() > 0) {
 						unit.moveAlongPath();
 					}

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -4,50 +4,50 @@ using C7GameData.AIData;
 
 namespace C7Engine
 {
-    using C7GameData;
-    using System;
-    public class TurnHandling
-    {
-        public static void EndTurn()
-        {
-            GameData gameData = EngineStorage.gameData;
-            Console.WriteLine("\n*** Processing turn " + gameData.turn + " ***");
-            //Barbarians.  First, generate new barbarian units.
-            foreach (Tile tile in gameData.map.barbarianCamps)
-            {
-                //7% chance of a new barbarian.  Probably should scale based on barbarian activity.
-                int result = gameData.rng.Next(100);
-                // Console.WriteLine("Random barb result = " + result);
-                if (result < 7) {
-                    MapUnit newUnit = new MapUnit();
-                    newUnit.location = tile;
-                    newUnit.owner = gameData.players[0];
-                    newUnit.unitType = gameData.unitPrototypes["Warrior"];
-                    newUnit.hitPointsRemaining = 3;
-                    newUnit.isFortified = true; //todo: hack for unit selection
+	using C7GameData;
+	using System;
+	public class TurnHandling
+	{
+		public static void EndTurn()
+		{
+			GameData gameData = EngineStorage.gameData;
+			Console.WriteLine("\n*** Processing turn " + gameData.turn + " ***");
+			//Barbarians.  First, generate new barbarian units.
+			foreach (Tile tile in gameData.map.barbarianCamps)
+			{
+				//7% chance of a new barbarian.  Probably should scale based on barbarian activity.
+				int result = gameData.rng.Next(100);
+				// Console.WriteLine("Random barb result = " + result);
+				if (result < 7) {
+					MapUnit newUnit = new MapUnit();
+					newUnit.location = tile;
+					newUnit.owner = gameData.players[0];
+					newUnit.unitType = gameData.unitPrototypes["Warrior"];
+					newUnit.hitPointsRemaining = 3;
+					newUnit.isFortified = true; //todo: hack for unit selection
 
-                    tile.unitsOnTile.Add(newUnit);
-                    gameData.mapUnits.Add(newUnit);
-                    Console.WriteLine("New barbarian added at " + tile);
-                }
-                else if (tile.NeighborsWater() && result < 10) {
-                    MapUnit newUnit = new MapUnit();
-                    newUnit.location = tile;
-                    newUnit.owner = gameData.players[0];    //todo: make this reliably point to the barbs
-                    newUnit.unitType = gameData.unitPrototypes["Galley"];
-                    newUnit.hitPointsRemaining = 3;
-                    newUnit.isFortified = true; //todo: hack for unit selection
+					tile.unitsOnTile.Add(newUnit);
+					gameData.mapUnits.Add(newUnit);
+					Console.WriteLine("New barbarian added at " + tile);
+				}
+				else if (tile.NeighborsWater() && result < 10) {
+					MapUnit newUnit = new MapUnit();
+					newUnit.location = tile;
+					newUnit.owner = gameData.players[0];    //todo: make this reliably point to the barbs
+					newUnit.unitType = gameData.unitPrototypes["Galley"];
+					newUnit.hitPointsRemaining = 3;
+					newUnit.isFortified = true; //todo: hack for unit selection
 
-                    tile.unitsOnTile.Add(newUnit);
-                    gameData.mapUnits.Add(newUnit);
-                    Console.WriteLine("New barbarian galley added at " + tile);
-                }
-            }
-            //Call the barbarian AI
-            //TODO: The AIs should be stored somewhere on the game state as some of them will store state (plans, strategy, etc.)
-            //For now, we only have a random AI, so that will be in a future commit
-            BarbarianAI barbarianAI = new BarbarianAI();
-            barbarianAI.PlayTurn(gameData.players[0], gameData);
+					tile.unitsOnTile.Add(newUnit);
+					gameData.mapUnits.Add(newUnit);
+					Console.WriteLine("New barbarian galley added at " + tile);
+				}
+			}
+			//Call the barbarian AI
+			//TODO: The AIs should be stored somewhere on the game state as some of them will store state (plans, strategy, etc.)
+			//For now, we only have a random AI, so that will be in a future commit
+			BarbarianAI barbarianAI = new BarbarianAI();
+			barbarianAI.PlayTurn(gameData.players[0], gameData);
 
 			//Non-Barbarian AIs
 			foreach (Player player in gameData.players)
@@ -55,11 +55,11 @@ namespace C7Engine
 				PlayerAI.PlayTurn(player, gameData.rng);
 			}
 
-            //City Production
-            foreach (City city in gameData.cities)
-            {
-                IProducible producedItem = city.ComputeTurnProduction();
-                if (producedItem != null) {
+			//City Production
+			foreach (City city in gameData.cities)
+			{
+				IProducible producedItem = city.ComputeTurnProduction();
+				if (producedItem != null) {
 					if (producedItem is UnitPrototype prototype) {
 						MapUnit newUnit = prototype.GetInstance();
 						newUnit.owner = city.owner;
@@ -69,28 +69,28 @@ namespace C7Engine
 						city.location.unitsOnTile.Add(newUnit);
 						gameData.mapUnits.Add(newUnit);
 						city.owner.AddUnit(newUnit);
-	                }
-					
+					}
+
 					city.SetItemBeingProduced(CityProductionAI.GetNextItemToBeProduced(city, producedItem));
-                }
-            }
-            //Reset movement points available for all units
-            foreach (MapUnit mapUnit in gameData.mapUnits)
-            {
-                mapUnit.movementPointsRemaining = mapUnit.unitType.movement;
-            }
-            //Clear all wait queue, so if a player ended the turn without handling all waited units, they are selected
-            //at the same place in the order.  Confirmed this is what Civ3 does.
-            UnitInteractions.ClearWaitQueue();
-            gameData.turn++;
+				}
+			}
+			//Reset movement points available for all units
+			foreach (MapUnit mapUnit in gameData.mapUnits)
+			{
+				mapUnit.movementPointsRemaining = mapUnit.unitType.movement;
+			}
+			//Clear all wait queue, so if a player ended the turn without handling all waited units, they are selected
+			//at the same place in the order.  Confirmed this is what Civ3 does.
+			UnitInteractions.ClearWaitQueue();
+			gameData.turn++;
 
-	    new MsgStartTurn().send();
-        }
+			new MsgStartTurn().send();
+		}
 
-        ///Eventually we'll have a game year or month or whatever, but for now this provides feedback on our progression
-        public static int GetTurnNumber()
-        {
-            return EngineStorage.gameData.turn;
-        }
-    }
+		///Eventually we'll have a game year or month or whatever, but for now this provides feedback on our progression
+		public static int GetTurnNumber()
+		{
+			return EngineStorage.gameData.turn;
+		}
+	}
 }

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -84,6 +84,11 @@ namespace C7Engine
 			UnitInteractions.ClearWaitQueue();
 			gameData.turn++;
 
+			foreach (MapUnit mapUnit in gameData.mapUnits) {
+				if (mapUnit.path?.Length() > 0) {
+					mapUnit.moveAlongPath();
+				}
+			}
 			new MsgStartTurn().send();
 		}
 

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -85,7 +85,7 @@ namespace C7Engine
 			gameData.turn++;
 
 			foreach (MapUnit mapUnit in gameData.mapUnits) {
-				if (mapUnit.path?.Length() > 0) {
+				if (mapUnit.path?.PathLength() > 0) {
 					mapUnit.moveAlongPath();
 				}
 			}

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -11,6 +11,16 @@ namespace C7Engine
 		public static void EndTurn()
 		{
 			GameData gameData = EngineStorage.gameData;
+
+			foreach (Player player in gameData.players) {
+				foreach (MapUnit unit in player.units) {
+					Console.WriteLine(unit + ", path length: " + unit.path.PathLength());
+					if (unit.path?.PathLength() > 0) {
+						unit.moveAlongPath();
+					}
+				}
+			}
+
 			Console.WriteLine("\n*** Processing turn " + gameData.turn + " ***");
 			//Barbarians.  First, generate new barbarian units.
 			foreach (Tile tile in gameData.map.barbarianCamps)
@@ -84,11 +94,6 @@ namespace C7Engine
 			UnitInteractions.ClearWaitQueue();
 			gameData.turn++;
 
-			foreach (MapUnit mapUnit in gameData.mapUnits) {
-				if (mapUnit.path?.PathLength() > 0) {
-					mapUnit.moveAlongPath();
-				}
-			}
 			new MsgStartTurn().send();
 		}
 

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -1,98 +1,120 @@
 namespace C7Engine
 {
-    using C7GameData;
-    using System;
-    using System.Collections.Generic;
+	using C7GameData;
+	using System;
+	using System.Collections.Generic;
 
-    public class UnitInteractions
-    {
+	public class UnitInteractions
+	{
 
-        private static Queue<MapUnit> waitQueue = new Queue<MapUnit>();
+		private static Queue<MapUnit> waitQueue = new Queue<MapUnit>();
 
-        public static MapUnit getNextSelectedUnit(GameData gameData)
-        {
-            foreach (Player player in gameData.players) {
-                //TODO: Should pass in a player GUID instead of checking for human
-                //This current limits us to one human player, although it's better
-                //than the old limit of one non-barbarian player.
-                if (player.isHuman) {
-                    foreach (MapUnit unit in player.units) {
-                        if (unit.movementPointsRemaining > 0 && !unit.isFortified) {
-                            if (!waitQueue.Contains(unit)) {
-                                return unit;
-                            }
-                        }
-                    }
-                }
-            }
-            if (waitQueue.Count > 0) {
-                return waitQueue.Dequeue();
-            }
-            return MapUnit.NONE;
-        }
+		public static MapUnit getNextSelectedUnit(GameData gameData)
+		{
+			foreach (Player player in gameData.players) {
+				//TODO: Should pass in a player GUID instead of checking for human
+				//This current limits us to one human player, although it's better
+				//than the old limit of one non-barbarian player.
+				if (player.isHuman) {
+					foreach (MapUnit unit in player.units) {
+						if (unit.movementPointsRemaining > 0 && !unit.isFortified) {
+							if (!waitQueue.Contains(unit)) {
+								return UnitWithAvailableActions(unit);
+							}
+						}
+					}
+				}
+			}
+			if (waitQueue.Count > 0) {
+				return waitQueue.Dequeue();
+			}
+			return MapUnit.NONE;
+		}
 
-        /**
-         * Helper function to add the available actions to a unit
-         * based on what terrain it is on.
-         **/
-        public static MapUnit UnitWithAvailableActions(MapUnit unit)
-        {
-            unit.availableActions.Clear();
+		/**
+		 * Helper function to add the available actions to a unit
+		 * based on what terrain it is on.
+		 **/
+		private static MapUnit UnitWithAvailableActions(MapUnit unit)
+		{
+			unit.availableActions.Clear();
 
-            if (unit == MapUnit.NONE)
-                return unit;
+			//This should have "real" code someday.  For now, I'll hard-code a few things based
+			//on the unit type.  That will allow proving the end-to-end works, and we can
+			//add real support as we add more mechanics.  Probably some of it early, some of it...
+			//not so early.
+			//For now, we'll add 'all' the basic actions (e.g. vanilla, non-automated ones), though this is not necessarily right.
+			string[] basicActions = { "hold", "wait", "fortify", "disband", "goTo"};
+			unit.availableActions.AddRange(basicActions);
 
-            //This should have "real" code someday.  For now, I'll hard-code a few things based
-            //on the unit type.  That will allow proving the end-to-end works, and we can
-            //add real support as we add more mechanics.  Probably some of it early, some of it...
-            //not so early.
-            //For now, we'll add 'all' the basic actions (e.g. vanilla, non-automated ones), though this is not necessarily right.
-            string[] basicActions = { "hold", "wait", "fortify", "disband", "goTo"};
-            unit.availableActions.AddRange(basicActions);
+			string unitType = unit.unitType.name;
+			if (unitType.Equals("Warrior")) {
+				unit.availableActions.Add("pillage");
+			}
+			else if (unitType.Equals("Settler")) {
+				unit.availableActions.Add("buildCity");
+			}
+			else if (unitType.Equals("Worker")) {
+				unit.availableActions.Add("road");
+				unit.availableActions.Add("mine");
+				unit.availableActions.Add("irrigate");
+			}
+			else if (unit.unitType.Equals("Chariot")) {
+				unit.availableActions.Add("pillage");
+			}
+			else {
+				//It must be a catapult
+				unit.availableActions.Add("bombard");
+			}
 
-            string unitType = unit.unitType.name;
-            if (unitType.Equals("Warrior")) {
-                unit.availableActions.Add("pillage");
-            }
-            else if (unitType.Equals("Settler")) {
-                unit.availableActions.Add("buildCity");
-            }
-            else if (unitType.Equals("Worker")) {
-                unit.availableActions.Add("road");
-                unit.availableActions.Add("mine");
-                unit.availableActions.Add("irrigate");
-            }
-            else if (unit.unitType.Equals("Chariot")) {
-                unit.availableActions.Add("pillage");
-            }
-            else {
-                //It must be a catapult
-                unit.availableActions.Add("bombard");
-            }
+			//Always add an advanced action b/c we don't have code to make the buttons show up at the right spot if they're all hidden yet
+			unit.availableActions.Add("rename");
 
-            //Always add an advanced action b/c we don't have code to make the buttons show up at the right spot if they're all hidden yet
-            unit.availableActions.Add("rename");
+			return unit;
+		}
 
-            return unit;
-        }
+		public static void ClearWaitQueue()
+		{
+			waitQueue.Clear();
+		}
 
-        public static void waitUnit(GameData gameData, string guid)
-        {
-            foreach (MapUnit unit in gameData.mapUnits)
-            {
-                if (unit.guid == guid)
-                {
-                    Console.WriteLine("Found matching unit with guid " + guid + " of type " + unit.GetType().Name + "; adding it to the wait queue");
-                    waitQueue.Enqueue(unit);
-                }
-            }
-            Console.WriteLine("Failed to find a matching unit with guid " + guid);
-        }
+		public static void fortifyUnit(string guid)
+		{
+			new MsgSetFortification(guid, true).send();
+		}
 
-        public static void ClearWaitQueue()
-        {
-            waitQueue.Clear();
-        }
-    }
+		public static void moveUnit(string guid, TileDirection dir)
+		{
+			new MsgMoveUnit(guid, dir).send();
+		}
+
+		public static void beginUnitMoveTo(string guid, Tile dest)
+		{
+			new MsgBeginUnitMoveTo(guid, dest).send();
+		}
+
+		public static void holdUnit(string guid)
+		{
+			new MsgSkipUnitTurn(guid).send();
+		}
+
+		public static void waitUnit(GameData gameData, string guid)
+		{
+			foreach (MapUnit unit in gameData.mapUnits)
+			{
+				if (unit.guid == guid)
+				{
+					Console.WriteLine("Found matching unit with guid " + guid + " of type " + unit.GetType().Name + "; adding it to the wait queue");
+					waitQueue.Enqueue(unit);
+				}
+			}
+			Console.WriteLine("Failed to find a matching unit with guid " + guid);
+		}
+
+		public static void disbandUnit(string guid)
+		{
+			new MsgDisbandUnit(guid).send();
+		}
+
+	}
 }
-

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -39,6 +39,10 @@ namespace C7Engine
 		{
 			unit.availableActions.Clear();
 
+			if (unit == MapUnit.NONE) {
+				return unit;
+			}
+
 			//This should have "real" code someday.  For now, I'll hard-code a few things based
 			//on the unit type.  That will allow proving the end-to-end works, and we can
 			//add real support as we add more mechanics.  Probably some of it early, some of it...
@@ -78,26 +82,6 @@ namespace C7Engine
 			waitQueue.Clear();
 		}
 
-		public static void fortifyUnit(string guid)
-		{
-			new MsgSetFortification(guid, true).send();
-		}
-
-		public static void moveUnit(string guid, TileDirection dir)
-		{
-			new MsgMoveUnit(guid, dir).send();
-		}
-
-		public static void setUnitPath(string guid, Tile dest)
-		{
-			new MsgSetUnitPath(guid, dest).send();
-		}
-
-		public static void holdUnit(string guid)
-		{
-			new MsgSkipUnitTurn(guid).send();
-		}
-
 		public static void waitUnit(GameData gameData, string guid)
 		{
 			foreach (MapUnit unit in gameData.mapUnits)
@@ -110,11 +94,5 @@ namespace C7Engine
 			}
 			Console.WriteLine("Failed to find a matching unit with guid " + guid);
 		}
-
-		public static void disbandUnit(string guid)
-		{
-			new MsgDisbandUnit(guid).send();
-		}
-
 	}
 }

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -88,9 +88,9 @@ namespace C7Engine
 			new MsgMoveUnit(guid, dir).send();
 		}
 
-		public static void beginUnitMoveTo(string guid, Tile dest)
+		public static void setUnitPath(string guid, Tile dest)
 		{
-			new MsgBeginUnitMoveTo(guid, dest).send();
+			new MsgSetUnitPath(guid, dest).send();
 		}
 
 		public static void holdUnit(string guid)

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -19,7 +19,7 @@ namespace C7Engine
 					foreach (MapUnit unit in player.units) {
 						if (unit.movementPointsRemaining > 0 && !unit.IsBusy()) {
 							if (!waitQueue.Contains(unit)) {
-								return UnitWithAvailableActions(unit);
+								return unit;
 							}
 						}
 					}

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -35,7 +35,7 @@ namespace C7Engine
 		 * Helper function to add the available actions to a unit
 		 * based on what terrain it is on.
 		 **/
-		private static MapUnit UnitWithAvailableActions(MapUnit unit)
+		public static MapUnit UnitWithAvailableActions(MapUnit unit)
 		{
 			unit.availableActions.Clear();
 

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -17,7 +17,7 @@ namespace C7Engine
 				//than the old limit of one non-barbarian player.
 				if (player.isHuman) {
 					foreach (MapUnit unit in player.units) {
-						if (unit.movementPointsRemaining > 0 && !unit.isFortified) {
+						if (unit.movementPointsRemaining > 0 && !unit.IsBusy()) {
 							if (!waitQueue.Contains(unit)) {
 								return UnitWithAvailableActions(unit);
 							}

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -1,6 +1,7 @@
 namespace C7Engine
 {
 
+using System;
 using Pathing;
 using C7GameData;
 
@@ -108,7 +109,7 @@ public static class MapUnitExtensions {
 		}
 	}
 
-	public static void move(this MapUnit unit, TileDirection dir)
+	public static void move(this MapUnit unit, TileDirection dir, bool wait = false)
 	{
 		(int dx, int dy) = dir.toCoordDiff();
 		var newLoc = EngineStorage.gameData.map.tileAt(dx + unit.location.xCoordinate, dy + unit.location.yCoordinate);
@@ -144,25 +145,23 @@ public static class MapUnitExtensions {
 			unit.location = newLoc;
 			unit.movementPointsRemaining -= newLoc.overlayTerrainType.movementCost;
 			unit.OnEnterTile(newLoc);
-			unit.animate(MapUnit.AnimatedAction.RUN, false);
+			unit.animate(MapUnit.AnimatedAction.RUN, wait);
 		}
 	}
 
-	private static void moveAlongPath(this MapUnit unit)
+	public static void moveAlongPath(this MapUnit unit)
 	{
 		while (unit.movementPointsRemaining > 0 && unit.path?.Length() > 0) {
 			var dir = unit.location.directionTo(unit.path.Next());
-			unit.move(dir);
+			unit.move(dir, true); //TODO: don't wait on last move animation?
 		}
 	}
 
-	public static void beginMoveTo(this MapUnit unit, Tile dest)
+	public static void setUnitPath(this MapUnit unit, Tile dest)
 	{
-		System.Console.WriteLine("beginning move from " + unit.location + " to " + dest);
-
 		unit.path = PathingAlgorithmChooser.GetAlgorithm().PathFrom(unit.location, dest);
 		if (unit.path == TilePath.NONE) {
-			System.Console.WriteLine("PATH IS NONE!");
+			System.Console.WriteLine("Cannot move unit to " + dest + ", path is NONE!");
 		}
 		unit.moveAlongPath();
 	}

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -1,6 +1,7 @@
 namespace C7Engine
 {
 
+using Pathing;
 using C7GameData;
 
 //We should document why we're putting things in the extensions methods.  We discussed it a month or so ago, but I forget why at this point.
@@ -120,7 +121,7 @@ public static class MapUnitExtensions {
 			if ((defender != MapUnit.NONE) && (!unit.owner.IsAtPeaceWith(defender.owner))) {
 				if (unit.unitType.attack > 0) {
 					bool unitWonCombat = unit.fight(defender);
-					if (! unitWonCombat)
+					if (!unitWonCombat)
 						return;
 
 					// If there are still more enemy units on the destination tile we can't actually move into it
@@ -132,8 +133,9 @@ public static class MapUnitExtensions {
 				} else if (unit.unitType.bombard > 0) {
 					unit.bombard(newLoc);
 					return;
-				} else
+				} else {
 					return;
+				}
 			}
 
 			if (!unit.location.unitsOnTile.Remove(unit))
@@ -144,6 +146,25 @@ public static class MapUnitExtensions {
 			unit.OnEnterTile(newLoc);
 			unit.animate(MapUnit.AnimatedAction.RUN, false);
 		}
+	}
+
+	private static void moveAlongPath(this MapUnit unit)
+	{
+		while (unit.movementPointsRemaining > 0 && unit.path?.Length() > 0) {
+			var dir = unit.location.directionTo(unit.path.Next());
+			unit.move(dir);
+		}
+	}
+
+	public static void beginMoveTo(this MapUnit unit, Tile dest)
+	{
+		System.Console.WriteLine("beginning move from " + unit.location + " to " + dest);
+
+		unit.path = PathingAlgorithmChooser.GetAlgorithm().PathFrom(unit.location, dest);
+		if (unit.path == TilePath.NONE) {
+			System.Console.WriteLine("PATH IS NONE!");
+		}
+		unit.moveAlongPath();
 	}
 
 	public static void skipTurn(this MapUnit unit)

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -151,7 +151,7 @@ public static class MapUnitExtensions {
 
 	public static void moveAlongPath(this MapUnit unit)
 	{
-		while (unit.movementPointsRemaining > 0 && unit.path?.Length() > 0) {
+		while (unit.movementPointsRemaining > 0 && unit.path?.PathLength() > 0) {
 			var dir = unit.location.directionTo(unit.path.Next());
 			unit.move(dir, true); //TODO: don't wait on last move animation?
 		}
@@ -207,7 +207,7 @@ public static class MapUnitExtensions {
 		// obviously don't want to do here.
 		unit.disband();
 	}
-	
+
 	public static bool canTraverseTile(this MapUnit unit, Tile t) {
 		//TODO: Unit prototypes should have info about terrain classes (#148), and we shouldn't rely on names
 		if (unit.unitType.name == "Galley" && !t.IsLand())

--- a/C7GameData/AIData/TilePath.cs
+++ b/C7GameData/AIData/TilePath.cs
@@ -15,18 +15,27 @@ namespace C7GameData
 			this.path = path;
 		}
 
+		// The next tile in the path, or Tile.NONE if there
+		// are no remaining tiles, or the path is invalid
 		public Tile Next()
 		{
-			return path.Dequeue();
+			return PathLength() > 0 ? path.Dequeue() : Tile.NONE;
 		}
 
 		//TODO: Once we have roads, we should return the calculated cost, not just the length.
 		//This will require Dijkstra or another fancier pathing algorithm
 		public int PathLength() {
-			return path.Count;
+			return path != null ? path.Count : -1;
 		}
 
-		//Indicates no path was found to the requested destination.
+		// Indicates no path was found to the requested destination.
 		public static TilePath NONE = new TilePath();
+
+		// A valid path of length 0
+		public static TilePath EmptyPath(Tile destination)
+		{
+			return new TilePath(destination, new Queue<Tile>());
+		}
+
 	}
 }

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -20,6 +20,11 @@ namespace C7GameData
 			rng = new Random();
 		}
 
+		public MapUnit GetUnit(string guid)
+		{
+			return mapUnits.Find(u => u.guid == guid);
+		}
+
 		/**
 		 * This is intended as a place to set up post-load actions on the save, regardless of
 		 * whether it is loaded from a legacy Civ3 file or a C7 native file.

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -20,6 +20,10 @@ namespace C7GameData
 			rng = new Random();
 		}
 
+		public List<Player> GetHumanPlayers() {
+			return players.FindAll(p => p.isHuman);
+		}
+
 		public MapUnit GetUnit(string guid)
 		{
 			return mapUnits.Find(u => u.guid == guid);

--- a/C7GameData/MapUnit.cs
+++ b/C7GameData/MapUnit.cs
@@ -15,6 +15,7 @@ public class MapUnit
 	public UnitPrototype unitType {get; set;}
 	public Player owner {get; set;}
 	public Tile location {get; set;}
+	public TilePath path {get; set;}
 
 	public int movementPointsRemaining {get; set;}
 	public int hitPointsRemaining {get; set;}

--- a/C7GameData/MapUnit.cs
+++ b/C7GameData/MapUnit.cs
@@ -39,6 +39,10 @@ public class MapUnit
 		guid = Guid.NewGuid().ToString();
 	}
 
+	public bool IsBusy() {
+		return isFortified || (path != null && path.PathLength() > 0);
+	}
+
 	public override string ToString()
 	{
 		if (this != MapUnit.NONE) {

--- a/C7GameData/UnitPrototype.cs
+++ b/C7GameData/UnitPrototype.cs
@@ -1,37 +1,37 @@
 namespace C7GameData
 {
-    /**
-     * The prototype for a unit, which defines the characteristics of a unit.
-     * For example, a Spearman might have 1 attack, 2 defense, and 1 movement.
-     **/
-    public class UnitPrototype : IProducible
-    {
-	    public string name { get; set; }
-	    public int shieldCost { get; set; }
-	    public int populationCost { get; set; }
-        public int attack {get; set;}
-        public int defense {get; set;}
-        public int bombard {get; set;}
-        public int movement {get; set;}
-        public int iconIndex {get; set;}
+	/**
+	 * The prototype for a unit, which defines the characteristics of a unit.
+	 * For example, a Spearman might have 1 attack, 2 defense, and 1 movement.
+	 **/
+	public class UnitPrototype : IProducible
+	{
+		public string name { get; set; }
+		public int shieldCost { get; set; }
+		public int populationCost { get; set; }
+		public int attack {get; set;}
+		public int defense {get; set;}
+		public int bombard {get; set;}
+		public int movement {get; set;}
+		public int iconIndex {get; set;}
 
-        public bool canFoundCity {get; set;}
-        public bool canBuildRoads {get; set;}  //eventually there will be real worker tasks, for now let's just have one basic one.
+		public bool canFoundCity {get; set;}
+		public bool canBuildRoads {get; set;}  //eventually there will be real worker tasks, for now let's just have one basic one.
 
-        //probably some things like graphics and whether it's a helicopter someday
+		//probably some things like graphics and whether it's a helicopter someday
 
-        public override string ToString()
-        {
-            return $"{name} ({attack}/{defense}/{movement})";
-        }
+		public override string ToString()
+		{
+			return $"{name} ({attack}/{defense}/{movement})";
+		}
 
-        public MapUnit GetInstance()
-        {
-            MapUnit instance = new MapUnit();
-            instance.unitType = this;
-            instance.hitPointsRemaining = 3;    //todo: make this configurable
-            instance.movementPointsRemaining = movement;
-            return instance;
-        }
-    }
+		public MapUnit GetInstance()
+		{
+			MapUnit instance = new MapUnit();
+			instance.unitType = this;
+			instance.hitPointsRemaining = 3;    //todo: make this configurable
+			instance.movementPointsRemaining = movement;
+			return instance;
+		}
+	}
 }


### PR DESCRIPTION
Implements using the go to button to move units as per https://github.com/C7-Game/Prototype/issues/164. This PR does not visually indicate which tile the cursor is hovering over, or draw the path on the map.

There are some issues with the current implementation namely
- it's possible to click on destinations more than one turn away, and upon arriving the unit will attack if a unit is on the destination tile
- units always get to use their last movement point to move onto difficult terrain, and their movement points reset each round. I'm pretty sure this is not how civ 3 works for multi-turn moves
- when a unit continues moving along their path after the first turn their path is assigned, the engine does not notify the UI to centre the UI on the unit
- there is no way to cancel a units current path once it has been created (need to double check how this works in civ 3 but I think just making the unit active again should cancel their current path)
- `Game.inUnitGoToMode` is the boolean flag indicating if the player's most recent action was clicking the unit go to button / pressing G. this flag needs to be untoggled in a bunch of situations (the most obvious being the player presses esc to cancel selecting a go to tile) otherwise you will probably accidentally move a unit. I haven't checked all the possible situations in which civ 3 cancels go to, so I'm confident some are missing

I'm not sure where the best place to move units along their current path at the start of the player's turn is, and the best way to notify the UI to centre on these units, so I think we should save handling the edge cases and above issues for a future PR to improve on this one.