### PR TITLE
318 - Can't build cities next to or on existing cities

### DIFF
--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -400,7 +400,16 @@ public static class MapUnitExtensions {
 
 	public static bool canBuildCity(this MapUnit unit)
 	{
-		return unit.unitType.actions.Contains("buildCity") && unit.location.IsAllowCities();
+		if (!unit.unitType.actions.Contains("buildCity")) {
+			return false;
+		}
+		if (unit.location.HasCity || !unit.location.IsAllowCities()) {
+			return false;
+		}
+		if (unit.location.neighbors.Values.Count(tile => tile.HasCity) > 0) {
+			return false;
+		}
+		return true;
 	}
 
 	public static void buildCity(this MapUnit unit, string cityName)

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -406,10 +406,7 @@ public static class MapUnitExtensions {
 		if (unit.location.HasCity || !unit.location.IsAllowCities()) {
 			return false;
 		}
-		if (unit.location.neighbors.Values.Count(tile => tile.HasCity) > 0) {
-			return false;
-		}
-		return true;
+		return unit.location.neighbors.Values.All(tile => !tile.HasCity);
 	}
 
 	public static void buildCity(this MapUnit unit, string cityName)


### PR DESCRIPTION
Closes #318 .  This only applies to human players as the AI was already obeying this condition.