### PR TITLE
Fix the unit tests not compiling with net6.0

### DIFF
--- a/C7/LogManager.cs
+++ b/C7/LogManager.cs
@@ -18,11 +18,9 @@ public class LogManager : Node
 		//		Exception: exception
 		// Example: 22:25:32.528 [DBG] MainMenu: enter MainMenu._Ready
 		ExpressionTemplate consoleTemplate = new ExpressionTemplate(
-			"{@t:HH:mm:ss.fff} [{@l:u3}]{#if SourceContext is not null} {SourceContext}:{#end} {@m:lj}\n{#if @x is not null}\tException: {@x}{#end}",
-			theme: TemplateTheme.Code);
+			"{@t:HH:mm:ss.fff} [{@l:u3}]{#if SourceContext is not null} {SourceContext}:{#end} {@m:lj}{#if @x is not null}\tException: {@x}{#end}");
 
 		Log.Logger = new LoggerConfiguration()
-			.WriteTo.Console(formatter: consoleTemplate)
 			.WriteTo.GodotSink(formatter: consoleTemplate)
 			.MinimumLevel.Debug()
 			.CreateLogger();

--- a/C7/LogManager.cs
+++ b/C7/LogManager.cs
@@ -1,13 +1,6 @@
 using Godot;
 using Serilog;
 using Serilog.Templates;
-using Serilog.Templates.Themes;
-using Serilog.Core;
-using Serilog.Events;
-using Serilog.Configuration;
-using Serilog.Formatting;
-using System;
-using System.IO;
 
 public class LogManager : Node
 {

--- a/EngineTests/EngineTests.csproj
+++ b/EngineTests/EngineTests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\C7Engine\C7Engine.csproj" />
+    <ProjectReference Include="..\C7GameData\C7GameData.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
For some reason they need an explicit reference to C7GameData with net6.0, which they didn't with net4.7.2.  No idea why that changed, someone at MSFT must have thought it was a good idea.