### PR TITLE
Experience levels

### DIFF
--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -693,7 +693,8 @@ public class UnitLayer : LooseLayer {
 		var screenRect = new Rect2(indicatorLoc, new Vector2(6, 6));
 		looseView.DrawTextureRectRegion(unitMovementIndicators, screenRect, moveIndRect);
 
-		int hpIndHeight = 20, hpIndWidth = 6;
+		int hpIndHeight = 6 * (unit.maxHitPoints <= 5 ? unit.maxHitPoints : 5),
+		    hpIndWidth = 6;
 		var hpIndBackgroundRect = new Rect2(indicatorLoc + new Vector2(-1, 8), new Vector2(hpIndWidth, hpIndHeight));
 		if ((unit.unitType.attack > 0) || (unit.unitType.defense > 0)) {
 			float hpFraction = (float)unit.hitPointsRemaining / unit.maxHitPoints;

--- a/C7/c7-static-map-save.json
+++ b/C7/c7-static-map-save.json
@@ -3,26 +3,31 @@
   "rules": {
       "experienceLevels": [
 	  {
-	      "name": "Conscript",
+	      "key": "conscript",
+	      "displayName": "Conscript",
 	      "baseHitPoints": 2,
 	      "retreatChance": 0.34
 	  },
 	  {
-	      "name": "Regular",
+	      "key": "regular",
+	      "displayName": "Regular",
 	      "baseHitPoints": 3,
 	      "retreatChance": 0.50
 	  },
 	  {
-	      "name": "Veteran",
+	      "key": "veteran",
+	      "displayName": "Veteran",
 	      "baseHitPoints": 4,
 	      "retreatChance": 0.58
 	  },
 	  {
-	      "name": "Elite",
+	      "key": "elite",
+	      "displayName": "Elite",
 	      "baseHitPoints": 5,
 	      "retreatChance": 0.66
 	  }
-      ]
+      ],
+      "defaultExperienceLevelKey": "regular"
   },
   "gameData": {
     "turn": 0,

--- a/C7/c7-static-map-save.json
+++ b/C7/c7-static-map-save.json
@@ -1,6 +1,29 @@
 {
   "version": "v0.0early-prototype",
-  "rules": null,
+  "rules": {
+      "experienceLevels": [
+	  {
+	      "name": "Conscript",
+	      "baseHitPoints": 2,
+	      "retreatChance": 0.34
+	  },
+	  {
+	      "name": "Regular",
+	      "baseHitPoints": 3,
+	      "retreatChance": 0.50
+	  },
+	  {
+	      "name": "Veteran",
+	      "baseHitPoints": 4,
+	      "retreatChance": 0.58
+	  },
+	  {
+	      "name": "Elite",
+	      "baseHitPoints": 5,
+	      "retreatChance": 0.66
+	  }
+      ]
+  },
   "gameData": {
     "turn": 0,
     "map": {

--- a/C7Engine/EngineStorage.cs
+++ b/C7Engine/EngineStorage.cs
@@ -18,6 +18,7 @@ namespace C7Engine
 	{
 		public static Mutex gameDataMutex = new Mutex();
 		internal static GameData gameData {get; set;}
+		internal static C7RulesFormat rules {get; set;}
 		public static string uiControllerID;
 
 		private static Thread engineThread = null;
@@ -69,6 +70,12 @@ namespace C7Engine
 		public GameData gameData {
 			get {
 				return EngineStorage.gameData;
+			}
+		}
+
+		public C7RulesFormat rules {
+			get {
+				return EngineStorage.rules;
 			}
 		}
 	}

--- a/C7Engine/EntryPoints/CreateGame.cs
+++ b/C7Engine/EntryPoints/CreateGame.cs
@@ -21,7 +21,7 @@ namespace C7Engine
 			EngineStorage.rules = save.Rules;
 			// Consider if we have any need to keep a reference to the save object handy...probably not
 
-			var humanPlayer = save.GameData.CreateDummyGameData();
+			var humanPlayer = save.GameData.CreateDummyGameData(EngineStorage.rules);
 			EngineStorage.uiControllerID = humanPlayer.guid;
 			TurnHandling.OnBeginTurn(); // Call for the first turn
 			TurnHandling.AdvanceTurn();

--- a/C7Engine/EntryPoints/CreateGame.cs
+++ b/C7Engine/EntryPoints/CreateGame.cs
@@ -1,5 +1,6 @@
 namespace C7Engine
 {
+	using System;
 	using C7GameData;
 
 	public class CreateGame
@@ -17,9 +18,8 @@ namespace C7Engine
 
 			C7SaveFormat save = SaveManager.LoadSave(loadFilePath, defaultBicPath);
 			EngineStorage.gameData = save.GameData;
-
-			// possibly do something with save.Rules here when it exists
-			// and maybe consider if we have any need to keep a reference to the save object handy...probably not
+			EngineStorage.rules = save.Rules;
+			// Consider if we have any need to keep a reference to the save object handy...probably not
 
 			var humanPlayer = save.GameData.CreateDummyGameData();
 			EngineStorage.uiControllerID = humanPlayer.guid;

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -71,6 +71,8 @@ namespace C7Engine
 						newUnit.location = tile;
 						newUnit.owner = gameData.players[0];
 						newUnit.unitType = gameData.unitPrototypes["Warrior"];
+						newUnit.experienceLevelKey = EngineStorage.rules.defaultExperienceLevelKey;
+						newUnit.experienceLevel = EngineStorage.rules.defaultExperienceLevel;
 						newUnit.hitPointsRemaining = 3;
 						newUnit.isFortified = true; //todo: hack for unit selection
 
@@ -83,6 +85,8 @@ namespace C7Engine
 						newUnit.location = tile;
 						newUnit.owner = gameData.players[0];    //todo: make this reliably point to the barbs
 						newUnit.unitType = gameData.unitPrototypes["Galley"];
+						newUnit.experienceLevelKey = EngineStorage.rules.defaultExperienceLevelKey;
+						newUnit.experienceLevel = EngineStorage.rules.defaultExperienceLevel;
 						newUnit.hitPointsRemaining = 3;
 						newUnit.isFortified = true; //todo: hack for unit selection
 
@@ -102,6 +106,8 @@ namespace C7Engine
 							MapUnit newUnit = prototype.GetInstance();
 							newUnit.owner = city.owner;
 							newUnit.location = city.location;
+							newUnit.experienceLevelKey = EngineStorage.rules.defaultExperienceLevelKey;
+							newUnit.experienceLevel = EngineStorage.rules.defaultExperienceLevel;
 							newUnit.facingDirection = TileDirection.SOUTHWEST;
 
 							city.location.unitsOnTile.Add(newUnit);

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -72,7 +72,7 @@ public static class MapUnitExtensions {
 		MapUnit loser = (defender.hitPointsRemaining <= 0) ? defender : unit,
 			winner = (defender == loser) ? unit : defender;
 
-		winner.RollToPromote(winner == unit, false);
+		winner.RollToPromote(winner != defender, false);
 
 		// Play death animation
 		loser.animate(MapUnit.AnimatedAction.DEATH, true);

--- a/C7GameData/ExperienceLevel.cs
+++ b/C7GameData/ExperienceLevel.cs
@@ -4,22 +4,22 @@ namespace C7GameData
 
 	public class ExperienceLevel
 	{
-		public string name;
+		public string key;
+		public string displayName;
 		public int baseHitPoints;
 		public double retreatChance;
 
-		public ExperienceLevel(string name, int baseHitPoints, double retreatChance)
+		public ExperienceLevel(string key, string displayName, int baseHitPoints, double retreatChance)
 		{
-			this.name = name;
+			this.key = key;
+			this.displayName = displayName;
 			this.baseHitPoints = baseHitPoints;
 			this.retreatChance = retreatChance;
 		}
 
-		public static ExperienceLevel ImportFromCiv3(EXPR expr)
+		public static ExperienceLevel ImportFromCiv3(string key, EXPR expr)
 		{
-			return new ExperienceLevel(expr.Name, expr.BaseHitPoints, expr.RetreatBonus / 100.0);
+			return new ExperienceLevel(key, expr.Name, expr.BaseHitPoints, expr.RetreatBonus / 100.0);
 		}
-
-		public static ExperienceLevel DEFAULT;
 	}
 }

--- a/C7GameData/ExperienceLevel.cs
+++ b/C7GameData/ExperienceLevel.cs
@@ -1,0 +1,25 @@
+namespace C7GameData
+{
+	using QueryCiv3.Biq;
+
+	public class ExperienceLevel
+	{
+		public string name;
+		public int baseHitPoints;
+		public double retreatChance;
+
+		public ExperienceLevel(string name, int baseHitPoints, double retreatChance)
+		{
+			this.name = name;
+			this.baseHitPoints = baseHitPoints;
+			this.retreatChance = retreatChance;
+		}
+
+		public static ExperienceLevel ImportFromCiv3(EXPR expr)
+		{
+			return new ExperienceLevel(expr.Name, expr.BaseHitPoints, expr.RetreatBonus / 100.0);
+		}
+
+		public static ExperienceLevel DEFAULT;
+	}
+}

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -58,7 +58,7 @@ namespace C7GameData
 		 *
 		 * Returns the human player so the caller (which is the UI) can store it.
 		 **/
-		public Player CreateDummyGameData()
+		public Player CreateDummyGameData(C7RulesFormat rules)
 		{
 			this.turn = 0;
 
@@ -185,7 +185,7 @@ namespace C7GameData
 				if (player.isBarbarians) {
 					continue;
 				}
-				CreateStartingDummyUnits(player, startingLocations[i]);
+				CreateStartingDummyUnits(rules, player, startingLocations[i]);
 				i++;
 			}
 
@@ -195,7 +195,7 @@ namespace C7GameData
 			List<Tile> barbarianCamps = map.generateStartingLocations(rng, 10, 10);
 			foreach (Tile barbCampLocation in barbarianCamps) {
 				if (barbCampLocation.unitsOnTile.Count == 0) { // in case a starting location is under one of the human player's units
-					MapUnit barbWarrior = CreateDummyUnit(unitPrototypes["Warrior"], barbarianPlayer, barbCampLocation);
+					MapUnit barbWarrior = CreateDummyUnit(rules, unitPrototypes["Warrior"], barbarianPlayer, barbCampLocation);
 					barbWarrior.isFortified = true; // Can't do this through UnitInteractions b/c we don't have access to the engine. Really this
 					// whole procedure of generating a map should be part of the engine not the data module.
 					barbWarrior.facingDirection = TileDirection.SOUTHEAST;
@@ -210,16 +210,16 @@ namespace C7GameData
 			return carthagePlayer;
 		}
 
-		private void CreateStartingDummyUnits(Player player, Tile location)
+		private void CreateStartingDummyUnits(C7RulesFormat rules, Player player, Tile location)
 		{
-			CreateDummyUnit(unitPrototypes["Settler"],  player, location);
-			CreateDummyUnit(unitPrototypes["Warrior"],  player, location);
-			CreateDummyUnit(unitPrototypes["Worker"],   player, location);
-			CreateDummyUnit(unitPrototypes["Chariot"],  player, location);
-			CreateDummyUnit(unitPrototypes["Catapult"], player, location);
+			CreateDummyUnit(rules, unitPrototypes["Settler"],  player, location);
+			CreateDummyUnit(rules, unitPrototypes["Warrior"],  player, location);
+			CreateDummyUnit(rules, unitPrototypes["Worker"],   player, location);
+			CreateDummyUnit(rules, unitPrototypes["Chariot"],  player, location);
+			CreateDummyUnit(rules, unitPrototypes["Catapult"], player, location);
 		}
 
-		private MapUnit CreateDummyUnit(UnitPrototype proto, Player owner, Tile tile)
+		private MapUnit CreateDummyUnit(C7RulesFormat rules, UnitPrototype proto, Player owner, Tile tile)
 		{
 			//TODO: The fact that we have to check for this makes me wonder why...
 			if (tile != Tile.NONE) {
@@ -228,6 +228,8 @@ namespace C7GameData
 				unit.unitType = proto;
 				unit.owner = owner;
 				unit.location = tile;
+				unit.experienceLevelKey = rules.defaultExperienceLevel.key;
+				unit.experienceLevel = rules.defaultExperienceLevel;
 				unit.facingDirection = TileDirection.SOUTHWEST;
 				unit.movementPointsRemaining = proto.movement;
 				unit.hitPointsRemaining = 3;

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -203,8 +203,20 @@ namespace C7GameData
 		{
 			if (theBiq.Expr.Length != 4)
 				throw new Exception("BIQ data must include four experience levels.");
-			foreach (EXPR expr in theBiq.Expr)
-				c7Save.Rules.experienceLevels.Add(ExperienceLevel.ImportFromCiv3(expr));
+
+			Dictionary<string, ExperienceLevel> levelsByKey = new Dictionary<string, ExperienceLevel>();
+
+			foreach (EXPR expr in theBiq.Expr) {
+				// Generate a unique key for this level based on its name. If multiple levels have the same name, append apostrophes
+				// to the end until the key is unique.
+				string key = expr.Name;
+				while (levelsByKey.ContainsKey(key))
+					key += "'";
+
+				ExperienceLevel level = ExperienceLevel.ImportFromCiv3(key, expr);
+				c7Save.Rules.experienceLevels.Add(level);
+				levelsByKey.Add(key, level);
+			}
 		}
 
 		private static void SetWorldWrap(SavData civ3Save, C7SaveFormat c7Save)

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -216,6 +216,11 @@ namespace C7GameData
 				ExperienceLevel level = ExperienceLevel.ImportFromCiv3(key, expr);
 				c7Save.Rules.experienceLevels.Add(level);
 				levelsByKey.Add(key, level);
+
+				if (levelsByKey.Count == 2) {
+					c7Save.Rules.defaultExperienceLevelKey = key;
+					c7Save.Rules.defaultExperienceLevel = level;
+				}
 			}
 		}
 

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -29,6 +29,7 @@ namespace C7GameData
 			BiqData theBiq = civ3Save.Bic;
 
 			ImportCiv3TerrainTypes(theBiq, c7Save);
+			ImportCiv3ExperienceLevels(theBiq, c7Save);
 			Dictionary<int, Resource> resourcesByIndex = ImportCiv3Resources(civ3Save.Bic, c7Save);
 			SetMapDimensions(civ3Save, c7Save);
 			SetWorldWrap(civ3Save, c7Save);
@@ -89,6 +90,7 @@ namespace C7GameData
 			BiqData theBiq = new BiqData(biqBytes);
 			
 			ImportCiv3TerrainTypes(theBiq, c7Save);
+			ImportCiv3ExperienceLevels(theBiq, c7Save);
 			Dictionary<int, Resource> resourcesByIndex = ImportCiv3Resources(theBiq, c7Save);
 			SetMapDimensions(theBiq, c7Save);
 			SetWorldWrap(theBiq, c7Save);
@@ -195,6 +197,14 @@ namespace C7GameData
 				c7Save.GameData.terrainTypes.Add(c7TerrainType);
 				civ3Index++;
 			}
+		}
+
+		private static void ImportCiv3ExperienceLevels(BiqData theBiq, C7SaveFormat c7Save)
+		{
+			if (theBiq.Expr.Length != 4)
+				throw new Exception("BIQ data must include four experience levels.");
+			foreach (EXPR expr in theBiq.Expr)
+				c7Save.Rules.experienceLevels.Add(ExperienceLevel.ImportFromCiv3(expr));
 		}
 
 		private static void SetWorldWrap(SavData civ3Save, C7SaveFormat c7Save)

--- a/C7GameData/MapUnit.cs
+++ b/C7GameData/MapUnit.cs
@@ -80,7 +80,7 @@ public class MapUnit
 		UnitPrototype type = this.unitType;
 		string hPDesc = ((type.attack > 0) || (type.defense > 0)) ? $" ({hitPointsRemaining}/{maxHitPoints})" : "";
 		string attackDesc = (type.bombard > 0) ? $"{type.attack}({type.bombard})" : type.attack.ToString();
-		return $"Regular{hPDesc} {type.name} ({attackDesc}.{type.defense}.{movementPointsRemaining}/{type.movement})";
+		return $"{experienceLevel.displayName}{hPDesc} {type.name} ({attackDesc}.{type.defense}.{movementPointsRemaining}/{type.movement})";
 	}
 
 	// TODO: The contents of this enum are copy-pasted from UnitAction in Civ3UnitSprite.cs. We should unify these so we don't have two different

--- a/C7GameData/MapUnit.cs
+++ b/C7GameData/MapUnit.cs
@@ -5,6 +5,7 @@ namespace C7GameData
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 /**
  * A unit on the map.  Not to be confused with a unit prototype.
@@ -17,11 +18,15 @@ public class MapUnit
 	public Tile location {get; set;}
 	public TilePath path {get; set;}
 
+	public string experienceLevelKey;
+	[JsonIgnore]
+	public ExperienceLevel experienceLevel {get; set;}
+
 	public int movementPointsRemaining {get; set;}
 	public int hitPointsRemaining {get; set;}
 	public int maxHitPoints {
 		get {
-			return 3; // Eventually we'll add HP from experience and the type's inherent bonus
+			return experienceLevel.baseHitPoints; // TODO: Include bonus HP from unit type
 		}
 	}
 	public bool isFortified {get; set;}

--- a/C7GameData/RulesFormat.cs
+++ b/C7GameData/RulesFormat.cs
@@ -16,8 +16,21 @@ namespace C7GameData
 		[JsonIgnore]
 		public ExperienceLevel defaultExperienceLevel;
 
+		// TODO: Make sure these numbers are correct
+		public double promotionChanceAfterDefending = 1.0/16;
+		public double promotionChanceAfterAttacking = 1.0/8;
+
 		public C7RulesFormat() {
 			Version = "v0.0early-prototype";
+		}
+
+		public ExperienceLevel GetExperienceLevelAfter(ExperienceLevel experienceLevel)
+		{
+			int n = experienceLevels.IndexOf(experienceLevel);
+			if (n + 1 < experienceLevels.Count)
+				return experienceLevels[n + 1];
+			else
+				return null;
 		}
 	}
 }

--- a/C7GameData/RulesFormat.cs
+++ b/C7GameData/RulesFormat.cs
@@ -5,11 +5,15 @@ namespace C7GameData
     (e.g. in a mod) or as part of the save file. At least for now.
 */
 {
-    using System;
-    public class C7RulesFormat {
-        public string Version { get; set; }
-        public C7RulesFormat() {
-            Version = "v0.0early-prototype";
-        }
-    }
+	using System.Collections.Generic;
+
+	public class C7RulesFormat {
+		public string Version { get; set; }
+
+		public List<ExperienceLevel> experienceLevels = new List<ExperienceLevel>();
+
+		public C7RulesFormat() {
+			Version = "v0.0early-prototype";
+		}
+	}
 }

--- a/C7GameData/RulesFormat.cs
+++ b/C7GameData/RulesFormat.cs
@@ -6,11 +6,15 @@ namespace C7GameData
 */
 {
 	using System.Collections.Generic;
+	using System.Text.Json.Serialization;
 
 	public class C7RulesFormat {
 		public string Version { get; set; }
 
 		public List<ExperienceLevel> experienceLevels = new List<ExperienceLevel>();
+		public string defaultExperienceLevelKey;
+		[JsonIgnore]
+		public ExperienceLevel defaultExperienceLevel;
 
 		public C7RulesFormat() {
 			Version = "v0.0early-prototype";

--- a/C7GameData/SaveFormat.cs
+++ b/C7GameData/SaveFormat.cs
@@ -8,6 +8,7 @@ namespace C7GameData
 */
 {
 	using System;
+	using System.Collections.Generic;
 	using System.IO;
 	using System.IO.Compression;
 	using System.Text.Json;
@@ -88,7 +89,7 @@ namespace C7GameData
 				}
 			}
 
-			// Inflate things that are stored by reference
+			// Inflate things that are stored by reference, first tiles
 			foreach (Tile tile in save.GameData.map.tiles)
 			{
 				if (tile.ResourceKey == "NONE")
@@ -102,6 +103,15 @@ namespace C7GameData
 				tile.baseTerrainType = save.GameData.terrainTypes.Find(t => t.Key == tile.baseTerrainTypeKey);
 				tile.overlayTerrainType = save.GameData.terrainTypes.Find(t => t.Key == tile.overlayTerrainTypeKey);
 			}
+
+			// Inflate experience levels
+			var levelsByKey = new Dictionary<string, ExperienceLevel>();
+			foreach (ExperienceLevel eL in save.Rules.experienceLevels)
+				levelsByKey.Add(eL.key, eL);
+			save.Rules.defaultExperienceLevel = levelsByKey[save.Rules.defaultExperienceLevelKey];
+			foreach (MapUnit unit in save.GameData.mapUnits)
+				unit.experienceLevel = levelsByKey[unit.experienceLevelKey];
+
 			return save;
 		}
 

--- a/C7GameData/SaveFormat.cs
+++ b/C7GameData/SaveFormat.cs
@@ -32,9 +32,10 @@ namespace C7GameData
 		public C7SaveFormat()
 		{
 			GameData = new GameData();
+			Rules = new C7RulesFormat();
 		}
 
-		public C7SaveFormat(GameData gameData, C7RulesFormat rules = null)
+		public C7SaveFormat(GameData gameData, C7RulesFormat rules)
 		{
 			GameData = gameData;
 			Rules = rules;


### PR DESCRIPTION
Closes #193
Experience levels now work how you'd expect: each time a unit gets a kill it gets a chance to promote and its max HP is now determined by its exp level instead of hard coded to 3. I set the promotion odds to the numbers Quintillus mentioned in the issue. They feel right to me but we should still make sure at some point. Under the hood, experience levels are read from the JSON save or BIQ. To make that work, I followed the example of terrain types. I put experience levels in the C7RulesFormat object instead of the game data object since some comments indicated that's what it's there for. The rules object wasn't used for anything before this so I had to do some work wiring it up, e.g. including it in EngineStorage and passing it to the dummy game creation process.