### PR TITLE
Defensive bonuses

### DIFF
--- a/C7/c7-static-map-save.json
+++ b/C7/c7-static-map-save.json
@@ -27,7 +27,28 @@
 	      "retreatChance": 0.66
 	  }
       ],
-      "defaultExperienceLevelKey": "regular"
+      "defaultExperienceLevelKey": "regular",
+
+      "fortificationBonus": {
+	  "description": "Fortified",
+	  "amount": 0.25
+      },
+      "riverCrossingBonus": {
+	  "description": "Behind river",
+	  "amount": 0.25
+      },
+      "cityLevel1DefenseBonus": {
+	  "description": "Town",
+	  "amount": 0.00
+      },
+      "cityLevel2DefenseBonus": {
+	  "description": "City",
+	  "amount": 0.50
+      },
+      "cityLevel3DefenseBonus": {
+	  "description": "Metropolis",
+	  "amount": 1.00
+      }
   },
   "gameData": {
     "turn": 0,

--- a/C7/c7-static-map-save.json
+++ b/C7/c7-static-map-save.json
@@ -6,25 +6,29 @@
 	      "key": "conscript",
 	      "displayName": "Conscript",
 	      "baseHitPoints": 2,
-	      "retreatChance": 0.34
+	      "retreatChance": 0.34,
+	      "promotionChance": 0.50
 	  },
 	  {
 	      "key": "regular",
 	      "displayName": "Regular",
 	      "baseHitPoints": 3,
-	      "retreatChance": 0.50
+	      "retreatChance": 0.50,
+	      "promotionChance": 0.25
 	  },
 	  {
 	      "key": "veteran",
 	      "displayName": "Veteran",
 	      "baseHitPoints": 4,
-	      "retreatChance": 0.58
+	      "retreatChance": 0.58,
+	      "promotionChance": 0.125
 	  },
 	  {
 	      "key": "elite",
 	      "displayName": "Elite",
 	      "baseHitPoints": 5,
-	      "retreatChance": 0.66
+	      "retreatChance": 0.66,
+	      "promotionChance": 0.0
 	  }
       ],
       "defaultExperienceLevelKey": "regular",

--- a/C7/c7-static-map-save.json
+++ b/C7/c7-static-map-save.json
@@ -67273,7 +67273,11 @@
         "baseFoodProduction": 0,
         "baseShieldProduction": 1,
         "baseCommerceProduction": 0,
