### PR TITLE
Build Server Uses .Net 6.0, and DRY Out GitHub Actions Code

### DIFF
--- a/.github/workflows/composite/buildSetup/action.yml
+++ b/.github/workflows/composite/buildSetup/action.yml
@@ -1,0 +1,39 @@
+name: "Cross-Platform Setup"
+description: "Performs cross-platform build setup"
+
+runs:
+  using: "composite"
+  steps:
+  - name: Optionally set DEBUG_BUILD
+    if: github.event.inputs.debug-build == 'true'
+    run: |
+      echo "DEBUG_BUILD=-debug" >> $GITHUB_ENV
+  - name: Optionally set GH_USERNAME
+    if: github.event.inputs.include-username == 'true'
+    run: |
+      echo "GH_USERNAME=-${{ github.actor }}" >> $GITHUB_ENV
+  - name: Optionally set BUILD_TIME
+    if: github.event.inputs.include-datetime == 'true'
+    run: |
+      echo "BUILD_TIME=-$(date --iso-8601=minutes | sed -e 's/:/-/g' | sed -e 's/\+.*//')" >> $GITHUB_ENV
+  - name: Set .net6.0 SDK
+    run: |
+      wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+      dpkg -i packages-microsoft-prod.deb
+      rm packages-microsoft-prod.deb
+      apt-get update -qq
+      apt-get install -y apt-transport-https
+      apt-get update -qq
+      apt-get install -y dotnet-sdk-6.0
+  - name: Set FOLDER_NAME
+    run: |
+      echo "FOLDER_NAME=${EXPORT_NAME}${{ github.event.inputs.folder-suffix }}${GH_USERNAME}${BUILD_TIME}" >> $GITHUB_ENV
+  - name: Checkout
+    uses: actions/checkout@v2
+    with:
+      lfs: true
+  - name: Setup
+    run: |
+      mkdir -v -p ~/.local/share/godot/templates
+      mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable.mono ~/.local/share/godot/templates/${GODOT_VERSION}.stable.mono
+ 

--- a/.github/workflows/composite/buildSetup/action.yml
+++ b/.github/workflows/composite/buildSetup/action.yml
@@ -28,10 +28,6 @@ runs:
   - name: Set FOLDER_NAME
     run: |
       echo "FOLDER_NAME=${EXPORT_NAME}${{ github.event.inputs.folder-suffix }}${GH_USERNAME}${BUILD_TIME}" >> $GITHUB_ENV
-  - name: Checkout
-    uses: actions/checkout@v2
-    with:
-      lfs: true
   - name: Setup
     run: |
       mkdir -v -p ~/.local/share/godot/templates

--- a/.github/workflows/composite/buildSetup/action.yml
+++ b/.github/workflows/composite/buildSetup/action.yml
@@ -4,17 +4,23 @@ description: "Performs cross-platform build setup"
 runs:
   using: "composite"
   steps:
-  - name: Cross-Platform Build
+  - name: Optionally set DEBUG_BUILD
     shell: bash
     if: github.event.inputs.debug-build == 'true'
     run: |
       echo "DEBUG_BUILD=-debug" >> $GITHUB_ENV
+  - name: Optionally set GH_USERNAME
+    shell: bash
     if: github.event.inputs.include-username == 'true'
     run: |
       echo "GH_USERNAME=-${{ github.actor }}" >> $GITHUB_ENV
+  - name: Optionally set BUILD_TIME
+    shell: bash
     if: github.event.inputs.include-datetime == 'true'
     run: |
       echo "BUILD_TIME=-$(date --iso-8601=minutes | sed -e 's/:/-/g' | sed -e 's/\+.*//')" >> $GITHUB_ENV
+  - name: Set .net6.0 SDK
+    shell: bash
     run: |
       wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
       dpkg -i packages-microsoft-prod.deb
@@ -23,8 +29,12 @@ runs:
       apt-get install -y apt-transport-https
       apt-get update -qq
       apt-get install -y dotnet-sdk-6.0
