### PR TITLE
Add Dijkstra's Algorithm for Pathing

### DIFF
--- a/C7Engine/AI/Pathing/BFSLandAlgorithm.cs
+++ b/C7Engine/AI/Pathing/BFSLandAlgorithm.cs
@@ -16,7 +16,7 @@ namespace C7Engine.Pathing
 	public class BFSLandAlgorithm : PathingAlgorithm
 	{
 		//N.B. This should really be static, but we can't put a static method on interfaces, so it isn't.
-		public TilePath PathFrom(Tile start, Tile destination)
+		public override TilePath PathFrom(Tile start, Tile destination)
 		{
 			if (start == destination) {
 				return TilePath.EmptyPath(destination);
@@ -55,30 +55,6 @@ namespace C7Engine.Pathing
 				}
 			}
 			return TilePath.NONE;
-		}
-
-		/**
-		 * Should not be public.  Only public so we can test
-		 * it in isolation.
-		 *
-		 * In Java, I could work around this a few ways... not sure how in C#.
-		 */
-		public static TilePath ConstructPath(Tile destination, Dictionary<Tile, Tile> predecessors)
-		{
-			List<Tile> tilesInPath = new List<Tile>();
-			tilesInPath.Add(destination);
-			Tile tile = destination;
-			while (predecessors.ContainsKey(tile)) {
-				tile = predecessors[tile];
-				tilesInPath.Add(tile);
-			}
-			tilesInPath.Reverse();
-			Queue<Tile> path = new Queue<Tile>();
-			foreach (Tile t in tilesInPath.Skip(1))
-			{
-				path.Enqueue(t);
-			}
-			return new TilePath(destination, path);
 		}
 	}
 }

--- a/C7Engine/AI/Pathing/DijkstrasLandAlgorithm.cs
+++ b/C7Engine/AI/Pathing/DijkstrasLandAlgorithm.cs
@@ -56,6 +56,11 @@ namespace C7Engine.Pathing
 					}
 				}
 				closest = getNextClosest();
+				// TODO: this is fastest if recomputing Dijkstra's for each unit
+				// and ignoring that units may path from the same starting tile
+				if (closest.Key == destination) {
+					break;
+				}
 			}
 
 			return ConstructPath(destination, predecessors);

--- a/C7Engine/AI/Pathing/DijkstrasLandAlgorithm.cs
+++ b/C7Engine/AI/Pathing/DijkstrasLandAlgorithm.cs
@@ -13,11 +13,33 @@ namespace C7Engine.Pathing
 	 * Notes: - Edge weight is defined by the movement cost of the 2nd node:
 	 *          w(u, v) = movement_cost(v)
 	 */