-        "movementCost": 1
+          "movementCost": 1,
+	  "defenseBonus": {
+	      "description": "Desert",
+	      "amount": 0.10
+	  }
       },
       {
         "key": "plains",
@@ -67281,7 +67285,11 @@
         "baseFoodProduction": 1,
         "baseShieldProduction": 1,
         "baseCommerceProduction": 0,
-        "movementCost": 1
+          "movementCost": 1,
+	  "defenseBonus": {
+	      "description": "Plains",
+	      "amount": 0.10
+	  }
       },
       {
         "key": "grassland",
@@ -67289,7 +67297,11 @@
         "baseFoodProduction": 2,
         "baseShieldProduction": 0,
         "baseCommerceProduction": 0,
-        "movementCost": 1
+          "movementCost": 1,
+	  "defenseBonus": {
+	      "description": "Grassland",
+	      "amount": 0.10
+	  }
       },
       {
         "key": "tundra",
@@ -67297,7 +67309,11 @@
         "baseFoodProduction": 1,
         "baseShieldProduction": 0,
         "baseCommerceProduction": 0,
-        "movementCost": 1
+          "movementCost": 1,
+	  "defenseBonus": {
+	      "description": "Tundra",
+	      "amount": 0.10
+	  }
       },
       {
         "key": "flood plain",
@@ -67305,7 +67321,11 @@
         "baseFoodProduction": 3,
         "baseShieldProduction": 0,
         "baseCommerceProduction": 0,
-        "movementCost": 1
+          "movementCost": 1,
+	  "defenseBonus": {
+	      "description": "Flood Plain",
+	      "amount": 0.10
+	  }
       },
       {
         "key": "hills",
@@ -67313,7 +67333,11 @@
         "baseFoodProduction": 1,
         "baseShieldProduction": 1,
         "baseCommerceProduction": 0,
-        "movementCost": 2
+          "movementCost": 2,
+	  "defenseBonus": {
+	      "description": "Hills",
+	      "amount": 0.50
+	  }
       },
       {
         "key": "mountains",
@@ -67321,7 +67345,11 @@
         "baseFoodProduction": 0,
         "baseShieldProduction": 1,
         "baseCommerceProduction": 0,
-        "movementCost": 3
+          "movementCost": 3,
+	  "defenseBonus": {
+	      "description": "Mountains",
+	      "amount": 1.00
+	  }
       },
       {
         "key": "forest",
@@ -67329,7 +67357,11 @@
         "baseFoodProduction": 1,
         "baseShieldProduction": 2,
         "baseCommerceProduction": 0,
-        "movementCost": 2
+          "movementCost": 2,
+	  "defenseBonus": {
+	      "description": "Forest",
+	      "amount": 0.25
+	  }
       },
       {
         "key": "jungle",
@@ -67337,7 +67369,11 @@
         "baseFoodProduction": 1,
         "baseShieldProduction": 0,
         "baseCommerceProduction": 0,
-        "movementCost": 3
+          "movementCost": 3,
+	  "defenseBonus": {
+	      "description": "Jungle",
+	      "amount": 0.25
+	  }
       },
       {
         "key": "marsh",
@@ -67345,7 +67381,11 @@
         "baseFoodProduction": 1,
         "baseShieldProduction": 0,
         "baseCommerceProduction": 0,
-        "movementCost": 2
+          "movementCost": 2,
+	  "defenseBonus": {
+	      "description": "Marsh",
+	      "amount": 0.20
+	  }
       },
       {
         "key": "volcano",
@@ -67353,7 +67393,11 @@
         "baseFoodProduction": 0,
         "baseShieldProduction": 3,
         "baseCommerceProduction": 0,
-        "movementCost": 3
+          "movementCost": 3,
+	  "defenseBonus": {
+	      "description": "Volcano",
+	      "amount": 0.80
+	  }
       },
       {
         "key": "coast",
@@ -67361,7 +67405,11 @@
         "baseFoodProduction": 1,
         "baseShieldProduction": 0,
         "baseCommerceProduction": 2,
-        "movementCost": 1
+          "movementCost": 1,
+	  "defenseBonus": {
+	      "description": "Coast",
+	      "amount": 0.10
+	  }
       },
       {
         "key": "sea",
@@ -67369,7 +67417,11 @@
         "baseFoodProduction": 1,
         "baseShieldProduction": 0,
         "baseCommerceProduction": 1,
-        "movementCost": 1
+          "movementCost": 1,
+	  "defenseBonus": {
+	      "description": "Sea",
+	      "amount": 0.10
+	  }
       },
       {
         "key": "ocean",
@@ -67377,7 +67429,11 @@
         "baseFoodProduction": 0,
         "baseShieldProduction": 0,
         "baseCommerceProduction": 0,
-        "movementCost": 1
+          "movementCost": 1,
+	  "defenseBonus": {
+	      "description": "Ocean",
+	      "amount": 0.10
+	  }
       }
     ],
     "resources": [

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -39,6 +39,8 @@ public static class MapUnitExtensions {
 			if (unit.isFortified)
 				yield return rules.fortificationBonus;
 
+			yield return unit.location.overlayTerrainType.defenseBonus;
+
 			if ((! bombard) && (attackDirection is TileDirection dir) && unit.location.HasRiverCrossing(dir.reversed()))
 				yield return rules.riverCrossingBonus;
 

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -51,8 +51,8 @@ public static class MapUnitExtensions {
 		var defenderOriginalDirection = defender.facingDirection;
 		defender.facingDirection = unit.facingDirection.reversed();
 
-		int attackerStrength = unit.unitType.attack;
-		int defenderStrength = defender.unitType.defense;
+		double attackerStrength = unit    .StrengthVersus(defender, true , false, unit.facingDirection),
+		       defenderStrength = defender.StrengthVersus(unit    , false, false, unit.facingDirection);
 
 		if (attackerStrength + defenderStrength == 0)
 			return false;

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -103,8 +103,19 @@ public static class MapUnitExtensions {
 		var defenderOriginalDirection = defender.facingDirection;
 		defender.facingDirection = unit.facingDirection.reversed();
 
-		double attackerStrength = unit    .AttackStrengthVersus (defender, false, unit.facingDirection),
-		       defenderStrength = defender.DefenseStrengthVersus(unit    , false, unit.facingDirection);
+		IEnumerable<StrengthBonus> attackBonuses  = unit    .ListStrengthBonusesVersus(defender, true , false, unit.facingDirection),
+		                           defenseBonuses = defender.ListStrengthBonusesVersus(unit    , false, false, unit.facingDirection);
+
+		double attackerStrength = unit    .unitType.attack  * StrengthBonus.ListToMultiplier(attackBonuses),
+		       defenderStrength = defender.unitType.defense * StrengthBonus.ListToMultiplier(defenseBonuses);
+
+		Console.WriteLine($"Combat log: {unit.unitType.name} ({attackerStrength}) attacking {defender.unitType.name} ({defenderStrength})");
+		Console.WriteLine($"\tAttacker: {unit.unitType.name}, base strength {unit.unitType.attack}");
+		foreach (StrengthBonus bonus in attackBonuses)
+			Console.WriteLine($"\t\t+{100.0*bonus.amount}%\t{bonus.description}");
+		Console.WriteLine($"\tDefender: {defender.unitType.name}, base strength {defender.unitType.defense}");
+		foreach (StrengthBonus bonus in defenseBonuses)
+			Console.WriteLine($"\t\t+{100.0*bonus.amount}%\t{bonus.description}");
 
 		double attackerOdds = attackerStrength / (attackerStrength + defenderStrength);
 		if (Double.IsNaN(attackerOdds))

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -33,9 +33,18 @@ public static class MapUnitExtensions {
 
 	public static IEnumerable<StrengthBonus> ListStrengthBonusesVersus(this MapUnit unit, MapUnit opponent, bool attacking, bool bombard, TileDirection? attackDirection)
 	{
+		C7RulesFormat rules = EngineStorage.rules;
+
 		if (! attacking) { // Defending against attack from opponent
 			if (unit.isFortified)
-				yield return new StrengthBonus { description = "Fortification", amount = 0.25 };
+				yield return rules.fortificationBonus;
+
+			if ((! bombard) && (attackDirection is TileDirection dir) && unit.location.HasRiverCrossing(dir.reversed()))
+				yield return rules.riverCrossingBonus;
+
+			// TODO: Bonus should vary depending on city level. First we must load the thresholds for level 2/3 into the scenario data.
+			if (unit.location.cityAtTile != null)
+				yield return rules.cityLevel2DefenseBonus;
 		}
 	}
 

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -51,13 +51,12 @@ public static class MapUnitExtensions {
 		var defenderOriginalDirection = defender.facingDirection;
 		defender.facingDirection = unit.facingDirection.reversed();
 
-		double attackerStrength = unit    .StrengthVersus(defender, true , false, unit.facingDirection),
-		       defenderStrength = defender.StrengthVersus(unit    , false, false, unit.facingDirection);
+		double attackerStrength = unit    .AttackStrengthVersus (defender, false, unit.facingDirection),
+		       defenderStrength = defender.DefenseStrengthVersus(unit    , false, unit.facingDirection);
 
-		if (attackerStrength + defenderStrength == 0)
+		double attackerOdds = attackerStrength / (attackerStrength + defenderStrength);
+		if (Double.IsNaN(attackerOdds))
 			return false;
-
-		double attackerOdds = (double)attackerStrength / (attackerStrength + defenderStrength);
 
 		// Do combat rounds
 		while ((unit.hitPointsRemaining > 0) && (defender.hitPointsRemaining > 0)) {
@@ -93,8 +92,11 @@ public static class MapUnitExtensions {
 		var unitOriginalOrientation = unit.facingDirection;
 		unit.facingDirection = unit.location.directionTo(tile);
 
-		int defenderStrength = target.unitType.defense;
-		double attackerOdds = defenderStrength > 0 ? (double)unit.unitType.bombard / (unit.unitType.bombard + defenderStrength) : 1.0;
+		double bombardStrength  = unit  .AttackStrengthVersus (target, true, unit.facingDirection);
+		double defenderStrength = target.DefenseStrengthVersus(unit  , true, unit.facingDirection);
+		double attackerOdds = bombardStrength / (bombardStrength + defenderStrength);
+		if (Double.IsNaN(attackerOdds))
+			return;
 
 		unit.animate(MapUnit.AnimatedAction.ATTACK1, true);
 		unit.movementPointsRemaining -= 1;

--- a/C7Engine/TileExtensions.cs
+++ b/C7Engine/TileExtensions.cs
@@ -1,0 +1,18 @@
+namespace C7Engine
+{
+	using C7GameData;
+
+	public static class TileExtensions {
+		public static MapUnit FindTopDefender(this Tile tile, MapUnit opponent)
+		{
+			if (tile.unitsOnTile.Count > 0) {
+				MapUnit tr = tile.unitsOnTile[0];
+				foreach (MapUnit u in tile.unitsOnTile)
+					if (u.HasPriorityAsDefender(tr, opponent))
+						tr = u;
+				return tr;
+			} else
+				return MapUnit.NONE;
+		}
+	}
+}

--- a/C7GameData/ExperienceLevel.cs
+++ b/C7GameData/ExperienceLevel.cs
@@ -8,18 +8,21 @@ namespace C7GameData
 		public string displayName;
 		public int baseHitPoints;
 		public double retreatChance;
+		public double promotionChance;
 
-		public ExperienceLevel(string key, string displayName, int baseHitPoints, double retreatChance)
+		public ExperienceLevel(string key, string displayName, int baseHitPoints, double retreatChance, double promotionChance)
 		{
 			this.key = key;
 			this.displayName = displayName;
 			this.baseHitPoints = baseHitPoints;
 			this.retreatChance = retreatChance;
+			this.promotionChance = promotionChance;
 		}
 
-		public static ExperienceLevel ImportFromCiv3(string key, EXPR expr)
+		public static ExperienceLevel ImportFromCiv3(string key, EXPR expr, int levelIndex)
 		{
-			return new ExperienceLevel(key, expr.Name, expr.BaseHitPoints, expr.RetreatBonus / 100.0);
+			var promotionChances = new double[] { 0.5, 0.25, 0.125, 0.0 };
+			return new ExperienceLevel(key, expr.Name, expr.BaseHitPoints, expr.RetreatBonus / 100.0, promotionChances[levelIndex]);
 		}
 	}
 }

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -30,6 +30,7 @@ namespace C7GameData
 
 			ImportCiv3TerrainTypes(theBiq, c7Save);
 			ImportCiv3ExperienceLevels(theBiq, c7Save);
+			ImportCiv3DefensiveBonuses(theBiq, c7Save);
 			Dictionary<int, Resource> resourcesByIndex = ImportCiv3Resources(civ3Save.Bic, c7Save);
 			SetMapDimensions(civ3Save, c7Save);
 			SetWorldWrap(civ3Save, c7Save);
@@ -91,6 +92,7 @@ namespace C7GameData
 			
 			ImportCiv3TerrainTypes(theBiq, c7Save);
 			ImportCiv3ExperienceLevels(theBiq, c7Save);
+			ImportCiv3DefensiveBonuses(theBiq, c7Save);
 			Dictionary<int, Resource> resourcesByIndex = ImportCiv3Resources(theBiq, c7Save);
 			SetMapDimensions(theBiq, c7Save);
 			SetWorldWrap(theBiq, c7Save);
@@ -222,6 +224,30 @@ namespace C7GameData
 					c7Save.Rules.defaultExperienceLevel = level;
 				}
 			}
+		}
+
+		private static void ImportCiv3DefensiveBonuses(BiqData theBiq, C7SaveFormat c7Save)
+		{
+			c7Save.Rules.fortificationBonus = new StrengthBonus {
+				description = "Fortified",
+				amount = theBiq.Rule[0].FortificationsDefensiveBonus / 100.0
+			};
+			c7Save.Rules.riverCrossingBonus = new StrengthBonus {
+				description = "Behind river",
+				amount = theBiq.Rule[0].RiverDefensiveBonus / 100.0
+			};
+			c7Save.Rules.cityLevel1DefenseBonus = new StrengthBonus {
+				description = "Town",
+				amount = theBiq.Rule[0].TownDefenseBonus / 100.0
+			};
+			c7Save.Rules.cityLevel2DefenseBonus = new StrengthBonus {
+				description = "City",
+				amount = theBiq.Rule[0].CityDefenseBonus / 100.0
+			};
+			c7Save.Rules.cityLevel3DefenseBonus = new StrengthBonus {
+				description = "Metropolis",
+				amount = theBiq.Rule[0].MetropolisDefenseBonus / 100.0
+			};
 		}
 
 		private static void SetWorldWrap(SavData civ3Save, C7SaveFormat c7Save)

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -215,7 +215,7 @@ namespace C7GameData
 				while (levelsByKey.ContainsKey(key))
 					key += "'";
 
-				ExperienceLevel level = ExperienceLevel.ImportFromCiv3(key, expr);
+				ExperienceLevel level = ExperienceLevel.ImportFromCiv3(key, expr, levelsByKey.Count);
 				c7Save.Rules.experienceLevels.Add(level);
 				levelsByKey.Add(key, level);
 

--- a/C7GameData/MapUnit.cs
+++ b/C7GameData/MapUnit.cs
@@ -66,15 +66,15 @@ public class MapUnit
 		}
 	}
 
-	public double StrengthVersus(MapUnit opponent, bool attacking, bool bombard, TileDirection? attackDirection)
+	public double AttackStrengthVersus(MapUnit opponent, bool bombard, TileDirection? attackDirection)
 	{
-		double bonusFactor = 1.0;
-		foreach (StrengthBonus bonus in ListStrengthBonusesVersus(opponent, attacking, bombard, attackDirection))
-			bonusFactor += bonus.amount;
-		if (bonusFactor > 0.0) {
-			return bonusFactor * (attacking ? unitType.attack : unitType.defense);
-		} else
-			return 0.0;
+		double multiplier = StrengthBonus.ListToMultiplier(ListStrengthBonusesVersus(opponent, true, bombard, attackDirection));
+		return multiplier * (bombard ? unitType.bombard : unitType.attack);
+	}
+
+	public double DefenseStrengthVersus(MapUnit opponent, bool bombard, TileDirection? attackDirection)
+	{
+		return unitType.defense * StrengthBonus.ListToMultiplier(ListStrengthBonusesVersus(opponent, false, bombard, attackDirection));
 	}
 
 	// Answers the question: if "opponent" is attacking the tile that this unit is standing on, does this unit defend instead of "otherDefender"?
@@ -91,8 +91,8 @@ public class MapUnit
 		else if (otherDefenderIsEnemy && ! weAreEnemy)
 			return false;
 		else {
-			double ourTotalStrength   =               StrengthVersus(opponent, false, false, null) *               hitPointsRemaining,
-			       theirTotalStrength = otherDefender.StrengthVersus(opponent, false, false, null) * otherDefender.hitPointsRemaining;
+			double ourTotalStrength   =               DefenseStrengthVersus(opponent, false, null) *               hitPointsRemaining,
+			       theirTotalStrength = otherDefender.DefenseStrengthVersus(opponent, false, null) * otherDefender.hitPointsRemaining;
 			return ourTotalStrength > theirTotalStrength;
 		}
 	}

