### PR TITLE
Disable animations with shift

### DIFF
--- a/C7/AnimationTracker.cs
+++ b/C7/AnimationTracker.cs
@@ -8,6 +8,7 @@ using C7Engine;
 
 public class AnimationTracker {
 	private Civ3AnimData civ3AnimData;
+	public bool endAllImmediately = false; // If true, update() ends all running animations regardless of time remaining.
 
 	public AnimationTracker(Civ3AnimData civ3AnimData)
 	{
@@ -109,7 +110,7 @@ public class AnimationTracker {
 
 	public void update()
 	{
-		long currentTimeMS = getCurrentTimeMS();
+		long currentTimeMS = (! endAllImmediately) ? getCurrentTimeMS() : long.MaxValue;
 		var keysToRemove = new List<string>();
 		foreach (var guidAAPair in activeAnims.Where(guidAAPair => guidAAPair.Value.endTimeMS <= currentTimeMS)) {
 			var (id, aa) = (guidAAPair.Key, guidAAPair.Value);

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -213,6 +213,12 @@ public class Game : Node2D
 		}
 	}
 
+	public void SetAnimationsEnabled(bool enabled)
+	{
+		new MsgSetAnimationsEnabled(enabled).send();
+		animTracker.endAllImmediately = ! enabled;
+	}
+
 	/**
 	 * Currently (11/14/2021), all unit selection goes through here.
 	 * Both code paths are in Game.cs for now, so it's local, but we may
@@ -417,9 +423,9 @@ public class Game : Node2D
 				OldPosition = eventMouseMotion.Position;
 			}
 		}
-		else if (@event is InputEventKey eventKey && eventKey.Pressed)
+		else if (@event is InputEventKey eventKeyDown && eventKeyDown.Pressed)
 		{
-			if (eventKey.Scancode == (int)Godot.KeyList.Enter)
+			if (eventKeyDown.Scancode == (int)Godot.KeyList.Enter)
 			{
 				GD.Print("Enter pressed");
 				if (CurrentlySelectedUnit == MapUnit.NONE)
@@ -431,7 +437,7 @@ public class Game : Node2D
 					GD.Print("There is a " + CurrentlySelectedUnit.unitType.name + " selected; not ending turn");
 				}
 			}
-			else if (eventKey.Scancode == (int)Godot.KeyList.Space)
+			else if (eventKeyDown.Scancode == (int)Godot.KeyList.Space)
 			{
 				GD.Print("Space pressed");
 				if (CurrentlySelectedUnit == MapUnit.NONE)
@@ -439,12 +445,12 @@ public class Game : Node2D
 					this.OnPlayerEndTurn();
 				}
 			}
-			else if ((eventKey.Scancode >= (int)Godot.KeyList.Kp1) && (eventKey.Scancode <= (int)Godot.KeyList.Kp9))
+			else if ((eventKeyDown.Scancode >= (int)Godot.KeyList.Kp1) && (eventKeyDown.Scancode <= (int)Godot.KeyList.Kp9))
 			{ // Move units with the numpad keys
 				if (CurrentlySelectedUnit != MapUnit.NONE)
 				{
 					TileDirection dir;
-					switch (eventKey.Scancode - (int)Godot.KeyList.Kp0) {
+					switch (eventKeyDown.Scancode - (int)Godot.KeyList.Kp0) {
 					case 1: dir = TileDirection.SOUTHWEST; break;
 					case 2: dir = TileDirection.SOUTH;     break;
 					case 3: dir = TileDirection.SOUTHEAST; break;
@@ -460,12 +466,12 @@ public class Game : Node2D
 					setSelectedUnit(CurrentlySelectedUnit);	//also triggers updating the lower-left info box
 				}
 			}
-			else if ((eventKey.Scancode >= (int)Godot.KeyList.Home) && (eventKey.Scancode <= (int)Godot.KeyList.Pagedown))
+			else if ((eventKeyDown.Scancode >= (int)Godot.KeyList.Home) && (eventKeyDown.Scancode <= (int)Godot.KeyList.Pagedown))
 			{ // Move units with the arrow and fn keys
 				if (CurrentlySelectedUnit != MapUnit.NONE)
 				{
 					TileDirection dir;
-					switch (eventKey.Scancode) {
+					switch (eventKeyDown.Scancode) {
 					case (int)Godot.KeyList.Home:     dir = TileDirection.NORTHWEST; break; // fn-left arrow
 					case (int)Godot.KeyList.End:      dir = TileDirection.SOUTHWEST; break; // fn-right arrow
 					case (int)Godot.KeyList.Left:     dir = TileDirection.WEST;      break;
@@ -480,11 +486,11 @@ public class Game : Node2D
 					setSelectedUnit(CurrentlySelectedUnit);	//also triggers updating the lower-left info box
 				}
 			}
-			else if (eventKey.Scancode == (int)Godot.KeyList.G && eventKey.Control)
+			else if (eventKeyDown.Scancode == (int)Godot.KeyList.G && eventKeyDown.Control)
 			{
 				mapView.gridLayer.visible = !mapView.gridLayer.visible;
 			}
-			else if (eventKey.Scancode == (int)Godot.KeyList.Escape)
+			else if (eventKeyDown.Scancode == (int)Godot.KeyList.Escape)
 			{
 				if (!inUnitGoToMode) {
 					GD.Print("Got request for escape/quit");
@@ -492,7 +498,7 @@ public class Game : Node2D
 					popupOverlay.ShowPopup(new EscapeQuitPopup(), PopupOverlay.PopupCategory.Info);
 				}
 			}
-			else if (eventKey.Scancode == (int)Godot.KeyList.Z)
+			else if (eventKeyDown.Scancode == (int)Godot.KeyList.Z)
 			{
 				if (mapView.cameraZoom != 1) {
 					mapView.setCameraZoomFromMiddle(1.0f);
@@ -505,11 +511,21 @@ public class Game : Node2D
 					slider.Value = 0.5f;
 				}
 			}
+			else if (eventKeyDown.Scancode == (int)Godot.KeyList.Shift && ! eventKeyDown.Echo)
+			{
+				SetAnimationsEnabled(false);
+			}
 
 			// always turn off go to mode unless G key is pressed
 			// do this after processing esc key
-			setGoToMode(eventKey.Scancode == (int)Godot.KeyList.G);
-
+			setGoToMode(eventKeyDown.Scancode == (int)Godot.KeyList.G);
+		}
+		else if (@event is InputEventKey eventKeyUp && ! eventKeyUp.Pressed)
+		{
+			if (eventKeyUp.Scancode == (int)Godot.KeyList.Shift)
+			{
+				SetAnimationsEnabled(true);
+			}
 		}
 		else if (@event is InputEventMagnifyGesture magnifyGesture)
 		{

--- a/C7Engine/EngineStorage.cs
+++ b/C7Engine/EngineStorage.cs
@@ -20,6 +20,7 @@ namespace C7Engine
 		internal static GameData gameData {get; set;}
 		internal static C7RulesFormat rules {get; set;}
 		public static string uiControllerID;
+		internal static bool animationsEnabled = true;
 
 		private static Thread engineThread = null;
 		internal static AutoResetEvent uiEvent = new AutoResetEvent(false); // Used to block engineThread while waiting for the UI, f.e. while

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -172,4 +172,18 @@ namespace C7Engine
 			TurnHandling.AdvanceTurn();
 		}
 	}
+
+	public class MsgSetAnimationsEnabled : MessageToEngine {
+		private bool enabled;
+
+		public MsgSetAnimationsEnabled(bool enabled)
+		{
+			this.enabled = enabled;
+		}
+
+		public override void process()
+		{
+			EngineStorage.animationsEnabled = enabled;
+		}
+	}
 }

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -11,11 +11,13 @@ using C7GameData;
 public static class MapUnitExtensions {
 	public static void animate(this MapUnit unit, MapUnit.AnimatedAction action, bool wait, AnimationEnding ending = AnimationEnding.Stop)
 	{
-		new MsgStartUnitAnimation(unit, action, wait ? EngineStorage.uiEvent : null, ending).send();
-		if (wait) {
-			EngineStorage.gameDataMutex.ReleaseMutex();
-			EngineStorage.uiEvent.WaitOne();
-			EngineStorage.gameDataMutex.WaitOne();
+		if (EngineStorage.animationsEnabled) {
+			new MsgStartUnitAnimation(unit, action, wait ? EngineStorage.uiEvent : null, ending).send();
+			if (wait) {
+				EngineStorage.gameDataMutex.ReleaseMutex();
+				EngineStorage.uiEvent.WaitOne();
+				EngineStorage.gameDataMutex.WaitOne();
+			}
 		}
 	}
 
@@ -170,9 +172,9 @@ public static class MapUnitExtensions {
 		unit.movementPointsRemaining -= 1;
 		if (EngineStorage.gameData.rng.NextDouble() < attackerOdds) {
 			target.hitPointsRemaining -= 1;
-			new MsgStartEffectAnimation(tile, AnimatedEffect.Hit3, null, AnimationEnding.Stop).send();
+			tile.Animate(AnimatedEffect.Hit3, false);
 		} else
-			new MsgStartEffectAnimation(tile, AnimatedEffect.Miss, null, AnimationEnding.Stop).send();
+			tile.Animate(AnimatedEffect.Miss, false);
 
 		if (target.hitPointsRemaining <= 0) {
 			unit.RollToPromote(target, false);

--- a/C7Engine/TileExtensions.cs
+++ b/C7Engine/TileExtensions.cs
@@ -14,5 +14,17 @@ namespace C7Engine
 			} else
 				return MapUnit.NONE;
 		}
+
+		public static void Animate(this Tile tile, AnimatedEffect effect, bool wait)
+		{
+			if (EngineStorage.animationsEnabled) {
+				new MsgStartEffectAnimation(tile, effect, wait ? EngineStorage.uiEvent : null, AnimationEnding.Stop).send();
+				if (wait) {
+					EngineStorage.gameDataMutex.ReleaseMutex();
+					EngineStorage.uiEvent.WaitOne();
+					EngineStorage.gameDataMutex.WaitOne();
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
This relatively small PR lets players disable animations by holding down the shift key. That way it's possible to click through the turns much more quickly. Also I noticed that the game becomes sluggish after 20 or so turns, and I was concerned that animations were responsible, so I implemented this to test if disabling them would improve turn times. It does not.