### PR TITLE
Refactor GUID

### DIFF
--- a/C7/AnimationTracker.cs
+++ b/C7/AnimationTracker.cs
@@ -57,7 +57,7 @@ public class AnimationTracker {
 
 	public void startAnimation(MapUnit unit, MapUnit.AnimatedAction action, AutoResetEvent completionEvent, AnimationEnding ending)
 	{
-		startAnimation(unit.guid, civ3AnimData.forUnit(unit.unitType.name, action), completionEvent, ending);
+		startAnimation(unit.guid.ToString(), civ3AnimData.forUnit(unit.unitType.name, action), completionEvent, ending);
 	}
 
 	public void startAnimation(Tile tile, AnimatedEffect effect, AutoResetEvent completionEvent, AnimationEnding ending)
@@ -68,16 +68,16 @@ public class AnimationTracker {
 	public void endAnimation(MapUnit unit)
 	{
 		ActiveAnimation aa;
-		if (activeAnims.TryGetValue(unit.guid, out aa)) {
+		if (activeAnims.TryGetValue(unit.guid.ToString(), out aa)) {
 			if (aa.completionEvent != null)
 				aa.completionEvent.Set();
-			activeAnims.Remove(unit.guid);
+			activeAnims.Remove(unit.guid.ToString());
 		}
 	}
 
 	public bool hasCurrentAction(MapUnit unit)
 	{
-		return activeAnims.ContainsKey(unit.guid);
+		return activeAnims.ContainsKey(unit.guid.ToString());
 	}
 
 	public (MapUnit.AnimatedAction, float) getCurrentActionAndProgress(string id)
@@ -99,7 +99,7 @@ public class AnimationTracker {
 
 	public (MapUnit.AnimatedAction, float) getCurrentActionAndProgress(MapUnit unit)
 	{
-		return getCurrentActionAndProgress(unit.guid);
+		return getCurrentActionAndProgress(unit.guid.ToString());
 	}
 
 	public (MapUnit.AnimatedAction, float) getCurrentActionAndProgress(Tile tile)

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Godot;
 using C7GameData;
@@ -113,7 +114,7 @@ public class RightClickTileMenu : RightClickMenu
 		ResetItems(tile);
 	}
 
-	private bool isUnitFortified(MapUnit unit, Dictionary<string, bool> uiStates) {
+	private bool isUnitFortified(MapUnit unit, Dictionary<Guid, bool> uiStates) {
 		if (uiStates is null || !uiStates.ContainsKey(unit.guid)) {
 			return unit.isFortified;
 		}
@@ -131,7 +132,7 @@ public class RightClickTileMenu : RightClickMenu
 	// and false if they were selected in the previous action. This is to update the UI
 	// since the actions update the engine asynchronously and otherwise the UI may not
 	// reflect these changes immediately.
-	public void ResetItems(Tile tile, Dictionary<string, bool> uiUpdatedUnitStates = null) {
+	public void ResetItems(Tile tile, Dictionary<Guid, bool> uiUpdatedUnitStates = null) {
 		RemoveAll();
 
 		int fortifiedCount = 0;
@@ -154,13 +155,13 @@ public class RightClickTileMenu : RightClickMenu
 		}
 	}
 
-	public void SelectUnit(string guid) {
+	public void SelectUnit(Guid guid) {
 		using (var gameDataAccess = new UIGameDataAccess()) {
 			MapUnit toSelect = gameDataAccess.gameData.mapUnits.Find(u => u.guid == guid);
 			if (toSelect != null && toSelect.owner == game.controller) {
 				game.setSelectedUnit(toSelect);
 				new MsgSetFortification(toSelect.guid, false).send();
-				ResetItems(toSelect.location, new Dictionary<string, bool>() {{toSelect.guid, false}});
+				ResetItems(toSelect.location, new Dictionary<Guid, bool>() {{toSelect.guid, false}});
 			}
 		}
 		if (!Input.IsKeyPressed((int)KeyList.Shift)) {
@@ -172,7 +173,7 @@ public class RightClickTileMenu : RightClickMenu
 		using (var gameDataAccess = new UIGameDataAccess()) {
 			bool hasSelectedUnit = false;
 			Tile tile = gameDataAccess.gameData.map.tileAt(tileX, tileY);
-			Dictionary<string, bool> modified = new Dictionary<string, bool>();
+			Dictionary<Guid, bool> modified = new Dictionary<Guid, bool>();
 			foreach (MapUnit unit in tile.unitsOnTile) {
 				if (unit.isFortified != isFortify) {
 					modified[unit.guid] = isFortify;
@@ -194,7 +195,7 @@ public class RightClickTileMenu : RightClickMenu
 
 public class RightClickChooseProductionMenu : RightClickMenu
 {
-	private string cityGUID;
+	private Guid cityGUID;
 
 	private ImageTexture GetProducibleIcon(IProducible producible)
 	{

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -1,13 +1,14 @@
 namespace C7Engine
 {
+	using System;
 	using C7GameData;
 
 	public class CityInteractions
 	{
-		public static void BuildCity(int x, int y, string playerGuid, string name)
+		public static void BuildCity(int x, int y, Guid playerGuid, string name)
 		{
 			GameData gameData = EngineStorage.gameData;
-			Player owner = gameData.players.Find(player => player.guid == playerGuid);
+			Player owner = gameData.GetPlayer(playerGuid);
 			Tile tileWithNewCity = gameData.map.tileAt(x, y);
 			City newCity = new City(tileWithNewCity, owner, name);
 			newCity.SetItemBeingProduced(gameData.unitPrototypes["Warrior"]);

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -22,10 +22,10 @@ namespace C7Engine
 
 	public class MsgSetFortification : MessageToEngine
 	{
-		private string unitGUID;
+		private Guid unitGUID;
 		private bool fortifyElseWake;
 
-		public MsgSetFortification(string unitGUID, bool fortifyElseWake)
+		public MsgSetFortification(Guid unitGUID, bool fortifyElseWake)
 		{
 			this.unitGUID = unitGUID;
 			this.fortifyElseWake = fortifyElseWake;
@@ -48,10 +48,10 @@ namespace C7Engine
 
 	public class MsgMoveUnit : MessageToEngine
 	{
-		private string unitGUID;
+		private Guid unitGUID;
 		private TileDirection dir;
 
-		public MsgMoveUnit(string unitGUID, TileDirection dir)
+		public MsgMoveUnit(Guid unitGUID, TileDirection dir)
 		{
 			this.unitGUID = unitGUID;
 			this.dir = dir;
@@ -66,11 +66,11 @@ namespace C7Engine
 
 	public class MsgSetUnitPath : MessageToEngine
 	{
-		private string unitGUID;
+		private Guid unitGUID;
 		private int destX;
 		private int destY;
 
-		public MsgSetUnitPath(string unitGUID, Tile tile)
+		public MsgSetUnitPath(Guid unitGUID, Tile tile)
 		{
 			this.unitGUID = unitGUID;
 			this.destX = tile.xCoordinate;
@@ -86,9 +86,9 @@ namespace C7Engine
 
 	public class MsgSkipUnitTurn : MessageToEngine
 	{
-		private string unitGUID;
+		private Guid unitGUID;
 
-		public MsgSkipUnitTurn(string unitGUID)
+		public MsgSkipUnitTurn(Guid unitGUID)
 		{
 			this.unitGUID = unitGUID;
 		}
@@ -101,9 +101,9 @@ namespace C7Engine
 	}
 
 	public class MsgDisbandUnit : MessageToEngine {
-		private string unitGUID;
+		private Guid unitGUID;
 
-		public MsgDisbandUnit(string unitGUID)
+		public MsgDisbandUnit(Guid unitGUID)
 		{
 			this.unitGUID = unitGUID;
 		}
@@ -116,10 +116,10 @@ namespace C7Engine
 	}
 
 	public class MsgBuildCity : MessageToEngine {
-		private string unitGUID;
+		private Guid unitGUID;
 		private string cityName;
 
-		public MsgBuildCity(string unitGUID, string cityName)
+		public MsgBuildCity(Guid unitGUID, string cityName)
 		{
 			this.unitGUID = unitGUID;
 			this.cityName = cityName;
@@ -133,10 +133,10 @@ namespace C7Engine
 	}
 
 	public class MsgChooseProduction : MessageToEngine {
-		private string cityGUID;
+		private Guid cityGUID;
 		private string producibleName;
 
-		public MsgChooseProduction(string cityGUID, string producibleName)
+		public MsgChooseProduction(Guid cityGUID, string producibleName)
 		{
 			this.cityGUID = cityGUID;
 			this.producibleName = producibleName;
@@ -144,7 +144,7 @@ namespace C7Engine
 
 		public override void process()
 		{
-			City city = EngineStorage.gameData.cities.Find(c => c.guid == cityGUID);
+			City city = EngineStorage.gameData.GetCity(cityGUID);
 			if (city != null) {
 				foreach (IProducible producible in city.ListProductionOptions()) {
 					if (producible.name == producibleName) {

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -1,5 +1,6 @@
 namespace C7Engine
 {
+	using System;
 	using System.Threading;
 	using C7GameData;
 
@@ -11,7 +12,7 @@ namespace C7Engine
 	}
 
 	public class MsgStartUnitAnimation : MessageToUI {
-		public string unitGUID;
+		public Guid unitGUID;
 		public MapUnit.AnimatedAction action;
 		public AutoResetEvent completionEvent;
 		public AnimationEnding ending;

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -82,12 +82,9 @@ namespace C7Engine
 			waitQueue.Clear();
 		}
 
-		public static void waitUnit(GameData gameData, string guid)
-		{
-			foreach (MapUnit unit in gameData.mapUnits)
-			{
-				if (unit.guid == guid)
-				{
+		public static void waitUnit(GameData gameData, Guid guid) {
+			foreach (MapUnit unit in gameData.mapUnits) {
+				if (unit.guid == guid) {
 					Console.WriteLine("Found matching unit with guid " + guid + " of type " + unit.GetType().Name + "; adding it to the wait queue");
 					waitQueue.Enqueue(unit);
 				}

--- a/C7GameData/City.cs
+++ b/C7GameData/City.cs
@@ -1,9 +1,9 @@
 namespace C7GameData
 {
     using System;
-    public class City
+
+    public class City : Unique
     {
-        public string guid {get;}
         public Tile location {get;}
         public string name;
         public int size = 1;
@@ -23,7 +23,6 @@ namespace C7GameData
 
         public City(Tile location, Player owner, string name)
         {
-            guid = Guid.NewGuid().ToString();
             this.location = location;
             this.owner = owner;
             this.name = name;
@@ -93,6 +92,6 @@ namespace C7GameData
 
             return null;
         }
-        
+
     }
 }

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -20,13 +20,20 @@ namespace C7GameData
 			rng = new Random();
 		}
 
+		public Player GetPlayer(Guid guid) {
+			return players.Find(p => p.guid == guid);
+		}
+
 		public List<Player> GetHumanPlayers() {
 			return players.FindAll(p => p.isHuman);
 		}
 
-		public MapUnit GetUnit(string guid)
-		{
+		public MapUnit GetUnit(Guid guid) {
 			return mapUnits.Find(u => u.guid == guid);
+		}
+
+		public City GetCity(Guid guid) {
+			return cities.Find(c => c.guid == guid);
 		}
 
 		/**

--- a/C7GameData/MapUnit.cs
+++ b/C7GameData/MapUnit.cs
@@ -9,9 +9,8 @@ using System.Collections.Generic;
 /**
  * A unit on the map.  Not to be confused with a unit prototype.
  **/
-public class MapUnit
+public class MapUnit : Unique
 {
-	public string guid  {get;}
 	public UnitPrototype unitType {get; set;}
 	public Player owner {get; set;}
 	public Tile location {get; set;}
@@ -34,11 +33,6 @@ public class MapUnit
 	public List<string> availableActions = new List<string>();
 	public UnitAIData currentAIData;
 
-	public MapUnit()
-	{
-		guid = Guid.NewGuid().ToString();
-	}
-
 	public bool IsBusy() {
 		return isFortified || (path != null && path.PathLength() > 0);
 	}
@@ -46,7 +40,7 @@ public class MapUnit
 	public override string ToString()
 	{
 		if (this != MapUnit.NONE) {
-			return unitType.name + " with " + movementPointsRemaining + " movement points and " + hitPointsRemaining + " hit points, guid = " + guid;
+			return $"{unitType.name} with {movementPointsRemaining} movement points and {hitPointsRemaining} hit points, guid = {guid}";
 		}
 		else {
 			return "This is the NONE unit";

--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -2,71 +2,64 @@ using System.Collections.Generic;
 
 namespace C7GameData
 {
-using System;
-
-public class Player
-{
-	public string guid { get; set; }
-	public int color { get; set; }
-	public bool isBarbarians = false;
-	//TODO: Refactor front-end so it sends player GUID with requests.
-	//We should allow multiple humans, this is a temporary measure.
-	public bool isHuman = false;
-	public bool hasPlayedThisTurn = false;
-
-	public Civilization civilization;
-	private int cityNameIndex = 0;
-	
-	public List<MapUnit> units = new List<MapUnit>();
-	public List<City> cities = new List<City>();
-	public TileKnowledge tileKnowledge = new TileKnowledge();
-
-	public Player(uint color)
+	public class Player : Unique
 	{
-		guid = Guid.NewGuid().ToString();
-		this.color = (int)(color & 0xFFFFFFFF);
-	}
+		public int color { get; set; }
+		public bool isBarbarians = false;
+		//TODO: Refactor front-end so it sends player GUID with requests.
+		//We should allow multiple humans, this is a temporary measure.
+		public bool isHuman = false;
 
-	public Player(Civilization civilization, uint color)
-	{
-		this.civilization = civilization;
-		guid = Guid.NewGuid().ToString();
-		this.color = (int)(color & 0xFFFFFFFF);
-	}
+		public Civilization civilization;
+		private int cityNameIndex = 0;
 
-	public void AddUnit(MapUnit unit)
-	{
-		this.units.Add(unit);
-	}
+		public List<MapUnit> units = new List<MapUnit>();
+		public List<City> cities = new List<City>();
+		public TileKnowledge tileKnowledge = new TileKnowledge();
 
-	public string GetNextCityName()
-	{
-		string name = civilization.cityNames[cityNameIndex % civilization.cityNames.Count];
-		int bonusLoops = cityNameIndex / civilization.cityNames.Count;
-		if (bonusLoops % 2 == 1) {
-			name = "New " + name;
+		public Player(uint color)
+		{
+			this.color = (int)(color & 0xFFFFFFFF);
 		}
-		int suffix = (bonusLoops / 2) + 1;
-		if (suffix > 1) {
-			name = name + " " + suffix; //e.g. for bonusLoops = 2, we'll have "Athens 2"
+
+		public Player(Civilization civilization, uint color)
+		{
+			this.civilization = civilization;
+			this.color = (int)(color & 0xFFFFFFFF);
 		}
-		cityNameIndex++;
-		return name;
+
+		public void AddUnit(MapUnit unit)
+		{
+			this.units.Add(unit);
+		}
+
+		public string GetNextCityName()
+		{
+			string name = civilization.cityNames[cityNameIndex % civilization.cityNames.Count];
+			int bonusLoops = cityNameIndex / civilization.cityNames.Count;
+			if (bonusLoops % 2 == 1) {
+				name = "New " + name;
+			}
+			int suffix = (bonusLoops / 2) + 1;
+			if (suffix > 1) {
+				name = name + " " + suffix; //e.g. for bonusLoops = 2, we'll have "Athens 2"
+			}
+			cityNameIndex++;
+			return name;
+		}
+
+		public Player(){}
+
+		public bool IsAtPeaceWith(Player other)
+		{
+			// Right now it's a free-for-all but eventually we'll implement peace treaties and alliances
+			return other == this;
+		}
+
+		public bool SitsOutFirstTurn()
+		{
+			// TODO: Scenarios can also specify that certain players sit out the first turn. E.g. WW2 in the Pacific
+			return isBarbarians;
+		}
 	}
-
-	public Player(){}
-
-	public bool IsAtPeaceWith(Player other)
-	{
-		// Right now it's a free-for-all but eventually we'll implement peace treaties and alliances
-		return other == this;
-	}
-
-	public bool SitsOutFirstTurn()
-	{
-		// TODO: Scenarios can also specify that certain players sit out the first turn. E.g. WW2 in the Pacific
-		return isBarbarians;
-	}
-}
-
 }

--- a/C7GameData/Unique.cs
+++ b/C7GameData/Unique.cs
@@ -1,0 +1,7 @@
+namespace C7GameData {
+	using System;
+
+	public class Unique {
+		public Guid guid {get;} = Guid.NewGuid();
+	}
+}

--- a/ConvertCiv3Media/Civ3UnitSprite.cs
+++ b/ConvertCiv3Media/Civ3UnitSprite.cs
@@ -7,7 +7,7 @@ using IniParser.Model;
 namespace ConvertCiv3Media
 {
     // Under construction
-    
+
     // The order of direction animations in unit FLC files
     public enum Direction {
         SW,
@@ -50,7 +50,7 @@ namespace ConvertCiv3Media
         // *** Oh, they don't exist in other INI's Animation sections!
         // PauseROAD,
         // PauseMINE,
-        // PauseIRRIGATE      
+        // PauseIRRIGATE
 
     }
     // will probably make these to-override methods in Civ3UnitSprite instead


### PR DESCRIPTION
Change all current uses of guid strings to be System.Guid instead.
- System.Guid is passed by value, so comparing Guid structs doesn't require any dereferences, while comparing string requires 2
