### PR TITLE
Apply smoke effect in unit shader

### DIFF
--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -761,6 +761,8 @@ public class UnitLayer : LooseLayer {
 				discard;
 			else if (colorIndex >= 240) // indices in [240, 253] are shadows
 				COLOR = vec4(0.0, 0.0, 0.0, float(16 * (255 - colorIndex)) / 255.0);
+			else if (colorIndex >= 224) // indices in [224, 239] are smoke
+				COLOR = vec4(0.0, 0.0, 0.0, 0.1 + 0.032 * float(colorIndex - 224));
 			else {
 				vec2 paletteCoords = vec2(float(colorIndex % 16), float(colorIndex / 16)) / 16.0;
 				bool tintedByCiv = (colorIndex < 16) || ((colorIndex < 64) && (colorIndex % 2 == 0));


### PR DESCRIPTION
Tiny change to the unit shader to draw smoke effects. That formula for the alpha is probably not 100% accurate to the original game but it looks very close. I determined it experimentally by replacing the terrain in the original game with all white then screenshotting some smoke effects and inspecting the colors in GIMP.