### PR TITLE
273 - Fix slow explorer pathing

### DIFF
--- a/C7Engine/AI/Pathing/DijkstrasLandAlgorithm.cs
+++ b/C7Engine/AI/Pathing/DijkstrasLandAlgorithm.cs
@@ -40,6 +40,10 @@ namespace C7Engine.Pathing
 		}
 
 		public override TilePath PathFrom(Tile start, Tile destination) {
+			if (!destination.IsLand()) {
+				return TilePath.NONE;
+			}
+
 			// shortest distance from start to each tile on the continent
 			Dictionary<Tile, int> dist = new Dictionary<Tile, int>();
 			Dictionary<Tile, Tile> predecessors = new Dictionary<Tile, Tile>();

--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -54,7 +54,7 @@ namespace C7Engine
 				log.Information("No valid exploration locations for unit " + unit + " at location " + unit.location);
 				return false;
 			}
-			// log.Verbose($"Exploring for unit {unit}");
+			log.Verbose($"Exploring for unit {unit}");
 			KeyValuePair<Tile, float> topScoringTile = FindTopScoringTileForExploration(player, validNeighboringTiles, aiData.type);
 			Tile newLocation = topScoringTile.Key;
 

--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using C7GameData;
 using C7GameData.AIData;
@@ -53,7 +54,7 @@ namespace C7Engine
 				log.Information("No valid exploration locations for unit " + unit + " at location " + unit.location);
 				return false;
 			}
-			log.Debug($"Exploring for unit {unit}");
+			// log.Verbose($"Exploring for unit {unit}");
 			KeyValuePair<Tile, float> topScoringTile = FindTopScoringTileForExploration(player, validNeighboringTiles, aiData.type);
 			Tile newLocation = topScoringTile.Key;
 
@@ -69,12 +70,20 @@ namespace C7Engine
 		}
 
 		private static bool FindPathToNewExplorationArea(Player player, ExplorerAIData explorerData, MapUnit unit) {
+			Stopwatch watch = new Stopwatch();
+			watch.Start();
 			List<Tile> validExplorerTiles = new List<Tile>();
 			foreach (Tile t in player.tileKnowledge.AllKnownTiles()
 					.Where(t => unit.CanEnterTile(t, false) && t.cityAtTile == null && numUnknownNeighboringTiles(player, t) > 0))
 			{
 				validExplorerTiles.Add(t);
 			}
+
+			int CrowFliesDistance(Tile x, Tile y) {
+				return x.distanceTo(unit.location) - y.distanceTo(unit.location);
+			};
+
+			validExplorerTiles.Sort(CrowFliesDistance);
 
 			if (validExplorerTiles.Count == 0) {
 				//Nowhere to explore.
@@ -86,13 +95,32 @@ namespace C7Engine
 			TilePath chosenPath = null;
 
 			PathingAlgorithm algo = PathingAlgorithmChooser.GetAlgorithm();
+			log.Debug("Explorer pathing from " + unit.location + " with " + unit.unitType);
 			foreach (Tile t in validExplorerTiles) {
+				if (t.distanceTo(unit.location) > lowestDistance) {
+					//Impossible to be shorter, skip it
+					continue;
+				}
+
+				long millis = watch.ElapsedMilliseconds;
 				TilePath path = algo.PathFrom(unit.location, t);
 				if (path.PathLength() < lowestDistance) {
 					lowestDistance = path.PathLength();
 					chosenPath = path;
 				}
+
+				long elapsedTimeForTile = watch.ElapsedMilliseconds - millis;
+
+				if (elapsedTimeForTile >= 10) {
+					log.Warning("Pathing time for {Tile} = {Time} ms", t, elapsedTimeForTile);
+				}
+
+				if (lowestDistance == 1) {
+					break;
+				}
 			}
+
+			log.Debug($"Explorer pathing took " + watch.ElapsedMilliseconds + " milliseconds");
 
 			if (chosenPath == null) {
 				//This could happen if there is e.g. a land tile that we could explore from, but on a different landmass.

--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -120,7 +120,12 @@ namespace C7Engine
 				}
 			}
 
-			log.Debug($"Explorer pathing took " + watch.ElapsedMilliseconds + " milliseconds");
+			long totalPathingTime = watch.ElapsedMilliseconds;
+			if (totalPathingTime >= 100) {
+				log.Warning($"Explorer pathing took " + totalPathingTime + " milliseconds from " + unit.location + " with " + unit.unitType);
+			} else {
+				log.Debug($"Explorer pathing took " + totalPathingTime + " milliseconds");
+			}
 
 			if (chosenPath == null) {
 				//This could happen if there is e.g. a land tile that we could explore from, but on a different landmass.


### PR DESCRIPTION
Closes #273 

There are two main optimizations here:

 - If we're pathing to water, don't even bother.  At some point we will want to bother, but since the algorithm doesn't support water yet, this prevents it from wasting time.
 - More importantly, the ExplorerAI now optimizes its calls to pathing.  It sorts all tiles it wants to query by crow-flies distances first, which is fast.  Then it starts calling them, but if it has already a tile whose path is as short or shorter than the crow-flies distances for the tile it's evaluating, then it skips it because it's impossible for the new one to be quicker.  Because it sorted by crow-flies distance first, this means that in most cases, most tiles will be skipped (the exception being if terrain features, namely water, prevent the shortest crow-flies tiles from being navigable without a lengthy detour).
 - As a corollary of the above, if it finds a path with length 1 (the shortest possible path, i.e. a tile right next door), it immediatley stops searching.

In my sample data, with a Babylon Warrior on turn 12, this takes the time down from 86ms to 1ms - very noticeable to not noticeable at all.  (Note that this was testing with a fixed seed of 123, which is not included in this branch)

Other notes:

 - This change relies on a high-level optimization to pathing, i.e. not calling the algorithm as much.  It's also possible to optimize the algorithm, either to make it faster, or to cache things so calls that would otherwise recalculate things don't have to recalculate things.  I suspect we'll use both of these options, but in this case the high-level one seemed a bit simpler, and proved to be quite effective.
 - I intentionally added some logging around this, of various levels, with the idea being to make it easier to notice if/when explorer pathing becomes slow in the future.  Longer term, I think we should enhance our pathing algorithm to keep metrics such as when it is called, how long it takes, etc. - as it's likely to be a major bottleneck if Civ3 is any indication.
 - See #273 for lots of detailed notes, including testing results.

Even with slow console logging and debug logging of explorer info (and with a few long calculations around bays), this gets us to turn 100 without the slowdowns we were seeing before.  Switching to file based logging extends that to 200 turns, at which point we're back to Aztec where it's likely the UI that starts slowing things down with tons of cities present.