### PR TITLE
Tests to .NET 4.7.2/C# 8.0.

### DIFF
--- a/C7GameDataTests/C7GameDataTests.csproj
+++ b/C7GameDataTests/C7GameDataTests.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
         <Nullable>enable</Nullable>
-
+		<LangVersion>8.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/C7GameDataTests/C7GameDataTests.csproj
+++ b/C7GameDataTests/C7GameDataTests.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net472</TargetFramework>
         <Nullable>enable</Nullable>
-		    <LangVersion>8.0</LangVersion>
+        <LangVersion>8.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/C7GameDataTests/C7GameDataTests.csproj
+++ b/C7GameDataTests/C7GameDataTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net472</TargetFramework>
-        <Nullable>enable</Nullable>
         <LangVersion>8.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>


### PR DESCRIPTION
Fixes the issue WildWeazel was having running them locally.  Don't know why it worked for me with .NET 6.0, probably having more frameworks installed.

Looks like pcen already hotfixed most of this, so it's actually just the C# 8.0 change.