### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,10 +29,10 @@ csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
 # indentation
-# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0049
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#indentation-options
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
-csharp_indent_labels = one_less_than_current
+csharp_indent_labels = flush_left
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents_when_block = true
@@ -41,7 +41,7 @@ csharp_indent_case_contents_when_block = true
 # https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0007-ide0008
 # https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0049
 csharp_style_var_for_built_in_types = false:warning
-csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_when_type_is_apparent = false:warning
 csharp_style_var_elsewhere = false:warning
 dotnet_style_predefined_type_for_locals_parameters_members = true:warning
 dotnet_style_predefined_type_for_member_access = true:warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,71 @@
+root = true
+
+# Defaults
+
+[*]
+charset = utf-8
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+end_of_line = lf
+
+
+# C#
+
+[*.cs]
+
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
+dotnet_sort_system_directives_first = true
+
+# new lines
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#new-line-options
+csharp_new_line_before_open_brace = none
+csharp_new_line_before_else = false
+csharp_new_line_before_catch = false
+csharp_new_line_before_finally = false
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# indentation
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0049
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = true
+
+# type rules
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0007-ide0008
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0049
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = false:warning
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+
+# spacing
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#spacing-options
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_after_comma = true
+csharp_space_before_comma = false
+csharp_space_after_dot = false
+csharp_space_before_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_around_declaration_statements = ignore
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false

--- a/C7/C7.sln
+++ b/C7/C7.sln
@@ -21,6 +21,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildDevSave", "..\_Console
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VSStub", "VSStub\VSStub.csproj", "{D420363F-5260-42D6-883A-BC1D970B39D9}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8C955B11-CC6A-4BED-BE2A-89DB985A3A18}"
+	ProjectSection(SolutionItems) = preProject
+		..\.editorconfig = ..\.editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ An installation of Sid Meier's Civilzation III Complete (or Conquests) is requir
 
 Find the project interesting enough you'd like to contribute?  See the [Contributing Page](https://github.com/C7-Game/Prototype/wiki/Contributing) on our Wiki for more information!
 
+To set up a working development environment, check out [the docs](./doc/dev_environment.md).
+
 At the moment, additional developer bandwidth is probably the most-needed asset, but all sorts of help (art, writing, project management, sheep-herding) could be useful.
 
 ## What is those subfolders?

--- a/doc/dev_environment.md
+++ b/doc/dev_environment.md
@@ -1,0 +1,56 @@
+# Development Environment
+
+This document provides steps to set up a working C7 development environment.
+
+# Requirements
+## .NET SDK
+Download [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet).
+
+## Godot
+Install the Mono version of [Godot](https://godotengine.org/download). This includes the Godot IDE which is useful for building C7 and in some cases developing UI, but it is not recommended for C# code editing.
+
+# IDEs
+There are two free IDEs recommended for C# development. Follow the steps below for setting up a working development environment in these editors and troubleshooting for common issues. Another alternative is to use [JetBrains Rider](https://www.jetbrains.com/rider/download/), a commercial IDE for C# development. There is a
+[CFC thread](https://forums.civfanatics.com/threads/dev-jetbrains-rider-impressions.675190/) on Rider that may provide additional information on setting it up.
+
+## Visual Studio Code
+Follow the [official guide](https://code.visualstudio.com/docs/setup/setup-overview#_cross-platform) to install Visual Studio Code for your platform.
+
+Next, install the following plugins from the marketplace:
+1. [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) - this provides syntax highlighting, IntelliSense, find references, and other nice IDE-like features for C#.
+2. [C# Tools for Godot](https://marketplace.visualstudio.com/items?itemName=neikeq.godot-csharp-vscode) - this enables launching C7 from VS Code and debugging
+
+Finally, set up code formatting. For Visual Studio Code, formatting is done with OmniSharp and configured by the `.editorconfig` file. In order to configure OmniSharp, do the following:
+1. In your home directory, create `~/.omnisharp/omnisharp.json` with the following contents
+```
+{
+  "RoslynExtensionsOptions": {
+    "enableAnalyzersSupport": true,
+  },
+  "FormattingOptions": {
+    "enableEditorConfigSupport": true,
+  }
+}
+```
+2. Add the following options to your VS Code `settings.json` (either workspace settings or your user level settings)
+```
+"omnisharp.enableMsBuildLoadProjectsOnDemand": true,
+"omnisharp.enableEditorConfigSupport": true,
+"omnisharp.enableRoslynAnalyzers": true,
+```
+3. Optionally but recommended, add this option to your VS Code `settings.json` to enable formatting on save
+```
+"[csharp]": {
+  "editor.formatOnSave": true,
+}
+```
+
+### Troubleshooting
+- Linting or IntelliSense are completely broken
+  - try adding `"omnisharp.useGlobalMono": "always"` to `settings.json`
+  - you may need to rebuild the entire project through the Godot IDE
+
+## Visual Studio 2019 Community Edition
+It's important to use Visual Studio 2019, as you cannot run/debug Godot from Visual Studio 2022 yet, and 2019 was the first version to be supported.
+
+The Visual Studio solution file is already aware of the `.editorconfig` file, so no further setup is required.


### PR DESCRIPTION
adds a `.editorconfig`

configures:
- new line rules based on the [google C# style guide](https://google.github.io/styleguide/csharp-style.html#whitespace-rules)
  - rational: most familiar for developers coming from Java / C++ and shortens files
- indentation is tabs
  - rational: this has already been picked as the standard moving forward
- use `var` when type is clear (ie. a new statement)
  - rational: somewhat arbitrary but some code already uses var, and this way types are still explicit when you can't see the type on the same line

does not configure:
- naming conventions
  - why not: the code is inconsistent and renaming a bunch of variables right now is more likely to break stuff