### PR TITLE
Log to a file by default

### DIFF
--- a/C7/C7.csproj
+++ b/C7/C7.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Expressions" Version="3.3.0" />
   </ItemGroup>
 </Project>

--- a/C7/LogManager.cs
+++ b/C7/LogManager.cs
@@ -1,3 +1,4 @@
+using System;
 using Godot;
 using Serilog;
 using Serilog.Templates;
@@ -22,7 +23,10 @@ public class LogManager : Node
 		// Includes all logs of an 'Information' level regardless of namespace, and all logs of
 		// the C7Engine.AI namespace regardless of log level.
 		Log.Logger = new LoggerConfiguration()
-			.WriteTo.GodotSink(formatter: consoleTemplate)
+			// .WriteTo.GodotSink(formatter: consoleTemplate)	//Writing to console can slow the game down considerably (see #278).  Thus it is disabled by default.
+			.WriteTo.File("log.txt", buffered: true, flushToDiskInterval: TimeSpan.FromMilliseconds(250), fileSizeLimitBytes: 5242880,	//5 MB
+			              outputTemplate: "[{Level:u3}] {Timestamp:HH:mm:ss} {SourceContext}: {Message:lj} {NewLine}{Exception}")
+
 			.Filter.ByIncludingOnly("(@l = 'Fatal' OR @l = 'Error' OR @l = 'Warning' OR @l = 'Information')")	//suggested:  OR SourceContext like 'C7Engine.AI.%' (insert the namespace you need to debug)
 			.MinimumLevel.Debug()
 			.CreateLogger();


### PR DESCRIPTION
This is much quicker than writing to the Godot sink, which in turn writes to the console.

This allows investigating of performance hot spots without logging of the performance taking up more overhead than the actual performance hot spot.

See the extensive notes on Closes #278 .  When investigating why turn times were slow, the logging I added made things another order of magnitude slower.  These changes at least significantly decrease that overhead.