### PR TITLE
#208 - Teach the AI to favor exploration near its cities, unless it has a surplus of explorers.

### DIFF
--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -100,12 +100,26 @@ namespace C7Engine
 					//Isn't a Settler.  If there's a city at the location, it's defended.  No boats involved.  What's our priority?
 					//If there is land to explore, we'll try to explore it.
 					//Long-term TODO: Should only send tiles on this landmass.
-					KeyValuePair<Tile, int> tileToExplore = ExplorerAI.FindTopScoringTileForExploration(player, player.tileKnowledge.AllKnownTiles().Where(t => t.IsLand()));
+					KeyValuePair<Tile, float> tileToExplore = ExplorerAI.FindTopScoringTileForExploration(player, player.tileKnowledge.AllKnownTiles().Where(t => t.IsLand()), ExplorerAIData.ExplorationType.RANDOM);
 					if (tileToExplore.Value > 0) {
 						ExplorerAIData ai = new ExplorerAIData();
-						ai.type = ExplorerAIData.ExplorationType.RANDOM;
+						//What type of exploration should we do?
+						int nearbyExplorers = 0;
+						foreach (MapUnit mapUnit in player.units)
+						{
+							if (mapUnit.currentAIData is ExplorerAIData explorerAI) {
+								if (explorerAI.type == ExplorerAIData.ExplorationType.NEAR_CITIES) {
+									nearbyExplorers++;
+								}
+							}
+						}
+						if (nearbyExplorers < (player.cities.Count + 1)) {
+							ai.type = ExplorerAIData.ExplorationType.NEAR_CITIES;
+						} else {
+							ai.type = ExplorerAIData.ExplorationType.RANDOM;
+						}
 						unit.currentAIData = ai;
-						Console.WriteLine("Set random exploration AI for " + unit);
+						Console.WriteLine($"Set {ai.type} exploration AI for {unit}");
 					}
 					else {
 						//Nowhere to explore.  What to do now?

--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -16,7 +16,7 @@ namespace C7Engine
 				return MoveToNextTileOnPath(explorerData, unit);
 			}
 			else {
-				bool foundNeighboringTileToExplore = ExploreNeighboringTile(player, unit);
+				bool foundNeighboringTileToExplore = ExploreNeighboringTile(player, unit, explorerData);
 				if (foundNeighboringTileToExplore) {
 					return true;
 				}
@@ -45,13 +45,14 @@ namespace C7Engine
 			return false;
 		}
 
-		private static bool ExploreNeighboringTile(Player player, MapUnit unit) {
+		private static bool ExploreNeighboringTile(Player player, MapUnit unit, ExplorerAIData aiData) {
 			List<Tile> validNeighboringTiles = unit.unitType.categories.Contains("Sea") ? unit.location.GetCoastNeighbors() : unit.location.GetLandNeighbors();
 			if (validNeighboringTiles.Count == 0) {
 				Console.WriteLine("No valid locations for unit " + unit + " at location " + unit.location);
 				return false;
 			}
-			KeyValuePair<Tile, int> topScoringTile = FindTopScoringTileForExploration(player, validNeighboringTiles);
+			//Console.WriteLine($"Exploring for unit {unit}"); //debugging print
+			KeyValuePair<Tile, float> topScoringTile = FindTopScoringTileForExploration(player, validNeighboringTiles, aiData.type);
 			Tile newLocation = topScoringTile.Key;
 
 			if (newLocation != Tile.NONE && topScoringTile.Value > 0) {
@@ -100,16 +101,34 @@ namespace C7Engine
 			return true;
 		}
 
-		public static KeyValuePair<Tile, int> FindTopScoringTileForExploration(Player player, IEnumerable<Tile> possibleNewLocations)
+		public static KeyValuePair<Tile, float> FindTopScoringTileForExploration(Player player, IEnumerable<Tile> possibleNewLocations, ExplorerAIData.ExplorationType type)
 		{
 			//Technically, this should be the *estimated* new tiles revealed.  If a mountain blocks visibility,
 			//we won't know that till we move there.
-			Dictionary<Tile, int> numNewTilesRevealed = new Dictionary<Tile, int>();
-			foreach (Tile t in possibleNewLocations)
-			{
-				numNewTilesRevealed[t] = numUnknownNeighboringTiles(player, t);
+			Dictionary<Tile, float> explorationScore = new Dictionary<Tile, float>();
+			foreach (Tile t in possibleNewLocations) {
+				int baseScore = numUnknownNeighboringTiles(player, t);
+				if (baseScore == 0) {
+					explorationScore[t] = 0;
+				}
+				else if (type == ExplorerAIData.ExplorationType.NEAR_CITIES) {
+					if (baseScore == 0) {
+						explorationScore[t] = 0;
+					}
+					int distanceToNearestCity = int.MaxValue;
+					foreach (City c in player.cities) {
+						int distance = t.distanceTo(c.location);
+						if (distance < distanceToNearestCity) {
+							distanceToNearestCity = distance;
+						}
+					}
+					explorationScore[t] = 100 - 4 * distanceToNearestCity * distanceToNearestCity + baseScore;
+					// Console.WriteLine($"Exploration score for {t}: {explorationScore[t]}"); //debugging print
+				} else {
+					explorationScore[t] = baseScore;
+				}
 			}
-			IOrderedEnumerable<KeyValuePair<Tile, int>> orderedScores = numNewTilesRevealed.OrderByDescending(t => t.Value);
+			IOrderedEnumerable<KeyValuePair<Tile, float>> orderedScores = explorationScore.OrderByDescending(t => t.Value);
 			return orderedScores.First();
 		}
 

--- a/C7GameData/AIData/ExplorerAIData.cs
+++ b/C7GameData/AIData/ExplorerAIData.cs
@@ -5,6 +5,7 @@ namespace C7GameData.AIData
 		public enum ExplorationType
 		{
 			RANDOM,
+			NEAR_CITIES,
 			COASTLINE,
 			DIRECTIONAL,
 			SCOUT_RIVAL,
@@ -12,7 +13,7 @@ namespace C7GameData.AIData
 		}
 		public ExplorationType type;
         public TilePath path;
-		
+
 		public override string ToString()
 		{
 			return type + " exploration";


### PR DESCRIPTION
This looks more realistic, and is a near-prerequisite for having the AI use revealed tiles data to settle cities effectively (#207).

For now, I've set the AI to devote up to (# of cities + 1) units to exploring nearby tiles.  Longer term, I expect we'll have enhancements to make the AI more configurable, and less hard-coded in choosing strategies, but we're still a bit early on strategies to choose between for that.

You should be able to observe the differences by watching the AI.