### PR TITLE
284 - Dummy units are only added if prototypes for them exist

### DIFF
--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -229,13 +229,14 @@ namespace C7GameData
 			return carthagePlayer;
 		}
 
-		private void CreateStartingDummyUnits(Player player, Tile location)
-		{
-			CreateDummyUnit(unitPrototypes["Settler"],  player, location);
-			CreateDummyUnit(unitPrototypes["Warrior"],  player, location);
-			CreateDummyUnit(unitPrototypes["Worker"],   player, location);
-			CreateDummyUnit(unitPrototypes["Chariot"],  player, location);
-			CreateDummyUnit(unitPrototypes["Catapult"], player, location);
+		private void CreateStartingDummyUnits(Player player, Tile location) {
+			string[] unitNames = { "Settler", "Warrior", "Worker", "Chariot", "Catapult" };
+			foreach (string unitName in unitNames)
+			{
+				if (unitPrototypes.ContainsKey(unitName)) {
+					CreateDummyUnit(unitPrototypes[unitName],  player, location);
+				}
+			}
 		}
 
 		private MapUnit CreateDummyUnit(UnitPrototype proto, Player owner, Tile tile)


### PR DESCRIPTION
Closes #284 

This is the short fix for the problem in the issue, which will make scenarios loadable again.  I'll spin out a separate card for the long-term fix.