### PR TITLE
282 - Fixed Seed

### DIFF
--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -29,7 +29,7 @@ namespace C7Engine {
 							log.Warning("WARNING: No valid tiles for barbarian to move to");
 							continue;
 						}
-						Tile newLocation = validTiles[gameData.rng.Next(validTiles.Count)];
+						Tile newLocation = validTiles[GameData.rng.Next(validTiles.Count)];
 						//Because it chooses a semi-cardinal direction at random, not accounting for map, it could get none
 						//if it tries to move e.g. north from the north pole.  Hence, this check.
 						if (newLocation != Tile.NONE) {

--- a/C7Engine/AI/CityProductionAI.cs
+++ b/C7Engine/AI/CityProductionAI.cs
@@ -33,8 +33,7 @@ namespace C7Engine
 			}
 			if (lastProduced == unitPrototypes["Warrior"]) {
 				if (city.location.NeighborsWater()) {
-					Random rng = new Random();
-					if (rng.Next(3) == 0) {
+					if (EngineStorage.gameData.rng.Next(3) == 0) {
 						return unitPrototypes["Galley"];
 					}
 					else {

--- a/C7Engine/AI/CityProductionAI.cs
+++ b/C7Engine/AI/CityProductionAI.cs
@@ -33,7 +33,7 @@ namespace C7Engine
 			}
 			if (lastProduced == unitPrototypes["Warrior"]) {
 				if (city.location.NeighborsWater()) {
-					if (EngineStorage.gameData.rng.Next(3) == 0) {
+					if (GameData.rng.Next(3) == 0) {
 						return unitPrototypes["Galley"];
 					}
 					else {

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -42,7 +42,7 @@ namespace C7Engine
 							new BarbarianAI().PlayTurn(player, gameData);
 							player.hasPlayedThisTurn = true;
 						} else if (! player.isHuman) {
-							PlayerAI.PlayTurn(player, gameData.rng);
+							PlayerAI.PlayTurn(player, GameData.rng);
 							player.hasPlayedThisTurn = true;
 						} else {
 							player.hasPlayedThisTurn = true;
@@ -62,7 +62,7 @@ namespace C7Engine
 				foreach (Tile tile in gameData.map.barbarianCamps)
 				{
 					//7% chance of a new barbarian.  Probably should scale based on barbarian activity.
-					int result = gameData.rng.Next(100);
+					int result = GameData.rng.Next(100);
 					log.Verbose("Random barb result = " + result);
 					if (result < 7) {
 						MapUnit newUnit = new MapUnit();

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -91,7 +91,7 @@ public static class MapUnitExtensions {
 			promotionChance /= 2.0;
 		// TODO: Double promotionChance if unit is owned by a militaristic civ
 
-		if (EngineStorage.gameData.rng.NextDouble() < promotionChance) {
+		if (GameData.rng.NextDouble() < promotionChance) {
 			ExperienceLevel nextLevel = EngineStorage.gameData.GetExperienceLevelAfter(unit.experienceLevel);
 			if (nextLevel != null) {
 				unit.experienceLevelKey = nextLevel.key;
@@ -153,7 +153,7 @@ public static class MapUnitExtensions {
 
 			// dADB = defense Against Defensive Bombard
 			double dADB = attacker.StrengthVersus(defensiveBombarder, CombatRole.DefensiveBombardDefense, defensiveBombarder.facingDirection);
-			if (EngineStorage.gameData.rng.NextDouble() < defensiveBombarderStrength / (defensiveBombarderStrength + dADB))
+			if (GameData.rng.NextDouble() < defensiveBombarderStrength / (defensiveBombarderStrength + dADB))
 				attacker.hitPointsRemaining -= 1;
 
 			defensiveBombarder.defensiveBombardsRemaining -= 1;
@@ -166,10 +166,10 @@ public static class MapUnitExtensions {
 		while (true) {
 			defender.animate(MapUnit.AnimatedAction.ATTACK1, false);
 			attacker.animate(MapUnit.AnimatedAction.ATTACK1, true );
-			if (EngineStorage.gameData.rng.NextDouble() < attackerOdds) {
+			if (GameData.rng.NextDouble() < attackerOdds) {
 				if (defenderEligibleToRetreat &&
 				    defender.hitPointsRemaining == 1 &&
-				    EngineStorage.gameData.rng.NextDouble() < defender.RetreatChance(attacker, false)) {
+				    GameData.rng.NextDouble() < defender.RetreatChance(attacker, false)) {
 					// TODO: Defender retreat behavior requires some more work. There's an issue for it here:
 					// https://github.com/C7-Game/Prototype/issues/274
 					Tile retreatDestination = defender.location.neighbors[attacker.facingDirection];
@@ -186,7 +186,7 @@ public static class MapUnitExtensions {
 				}
 			} else {
 				if (attacker.hitPointsRemaining == 1 &&
-				    EngineStorage.gameData.rng.NextDouble() < attacker.RetreatChance(defender, true)) {
+				    GameData.rng.NextDouble() < attacker.RetreatChance(defender, true)) {
 					result = CombatResult.AttackerRetreated;
 					break;
 				}
@@ -228,7 +228,7 @@ public static class MapUnitExtensions {
 
 		unit.animate(MapUnit.AnimatedAction.ATTACK1, true);
 		unit.movementPointsRemaining -= 1;
-		if (EngineStorage.gameData.rng.NextDouble() < attackerOdds) {
+		if (GameData.rng.NextDouble() < attackerOdds) {
 			target.hitPointsRemaining -= 1;
 			tile.Animate(AnimatedEffect.Hit3, false);
 		} else

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -34,7 +34,7 @@ namespace C7GameData
 		public GameData()
 		{
 			map = new GameMap();
-			rng = new Random();
+			rng = new Random(123);
 		}
 
 		public List<Player> GetHumanPlayers() {

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -6,7 +6,7 @@ namespace C7GameData
 	public class GameData
 	{
 		public int turn {get; set;}
-		public Random rng; // TODO: Is GameData really the place for this?
+		public static Random rng; // TODO: Is GameData really the place for this?
 		public GameMap map {get; set;}
 		public List<Player> players = new List<Player>();
 		public List<TerrainType> terrainTypes = new List<TerrainType>();
@@ -195,7 +195,7 @@ namespace C7GameData
 			Player computerPlayerThree = new Player(theNetherlands, orange);
 			players.Add(computerPlayerThree);
 
-			List<Tile> startingLocations = map.generateStartingLocations(rng, players.Count, 10);
+			List<Tile> startingLocations = map.generateStartingLocations(players.Count, 10);
 
 			int i = 0;
 			foreach (Player player in players)
@@ -210,7 +210,7 @@ namespace C7GameData
 			//Todo: We're using the same method for start locs and barb camps.  Really, we should use a similar one for
 			//variation, but the barb camp one should also take into account things like not spawning in revealed
 			//tiles.  It also would be really nice to be able to generate them separately and not have them overlap.
-			List<Tile> barbarianCamps = map.generateStartingLocations(rng, 10, 10);
+			List<Tile> barbarianCamps = map.generateStartingLocations(10, 10);
 			foreach (Tile barbCampLocation in barbarianCamps) {
 				if (barbCampLocation.unitsOnTile.Count == 0) { // in case a starting location is under one of the human player's units
 					MapUnit barbWarrior = CreateDummyUnit(unitPrototypes["Warrior"], barbarianPlayer, barbCampLocation);

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -34,7 +34,8 @@ namespace C7GameData
 		public GameData()
 		{
 			map = new GameMap();
-			rng = new Random(123);
+			rng = new Random();
+			// rng = new Random(123);	//Set a fixed seed here until we add it to the UI
 		}
 
 		public List<Player> GetHumanPlayers() {

--- a/C7GameData/GameMap.cs
+++ b/C7GameData/GameMap.cs
@@ -170,6 +170,7 @@ namespace C7GameData
 		public List<Tile> generateStartingLocations(Random rng, int num, int minDistBetween)
 		{
 			var tr = new List<Tile>();
+			rng = new Random(123);
 			for (int n = 0; n < num; n++) {
 				bool foundOne = false;
 				for (int numTries = 0; (! foundOne) && (numTries < 100); numTries++) {

--- a/C7GameData/GameMap.cs
+++ b/C7GameData/GameMap.cs
@@ -167,14 +167,13 @@ namespace C7GameData
 
 		public delegate int[,] TerrainNoiseMapGenerator(int rng, int width, int height);
 
-		public List<Tile> generateStartingLocations(Random rng, int num, int minDistBetween)
+		public List<Tile> generateStartingLocations(int num, int minDistBetween)
 		{
 			var tr = new List<Tile>();
-			rng = new Random(123);
 			for (int n = 0; n < num; n++) {
 				bool foundOne = false;
 				for (int numTries = 0; (! foundOne) && (numTries < 100); numTries++) {
-					var randTile = tiles[rng.Next(0, tiles.Count)];
+					var randTile = tiles[GameData.rng.Next(0, tiles.Count)];
 					if (randTile.baseTerrainType.isWater())
 						continue;
 					int distToNearestOtherLoc = Int32.MaxValue;

--- a/C7GameData/SaveFormat.cs
+++ b/C7GameData/SaveFormat.cs
@@ -41,12 +41,6 @@ namespace C7GameData
 		{
 			GameData.PerformPostLoadActions();
 
-			//If we are loading from JSON and it lacks an RNG, set one
-			//This should be a temporary hack until we have a more stable C7 default rule set.
-			if (GameData.rng == null) {
-				GameData.rng = new Random(123);
-			}
-
 			return true;
 		}
 

--- a/C7GameData/SaveFormat.cs
+++ b/C7GameData/SaveFormat.cs
@@ -44,7 +44,7 @@ namespace C7GameData
 			//If we are loading from JSON and it lacks an RNG, set one
 			//This should be a temporary hack until we have a more stable C7 default rule set.
 			if (GameData.rng == null) {
-				GameData.rng = new Random();
+				GameData.rng = new Random(123);
 			}
 
 			return true;


### PR DESCRIPTION
Closes #282 

This allows setting a fixed seed with one line of code being uncommented in GameData.cs.  Eventually, this will be configurable through the UI, but for now it allows debugging performance or AI issues with much more repeatability.

As a note, I made it static because somehow, passing the RNG as a parameter resulted in getting different results with the passed-by-parameter RNG each time I ran the game.  I'm not entirely sure why that was the case but it was definitely giving different results each time.  Overall however, "one RNG to rule them all" does seem like the sensible way to go to ensure we don't introduce another one somehow and throw off the eventual fixed RNG setting.