### PR TITLE
258: Remove GD.Prints

### DIFF
--- a/C7/Credits.cs
+++ b/C7/Credits.cs
@@ -1,21 +1,23 @@
 using Godot;
+using Serilog;
 
 public class Credits : Node2D
 {
 	private string creditsText = "Could not load credits file";
 
+	private static ILogger log = Log.ForContext<Credits>();
+
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()
 	{
-		GD.Print("Now rolling the credits!");
+		log.Information("Now rolling the credits!");
 		try
 		{
 			creditsText = System.IO.File.ReadAllText("./credits.txt");
 		}
 		catch(System.Exception ex)
 		{
-			GD.PrintErr("Failed to read from credits.txt!");
-			GD.PushError(ex.ToString());
+			log.Error(ex, "Failed to read from credits.txt!");
 		}
 		ShowCredits();
 	}
@@ -24,7 +26,7 @@ public class Credits : Node2D
 	{
 		ImageTexture CreditsTexture = Util.LoadTextureFromPCX("Art/Credits/credits_background.pcx");
 		ImageTexture GoBackTexture = Util.LoadTextureFromPCX("Art/exitBox-backgroundStates.pcx", 0, 0, 72, 48);
-		
+
 		TextureRect CreditsBackground = new TextureRect();
 		CreditsBackground.Texture = CreditsTexture;
 		AddChild(CreditsBackground);
@@ -35,7 +37,7 @@ public class Credits : Node2D
 		creditsLabel.BbcodeEnabled = true;
 		creditsLabel.BbcodeText = creditsText;
 		AddChild(creditsLabel);
-		
+
 		TextureButton GoBackButton = new TextureButton();
 		GoBackButton.TextureNormal = GoBackTexture;
 		GoBackButton.SetPosition(new Vector2(952, 720));
@@ -44,7 +46,7 @@ public class Credits : Node2D
 	}
 	public void ReturnToMenu()
 	{
-		GD.Print("Returning to main menu");
-		GetTree().ChangeScene("res://MainMenu.tscn");    
+		log.Information("Returning to main menu");
+		GetTree().ChangeScene("res://MainMenu.tscn");
 	}
 }