+  - name: Set FOLDER_NAME
+    shell: bash
     run: |
       echo "FOLDER_NAME=${EXPORT_NAME}${{ github.event.inputs.folder-suffix }}${GH_USERNAME}${BUILD_TIME}" >> $GITHUB_ENV
+  - name: Setup
+    shell: bash
     run: |
       mkdir -v -p ~/.local/share/godot/templates
       mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable.mono ~/.local/share/godot/templates/${GODOT_VERSION}.stable.mono

--- a/.github/workflows/composite/buildSetup/action.yml
+++ b/.github/workflows/composite/buildSetup/action.yml
@@ -4,23 +4,17 @@ description: "Performs cross-platform build setup"
 runs:
   using: "composite"
   steps:
-  - name: Optionally set DEBUG_BUILD
+  - name: Cross-Platform Build
     shell: bash
     if: github.event.inputs.debug-build == 'true'
     run: |
       echo "DEBUG_BUILD=-debug" >> $GITHUB_ENV
-  - name: Optionally set GH_USERNAME
-    shell: bash
     if: github.event.inputs.include-username == 'true'
     run: |
       echo "GH_USERNAME=-${{ github.actor }}" >> $GITHUB_ENV
-  - name: Optionally set BUILD_TIME
-    shell: bash
     if: github.event.inputs.include-datetime == 'true'
     run: |
       echo "BUILD_TIME=-$(date --iso-8601=minutes | sed -e 's/:/-/g' | sed -e 's/\+.*//')" >> $GITHUB_ENV
-  - name: Set .net6.0 SDK
-    shell: bash
     run: |
       wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
       dpkg -i packages-microsoft-prod.deb
@@ -29,12 +23,8 @@ runs:
       apt-get install -y apt-transport-https
       apt-get update -qq
       apt-get install -y dotnet-sdk-6.0
-  - name: Set FOLDER_NAME
-    shell: bash
     run: |
       echo "FOLDER_NAME=${EXPORT_NAME}${{ github.event.inputs.folder-suffix }}${GH_USERNAME}${BUILD_TIME}" >> $GITHUB_ENV
-  - name: Setup
-    shell: bash
     run: |
       mkdir -v -p ~/.local/share/godot/templates
       mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable.mono ~/.local/share/godot/templates/${GODOT_VERSION}.stable.mono

--- a/.github/workflows/composite/buildSetup/action.yml
+++ b/.github/workflows/composite/buildSetup/action.yml
@@ -1,8 +1,5 @@
 name: "Cross-Platform Setup"
 description: "Performs cross-platform build setup"
-defaults:
-  run:
-    shell: bash
 
 runs:
   using: "composite"

--- a/.github/workflows/composite/buildSetup/action.yml
+++ b/.github/workflows/composite/buildSetup/action.yml
@@ -1,26 +1,25 @@
 name: "Cross-Platform Setup"
 description: "Performs cross-platform build setup"
+defaults:
+  run:
+    shell: bash
 
 runs:
   using: "composite"
   steps:
   - name: Optionally set DEBUG_BUILD
-    shell: bash
     if: github.event.inputs.debug-build == 'true'
     run: |
       echo "DEBUG_BUILD=-debug" >> $GITHUB_ENV
   - name: Optionally set GH_USERNAME
-    shell: bash
     if: github.event.inputs.include-username == 'true'
     run: |
       echo "GH_USERNAME=-${{ github.actor }}" >> $GITHUB_ENV
   - name: Optionally set BUILD_TIME
-    shell: bash
     if: github.event.inputs.include-datetime == 'true'
     run: |
       echo "BUILD_TIME=-$(date --iso-8601=minutes | sed -e 's/:/-/g' | sed -e 's/\+.*//')" >> $GITHUB_ENV
   - name: Set .net6.0 SDK
-    shell: bash
     run: |
       wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
       dpkg -i packages-microsoft-prod.deb
@@ -30,11 +29,9 @@ runs:
       apt-get update -qq
       apt-get install -y dotnet-sdk-6.0
   - name: Set FOLDER_NAME
