### PR TITLE
Only allow selecting units belonging to the current player

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -359,7 +359,7 @@ public class Game : Node2D
 							if (tile != null) {
 								MapUnit to_select = tile.unitsOnTile.Find(u => u.movementPointsRemaining > 0);
 								//TODO: Better check for "current/human player"
-								if (to_select != null && to_select.owner.color == 0x4040FFFF)
+								if (to_select != null && to_select.owner == controller)
 									setSelectedUnit(to_select);
 							}
 						}

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -358,7 +358,6 @@ public class Game : Node2D
 							var tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
 							if (tile != null) {
 								MapUnit to_select = tile.unitsOnTile.Find(u => u.movementPointsRemaining > 0);
-								//TODO: Better check for "current/human player"
 								if (to_select != null && to_select.owner == controller)
 									setSelectedUnit(to_select);
 							}


### PR DESCRIPTION
Not units whose color matches that of Babylon.

Closes #296 , closes #297 