### PR TITLE
Naval Unit Improvements

### DIFF
--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -248,9 +248,12 @@ public static class MapUnitExtensions {
 		GameData gD = EngineStorage.gameData;
 		City city = location.cityAtTile;
 		bool inFriendlyCity = (city != null) && (city != City.NONE) && unit.owner.IsAtPeaceWith(city.owner);
-		return inFriendlyCity ? gD.healRateInCity : gD.healRateInNeutralField;
-		// TODO: Consider friendly/neutral/enemy territory once that's implemented, barracks, the Red Cross, and rules for naval units (they
-		// shouldn't be able to heal outside of port).
+		if (inFriendlyCity)
+			return gD.healRateInCity;
+		if (unit.unitType.categories.Contains("Sea"))
+			return 0;
+		return gD.healRateInNeutralField;
+		// TODO: Consider friendly/neutral/enemy territory once that's implemented, barracks, the Red Cross
 	}
 
 	public static void OnBeginTurn(this MapUnit unit)

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -289,9 +289,12 @@ public static class MapUnitExtensions {
 	public static bool CanEnterTile(this MapUnit unit, Tile tile, bool allowCombat)
 	{
 		// Keep land units on land and sea units on water
-		if (unit.unitType.categories.Contains("Sea") && tile.IsLand())
+		if (unit.unitType.categories.Contains("Sea") && tile.IsLand()) {
+			if (tile.HasCity && tile.cityAtTile.owner == unit.owner) {
+				return true;
+			}
 			return false;
-		else if (unit.unitType.categories.Contains("Land") && ! tile.IsLand())
+		} else if (unit.unitType.categories.Contains("Land") && ! tile.IsLand())
 			return false;
 
 		// Check for units belonging to other civs


### PR DESCRIPTION
Closes #305 
Closes #319 

This is part of a batch of naval improvements, and should be merged before #321, sorry for creating them in the wrong order!

The first commit changes it so boats now only heal in port.

The second commit allows boats to go back to port after heading out on the waves, since I realized they couldn't heal at all after the first commit!

This (potentially) concludes my night of fixing naval annoyances and making that part of the game a little bit better.  Unless I decide to teach the AI a little bit about how boats are supposed to work.