--- a/C7GameData/MapUnit.cs
+++ b/C7GameData/MapUnit.cs
@@ -58,45 +58,6 @@ public class MapUnit
 		}
 	}
 
-	public IEnumerable<StrengthBonus> ListStrengthBonusesVersus(MapUnit opponent, bool attacking, bool bombard, TileDirection? attackDirection)
-	{
-		if (! attacking) { // Defending against attack from opponent
-			if (isFortified)
-				yield return new StrengthBonus { description = "Fortification", amount = 0.25 };
-		}
-	}
-
-	public double AttackStrengthVersus(MapUnit opponent, bool bombard, TileDirection? attackDirection)
-	{
-		double multiplier = StrengthBonus.ListToMultiplier(ListStrengthBonusesVersus(opponent, true, bombard, attackDirection));
-		return multiplier * (bombard ? unitType.bombard : unitType.attack);
-	}
-
-	public double DefenseStrengthVersus(MapUnit opponent, bool bombard, TileDirection? attackDirection)
-	{
-		return unitType.defense * StrengthBonus.ListToMultiplier(ListStrengthBonusesVersus(opponent, false, bombard, attackDirection));
-	}
-
-	// Answers the question: if "opponent" is attacking the tile that this unit is standing on, does this unit defend instead of "otherDefender"?
-	// Note that otherDefender does not necessarily belong to the same civ as this unit. Under standard Civ 3 rules you can't have units belonging
-	// to two different civs on the same tile, but we don't want to assume that. In that case, whoever is an enemy of "opponent" should get
-	// priority. Otherwise it's just whoever is stronger on defense.
-	public bool HasPriorityAsDefender(MapUnit otherDefender, MapUnit opponent)
-	{
-		Player opponentPlayer = opponent.owner;
-		bool weAreEnemy           = (opponentPlayer != null) ? ! opponentPlayer.IsAtPeaceWith(this.owner)          : false;
-		bool otherDefenderIsEnemy = (opponentPlayer != null) ? ! opponentPlayer.IsAtPeaceWith(otherDefender.owner) : false;
-		if (weAreEnemy && ! otherDefenderIsEnemy)
-			return true;
-		else if (otherDefenderIsEnemy && ! weAreEnemy)
-			return false;
-		else {
-			double ourTotalStrength   =               DefenseStrengthVersus(opponent, false, null) *               hitPointsRemaining,
-			       theirTotalStrength = otherDefender.DefenseStrengthVersus(opponent, false, null) * otherDefender.hitPointsRemaining;
-			return ourTotalStrength > theirTotalStrength;
-		}
-	}
-
 	public string Describe()
 	{
 		UnitPrototype type = this.unitType;

--- a/C7GameData/RulesFormat.cs
+++ b/C7GameData/RulesFormat.cs
@@ -12,6 +12,16 @@ namespace C7GameData
 	{
 		public string description;
 		public double amount; // e.g. 0.25 = +25% strength
+
+		// Converts a list of strength bonuses to a multiplier on strength. For example, a list of two bonuses of +10% and +25% would return a
+		// multiplier of 1.35. Multipliers cannot be less than zero.
+		public static double ListToMultiplier(IEnumerable<StrengthBonus> bonuses)
+		{
+			double m = 1.0;
+			foreach (StrengthBonus bonus in bonuses)
+				m += bonus.amount;
+			return (m >= 0.0) ? m : 0.0;
+		}
 	}
 
 	public class C7RulesFormat

--- a/C7GameData/RulesFormat.cs
+++ b/C7GameData/RulesFormat.cs
@@ -8,7 +8,14 @@ namespace C7GameData
 	using System.Collections.Generic;
 	using System.Text.Json.Serialization;
 
-	public class C7RulesFormat {
+	public struct StrengthBonus
+	{
+		public string description;
+		public double amount; // e.g. 0.25 = +25% strength
+	}
+
+	public class C7RulesFormat
+	{
 		public string Version { get; set; }
 
 		public List<ExperienceLevel> experienceLevels = new List<ExperienceLevel>();

--- a/C7GameData/RulesFormat.cs
+++ b/C7GameData/RulesFormat.cs
@@ -37,6 +37,12 @@ namespace C7GameData
 		public double promotionChanceAfterDefending = 1.0/16;
 		public double promotionChanceAfterAttacking = 1.0/8;
 
+		public StrengthBonus fortificationBonus;
+		public StrengthBonus riverCrossingBonus;
+		public StrengthBonus cityLevel1DefenseBonus;
+		public StrengthBonus cityLevel2DefenseBonus;
+		public StrengthBonus cityLevel3DefenseBonus;
+
 		public C7RulesFormat() {
 			Version = "v0.0early-prototype";
 		}

--- a/C7GameData/TerrainType.cs
+++ b/C7GameData/TerrainType.cs
@@ -17,6 +17,7 @@ namespace C7GameData
         public int baseShieldProduction {get; set; }
         public int baseCommerceProduction {get; set; }
         public int movementCost {get; set; }
+        public StrengthBonus defenseBonus;
 
         //some stuff about graphics would probably make sense, too
 
@@ -50,6 +51,10 @@ namespace C7GameData
             c7Terrain.baseShieldProduction = civ3Terrain.Shields;
             c7Terrain.baseCommerceProduction = civ3Terrain.Commerce;
             c7Terrain.movementCost = civ3Terrain.MovementCost;
+            c7Terrain.defenseBonus = new StrengthBonus {
+                description = civ3Terrain.Name,
+                amount = civ3Terrain.DefenseBonus / 100.0
+	    };
             return c7Terrain;
         }
 

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -52,18 +52,6 @@ namespace C7GameData
 			unitsOnTile = new List<MapUnit>();
 		}
 
-		public MapUnit findTopDefender(MapUnit opponent)
-		{
-			if (unitsOnTile.Count > 0) {
-				var tr = unitsOnTile[0];
-				foreach (var u in unitsOnTile)
-					if (u.HasPriorityAsDefender(tr, opponent))
-						tr = u;
-				return tr;
-			} else
-				return MapUnit.NONE;
-		}
-		
 		public static Tile NONE = new Tile();
 
 		//This should be used when we want to check if land tiles are next to water tiles.

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -91,6 +91,21 @@ namespace C7GameData
 			return neighbors.Values.Where(tile => tile.baseTerrainType.Key == "coast").ToList();
 		}
 
