### PR TITLE
Work-around to loading images via res://SomePath.jpg not working in release mode

### DIFF
--- a/C7/MainMenu.cs
+++ b/C7/MainMenu.cs
@@ -69,10 +69,7 @@ public class MainMenu : Node2D
 
 	private void SetMainMenuBackground()
 	{
-		ImageTexture TitleScreenTexture = Util.LoadTextureFromPCX("Art/title.pcx");
-		Image backgroundImage = new Image();
-		backgroundImage.Load("res://Title_Screen.jpg");
-		TitleScreenTexture.CreateFromImage(backgroundImage);
+		ImageTexture TitleScreenTexture = Util.LoadTextureFromC7JPG("Title_Screen.jpg");
 		MainMenuBackground = GetNode<TextureRect>("CanvasLayer/MainMenuBackground");
 		MainMenuBackground.StretchMode = TextureRect.StretchModeEnum.Scale;
 		MainMenuBackground.Texture = TitleScreenTexture;

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -125,6 +125,28 @@ public class Util
 		textureCache[relPath] = texture;
 		return texture;
 	}
+
+	//Send this function a path (e.g. Title_Screen.jpg) and it will 
+	//load it up and convert it in both debug and release modes.
+	//Note: We probably will need variants of this for other file types, too.
+	static public ImageTexture LoadTextureFromC7JPG(string relPath) {
+		Image backgroundImage = new Image();
+		if (OS.IsDebugBuild()) {
+			//This loads it from the local resource folder in debug mode.
+			//Doesn't work in release mode, which according to https://github.com/godotengine/godot/issues/24222#issuecomment-709092664
+			//is due to a design issue in Godot's import pipeline
+			backgroundImage.Load("res://" + relPath);
+		}
+		else {
+			//This loads it from the folder where the executable is in release mode.
+			//Doesn't work in debug mode because the executable will be where Godot is installed,
+			//not where our project is located.
+			backgroundImage.Load(OS.GetExecutablePath().GetBaseDir().PlusFile(relPath));
+		}
+		ImageTexture texture = new ImageTexture();
+		texture.CreateFromImage(backgroundImage);
+		return texture;
+	}
 	
 	private static Dictionary<string, ImageTexture> textureCache = new Dictionary<string, ImageTexture>();
 	//Send this function a path (e.g. Art/exitBox-backgroundStates.pcx), and the coordinates of the extracted image you need from that PCX

--- a/C7/VSStub/VSStub.csproj
+++ b/C7/VSStub/VSStub.csproj
@@ -14,6 +14,16 @@
     <Deterministic>true</Deterministic>
     <ProjectTypeGuids>{8F3E2DF0-C35C-4265-82FC-BEA011F4A7ED};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants></DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Unfortunately, I couldn't find a good way to keep that working in debug mode; most didn't work, and the rest will be deprecated with Godot 4.0 and added complexity.

So instead, I added a utility method that will use the current method in debug mode, and use a release-appropriate method.  That latter method was discovered in a comment in the Godot Mono source code; unfortunately I closed the file before noting which one it was.

Also, commit a change to the VSStub.csproj project that enables building it in release mode (see answer #2 at https://stackoverflow.com/questions/15134384/the-outputpath-property-is-not-set-for-project).  This might fix the issues that WildWeazel and others have had with VSStub.