-    shell: bash
     run: |
       echo "FOLDER_NAME=${EXPORT_NAME}${{ github.event.inputs.folder-suffix }}${GH_USERNAME}${BUILD_TIME}" >> $GITHUB_ENV
   - name: Setup
-    shell: bash
     run: |
       mkdir -v -p ~/.local/share/godot/templates
       mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable.mono ~/.local/share/godot/templates/${GODOT_VERSION}.stable.mono

--- a/.github/workflows/composite/buildSetup/action.yml
+++ b/.github/workflows/composite/buildSetup/action.yml
@@ -5,18 +5,22 @@ runs:
   using: "composite"
   steps:
   - name: Optionally set DEBUG_BUILD
+    shell: bash
     if: github.event.inputs.debug-build == 'true'
     run: |
       echo "DEBUG_BUILD=-debug" >> $GITHUB_ENV
   - name: Optionally set GH_USERNAME
+    shell: bash
     if: github.event.inputs.include-username == 'true'
     run: |
       echo "GH_USERNAME=-${{ github.actor }}" >> $GITHUB_ENV
   - name: Optionally set BUILD_TIME
+    shell: bash
     if: github.event.inputs.include-datetime == 'true'
     run: |
       echo "BUILD_TIME=-$(date --iso-8601=minutes | sed -e 's/:/-/g' | sed -e 's/\+.*//')" >> $GITHUB_ENV
   - name: Set .net6.0 SDK
+    shell: bash
     run: |
       wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
       dpkg -i packages-microsoft-prod.deb
@@ -26,9 +30,11 @@ runs:
       apt-get update -qq
       apt-get install -y dotnet-sdk-6.0
   - name: Set FOLDER_NAME
+    shell: bash
     run: |
       echo "FOLDER_NAME=${EXPORT_NAME}${{ github.event.inputs.folder-suffix }}${GH_USERNAME}${BUILD_TIME}" >> $GITHUB_ENV
   - name: Setup
+    shell: bash
     run: |
       mkdir -v -p ~/.local/share/godot/templates
       mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable.mono ~/.local/share/godot/templates/${GODOT_VERSION}.stable.mono

--- a/.github/workflows/export-c7.yml
+++ b/.github/workflows/export-c7.yml
@@ -18,6 +18,10 @@ on:
         description: Append ISO8601 date/time to folder name
         default: true
 
+defaults:
+  run:
+    shell: bash
+
 env:
   GODOT_VERSION: 3.4.4
   EXPORT_NAME: C7

--- a/.github/workflows/export-c7.yml
+++ b/.github/workflows/export-c7.yml
@@ -28,38 +28,7 @@ jobs:
     container:
       image: barichello/godot-ci:mono-3.4.4
     steps:
-    - name: Optionally set DEBUG_BUILD
-      if: github.event.inputs.debug-build == 'true'
-      run: |
-        echo "DEBUG_BUILD=-debug" >> $GITHUB_ENV
-    - name: Optionally set GH_USERNAME
-      if: github.event.inputs.include-username == 'true'
-      run: |
-        echo "GH_USERNAME=-${{ github.actor }}" >> $GITHUB_ENV
-    - name: Optionally set BUILD_TIME
-      if: github.event.inputs.include-datetime == 'true'
-      run: |
-        echo "BUILD_TIME=-$(date --iso-8601=minutes | sed -e 's/:/-/g' | sed -e 's/\+.*//')" >> $GITHUB_ENV
-    - name: Set .net6.0 SDK
-      run: |
-        wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-        dpkg -i packages-microsoft-prod.deb
-        rm packages-microsoft-prod.deb
-        apt-get update -qq
-        apt-get install -y apt-transport-https
-        apt-get update -qq
-        apt-get install -y dotnet-sdk-6.0
-    - name: Set FOLDER_NAME
-      run: |
-        echo "FOLDER_NAME=${EXPORT_NAME}${{ github.event.inputs.folder-suffix }}${GH_USERNAME}${BUILD_TIME}" >> $GITHUB_ENV
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        lfs: true
-    - name: Setup
-      run: |
-        mkdir -v -p ~/.local/share/godot/templates
-        mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable.mono ~/.local/share/godot/templates/${GODOT_VERSION}.stable.mono
+    - uses: ./.github/workflows/composite/buildSetup
     - name: Windows Build
       run: |
         mkdir -v -p build/${FOLDER_NAME}