+		public bool HasRiverCrossing(TileDirection dir)
+		{
+			switch (dir) {
+			case TileDirection.NORTH:     return (riverNortheast && riverNorthwest) || (neighbors[TileDirection.NORTH].riverSoutheast && neighbors[TileDirection.NORTH].riverSouthwest);
+			case TileDirection.NORTHEAST: return riverNortheast;
+			case TileDirection.EAST:      return (riverNortheast && riverSoutheast) || (neighbors[TileDirection.EAST ].riverSouthwest && neighbors[TileDirection.EAST ].riverNorthwest);
+			case TileDirection.SOUTHEAST: return riverSoutheast;
+			case TileDirection.SOUTH:     return (riverSoutheast && riverSouthwest) || (neighbors[TileDirection.SOUTH].riverNorthwest && neighbors[TileDirection.SOUTH].riverNortheast);
+			case TileDirection.SOUTHWEST: return riverSouthwest;
+			case TileDirection.WEST:      return (riverSouthwest && riverNorthwest) || (neighbors[TileDirection.WEST ].riverNortheast && neighbors[TileDirection.WEST ].riverSoutheast);
+			case TileDirection.NORTHWEST: return riverNorthwest;
+			default: throw new ArgumentOutOfRangeException("Invalid TileDirection");
+			}
+		}
+
 		public bool IsLand()
 		{
 			return !baseTerrainType.isWater();

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -91,16 +91,38 @@ namespace C7GameData
 			return neighbors.Values.Where(tile => tile.baseTerrainType.Key == "coast").ToList();
 		}
 
