### PR TITLE
Set the initial zoom on the slider to 1.0, rather than 0.3

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -150,7 +150,7 @@ size_flags_vertical = 3
 min_value = 0.1
 max_value = 2.0
 step = 0.1
-value = 0.3
+value = 1.0
 
 [node name="QuitButton" type="Button" parent="CanvasLayer/SlideOutBar/VBoxContainer"]
 margin_top = 448.0


### PR DESCRIPTION
  This fixes the initial zoom-out (or zoom-in) so zooming out takes you to a 0.9 zoom level instead of a 0.2 zoom level (and 1.1 instead of 0.4 for zooming in).

Longer term, we probably shouldn't store this on a component that isn't going to be here long term, but it's still the only way to get back to the main menu, so for now I'm okay with a quick fix here and a refactor when we remove the component later.

Closes #301 