@@ -83,38 +52,7 @@ jobs:
     container:
       image: barichello/godot-ci:mono-3.4.4
     steps:
-    - name: Optionally set DEBUG_BUILD
-      if: github.event.inputs.debug-build == 'true'
-      run: |
-        echo "DEBUG_BUILD=-debug" >> $GITHUB_ENV
-    - name: Optionally set GH_USERNAME
-      if: github.event.inputs.include-username == 'true'
-      run: |
-        echo "GH_USERNAME=-${{ github.actor }}" >> $GITHUB_ENV
-    - name: Optionally set BUILD_TIME
-      if: github.event.inputs.include-datetime == 'true'
-      run: |
-        echo "BUILD_TIME=-$(date --iso-8601=minutes | sed -e 's/:/-/g' | sed -e 's/\+.*//')" >> $GITHUB_ENV
-    - name: Set .net6.0 SDK
-      run: |
-        wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-        dpkg -i packages-microsoft-prod.deb
-        rm packages-microsoft-prod.deb
-        apt-get update -qq
-        apt-get install -y apt-transport-https
-        apt-get update -qq
-        apt-get install -y dotnet-sdk-6.0
-    - name: Set FOLDER_NAME
-      run: |
-        echo "FOLDER_NAME=${EXPORT_NAME}${{ github.event.inputs.folder-suffix }}${GH_USERNAME}${BUILD_TIME}" >> $GITHUB_ENV
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        lfs: true
-    - name: Setup
-      run: |
-        mkdir -v -p ~/.local/share/godot/templates
-        mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable.mono ~/.local/share/godot/templates/${GODOT_VERSION}.stable.mono
+    - uses: ./.github/workflows/composite/buildSetup
     - name: Linux Build
       run: |
         mkdir -v -p build/${FOLDER_NAME}
@@ -141,38 +79,7 @@ jobs:
     container:
       image: barichello/godot-ci:mono-3.4.4
     steps:
-    - name: Optionally set DEBUG_BUILD
-      if: github.event.inputs.debug-build == 'true'
-      run: |
-        echo "DEBUG_BUILD=-debug" >> $GITHUB_ENV
-    - name: Optionally set GH_USERNAME
-      if: github.event.inputs.include-username == 'true'
-      run: |
-        echo "GH_USERNAME=-${{ github.actor }}" >> $GITHUB_ENV
-    - name: Optionally set BUILD_TIME
-      if: github.event.inputs.include-datetime == 'true'
-      run: |
-        echo "BUILD_TIME=-$(date --iso-8601=minutes | sed -e 's/:/-/g' | sed -e 's/\+.*//')" >> $GITHUB_ENV
-    - name: Set .net6.0 SDK
-      run: |
-        wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-        dpkg -i packages-microsoft-prod.deb
-        rm packages-microsoft-prod.deb
-        apt-get update -qq
-        apt-get install -y apt-transport-https
-        apt-get update -qq
-        apt-get install -y dotnet-sdk-6.0
-    - name: Set FOLDER_NAME
-      run: |
-        echo "FOLDER_NAME=${EXPORT_NAME}${{ github.event.inputs.folder-suffix }}${GH_USERNAME}${BUILD_TIME}" >> $GITHUB_ENV
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        lfs: true
-    - name: Setup
-      run: |
-        mkdir -v -p ~/.local/share/godot/templates
-        mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable.mono ~/.local/share/godot/templates/${GODOT_VERSION}.stable.mono
+    - uses: ./.github/workflows/composite/buildSetup
     - name: Mac Build
       run: |
         mkdir -v -p build/${FOLDER_NAME}

--- a/.github/workflows/export-c7.yml
+++ b/.github/workflows/export-c7.yml
@@ -40,6 +40,15 @@ jobs:
       if: github.event.inputs.include-datetime == 'true'
       run: |
         echo "BUILD_TIME=-$(date --iso-8601=minutes | sed -e 's/:/-/g' | sed -e 's/\+.*//')" >> $GITHUB_ENV