-	public class DijkstrasLandAlgorithm : PathingAlgorithm
-	{
-		//N.B. This should really be static, but we can't put a static method on interfaces, so it isn't.
-		public TilePath PathFrom(Tile start, Tile destination)
-		{
+	public class DijkstrasLandAlgorithm : PathingAlgorithm {
+
+		// Returns the next closest vertex in the graph, and updates the visited set to include
+		// the returned vertex
+		private KeyValuePair<Tile, int> getNextClosest(Dictionary<Tile, int> dist, HashSet<Tile> visited) {
+			// TODO: pick a different data structure to avoid O(n) search
+			KeyValuePair<Tile, int> next = new KeyValuePair<Tile, int>(Tile.NONE, int.MaxValue);
+			foreach (KeyValuePair<Tile, int> pair in dist) {
+				if (pair.Value < next.Value && !visited.Contains(pair.Key)) {
+					next = pair;
+				}
+			}
+			visited.Add(next.Key);
+			return next;
+		}
+
+		// Updates the shortest distance to a vertex. Returns true if the distance parameter
+		// is shorter than the shortest known distance and dist is updated, and false otherwise.
+		private bool updateShortestDistance(Tile tile, int distance, Dictionary<Tile, int> dist) {
+			if (!dist.ContainsKey(tile) || dist[tile] > distance) {
+				dist[tile] = distance;
+				return true;
+			}
+			return false;
+		}
+
+		public override TilePath PathFrom(Tile start, Tile destination) {
 			// shortest distance from start to each tile on the continent
 			Dictionary<Tile, int> dist = new Dictionary<Tile, int>();
 			Dictionary<Tile, Tile> predecessors = new Dictionary<Tile, Tile>();
@@ -25,63 +47,21 @@ namespace C7Engine.Pathing
 
 			dist[start] = 0;
 
-			bool updateShortestDistance(Tile tile, int distance) {
-				if (!dist.ContainsKey(tile)) {
-					dist[tile] = distance;
-					return true;
-				} else if (dist[tile] > distance) {
-					dist[tile] = distance;
-					return true;
-				}
-				return false;
-			}
-
-			// TODO not O(n) search
-			KeyValuePair<Tile, int> getNextClosest() {
-				KeyValuePair<Tile, int> next = new KeyValuePair<Tile, int>(Tile.NONE, int.MaxValue);
-				foreach (KeyValuePair<Tile, int> pair in dist) {
-					if (pair.Value < next.Value && !visited.Contains(pair.Key)) {
-						next = pair;
-					}
-				}
-				visited.Add(next.Key);
-				return next;
-			}
-
-			KeyValuePair<Tile, int> closest = getNextClosest();
+			KeyValuePair<Tile, int> closest = getNextClosest(dist, visited);
 			while (closest.Key != Tile.NONE) {
 				foreach (Tile tile in closest.Key.GetLandNeighbors()) {
-					if (!visited.Contains(tile) && updateShortestDistance(tile, closest.Value + tile.MovementCost())) {
+					if (!visited.Contains(tile) && updateShortestDistance(tile, closest.Value + tile.MovementCost(), dist)) {
 						predecessors[tile] = closest.Key;
 					}
 				}
-				closest = getNextClosest();
+				closest = getNextClosest(dist, visited);
 				// TODO: this is fastest if recomputing Dijkstra's for each unit
 				// and ignoring that units may path from the same starting tile
 				if (closest.Key == destination) {
 					break;
 				}
 			}
-
 			return ConstructPath(destination, predecessors);
-		}
-
-		// Should not be public
-		public static TilePath ConstructPath(Tile destination, Dictionary<Tile, Tile> predecessors)
-		{
-			List<Tile> tilesInPath = new List<Tile>() {destination};
-			Tile tile = destination;
-			while (predecessors.ContainsKey(tile)) {
-				tile = predecessors[tile];
-				tilesInPath.Add(tile);
-			}
-			tilesInPath.Reverse();
-			Queue<Tile> path = new Queue<Tile>();
-			foreach (Tile t in tilesInPath.Skip(1))
-			{
-				path.Enqueue(t);
-			}
-			return new TilePath(destination, path);
 		}
 	}
 }

--- a/C7Engine/AI/Pathing/DijkstrasLandAlgorithm.cs
+++ b/C7Engine/AI/Pathing/DijkstrasLandAlgorithm.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using C7GameData;
+
+namespace C7Engine.Pathing
+{
+	/**
+	 * Uses Dijkstra's Algorithm to find a path between two tiles.
+	 * Advantages: Finds the shortest path accounting for tile movement cost
+	 * Disadvantages: Expensive, will exhaustively search every tile on the continent
+	 *
+	 * Notes: - Edge weight is defined by the movement cost of the 2nd node:
+	 *          w(u, v) = movement_cost(v)
+	 */
+	public class DijkstrasLandAlgorithm : PathingAlgorithm
+	{
+		//N.B. This should really be static, but we can't put a static method on interfaces, so it isn't.
+		public TilePath PathFrom(Tile start, Tile destination)
+		{
+			// shortest distance from start to each tile on the continent
+			Dictionary<Tile, int> dist = new Dictionary<Tile, int>();
+			Dictionary<Tile, Tile> predecessors = new Dictionary<Tile, Tile>();
+			HashSet<Tile> visited = new HashSet<Tile>();
+
+			dist[start] = 0;
+
+			bool updateShortestDistance(Tile tile, int distance) {
+				if (!dist.ContainsKey(tile)) {
+					dist[tile] = distance;
+					return true;
+				} else if (dist[tile] > distance) {
+					dist[tile] = distance;
+					return true;
+				}
+				return false;
+			}
+
+			// TODO not O(n) search
+			KeyValuePair<Tile, int> getNextClosest() {
+				KeyValuePair<Tile, int> next = new KeyValuePair<Tile, int>(Tile.NONE, int.MaxValue);
+				foreach (KeyValuePair<Tile, int> pair in dist) {
+					if (pair.Value < next.Value && !visited.Contains(pair.Key)) {
+						next = pair;
+					}
+				}
+				visited.Add(next.Key);
+				return next;
+			}
+
+			KeyValuePair<Tile, int> closest = getNextClosest();
+			while (closest.Key != Tile.NONE) {
+				foreach (Tile tile in closest.Key.GetLandNeighbors()) {
+					if (!visited.Contains(tile) && updateShortestDistance(tile, closest.Value + tile.MovementCost())) {
+						predecessors[tile] = closest.Key;
+					}
+				}
+				closest = getNextClosest();
+			}
+
+			return ConstructPath(destination, predecessors);
+		}
+
+		// Should not be public
+		public static TilePath ConstructPath(Tile destination, Dictionary<Tile, Tile> predecessors)
+		{
+			List<Tile> tilesInPath = new List<Tile>() {destination};
+			Tile tile = destination;
+			while (predecessors.ContainsKey(tile)) {
+				tile = predecessors[tile];
+				tilesInPath.Add(tile);
+			}
+			tilesInPath.Reverse();
+			Queue<Tile> path = new Queue<Tile>();
+			foreach (Tile t in tilesInPath.Skip(1))
+			{
+				path.Enqueue(t);
+			}
+			return new TilePath(destination, path);
+		}
+	}
+}

--- a/C7Engine/AI/Pathing/PathingAlgorithm.cs
+++ b/C7Engine/AI/Pathing/PathingAlgorithm.cs
@@ -1,9 +1,27 @@
+using System.Collections.Generic;
+using System.Linq;
 using C7GameData;
 
 namespace C7Engine.Pathing
 {
-	public interface PathingAlgorithm
-	{
-		TilePath PathFrom(Tile start, Tile destination);
+	public abstract class PathingAlgorithm {
+		public abstract TilePath PathFrom(Tile start, Tile destination);
+
+		// Should not be public
+		public TilePath ConstructPath(Tile destination, Dictionary<Tile, Tile> predecessors) {
+			List<Tile> tilesInPath = new List<Tile>() {destination};
+			Tile tile = destination;
+			while (predecessors.ContainsKey(tile)) {
+				tile = predecessors[tile];
+				tilesInPath.Add(tile);
+			}
+			tilesInPath.Reverse();
+			Queue<Tile> path = new Queue<Tile>();
+			foreach (Tile t in tilesInPath.Skip(1)) {
+				path.Enqueue(t);
+			}
+			return new TilePath(destination, path);
+		}
 	}
+
 }

--- a/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
+++ b/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
@@ -7,8 +7,8 @@ namespace C7Engine.Pathing
 	 */
 	public class PathingAlgorithmChooser
 	{
-		private static PathingAlgorithm theAlgorithm = new BFSLandAlgorithm();
-		
+		private static PathingAlgorithm theAlgorithm = new DijkstrasLandAlgorithm();
+
 		public static PathingAlgorithm GetAlgorithm()
 		{
 			return theAlgorithm;

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -1,7 +1,4 @@
-using System.Collections.Generic;
-using System.Linq;
 using C7Engine.AI;
-using C7GameData.AIData;
 
 namespace C7Engine
 {
@@ -15,13 +12,13 @@ namespace C7Engine
 			Console.WriteLine("\n*** Beginning turn " + gameData.turn + " ***");
 
 			//Reset movement points available for all units
-			foreach (MapUnit mapUnit in gameData.mapUnits)
-			{
+			foreach (MapUnit mapUnit in gameData.mapUnits) {
 				mapUnit.movementPointsRemaining = mapUnit.unitType.movement;
 			}
 
-			foreach (Player player in gameData.players)
+			foreach (Player player in gameData.players) {
 				player.hasPlayedThisTurn = false;
+			}
 		}
 
 		// Implements the game loop. This method is called when the game is started and when the player signals that they're done moving.
@@ -47,8 +44,9 @@ namespace C7Engine
 						} else if (! player.isHuman) {
 							PlayerAI.PlayTurn(player, gameData.rng);
 							player.hasPlayedThisTurn = true;
-						} else
+						} else {
 							player.hasPlayedThisTurn = true;
+						}
 					}
 				}
 

--- a/C7GameData/AIData/TilePath.cs
+++ b/C7GameData/AIData/TilePath.cs
@@ -7,18 +7,19 @@ namespace C7GameData
 		private Tile destination; //stored in case we need to re-calculate
 		private Queue<Tile> path;
 
-		private TilePath() {}
+		private TilePath() {
+			destination = Tile.NONE;
+			path = new Queue<Tile>();
+		}
 
-		public TilePath(Tile destination, Queue<Tile> path)
-		{
+		public TilePath(Tile destination, Queue<Tile> path) {
 			this.destination = destination;
 			this.path = path;
 		}
 
 		// The next tile in the path, or Tile.NONE if there
 		// are no remaining tiles, or the path is invalid
-		public Tile Next()
-		{
+		public Tile Next() {
 			return PathLength() > 0 ? path.Dequeue() : Tile.NONE;
 		}
 
@@ -32,8 +33,7 @@ namespace C7GameData
 		public static TilePath NONE = new TilePath();
 
 		// A valid path of length 0
-		public static TilePath EmptyPath(Tile destination)
-		{
+		public static TilePath EmptyPath(Tile destination) {
 			return new TilePath(destination, new Queue<Tile>());
 		}
 

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -38,13 +38,7 @@ namespace C7GameData
 		public void PerformPostLoadActions()
 		{
 			//Let each tile know who its neighbors are.  It needs to know this so its graphics can be selected appropriately.
-			foreach (Tile tile in map.tiles) {
-				Dictionary<TileDirection, Tile> neighbors = new Dictionary<TileDirection, Tile>();
-				foreach (TileDirection direction in Enum.GetValues(typeof(TileDirection))) {
-					neighbors[direction] = map.tileNeighbor(tile, direction);
-				}
-				tile.neighbors = neighbors;
-			}
+			map.computeNeighbors();
 		}
 
 		/**

--- a/C7GameData/GameMap.cs
+++ b/C7GameData/GameMap.cs
@@ -1,221 +1,231 @@
 namespace C7GameData
 {
-    using System;
-    using System.Collections.Generic;
-    /**
-     * The game map, at the top level.
-     */
-    public class GameMap
-    {
-        // This may not belong here, but I'm not sure where it should go just now
-        public string RelativeModPath = "";
-        // TODO : protect setters while still allowing JSON deserialization
-        public int numTilesWide { get; set; }
-        public int numTilesTall { get; set; }
-        public bool wrapHorizontally, wrapVertically;
+	using System;
+	using System.Collections.Generic;
+	/**
+	 * The game map, at the top level.
+	 */
+	public class GameMap
+	{
+		// This may not belong here, but I'm not sure where it should go just now
+		public string RelativeModPath = "";
+		// TODO : protect setters while still allowing JSON deserialization
+		public int numTilesWide { get; set; }
+		public int numTilesTall { get; set; }
+		public bool wrapHorizontally, wrapVertically;
 
-        // The terrainNoiseMap is a full width-by-height matrix unlike the normal game map which has only width/2 tiles per row which are staggered.
-        // This is kind of a temporary thing. The reason it works this way right now is because I'm just rearranging the generation code from
-        // TerrainAsTileMap, eventually we'll want a more complex map generator which probably won't need this var.
-        [System.Text.Json.Serialization.JsonIgnore]
-        public int[,] terrainNoiseMap;
+		// The terrainNoiseMap is a full width-by-height matrix unlike the normal game map which has only width/2 tiles per row which are staggered.
+		// This is kind of a temporary thing. The reason it works this way right now is because I'm just rearranging the generation code from
+		// TerrainAsTileMap, eventually we'll want a more complex map generator which probably won't need this var.
+		[System.Text.Json.Serialization.JsonIgnore]
+		public int[,] terrainNoiseMap;
 
-        public List<TerrainType> terrainTypes = new List<TerrainType>();
-        public List<Tile> tiles { get; set;}
+		public List<TerrainType> terrainTypes = new List<TerrainType>();
+		public List<Tile> tiles { get; set;}
 		public List<Tile> barbarianCamps = new List<Tile>();
 
-        public GameMap()
-        {
-            this.tiles = new List<Tile>();
-        }
+		public GameMap()
+		{
+			this.tiles = new List<Tile>();
+		}
 
-        public int tileCoordsToIndex(int x, int y)
-        {
-            return y * numTilesWide/2 + (y%2 == 0 ? x/2 : (x-1)/2);
-        }
+		public int tileCoordsToIndex(int x, int y)
+		{
+			return y * numTilesWide/2 + (y%2 == 0 ? x/2 : (x-1)/2);
+		}
 
-        public void tileIndexToCoords(int index, out int x, out int y)
-        {
-            int doubleRow = index / numTilesWide;
-            int doubleRowRem = index % numTilesWide;
-            if (doubleRowRem < numTilesWide/2) {
-                x = 2 * doubleRowRem;
-                y = 2 * doubleRow;
-            } else {
-                x = 1 + 2 * (doubleRowRem - numTilesWide/2);
-                y = 2 * doubleRow + 1;
-            }
-        }
+		public void tileIndexToCoords(int index, out int x, out int y)
+		{
+			int doubleRow = index / numTilesWide;
+			int doubleRowRem = index % numTilesWide;
+			if (doubleRowRem < numTilesWide/2) {
+				x = 2 * doubleRowRem;
+				y = 2 * doubleRow;
+			} else {
+				x = 1 + 2 * (doubleRowRem - numTilesWide/2);
+				y = 2 * doubleRow + 1;
+			}
+		}
 
-        // This method verifies that the conversion between tile index and coords is consistent for all possible valid inputs. It's not called
-        // anywhere but I'm keeping it around in case we ever need to work on the conversion methods again.
-        public void testTileIndexComputation()
-        {
-            for (int y = 0; y < numTilesTall; y++)
-                for (int x = y%2; x < numTilesWide; x += 2) {
-                    int rx, ry;
-                    int index = tileCoordsToIndex(x, y);
-                    tileIndexToCoords(index, out rx, out ry);
-                    if ((rx != x) || (ry != y))
-                        throw new System.Exception(String.Format("Error computing tile index/coords: ({0}, {1}) -> {2} -> ({3}, {4})", x, y, index, rx, ry));
-                }
+		public void computeNeighbors() {
+			foreach (Tile tile in tiles) {
+				Dictionary<TileDirection, Tile> neighbors = new Dictionary<TileDirection, Tile>();
+				foreach (TileDirection direction in Enum.GetValues(typeof(TileDirection))) {
+					neighbors[direction] = tileNeighbor(tile, direction);
+				}
+				tile.neighbors = neighbors;
+			}
+		}
 
-            for (int i = 0; i < numTilesWide * numTilesTall / 2; i++) {
-                int x, y;
-                tileIndexToCoords(i, out x, out y);
-                int ri = tileCoordsToIndex(x, y);
-                if (ri != i)
-                    throw new System.Exception(String.Format("Error computing tile index/coords: {0} -> ({1}, {2}) -> {3}", i, x, y, ri));
-            }
-        }
+		// This method verifies that the conversion between tile index and coords is consistent for all possible valid inputs. It's not called
+		// anywhere but I'm keeping it around in case we ever need to work on the conversion methods again.
+		public void testTileIndexComputation()
+		{
+			for (int y = 0; y < numTilesTall; y++)
+				for (int x = y%2; x < numTilesWide; x += 2) {
+					int rx, ry;
+					int index = tileCoordsToIndex(x, y);
+					tileIndexToCoords(index, out rx, out ry);
+					if ((rx != x) || (ry != y))
+						throw new Exception(String.Format("Error computing tile index/coords: ({0}, {1}) -> {2} -> ({3}, {4})", x, y, index, rx, ry));
+				}
 
-        public bool isRowAt(int y)
-        {
-            return wrapVertically || ((y >= 0) && (y < numTilesTall));
-        }
+			for (int i = 0; i < numTilesWide * numTilesTall / 2; i++) {
+				int x, y;
+				tileIndexToCoords(i, out x, out y);
+				int ri = tileCoordsToIndex(x, y);
+				if (ri != i)
+					throw new Exception(String.Format("Error computing tile index/coords: {0} -> ({1}, {2}) -> {3}", i, x, y, ri));
+			}
+		}
 
-        public bool isTileAt(int x, int y)
-        {
-            bool evenRow = y%2 == 0;
-            bool xInBounds; {
-                if (wrapHorizontally)
-                    xInBounds = true;
-                else if (evenRow)
-                    xInBounds = (x >= 0) && (x <= numTilesWide - 2);
-                else
-                    xInBounds = (x >= 1) && (x <= numTilesWide - 1);
-            }
-            return xInBounds && isRowAt(y) && (evenRow ? (x%2 == 0) : (x%2 != 0));
-        }
+		public bool isRowAt(int y)
+		{
+			return wrapVertically || ((y >= 0) && (y < numTilesTall));
+		}
 
-        public int wrapTileX(int x)
-        {
-            if (wrapHorizontally) {
-                int tr = x % numTilesWide;
-                return (tr >= 0) ? tr : tr + numTilesWide;
-            } else
-                return x;
-        }
+		public bool isTileAt(int x, int y)
+		{
+			bool evenRow = y%2 == 0;
+			bool xInBounds; {
+				if (wrapHorizontally)
+					xInBounds = true;
+				else if (evenRow)
+					xInBounds = (x >= 0) && (x <= numTilesWide - 2);
+				else
+					xInBounds = (x >= 1) && (x <= numTilesWide - 1);
+			}
+			return xInBounds && isRowAt(y) && (evenRow ? (x%2 == 0) : (x%2 != 0));
+		}
 
-        public int wrapTileY(int y)
-        {
-            if (wrapVertically) {
-                int tr = y % numTilesTall;
-                return (tr >= 0) ? tr : tr + numTilesTall;
-            } else
-                return y;
-        }
+		public int wrapTileX(int x)
+		{
+			if (wrapHorizontally) {
+				int tr = x % numTilesWide;
+				return (tr >= 0) ? tr : tr + numTilesWide;
+			} else
+				return x;
+		}
 
-        public Tile tileAt(int x, int y)
-        {
-            if (isTileAt(x, y))
-                return tiles[tileCoordsToIndex(wrapTileX(x), wrapTileY(y))];
-            else
-                return Tile.NONE; // TODO: Consider using empty tile object instead of null
-        }
+		public int wrapTileY(int y)
+		{
+			if (wrapVertically) {
+				int tr = y % numTilesTall;
+				return (tr >= 0) ? tr : tr + numTilesTall;
+			} else
+				return y;
+		}
 
-        /**
-         * Returns the Tile that neighbors the given Tile in a certain direction,
-         * or the NONE tile if there is no neighbor in said direction.
-         **/
-        public Tile tileNeighbor(Tile center, TileDirection direction) {
-            int x = center.xCoordinate;
-            int y = center.yCoordinate;
-            switch (direction) {
-                case TileDirection.NORTH:
-                    y-=2;
-                    break;
-                case TileDirection.NORTHEAST:
-                    y--;
-                    x++;
-                    break;
-                case TileDirection.EAST:
-                    x+=2;
-                    break;
-                case TileDirection.SOUTHEAST:
-                    y++;
-                    x++;
-                    break;
-                case TileDirection.SOUTH:
-                    y+=2;
-                    break;
-                case TileDirection.SOUTHWEST:
-                    y++;
-                    x--;
-                    break;
-                case TileDirection.WEST:
-                    x-=2;
-                    break;
-                case TileDirection.NORTHWEST:
-                    x--;
-                    y--;
-                    break;
-            }
-            //TODO: World wrap should also be accounted for.
-            return tileAt(x, y);
-        }
+		public Tile tileAt(int x, int y)
+		{
+			if (isTileAt(x, y))
+				return tiles[tileCoordsToIndex(wrapTileX(x), wrapTileY(y))];
+			else
+				return Tile.NONE;
+		}
 
-        public delegate int[,] TerrainNoiseMapGenerator(int rng, int width, int height);
+		/**
+		 * Returns the Tile that neighbors the given Tile in a certain direction,
+		 * or the NONE tile if there is no neighbor in said direction.
+		 **/
+		public Tile tileNeighbor(Tile center, TileDirection direction) {
+			int x = center.xCoordinate;
+			int y = center.yCoordinate;
+			switch (direction) {
+				case TileDirection.NORTH:
+					y-=2;
+					break;
+				case TileDirection.NORTHEAST:
+					y--;
+					x++;
+					break;
+				case TileDirection.EAST:
+					x+=2;
+					break;
+				case TileDirection.SOUTHEAST:
+					y++;
+					x++;
+					break;
+				case TileDirection.SOUTH:
+					y+=2;
+					break;
+				case TileDirection.SOUTHWEST:
+					y++;
+					x--;
+					break;
+				case TileDirection.WEST:
+					x-=2;
+					break;
+				case TileDirection.NORTHWEST:
+					x--;
+					y--;
+					break;
+			}
+			//TODO: World wrap should also be accounted for.
+			return tileAt(x, y);
+		}
 
-        public List<Tile> generateStartingLocations(Random rng, int num, int minDistBetween)
-        {
-            var tr = new List<Tile>();
-            for (int n = 0; n < num; n++) {
-                bool foundOne = false;
-                for (int numTries = 0; (! foundOne) && (numTries < 100); numTries++) {
-                    var randTile = tiles[rng.Next(0, tiles.Count)];
-                    if (randTile.baseTerrainType.isWater())
-                        continue;
-                    int distToNearestOtherLoc = Int32.MaxValue;
-                    foreach (var sL in tr) {
-                        // TODO: This distance calculation is just a placeholder. Eventually we'll need to write an proper
-                        // function to find the distance between two tiles. This placeholder is not even very accurate, e.g. it
-                        // would say that a tile and its east neighbor are at distance 2.
-                        int dist = Math.Abs(sL.xCoordinate - randTile.xCoordinate) + Math.Abs(sL.yCoordinate - randTile.yCoordinate);
-                        if (dist < distToNearestOtherLoc)
-                            distToNearestOtherLoc = dist;
-                    }
-                    if (distToNearestOtherLoc >= minDistBetween) {
-                        tr.Add(randTile);
-                        foundOne = true;
-                    }
-                }
-            }
-            return tr;
-        }
+		public delegate int[,] TerrainNoiseMapGenerator(int rng, int width, int height);
 
-        /**
-         * Temporary method to generate a map. Right now it uses the basic generator passed in all the way from the UI but eventually we'll want to
-         * implement a more sophisticated generator in the engine.
-         **/
-         // TerrainType declarations here have been copied to ImportCiv3, and all loaded terrain is set with one of them
-         [Obsolete]
-        public static GameMap generateDummyGameMap(Random rng, TerrainNoiseMapGenerator terrainGen)
-        {
-            TerrainType grassland = new TerrainType();
-            grassland.DisplayName = "Grassland";
-            grassland.baseFoodProduction = 2;
-            grassland.baseShieldProduction = 1; //with only one terrain type, it needs to be > 0
-            grassland.baseCommerceProduction = 1;   //same as above
-            grassland.movementCost = 1;
+		public List<Tile> generateStartingLocations(Random rng, int num, int minDistBetween)
+		{
+			var tr = new List<Tile>();
+			for (int n = 0; n < num; n++) {
+				bool foundOne = false;
+				for (int numTries = 0; (! foundOne) && (numTries < 100); numTries++) {
+					var randTile = tiles[rng.Next(0, tiles.Count)];
+					if (randTile.baseTerrainType.isWater())
+						continue;
+					int distToNearestOtherLoc = Int32.MaxValue;
+					foreach (var sL in tr) {
+						// TODO: This distance calculation is just a placeholder. Eventually we'll need to write an proper
+						// function to find the distance between two tiles. This placeholder is not even very accurate, e.g. it
+						// would say that a tile and its east neighbor are at distance 2.
+						int dist = Math.Abs(sL.xCoordinate - randTile.xCoordinate) + Math.Abs(sL.yCoordinate - randTile.yCoordinate);
+						if (dist < distToNearestOtherLoc)
+							distToNearestOtherLoc = dist;
+					}
+					if (distToNearestOtherLoc >= minDistBetween) {
+						tr.Add(randTile);
+						foundOne = true;
+					}
+				}
+			}
+			return tr;
+		}
 
-            TerrainType plains = new TerrainType();
-            plains.DisplayName = "Plains";
-            plains.baseFoodProduction = 1;
-            plains.baseShieldProduction = 2;
-            plains.baseCommerceProduction = 1;
-            plains.movementCost = 1;
+		/**
+		 * Temporary method to generate a map. Right now it uses the basic generator passed in all the way from the UI but eventually we'll want to
+		 * implement a more sophisticated generator in the engine.
+		 **/
+		// TerrainType declarations here have been copied to ImportCiv3, and all loaded terrain is set with one of them
+		[Obsolete]
+		public static GameMap generateDummyGameMap(Random rng, TerrainNoiseMapGenerator terrainGen)
+		{
+			TerrainType grassland = new TerrainType();
+			grassland.DisplayName = "Grassland";
+			grassland.baseFoodProduction = 2;
+			grassland.baseShieldProduction = 1; //with only one terrain type, it needs to be > 0
+			grassland.baseCommerceProduction = 1;   //same as above
+			grassland.movementCost = 1;
 
-            TerrainType coast = new TerrainType();
-            coast.DisplayName = "Coast";
-            coast.baseFoodProduction = 2;
-            coast.baseShieldProduction = 0;
-            coast.baseCommerceProduction = 1;
-            coast.movementCost = 1;
+			TerrainType plains = new TerrainType();
+			plains.DisplayName = "Plains";
+			plains.baseFoodProduction = 1;
+			plains.baseShieldProduction = 2;
+			plains.baseCommerceProduction = 1;
+			plains.movementCost = 1;
 
-            GameMap dummyMap = new GameMap();
-            dummyMap.numTilesTall = 80;
-            dummyMap.numTilesWide = 80;
+			TerrainType coast = new TerrainType();
+			coast.DisplayName = "Coast";
+			coast.baseFoodProduction = 2;
+			coast.baseShieldProduction = 0;
+			coast.baseCommerceProduction = 1;
+			coast.movementCost = 1;
+
+			GameMap dummyMap = new GameMap();
+			dummyMap.numTilesTall = 80;
+			dummyMap.numTilesWide = 80;
 
 			// NOTE: The order of terrain types in this array must match the indices produced by terrainGen
 			dummyMap.terrainTypes.Add(plains);
@@ -236,98 +246,98 @@ namespace C7GameData
 			return dummyMap;
 		}
 
-        // STATUS 2021-11-26: This noise function is not currently referenced, but it is a very useful
-        //  noisemap generator that we will likely use in the future once we start trying
-        //  to generate a full-featured map.
-        // Inputs: noise field width and height, bool whether noise should smoothly wrap X or Y
-        // Actual fake-isometric map will have different shape, but for noise we'll go straight 2d matrix
-        // NOTE: Apparently this OpenSimplex implementation doesn't do octaves, including persistance or lacunarity
-        //  Might be able to implement them, use https://www.youtube.com/watch?v=MRNFcywkUSA&list=PLFt_AvWsXl0eBW2EiBtl_sxmDtSgZBxB3&index=4 as reference
-        // TODO: Parameterize octaves, persistence, scale/period; compare this generator to Godot's
-        // NOTE: Godot's OpenSimplexNoise returns -1 to 1; this one seems to be from 0 to 1 like most Simplex/Perlin implementations
-        public static double[,] tempMapGenPrototyping(int width, int height, bool wrapX = true, bool wrapY = false)
-        {
-            // TODO: I think my octaves implementation is broken; specifically it needs normalizing I think as additional octaves drive more extreme values
-            int octaves = 1;
-            double persistence = 0.5;
-            // The public domain OpenSiplex implementation always
-            //   seems to be 0 at 0,0, so let's offset from it.
-            double originOffset = 1000;
-            double scale = 0.03;
-            double xRadius = (double)width / (System.Math.PI * 2);
-            double yRadius = (double)height / (System.Math.PI * 2);
-            OpenSimplexNoise noise = new OpenSimplexNoise();
-            double[,] noiseField = new double[width, height];
+		// STATUS 2021-11-26: This noise function is not currently referenced, but it is a very useful
+		//  noisemap generator that we will likely use in the future once we start trying
+		//  to generate a full-featured map.
+		// Inputs: noise field width and height, bool whether noise should smoothly wrap X or Y
+		// Actual fake-isometric map will have different shape, but for noise we'll go straight 2d matrix
+		// NOTE: Apparently this OpenSimplex implementation doesn't do octaves, including persistance or lacunarity
+		//  Might be able to implement them, use https://www.youtube.com/watch?v=MRNFcywkUSA&list=PLFt_AvWsXl0eBW2EiBtl_sxmDtSgZBxB3&index=4 as reference
+		// TODO: Parameterize octaves, persistence, scale/period; compare this generator to Godot's
+		// NOTE: Godot's OpenSimplexNoise returns -1 to 1; this one seems to be from 0 to 1 like most Simplex/Perlin implementations
+		public static double[,] tempMapGenPrototyping(int width, int height, bool wrapX = true, bool wrapY = false)
+		{
+			// TODO: I think my octaves implementation is broken; specifically it needs normalizing I think as additional octaves drive more extreme values
+			int octaves = 1;
+			double persistence = 0.5;
+			// The public domain OpenSiplex implementation always
+			//   seems to be 0 at 0,0, so let's offset from it.
+			double originOffset = 1000;
+			double scale = 0.03;
+			double xRadius = (double)width / (System.Math.PI * 2);
+			double yRadius = (double)height / (System.Math.PI * 2);
+			OpenSimplexNoise noise = new OpenSimplexNoise();
+			double[,] noiseField = new double[width, height];
 
-            for (int x=0; x < width; x++)
-            {
-                double oX = originOffset + (scale * x);
-                // Set up cX,cY to make one circle as a function of x
-                double theta = ((double)x / (double)width) * (System.Math.PI * 2);
-                double cX = originOffset + (scale * xRadius * System.Math.Sin(theta));
-                double cY = originOffset + (scale * xRadius * System.Math.Cos(theta));
-                for (int y=0; y < height; y++)
-                {
-                    double oY = originOffset + (scale * y);
-                    // Set up ycX,ycY to make one circle as a function of y
-                    double yTheta = ((double)y / (double)height) * (System.Math.PI * 2);
-                    double ycX = originOffset + (scale * yRadius * System.Math.Sin(yTheta));
-                    double ycY = originOffset + (scale * yRadius * System.Math.Cos(yTheta));
+			for (int x=0; x < width; x++)
+			{
+				double oX = originOffset + (scale * x);
+				// Set up cX,cY to make one circle as a function of x
+				double theta = ((double)x / (double)width) * (System.Math.PI * 2);
+				double cX = originOffset + (scale * xRadius * System.Math.Sin(theta));
+				double cY = originOffset + (scale * xRadius * System.Math.Cos(theta));
+				for (int y=0; y < height; y++)
+				{
+					double oY = originOffset + (scale * y);
+					// Set up ycX,ycY to make one circle as a function of y
+					double yTheta = ((double)y / (double)height) * (System.Math.PI * 2);
+					double ycX = originOffset + (scale * yRadius * System.Math.Sin(yTheta));
+					double ycY = originOffset + (scale * yRadius * System.Math.Cos(yTheta));
 
-                    // No wrapping, just yoink values at scaled coordinates
-                    if (!(wrapX || wrapY))
-                    {
-                        // noiseField[x,y] = noise.Evaluate(oX, oY);
-                        for (int i=0;i<octaves;i++)
-                        {
-                            double offset = i * 1.5 * System.Math.Max(width, height) * scale;
-                            noiseField[x,y] += (octaves - i) * persistence * noise.Evaluate(oX + offset, oY + offset);
-                        }
-                        continue;
-                    }
-                    // Bi-axis wrapping requires two extra dimensions and circling through each
-                    if (wrapX && wrapY)
-                    {
-                        for (int i=0;i<octaves;i++)
-                        {
-                            double offset = i * 1.5 * System.Math.Max(width, height) * scale;
-                            double a = cX + offset;
-                            double b = cY + offset;
-                            double c = ycX + offset;
-                            double d = ycY + offset;
-                            noiseField[x,y] += (octaves - i) * persistence * noise.Evaluate(a, b, c, d);
-                        }
-                        // Skip the below tests, go to next loop iteration
-                        continue;
-                    }
-                    // Y wrapping as Y increments it instead traces a circle in a third dimension to match up its ends
-                    if (wrapY)
-                    {
-                        for (int i=0;i<octaves;i++)
-                        {
-                            double offset = i * 1.5 * System.Math.Max(width, height) * scale;
-                            double a = ycX + offset;
-                            double b = ycY + offset;
-                            double c = oX + offset;
-                            noiseField[x,y] += (octaves - i) * persistence * noise.Evaluate(a, b, c);
-                        }
-                        continue;
-                    }
-                    // Similar to Y wrapping
-                    if (wrapX)
-                    {
-                        for (int i=0;i<octaves;i++)
-                        {
-                            double offset = i * 1.5 * System.Math.Max(width, height) * scale;
-                            double a = cX + offset;
-                            double b = cY + offset;
-                            double c = oY + offset;
-                            noiseField[x,y] += (octaves - i) * persistence * noise.Evaluate(a, b, c);
-                        }
-                    }
-                }
-            }
-            return noiseField;
-        }
-    }
+					// No wrapping, just yoink values at scaled coordinates
+					if (!(wrapX || wrapY))
+					{
+						// noiseField[x,y] = noise.Evaluate(oX, oY);
+						for (int i=0;i<octaves;i++)
+						{
+							double offset = i * 1.5 * System.Math.Max(width, height) * scale;
+							noiseField[x,y] += (octaves - i) * persistence * noise.Evaluate(oX + offset, oY + offset);
+						}
+						continue;
+					}
+					// Bi-axis wrapping requires two extra dimensions and circling through each
+					if (wrapX && wrapY)
+					{
+						for (int i=0;i<octaves;i++)
+						{
+							double offset = i * 1.5 * System.Math.Max(width, height) * scale;
+							double a = cX + offset;
+							double b = cY + offset;
+							double c = ycX + offset;
+							double d = ycY + offset;
+							noiseField[x,y] += (octaves - i) * persistence * noise.Evaluate(a, b, c, d);
+						}
+						// Skip the below tests, go to next loop iteration
+						continue;
+					}
+					// Y wrapping as Y increments it instead traces a circle in a third dimension to match up its ends
+					if (wrapY)
+					{
+						for (int i=0;i<octaves;i++)
+						{
+							double offset = i * 1.5 * System.Math.Max(width, height) * scale;
+							double a = ycX + offset;
+							double b = ycY + offset;
+							double c = oX + offset;
+							noiseField[x,y] += (octaves - i) * persistence * noise.Evaluate(a, b, c);
+						}
+						continue;
+					}
+					// Similar to Y wrapping
+					if (wrapX)
+					{
+						for (int i=0;i<octaves;i++)
+						{
+							double offset = i * 1.5 * System.Math.Max(width, height) * scale;
+							double a = cX + offset;
+							double b = cY + offset;
+							double c = oY + offset;
+							noiseField[x,y] += (octaves - i) * persistence * noise.Evaluate(a, b, c);
+						}
+					}
+				}
+			}
+			return noiseField;
+		}
+	}
 }

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -52,6 +52,14 @@ namespace C7GameData
 			unitsOnTile = new List<MapUnit>();
 		}
 
+		// TODO: this should be either an extension in C7Engine, or otherwise
+		// calculated somewhere else, but it's not obvious to someone unfamiliar
+		// with the save format that it's the overaly terrain that has actual
+		// movement cost
+		public int MovementCost() {
+			return overlayTerrainType.movementCost;
+		}
+
 		public MapUnit findTopDefender(MapUnit opponent)
 		{
 			if (unitsOnTile.Count > 0) {
@@ -63,8 +71,11 @@ namespace C7GameData
 			} else
 				return MapUnit.NONE;
 		}
-		
-		public static Tile NONE = new Tile();
+
+		public static Tile NONE = new Tile() {
+			xCoordinate = -1,
+			yCoordinate = -1,
+		};
 
 		//This should be used when we want to check if land tiles are next to water tiles.
 		//Usually this is coast, but it could be Sea - see the "Deepwater Harbours" topics at CFC.
@@ -90,7 +101,7 @@ namespace C7GameData
 		}
 
 		public List<Tile> GetLandNeighbors() {
-			return neighbors.Values.Where(tile => !tile.baseTerrainType.isWater()).ToList();
+			return neighbors.Values.Where(tile => tile != NONE && !tile.baseTerrainType.isWater()).ToList();
 		}
 
 		/**

--- a/C7GameDataTests/C7GameDataTests.csproj
+++ b/C7GameDataTests/C7GameDataTests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <Nullable>enable</Nullable>
+        <TargetFramework>net472</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/EngineTests/AI/Pathing/BFSLandAlgorithmTest.cs
+++ b/EngineTests/AI/Pathing/BFSLandAlgorithmTest.cs
@@ -23,7 +23,7 @@ namespace EngineTests
 			predecessors[tileFour] = tileThree;
 			predecessors[tileThree] = tileTwo;
 			predecessors[tileTwo] = start;
-			TilePath path = BFSLandAlgorithm.ConstructPath(destination, predecessors);
+			TilePath path = new BFSLandAlgorithm().ConstructPath(destination, predecessors);
 
 			Assert.Equal(tileTwo, path.Next());
 			Assert.Equal(tileThree, path.Next());

--- a/EngineTests/AI/Pathing/DijkstrasLandAlgorithmTest.cs
+++ b/EngineTests/AI/Pathing/DijkstrasLandAlgorithmTest.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using C7Engine.Pathing;
+using C7GameData;
+using Xunit;
+
+namespace EngineTests {
+
+	public class DijkstrasLandAlgorithmTest {
+
+	}
+}


### PR DESCRIPTION
With this implementation, the weight of each edge is calculated with the newly added `Tile.MovementCost` function:
```
public int MovementCost() {
	return overlayTerrainType.movementCost;
}
```
This method probably doesn't belong in C7GameData, and in the future Dijkstra's will need to consider other factors such as units blocking the path, cities, and [roads](https://github.com/C7-Game/Prototype/issues/191). Furthermore, this implementation does not consider that units can always use their remaining movement point to move onto any tile, so sometimes units will take a suboptimal path.

The implementation also returns the path as soon as the destination tile has been visited, however in the future when multiple units are either pathing from the same starting tile, or one unit is attempting to discover a subpath to the same destination, it may be better to compute the shortest path to all tiles once and re-use the result for multiple units.