### PR TITLE
287 - Galleys No Longer Used for Land Defense

### DIFF
--- a/C7/LogManager.cs
+++ b/C7/LogManager.cs
@@ -27,7 +27,7 @@ public class LogManager : Node
 			.WriteTo.File("log.txt", buffered: true, flushToDiskInterval: TimeSpan.FromMilliseconds(250), fileSizeLimitBytes: 52428800,	//50 MB
 			              outputTemplate: "[{Level:u3}] {Timestamp:HH:mm:ss} {SourceContext}: {Message:lj} {NewLine}{Exception}")
 
-			.Filter.ByIncludingOnly("(@l = 'Fatal' OR @l = 'Error' OR @l = 'Warning' OR @l = 'Information') OR SourceContext like 'C7Engine.CityProductionAI%'")	//suggested:  OR SourceContext like 'C7Engine.AI.%' (insert the namespace you need to debug)
+			.Filter.ByIncludingOnly("(@l = 'Fatal' OR @l = 'Error' OR @l = 'Warning' OR @l = 'Information')")	//suggested:  OR SourceContext like 'C7Engine.AI.%' (insert the namespace you need to debug)
 			.MinimumLevel.Debug()
 			.CreateLogger();
 

--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -19,27 +19,36 @@ namespace C7Engine {
 			// Copy unit list into temporary array so we can remove units while iterating.
 			// TODO: We also need to handle units spawned during the loop, e.g. leaders, armies, enslaved units. This is not so much an
 			// issue for the barbs but will be for similar loops elsewhere in the AI logic.
-			foreach (Player barbarianPlayer in gameData.players.Where(player => player.isBarbarians))
-			{
-				foreach (MapUnit unit in barbarianPlayer.units) {
-					if (unit.location.unitsOnTile.Count > 1 || unit.location.hasBarbarianCamp == false) {
-						//Move randomly
-						List<Tile> validTiles = unit.unitType.categories.Contains("Sea") ? unit.location.GetCoastNeighbors() : unit.location.GetLandNeighbors();
-						if (validTiles.Count == 0) {
-							//This can happen if a barbarian galley spawns next to a 1-tile lake, moves there, and doesn't have anywhere else to go.
-							log.Warning("WARNING: No valid tiles for barbarian to move to");
-							continue;
-						}
-						Tile newLocation = validTiles[GameData.rng.Next(validTiles.Count)];
-						//Because it chooses a semi-cardinal direction at random, not accounting for map, it could get none
-						//if it tries to move e.g. north from the north pole.  Hence, this check.
-						if (newLocation != Tile.NONE) {
-							log.Debug("Moving barbarian at " + unit.location + " to " + newLocation);
-							unit.move(unit.location.directionTo(newLocation));
-						}
+			foreach (MapUnit unit in player.units.ToArray()) {
+				if (UnitIsFreeToMove(unit)) {
+					//Move randomly
+					List<Tile> validTiles = unit.unitType.categories.Contains("Sea") ? unit.location.GetCoastNeighbors() : unit.location.GetLandNeighbors();
+					if (validTiles.Count == 0) {
+						//This can happen if a barbarian galley spawns next to a 1-tile lake, moves there, and doesn't have anywhere else to go.
+						log.Warning("WARNING: No valid tiles for barbarian to move to");
+						continue;
+					}
+					Tile newLocation = validTiles[GameData.rng.Next(validTiles.Count)];
+					//Because it chooses a semi-cardinal direction at random, not accounting for map, it could get none
+					//if it tries to move e.g. north from the north pole.  Hence, this check.
+					if (newLocation != Tile.NONE) {
+						log.Debug("Moving barbarian at " + unit.location + " to " + newLocation);
+						unit.move(unit.location.directionTo(newLocation));
 					}
 				}
 			}
+		}
+		private static bool UnitIsFreeToMove(MapUnit unit)
+		{
+			if (!unit.location.hasBarbarianCamp) {
+				return true;
+			}
+			//If we're on a barb camp, only move if there's another unit defending
+			return unit.location.unitsOnTile.Exists(mapUnit => mapUnit != unit && UnitIsLandDefender(mapUnit));
+		}
+
+		private static bool UnitIsLandDefender(MapUnit unit) {
+			return unit.unitType.categories.Contains("Land") && unit.unitType.defense > 0;
 		}
 	}
 }

--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Serilog;
 
 namespace C7Engine {
@@ -18,9 +19,9 @@ namespace C7Engine {
 			// Copy unit list into temporary array so we can remove units while iterating.
 			// TODO: We also need to handle units spawned during the loop, e.g. leaders, armies, enslaved units. This is not so much an
 			// issue for the barbs but will be for similar loops elsewhere in the AI logic.
-			foreach(MapUnit unit in gameData.mapUnits.ToArray()) {
-				//TODO: Make it better fit the barbs and not be hard-coded to a magic number
-				if (unit.owner == gameData.players[0]) {
+			foreach (Player barbarianPlayer in gameData.players.Where(player => player.isBarbarians))
+			{
+				foreach (MapUnit unit in barbarianPlayer.units) {
 					if (unit.location.unitsOnTile.Count > 1 || unit.location.hasBarbarianCamp == false) {
 						//Move randomly
 						List<Tile> validTiles = unit.unitType.categories.Contains("Sea") ? unit.location.GetCoastNeighbors() : unit.location.GetLandNeighbors();

--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -21,19 +21,25 @@ namespace C7Engine {
 			// issue for the barbs but will be for similar loops elsewhere in the AI logic.
 			foreach (MapUnit unit in player.units.ToArray()) {
 				if (UnitIsFreeToMove(unit)) {
-					//Move randomly
-					List<Tile> validTiles = unit.unitType.categories.Contains("Sea") ? unit.location.GetCoastNeighbors() : unit.location.GetLandNeighbors();
-					if (validTiles.Count == 0) {
-						//This can happen if a barbarian galley spawns next to a 1-tile lake, moves there, and doesn't have anywhere else to go.
-						log.Warning("WARNING: No valid tiles for barbarian to move to");
-						continue;
-					}
-					Tile newLocation = validTiles[GameData.rng.Next(validTiles.Count)];
-					//Because it chooses a semi-cardinal direction at random, not accounting for map, it could get none
-					//if it tries to move e.g. north from the north pole.  Hence, this check.
-					if (newLocation != Tile.NONE) {
-						log.Debug("Moving barbarian at " + unit.location + " to " + newLocation);
-						unit.move(unit.location.directionTo(newLocation));
+					while (unit.movementPointsRemaining > 0) {
+						//Move randomly
+						List<Tile> validTiles = unit.unitType.categories.Contains("Sea") ? unit.location.GetCoastNeighbors() : unit.location.GetLandNeighbors();
+						if (validTiles.Count == 0) {
+							//This can happen if a barbarian galley spawns next to a 1-tile lake, moves there, and doesn't have anywhere else to go.
+							log.Warning("WARNING: No valid tiles for barbarian to move to");
+							continue;
+						}
+						Tile newLocation = validTiles[GameData.rng.Next(validTiles.Count)];
+						//Because it chooses a semi-cardinal direction at random, not accounting for map, it could get none
+						//if it tries to move e.g. north from the north pole.  Hence, this check.
+						if (newLocation != Tile.NONE) {
+							log.Debug("Moving barbarian at " + unit.location + " to " + newLocation);
+							unit.move(unit.location.directionTo(newLocation));
+							unit.movementPointsRemaining -= newLocation.MovementCost();
+						} else {
+							//Avoid potential infinite loop.
+							break;
+						}
 					}
 				}
 			}

--- a/C7Engine/AI/UnitAI/SettlerLocationAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerLocationAI.cs
@@ -115,7 +115,7 @@ namespace C7Engine
 				}
 			}
 
-			log.Information("Tile " + tile + " is a valid city location ");
+			log.Debug("Tile " + tile + " is a valid city location ");
 			return false;
 		}
 

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -80,7 +80,7 @@ namespace C7Engine
 						barbPlayer.units.Add(newUnit);
 						log.Debug("New barbarian added at " + tile);
 					}
-					else if (tile.NeighborsWater() && result < 60) {
+					else if (tile.NeighborsWater() && result < 6) {
 						MapUnit newUnit = new MapUnit();
 						newUnit.location = tile;
 						newUnit.owner = gameData.players[0];    //todo: make this reliably point to the barbs

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -59,6 +59,7 @@ namespace C7Engine
 				log.Information("\n*** Processing production for turn " + gameData.turn + " ***");
 
 				//Generate new barbarian units.
+				Player barbPlayer = gameData.players.Find(player => player.isBarbarians);
 				foreach (Tile tile in gameData.map.barbarianCamps)
 				{
 					//7% chance of a new barbarian.  Probably should scale based on barbarian activity.
@@ -76,9 +77,10 @@ namespace C7Engine
 
 						tile.unitsOnTile.Add(newUnit);
 						gameData.mapUnits.Add(newUnit);
+						barbPlayer.units.Add(newUnit);
 						log.Debug("New barbarian added at " + tile);
 					}
-					else if (tile.NeighborsWater() && result < 6) {
+					else if (tile.NeighborsWater() && result < 60) {
 						MapUnit newUnit = new MapUnit();
 						newUnit.location = tile;
 						newUnit.owner = gameData.players[0];    //todo: make this reliably point to the barbs
@@ -90,6 +92,7 @@ namespace C7Engine
 
 						tile.unitsOnTile.Add(newUnit);
 						gameData.mapUnits.Add(newUnit);
+						barbPlayer.units.Add(newUnit);
 						log.Debug("New barbarian galley added at " + tile);
 					}
 				}


### PR DESCRIPTION
This prevents the barbarians from using galleys to defend their camps.

I think we are okay in terms of non-barbarian cities, though feel free to produce a counterexample.