### PR TITLE
159 - Bump Godot Version

### DIFF
--- a/.github/workflows/export-c7.yml
+++ b/.github/workflows/export-c7.yml
@@ -26,7 +26,7 @@ jobs:
   Export-C7-Windows:
     runs-on: ubuntu-latest
     container:
-      image: barichello/godot-ci:mono-3.4
+      image: barichello/godot-ci:mono-${GODOT_VERSION}
     steps:
     - name: Optionally set DEBUG_BUILD
       if: github.event.inputs.debug-build == 'true'

--- a/.github/workflows/export-c7.yml
+++ b/.github/workflows/export-c7.yml
@@ -72,7 +72,7 @@ jobs:
   Export-C7-Linux:
     runs-on: ubuntu-latest
     container:
-      image: barichello/godot-ci:mono-3.4
+      image: barichello/godot-ci:mono-3.4.4
     steps:
     - name: Optionally set DEBUG_BUILD
       if: github.event.inputs.debug-build == 'true'
@@ -121,7 +121,7 @@ jobs:
   Export-C7-Mac:
     runs-on: ubuntu-latest
     container:
-      image: barichello/godot-ci:mono-3.4
+      image: barichello/godot-ci:mono-3.4.4
     steps:
     - name: Optionally set DEBUG_BUILD
       if: github.event.inputs.debug-build == 'true'

--- a/.github/workflows/export-c7.yml
+++ b/.github/workflows/export-c7.yml
@@ -19,7 +19,7 @@ on:
         default: true
 
 env:
-  GODOT_VERSION: 3.4
+  GODOT_VERSION: 3.4.4
   EXPORT_NAME: C7
 
 jobs:

--- a/.github/workflows/export-c7.yml
+++ b/.github/workflows/export-c7.yml
@@ -26,7 +26,7 @@ jobs:
   Export-C7-Windows:
     runs-on: ubuntu-latest
     container:
-      image: barichello/godot-ci:mono-${GODOT_VERSION}
+      image: barichello/godot-ci:mono-3.4.4
     steps:
     - name: Optionally set DEBUG_BUILD
       if: github.event.inputs.debug-build == 'true'


### PR DESCRIPTION
This bumps our build's process to use the latest version of Godot (3.4.4), which has been out for a week or so.

Fixes #159 

There still is room to go in de-duplicating this Actions file... but this at least gets us all the behind-the-scenes fixes from the recent past.

I ran a debug build at https://github.com/C7-Game/Prototype/actions/runs/2110471636 that you should be able to run and verify that it's using 3.4.4 (at least on Windows it shows the version in the Command Prompt that appears).