### PR TITLE
286 - Naval Units No Longer Defend Cities/Barb Camps

### DIFF
--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -63,6 +63,22 @@ public static class MapUnitExtensions {
 		return unit.unitType.BaseStrength(role) * StrengthBonus.ListToMultiplier(unit.ListStrengthBonusesVersus(opponent, role, attackDirection));
 	}
 
+	public static bool CanDefendAgainst(this MapUnit unit, MapUnit attacker) {
+		//Basically, unit type must match.  Sea/air units in a city/airfield can't defend against land units.
+		//Land units on a boat or planes on a carrier can't defend against boats.  Anti-air is another category that should be checked before the direct combat.
+		//Potential future hybrid units that have multiple categories (e.g. amphibious vehicles) may contain more than one category.
+		if (attacker.unitType.categories.Contains("Land") && !unit.unitType.categories.Contains("Land")) {
+			return false;
+		}
+		if (attacker.unitType.categories.Contains("Sea") && !unit.unitType.categories.Contains("Sea")) {
+			return false;
+		}
+		if (attacker.unitType.categories.Contains("Air") && !unit.unitType.categories.Contains("Air")) {
+			return false;
+		}
+		return true;
+	}
+
 	// Answers the question: if "opponent" is attacking the tile that this unit is standing on, does this unit defend instead of "otherDefender"?
 	// Note that otherDefender does not necessarily belong to the same civ as this unit. Under standard Civ 3 rules you can't have units belonging
 	// to two different civs on the same tile, but we don't want to assume that. In that case, whoever is an enemy of "opponent" should get
@@ -274,12 +290,14 @@ public static class MapUnitExtensions {
 	{
 		// Disperse barb camp
 		if (tile.hasBarbarianCamp && (!unit.owner.isBarbarians)) {
+			tile.DisbandNonDefendingUnits();
 			EngineStorage.gameData.map.barbarianCamps.Remove(tile);
 			tile.hasBarbarianCamp = false;
 		}
 
 		// Destroy enemy city on tile
-		if ((tile.cityAtTile != null) && (!unit.owner.IsAtPeaceWith(tile.cityAtTile.owner))) {
+		if (tile.HasCity && !unit.owner.IsAtPeaceWith(tile.cityAtTile.owner)) {
+			tile.DisbandNonDefendingUnits();
 			tile.cityAtTile.owner.cities.Remove(tile.cityAtTile);
 			EngineStorage.gameData.cities.Remove(tile.cityAtTile);
 			tile.cityAtTile = null;
@@ -319,7 +337,7 @@ public static class MapUnitExtensions {
 
 			// Trigger combat if the tile we're moving into has an enemy unit. Or if this unit can't fight, do nothing.
 			MapUnit defender = newLoc.FindTopDefender(unit);
-			if ((defender != MapUnit.NONE) && (!unit.owner.IsAtPeaceWith(defender.owner))) {
+			if (defender != MapUnit.NONE && !unit.owner.IsAtPeaceWith(defender.owner)) {
 				if (unit.unitType.attack > 0) {
 					CombatResult combatResult = unit.fight(defender);
 					// If we were killed then of course there's nothing more to do. If the combat couldn't happen for whatever
@@ -350,10 +368,10 @@ public static class MapUnitExtensions {
 
 			if (!unit.location.unitsOnTile.Remove(unit))
 				throw new System.Exception("Failed to remove unit from tile it's supposed to be on");
+			unit.OnEnterTile(newLoc);
 			newLoc.unitsOnTile.Add(unit);
 			unit.location = newLoc;
 			unit.movementPointsRemaining -= newLoc.overlayTerrainType.movementCost;
-			unit.OnEnterTile(newLoc);
 			unit.animate(MapUnit.AnimatedAction.RUN, wait);
 		}
 	}

--- a/C7Engine/TileExtensions.cs
+++ b/C7Engine/TileExtensions.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+
 namespace C7Engine
 {
 	using C7GameData;
@@ -6,13 +9,37 @@ namespace C7Engine
 		public static MapUnit FindTopDefender(this Tile tile, MapUnit opponent)
 		{
 			if (tile.unitsOnTile.Count > 0) {
-				MapUnit tr = tile.unitsOnTile[0];
+				IEnumerable<MapUnit> potentialDefenders = tile.unitsOnTile.Where(u => u.CanDefendAgainst(opponent));
+				if (potentialDefenders.Count() == 0) {
+					return MapUnit.NONE;
+				}
+
+				MapUnit leadingCandidate = tile.unitsOnTile[0];
 				foreach (MapUnit u in tile.unitsOnTile)
-					if (u.HasPriorityAsDefender(tr, opponent))
-						tr = u;
-				return tr;
+					if (u.HasPriorityAsDefender(leadingCandidate, opponent))
+						leadingCandidate = u;
+				return leadingCandidate;
 			} else
 				return MapUnit.NONE;
+		}
+
+		/// <summary>
+		/// Disbands non-defending units on a tile.  This should only be called when all defending units have been destroyed,
+		/// hence its name.  E.g. if only air/sea units remain after a land battle, this should be called.
+		///
+		/// Eventually, we should also have a method to make relevant units (workers, artillery, etc.) be captured.
+		/// </summary>
+		/// <param name="tile"></param>
+		public static void DisbandNonDefendingUnits(this Tile tile) {
+			//There may have been naval units, if so, disband them
+			if (tile.unitsOnTile.Count > 0) {
+				//Copy to a separate array so we don't crash due to concurrent modification exceptions
+				MapUnit[] unitsOnTile = new MapUnit[tile.unitsOnTile.Count];
+				tile.unitsOnTile.CopyTo(unitsOnTile);
+				foreach (MapUnit destroyedUnit in unitsOnTile) {
+					destroyedUnit.disband();
+				}
+			}
 		}
 
 		public static void Animate(this Tile tile, AnimatedEffect effect, bool wait)


### PR DESCRIPTION
(See PR #322 first, as this builds upon that one)

#286 - Naval units (or other units of non-matching unit category) will no longer be able to defend tiles.  In practice, this means they won't defend cities or barbarian camps as for now those are the only tiles that can have units of a different category.

The solution should be generally applicable to land/sea units on water, once we get to transport boats/carriers.

This does not attempt to add mechanics for capturing units; workers and catapults will still try to defend themselves with their 0 defense stat, just like they always have.

Note that the `unit.OnEnterTile(newLoc);` method is called earlier because it now clears out remaining units on the tile, and in the old order the unit moved onto the tile before that happened (and thus would get cleared out).  Also note that OnEnterTile _is_ modified, but GitHub did a poor job of hiding irrelevant code; it starts on line 289 of MapUnitExtensions.cs (but GitHub starts showing the code from 290).

Closes #286 