+    - name: Set .net6.0 SDK
+      run: |
+        wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+        dpkg -i packages-microsoft-prod.deb
+        rm packages-microsoft-prod.deb
+        apt-get update -qq
+        apt-get install -y apt-transport-https
+        apt-get update -qq
+        apt-get install -y dotnet-sdk-6.0
     - name: Set FOLDER_NAME
       run: |
         echo "FOLDER_NAME=${EXPORT_NAME}${{ github.event.inputs.folder-suffix }}${GH_USERNAME}${BUILD_TIME}" >> $GITHUB_ENV

--- a/.github/workflows/export-c7.yml
+++ b/.github/workflows/export-c7.yml
@@ -95,6 +95,15 @@ jobs:
       if: github.event.inputs.include-datetime == 'true'
       run: |
         echo "BUILD_TIME=-$(date --iso-8601=minutes | sed -e 's/:/-/g' | sed -e 's/\+.*//')" >> $GITHUB_ENV
+    - name: Set .net6.0 SDK
+      run: |
+        wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+        dpkg -i packages-microsoft-prod.deb
+        rm packages-microsoft-prod.deb
+        apt-get update -qq
+        apt-get install -y apt-transport-https
+        apt-get update -qq
+        apt-get install -y dotnet-sdk-6.0
     - name: Set FOLDER_NAME
       run: |
         echo "FOLDER_NAME=${EXPORT_NAME}${{ github.event.inputs.folder-suffix }}${GH_USERNAME}${BUILD_TIME}" >> $GITHUB_ENV
@@ -144,6 +153,15 @@ jobs:
       if: github.event.inputs.include-datetime == 'true'
       run: |
         echo "BUILD_TIME=-$(date --iso-8601=minutes | sed -e 's/:/-/g' | sed -e 's/\+.*//')" >> $GITHUB_ENV
+    - name: Set .net6.0 SDK
+      run: |
+        wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+        dpkg -i packages-microsoft-prod.deb
+        rm packages-microsoft-prod.deb
+        apt-get update -qq
+        apt-get install -y apt-transport-https
+        apt-get update -qq
+        apt-get install -y dotnet-sdk-6.0
     - name: Set FOLDER_NAME
       run: |
         echo "FOLDER_NAME=${EXPORT_NAME}${{ github.event.inputs.folder-suffix }}${GH_USERNAME}${BUILD_TIME}" >> $GITHUB_ENV

--- a/.github/workflows/export-c7.yml
+++ b/.github/workflows/export-c7.yml
@@ -28,6 +28,10 @@ jobs:
     container:
       image: barichello/godot-ci:mono-3.4.4
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: ./.github/workflows/composite/buildSetup
     - name: Windows Build
       run: |
@@ -52,6 +56,10 @@ jobs:
     container:
       image: barichello/godot-ci:mono-3.4.4
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: ./.github/workflows/composite/buildSetup
     - name: Linux Build
       run: |
@@ -79,6 +87,10 @@ jobs:
     container:
       image: barichello/godot-ci:mono-3.4.4
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: ./.github/workflows/composite/buildSetup
     - name: Mac Build
       run: |

--- a/.github/workflows/export-c7.yml
+++ b/.github/workflows/export-c7.yml
@@ -18,10 +18,6 @@ on:
         description: Append ISO8601 date/time to folder name
         default: true
 
-defaults:
-  run:
-    shell: bash
-
 env:
   GODOT_VERSION: 3.4.4
   EXPORT_NAME: C7


### PR DESCRIPTION
Closes #307 

Closes #309 

GitHub Actions isn't the world's most advanced CI product, but I still managed to DRY it out after some research on how to do that.  See #309 for more details about that.  This currently uses Composite Actions, which seemed like the most appropriate tool for the job, although I'm still not entirely convinced just building for all 3 platforms in one job wouldn't be a superior (if perhaps slightly slower) approach.