### PR TITLE
Fix the log formatting

### DIFF
--- a/C7/LogManager.cs
+++ b/C7/LogManager.cs
@@ -18,11 +18,9 @@ public class LogManager : Node
 		//		Exception: exception
 		// Example: 22:25:32.528 [DBG] MainMenu: enter MainMenu._Ready
 		ExpressionTemplate consoleTemplate = new ExpressionTemplate(
-			"{@t:HH:mm:ss.fff} [{@l:u3}]{#if SourceContext is not null} {SourceContext}:{#end} {@m:lj}\n{#if @x is not null}\tException: {@x}{#end}",
-			theme: TemplateTheme.Code);
+			"{@t:HH:mm:ss.fff} [{@l:u3}]{#if SourceContext is not null} {SourceContext}:{#end} {@m:lj}{#if @x is not null}\tException: {@x}{#end}");
 
 		Log.Logger = new LoggerConfiguration()
-			.WriteTo.Console(formatter: consoleTemplate)
 			.WriteTo.GodotSink(formatter: consoleTemplate)
 			.MinimumLevel.Debug()
 			.CreateLogger();

--- a/C7/LogManager.cs
+++ b/C7/LogManager.cs
@@ -1,13 +1,6 @@
 using Godot;
 using Serilog;
 using Serilog.Templates;
-using Serilog.Templates.Themes;
-using Serilog.Core;
-using Serilog.Events;
-using Serilog.Configuration;
-using Serilog.Formatting;
-using System;
-using System.IO;
 
 public class LogManager : Node
 {


### PR DESCRIPTION
Fixes #268 .  The log formatting was unfortunately not at all legible on my system before these changes.

1. Remove theme that was borking everything.  
2. Remove unnecessary newline.
3. Remove console sync; the Godot one will show up on the console

Tested on Windows 8.1 with the Godot IDE and Rider.

Creating as a draft since I want to see if I can get the suggestion from my last comment working here.