--- a/C7/MainMenu.cs
+++ b/C7/MainMenu.cs
@@ -24,7 +24,6 @@ public class MainMenu : Node2D
 	public override void _Ready()
 	{
 		log = LogManager.ForContext<MainMenu>();
-		GD.Print("MainMenu got logger: " + log);
 		log.Debug("enter MainMenu._Ready");
 
 		// To pass data between scenes, putting path string in a global singleton and reading it later in createGame

--- a/C7/Map/ResourceLayer.cs
+++ b/C7/Map/ResourceLayer.cs
@@ -1,11 +1,14 @@
 using C7GameData;
 using Godot;
 using Resource = C7GameData.Resource;
+using Serilog;
 
 namespace C7.Map
 {
 	public class ResourceLayer : LooseLayer
 	{
+		private ILogger log = LogManager.ForContext<ResourceLayer>();
+
 		private static readonly Vector2 resourceSize = new Vector2(50, 50);
 		private int maxRow;
 		private ImageTexture resourceTexture;
@@ -23,7 +26,7 @@ namespace C7.Map
 				int row = resourceIcon / 6;
 				int col = resourceIcon % 6;
 				if (row > maxRow) {
-					GD.Print("Resource icon for " + resource.Name + " is too high");
+					log.Warning("Resource icon for " + resource.Name + " is too high");
 					return;
 				}
 				Rect2 resourceRectangle = new Rect2(col * resourceSize.x, row * resourceSize.y, resourceSize);

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -5,6 +5,8 @@ using Godot;
 using ConvertCiv3Media;
 using C7GameData;
 using C7Engine;
+using Serilog;
+using Serilog.Events;
 
 // Loose layers are for drawing things on the map on a per-tile basis. (Historical aside: There used to be another kind of layer called a TileLayer
 // that was intended to draw regularly tiled objects like terrain sprites but using LooseLayers for everything was found to be a prefereable
@@ -846,6 +848,9 @@ public class BuildingLayer : LooseLayer {
 }
 
 public class CityLayer : LooseLayer {
+
+	private ILogger log = LogManager.ForContext<Game>();
+
 	private ImageTexture cityTexture;
 	private Vector2 citySpriteSize;
 	private DynamicFont smallFont = new DynamicFont();
@@ -874,7 +879,6 @@ public class CityLayer : LooseLayer {
 		}
 
 		City city = tile.cityAtTile;
-		// GD.Print("Tile " + tile.xCoordinate + ", " + tile.yCoordinate + " has a city named " + city.name);
 		Rect2 screenRect = new Rect2(tileCenter - (float)0.5 * citySpriteSize, citySpriteSize);
 		Rect2 textRect = new Rect2(new Vector2(0, 0), citySpriteSize);
 		looseView.DrawTextureRectRegion(cityTexture, screenRect, textRect);
@@ -887,12 +891,14 @@ public class CityLayer : LooseLayer {
 		int cityNameAndGrowthWidth = (int)smallFont.GetStringSize(cityNameAndGrowth).x;
 		int productionDescriptionWidth = (int)smallFont.GetStringSize(productionDescription).x;
 		int maxTextWidth = Math.Max(cityNameAndGrowthWidth, productionDescriptionWidth);
-		// GD.Print("Width of city name = " + maxTextWidth);
 
 		int cityLabelWidth = maxTextWidth + (city.IsCapital()? 70 : 45);	//TODO: Is 65 right?  70?  Will depend on whether it's capital, too
 		int textAreaWidth = cityLabelWidth - (city.IsCapital() ? 50 : 25);
-		// GD.Print("City label width: " + cityLabelWidth);
-		// GD.Print("Text area width: " + textAreaWidth);
+		if (log.IsEnabled(LogEventLevel.Verbose)) {
+			log.Verbose("Width of city name = " + maxTextWidth);
+			log.Verbose("City label width: " + cityLabelWidth);
+			log.Verbose("Text area width: " + textAreaWidth);
+		}
 		const int CITY_LABEL_HEIGHT = 23;
 		const int TEXT_ROW_HEIGHT = 9;
 		const int LEFT_RIGHT_BOXES_WIDTH = 24;

--- a/C7/UIElements/Advisors/Advisors.cs
+++ b/C7/UIElements/Advisors/Advisors.cs
@@ -1,5 +1,6 @@
 using Godot;
 using System;
+using Serilog;
 
 /**
  * Handles managing the advisor screens.
@@ -8,6 +9,7 @@ using System;
  */
 public class Advisors : CenterContainer
 {
+	private ILogger log = LogManager.ForContext<Advisors>();
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()
@@ -21,13 +23,13 @@ public class Advisors : CenterContainer
 //  // Called every frame. 'delta' is the elapsed time since the previous frame.
 //  public override void _Process(float delta)
 //  {
-//      
+//
 //  }
 
 
 	private void ShowLatestAdvisor()
 	{
-		GD.Print("Received request to show latest advisor");
+		log.Debug("Received request to show latest advisor");
 
 		if (this.GetChildCount() == 0) {
 			DomesticAdvisor advisor = new DomesticAdvisor();
@@ -35,13 +37,12 @@ public class Advisors : CenterContainer
 		}
 		this.Show();
 	}
-	
-	
+
 	private void _on_Advisor_hide()
 	{
 		this.Hide();
 	}
-	
+
 	private void OnShowSpecificAdvisor(string advisorType)
 	{
 		if (advisorType.Equals("F1")) {
@@ -52,7 +53,7 @@ public class Advisors : CenterContainer
 			this.Show();
 		}
 	}
-	
+
 	public override void _UnhandledInput(InputEvent @event)
 	{
 		if (this.Visible) {
@@ -68,7 +69,7 @@ public class Advisors : CenterContainer
 						GetTree().SetInputAsHandled();
 					}
 					else {
-						GD.Print("Advisor received a key press; stopping propagation.");
+						log.Debug("Advisor received a key press; stopping propagation.");
 						GetTree().SetInputAsHandled();
 					}
 				}

--- a/C7/UIElements/GameStatus/GameStatus.cs
+++ b/C7/UIElements/GameStatus/GameStatus.cs
@@ -1,9 +1,12 @@
 using Godot;
 using System;
 using C7GameData;
+using Serilog;
 
 public class GameStatus : MarginContainer
 {
+
+	private ILogger log = LogManager.ForContext<GameStatus>();
 
 	LowerRightInfoBox LowerRightInfoBox = new LowerRightInfoBox();
 	Timer endTurnAlertTimer;
@@ -17,25 +20,25 @@ public class GameStatus : MarginContainer
 		MarginTop = -(137 + 1);
 		AddChild(LowerRightInfoBox);
 	}
-	
+
 	public void OnNewUnitSelected(ParameterWrapper wrappedMapUnit)
 	{
 		MapUnit newUnit = wrappedMapUnit.GetValue<MapUnit>();
-		GD.Print("Selected unit: " + newUnit + " at " + newUnit.location);
+		log.Information("Selected unit: " + newUnit + " at " + newUnit.location);
 		LowerRightInfoBox.UpdateUnitInfo(newUnit, newUnit.location.overlayTerrainType);
 	}
-	
+
 	private void OnTurnEnded()
 	{
 		LowerRightInfoBox.StopToggling();
 	}
-	
+
 	private void OnTurnStarted(int turnNumber)
-	{		
+	{
 		//Oh hai, we do need this handler here!
 		LowerRightInfoBox.SetTurn(turnNumber);
 	}
-	
+
 	private void OnNoMoreAutoselectableUnits()
 	{
 		LowerRightInfoBox.SetEndOfTurnStatus();

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -2,9 +2,11 @@ using Godot;
 using System;
 using ConvertCiv3Media;
 using C7GameData;
+using Serilog;
 
 public class LowerRightInfoBox : TextureRect
 {
+	private ILogger log = LogManager.ForContext<LowerRightInfoBox>();
 
 	TextureButton nextTurnButton = new TextureButton();
 	ImageTexture nextTurnOnTexture;
@@ -106,7 +108,7 @@ public class LowerRightInfoBox : TextureRect
 
 		if (!timerStarted) {
 			blinkingTimer.Start();
-			GD.Print("Started a timer for blinking");
+			log.Debug("Started a timer for blinking");
 
 			timerStarted = true;
 		}
@@ -133,7 +135,7 @@ public class LowerRightInfoBox : TextureRect
 	}
 
 	private void turnEnded() {
-		GD.Print("Emitting the blinky button pressed signal");
+		log.Debug("Emitting the blinky button pressed signal");
 		GetParent().EmitSignal("BlinkyEndTurnButtonPressed");
 	}
 

--- a/C7/UIElements/Popups/BuildCityDialog.cs
+++ b/C7/UIElements/Popups/BuildCityDialog.cs
@@ -1,10 +1,13 @@
 using Godot;
+using Serilog;
 
 public class BuildCityDialog : Popup
 {
-	
+
 	LineEdit cityName = new LineEdit();
 	private string defaultName = "";
+
+	private ILogger log = LogManager.ForContext<BuildCityDialog>();
 
 	public BuildCityDialog(string defaultName)
 	{
@@ -92,7 +95,7 @@ public class BuildCityDialog : Popup
 	public void OnCityNameEntered(string name)
 	{
 		GetTree().SetInputAsHandled();
-		GD.Print("The user hit enter with a city name of " + name);
+		log.Debug("The user hit enter with a city name of " + name);
 		GetParent().EmitSignal("BuildCity", name);
 		GetParent().EmitSignal("HidePopup");
 	}

--- a/C7/UIElements/Popups/DisbandConfirmation.cs
+++ b/C7/UIElements/Popups/DisbandConfirmation.cs
@@ -2,14 +2,16 @@ using Godot;
 using System;
 using System.Diagnostics;
 using C7GameData;
+using Serilog;
 
 public class DisbandConfirmation : Popup
 {
+	private ILogger log = LogManager.ForContext<DisbandConfirmation>();
 
 	string unitType = "";
 
 	Stopwatch loadTimer = new Stopwatch();
-	
+
 	//So Godot doesn't print error " Cannot construct temporary MonoObject because the class does not define a parameterless constructor"
 	//Not sure how important that is *shrug*
 	public DisbandConfirmation() {}
@@ -68,7 +70,7 @@ public class DisbandConfirmation : Popup
 
 		loadTimer.Stop();
 		TimeSpan stopwatchElapsed = loadTimer.Elapsed;
-		GD.Print("Game scene load time: " + Convert.ToInt32(stopwatchElapsed.TotalMilliseconds) + " ms");
+		log.Verbose("Disband popup load time: " + Convert.ToInt32(stopwatchElapsed.TotalMilliseconds) + " ms");
 	}
 
 	private void disband()

--- a/C7/UIElements/Popups/Popup.cs
+++ b/C7/UIElements/Popups/Popup.cs
@@ -3,6 +3,7 @@ using ConvertCiv3Media;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Serilog;
 
 public class Margins
 {
@@ -30,6 +31,8 @@ public class Margins
  */
 public class Popup : TextureRect
 {
+	private ILogger log = LogManager.ForContext<Popup>();
+
     public BoxContainer.AlignMode alignment;
     public Margins margins;
 
@@ -146,7 +149,7 @@ public class Popup : TextureRect
         Image bottomRightPopup = PCXToGodot.getImageFromPCX(popupborders, 375, 91, 61, 44);
         imageTimer.Stop();
         TimeSpan stopwatchElapsed = imageTimer.Elapsed;
-        GD.Print("Image creation time: " + Convert.ToInt32(stopwatchElapsed.TotalMilliseconds) + " ms");
+        log.Debug("Image creation time: " + Convert.ToInt32(stopwatchElapsed.TotalMilliseconds) + " ms");
 
         //Dimensions are 530x320.  The leaderhead takes up 110.  So the popup is 530x210.
         //We have multiples of... 62? For the horizontal dimension, 45 for vertical.

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -2,9 +2,13 @@ using Godot;
 using ConvertCiv3Media;
 using System;
 using System.Diagnostics;
+using Serilog;
 
 public class PopupOverlay : HBoxContainer
 {
+
+	private ILogger log = LogManager.ForContext<PopupOverlay>();
+
 	[Signal] public delegate void UnitDisbanded();
 	[Signal] public delegate void Quit();
 	[Signal] public delegate void BuildCity(string name);
@@ -22,12 +26,12 @@ public class PopupOverlay : HBoxContainer
 
 	public override void _Ready()
 	{
-		base._Ready();	
+		base._Ready();
 	}
-	
+
 	private void OnHidePopup()
 	{
-		GD.Print("Hiding popup");
+		log.Debug("Hiding popup");
 		RemoveChild(currentChild);
 		Hide();
 	}
@@ -43,7 +47,7 @@ public class PopupOverlay : HBoxContainer
 	{
 		if (child == null) // not necessary if we don't pass null?
 		{
-			GD.PrintErr("Received request to show null popup");
+			log.Error("Received request to show null popup");
 			return;
 		}
 
@@ -69,7 +73,7 @@ public class PopupOverlay : HBoxContainer
 				soundFile = "Sounds/PopupInfo.wav";
 				break;
 			default:
-				GD.PrintErr("Invalid popup category");
+				log.Error("Invalid popup category");
 				break;
 		}
 		AudioStreamSample wav = Util.LoadWAVFromDisk(Util.Civ3MediaPath(soundFile));

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -1,9 +1,12 @@
 using Godot;
 using System.Collections.Generic;
 using C7GameData;
+using Serilog;
 
 public class UnitButtons : VBoxContainer
 {
+
+	private ILogger log = LogManager.ForContext<UnitButtons>();
 
 	[Signal] public delegate void UnitButtonPressed(string button);
 
@@ -96,7 +99,7 @@ public class UnitButtons : VBoxContainer
 				buttonMap[buttonKey].Visible = true;
 			}
 			else {
-				GD.PrintErr("Could not find button " + buttonKey);
+				log.Warning("Could not find button " + buttonKey);
 			}
 		}
 


### PR DESCRIPTION
Converts nearly all GD.Print statements to Serilog.

Exceptions are the right-click tile info (for devs knowing what's on a tile and its index, until we get that in the UI), GD.Prints related to logger configuration, and the Godot sink.

Note that this builds on the PR for #267 , so that one should be merged first.