+		// Returns whether or not there's a river crossing at the asterisk (*), looking forward from the carat (^), given the presence of
+		// rivers along the four labeled tile edges:
+		//        \     /
+		// farLeft \   /  farRight
+		//          \ /
+		//           *
+		//          / \
+		// nearLeft/   \  nearRight
+		//        /  ^  \
+		private bool FacingCrossingAtVertex(bool nearLeft, bool nearRight, bool farLeft, bool farRight)
+		{
+			return (nearLeft && nearRight) || (farLeft && farRight) || (nearLeft && farRight) || (farLeft && nearRight);
+		}
+
 		public bool HasRiverCrossing(TileDirection dir)
 		{
 			switch (dir) {
-			case TileDirection.NORTH:     return (riverNortheast && riverNorthwest) || (neighbors[TileDirection.NORTH].riverSoutheast && neighbors[TileDirection.NORTH].riverSouthwest);
+			case TileDirection.NORTH:
+				Tile north = neighbors[TileDirection.NORTH];
+				return FacingCrossingAtVertex(riverNorthwest, riverNortheast, north.riverSouthwest, north.riverSoutheast);
 			case TileDirection.NORTHEAST: return riverNortheast;
-			case TileDirection.EAST:      return (riverNortheast && riverSoutheast) || (neighbors[TileDirection.EAST ].riverSouthwest && neighbors[TileDirection.EAST ].riverNorthwest);
+			case TileDirection.EAST:
+				Tile east = neighbors[TileDirection.EAST];
+				return FacingCrossingAtVertex(riverNortheast, riverSoutheast, east.riverNorthwest, east.riverSouthwest);
 			case TileDirection.SOUTHEAST: return riverSoutheast;
-			case TileDirection.SOUTH:     return (riverSoutheast && riverSouthwest) || (neighbors[TileDirection.SOUTH].riverNorthwest && neighbors[TileDirection.SOUTH].riverNortheast);
+			case TileDirection.SOUTH:
+				Tile south = neighbors[TileDirection.SOUTH];
+				return FacingCrossingAtVertex(riverSoutheast, riverSouthwest, south.riverNortheast, south.riverNorthwest);
 			case TileDirection.SOUTHWEST: return riverSouthwest;
-			case TileDirection.WEST:      return (riverSouthwest && riverNorthwest) || (neighbors[TileDirection.WEST ].riverNortheast && neighbors[TileDirection.WEST ].riverSoutheast);
+			case TileDirection.WEST:
+				Tile west = neighbors[TileDirection.WEST];
+				return FacingCrossingAtVertex(riverSouthwest, riverNorthwest, west.riverSoutheast, west.riverNortheast);
 			case TileDirection.NORTHWEST: return riverNorthwest;
 			default: throw new ArgumentOutOfRangeException("Invalid TileDirection");
 			}


### PR DESCRIPTION
Closes #195, Closes #196
Adds defensive bonuses to the game. Bonuses are applied for fortification, terrain, river crossing, and city garrison. The city garrison bonus is a placeholder. It still needs to scale for city level, right now all cities have the level 2 bonus (+50% under standard rules).
The branch for this PR extends off of my experience levels branch. I did that so I could easily use the C7RulesFormat class to hold the defensive bonuses. Now it's looking like the rules object will be merged into the game data object. I'd like to get these PRs merged first, though, and settle that issue later. It wouldn't be difficult to move the defensive bonuses and experience levels over to the game data object.
As for how it's implemented: Instead of using `unit.unitType.defense` to get a unit's defense strength, you'd now use `unit.DefenseStrengthVersus(...)` which takes an opponent unit, a flag for bombard vs regular attack, and an optional attack direction. `DefenseStrengthVersus` computes the effective defense strength by summing a list of `StrengthBonuses` returned by `ListStrengthBonusesVersus`. This sounds like overkill but it's for a good purpose. `StrengthBonuses` include descriptions so they can be displayed in the interface for the player's erudition, like in Civ 4 when you hover over a possible attack. Also I added a little combat log that shows the bonuses when combat begins, this is useful for debugging. Lastly `ListStrengthBonusesVersus` is a convenient point to mod in additional strength bonuses, for example a bonus for spearmen versus mounted units or even Civ 4 style promotions.
I wrote that `HasRiverCrossing` function before I knew that the info it returns could be imported from the Civ 3 data. Quintillus already set that up for his river commerce PR so once that's merged I'll modify the river crossing code to use that instead.