### PR TITLE
191 refactor pathing algorithm

### DIFF
--- a/C7Engine/AI/Pathing/BinaryMinHeap.cs
+++ b/C7Engine/AI/Pathing/BinaryMinHeap.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+
+namespace C7Engine.Pathing {
+	/**
+	 * https://en.wikipedia.org/wiki/Binary_heap
+	 * min heap
+	 */
+	public class BinaryMinHeap<TValue> where TValue: IComparable<TValue> {
+		private readonly List<TValue> data = new List<TValue>();
+
+		public int count { get => data.Count; }
+
+		// average O(1), worst case O(log N)
+		public void insert(TValue v) {
+			data.Add(v);
+			siftUp(data.Count - 1);
+		}
+
+		// extract them smallest value, O(log N)
+		public TValue extract() {
+			TValue result = data[0];
+			data[0] = data[data.Count - 1];
+			data.RemoveAt(data.Count - 1);
+			if (data.Count > 0) {
+				siftDown(0);
+			}
+			return result;
+		}
+
+		private void siftUp(int childIndex) {
+			if (childIndex == 0) return;
+			int parentIndex = getParentIndex(childIndex);
+			if (!isRightOrder(parentIndex, childIndex)) {
+				swap(parentIndex, childIndex);
+				siftUp(parentIndex);
+			}
+		}
+
+		private void siftDown(int parentIndex) {
+			int leftChild = getLeftChild(parentIndex);
+			int rightChild = leftChild + 1;
+			if (rightChild < data.Count) {
+				// two children
+				bool leftShouldBeHigher = isRightOrder(leftChild, rightChild);
+				int topChildIndex = leftShouldBeHigher ? leftChild : rightChild;
+				if (!isRightOrder(parentIndex, topChildIndex)) {
+					swap(parentIndex, topChildIndex);
+					siftDown(topChildIndex);
+				}
+				return;
+			}
+
+			if (leftChild >= data.Count) {
+				// no children
+				return;
+			}
+
+			// one children
+			if (!isRightOrder(parentIndex, leftChild)) {
+				swap(parentIndex, leftChild);
+			}
+		}
+
+		private bool isRightOrder(int parentIndex, int childIndex) {
+			return data[parentIndex].CompareTo(data[childIndex]) <= 0;
+		}
+
+		private void swap(int index, int otherIndex) {
+			(data[index], data[otherIndex]) = (data[otherIndex], data[index]);
+		}
+
+		// 0 -> 0;  1,2 -> 0;  3,4 -> 1; 5,6 -> 2;
+		private static int getParentIndex(int index) {
+			return (index + 1) / 2 - 1;
+		}
+
+		// 0 -> 1; 1 -> 3; 2 -> 5; 3 -> 7
+		private static int getLeftChild(int index) {
+			return (index + 1) * 2 - 1;
+		}
+	}
+}

--- a/C7Engine/AI/Pathing/BinaryMinHeap.cs
+++ b/C7Engine/AI/Pathing/BinaryMinHeap.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 namespace C7Engine.Pathing {
 	/**
 	 * https://en.wikipedia.org/wiki/Binary_heap
-	 * min heap
 	 */
 	public class BinaryMinHeap<TValue> where TValue: IComparable<TValue> {
 		private readonly List<TValue> data = new List<TValue>();
@@ -17,7 +16,7 @@ namespace C7Engine.Pathing {
 			siftUp(data.Count - 1);
 		}
 
-		// extract them smallest value, O(log N)
+		// extract the smallest value, O(log N)
 		public TValue extract() {
 			TValue result = data[0];
 			data[0] = data[data.Count - 1];

--- a/C7Engine/AI/Pathing/DijkstrasAlgorithm.cs
+++ b/C7Engine/AI/Pathing/DijkstrasAlgorithm.cs
@@ -21,7 +21,7 @@ namespace C7Engine.Pathing {
 		 * when stopWhenReachDestination == false it calculates distances to each available point
 		 */
 		public static Dictionary<TNode, Edge<TNode>> run<TNode>(TNode start, TNode destination,
-			EdgeWalker<TNode> edgeWalker, bool stopWhenReachDestination = false)
+			EdgeWalker<TNode> edgeWalker, bool stopWhenReachDestination = true)
 		{
 			Dictionary<TNode, Edge<TNode>> visitedNodes = new Dictionary<TNode, Edge<TNode>>();
 			BinaryMinHeap<Edge<TNode>> edgesQueue = new BinaryMinHeap<Edge<TNode>>();

--- a/C7Engine/AI/Pathing/DijkstrasAlgorithm.cs
+++ b/C7Engine/AI/Pathing/DijkstrasAlgorithm.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Linq;
+using C7GameData;
+
+namespace C7Engine.Pathing {
+
+	public class DijkstrasAlgorithm: PathingAlgorithm {
+		private readonly EdgeWalker<Tile> edgeWalker;
+
+		public DijkstrasAlgorithm(EdgeWalker<Tile> edgeWalker) {
+			this.edgeWalker = edgeWalker;
+		}
+
+		public override TilePath PathFrom(Tile start, Tile destination) {
+			Dictionary<Tile, Edge<Tile>> walkingMap = run(start, destination, edgeWalker);
+			return makePath(walkingMap, destination);
+		}
+
+		/**
+		 * return Dictionary: Node -> Edge(previousNode, node, distanceToNodeFromStart)
+		 * with stopWhenReachDestination == false it calculate distances to each available point
+		 */
+		public static Dictionary<TNode, Edge<TNode>> run<TNode>(TNode start, TNode destination,
+			EdgeWalker<TNode> edgeWalker, bool stopWhenReachDestination = false)
+		{
+			Dictionary<TNode, Edge<TNode>> visitedNodes = new Dictionary<TNode, Edge<TNode>>();
+			BinaryMinHeap<Edge<TNode>> edgesQueue = new BinaryMinHeap<Edge<TNode>>();
+
+			edgesQueue.insert(new Edge<TNode>(start, start, 0.0f));
+
+			while (edgesQueue.count > 0) {
+				Edge<TNode> edge = edgesQueue.extract();
+
+				if (!visitedNodes.ContainsKey(edge.current)) {
+					visitedNodes[edge.current] = edge;
+					foreach (Edge<TNode> newEdge in edgeWalker.getEdges(edge.current)) {
+						newEdge.addDistance(edge);
+						edgesQueue.insert(newEdge);
+					}
+				}
+
+				if (stopWhenReachDestination && edge.current.Equals(destination)) break;
+			}
+
+			return visitedNodes;
+		}
+
+		private static TilePath makePath(Dictionary<Tile, Edge<Tile>> walkingMap, Tile destination) {
+			if (!walkingMap.ContainsKey(destination)) {
+				return TilePath.EmptyPath(destination);
+			}
+
+			List<Tile> tilesInPath = new List<Tile>() { destination };
+			while (true) {
+				Edge<Tile> edge = walkingMap[destination];
+				if (edge.prev.Equals(destination)) {
+					break;
+				}
+
+				destination = edge.prev;
+				tilesInPath.Add(destination);
+			}
+
+			tilesInPath.Reverse();
+			Queue<Tile> path = new Queue<Tile>();
+			foreach (Tile t in tilesInPath.Skip(1)) {
+				path.Enqueue(t);
+			}
+			return new TilePath(destination, path);
+		}
+	}
+}

--- a/C7Engine/AI/Pathing/DijkstrasAlgorithm.cs
+++ b/C7Engine/AI/Pathing/DijkstrasAlgorithm.cs
@@ -18,7 +18,7 @@ namespace C7Engine.Pathing {
 
 		/**
 		 * return Dictionary: Node -> Edge(previousNode, node, distanceToNodeFromStart)
-		 * with stopWhenReachDestination == false it calculate distances to each available point
+		 * when stopWhenReachDestination == false it calculates distances to each available point
 		 */
 		public static Dictionary<TNode, Edge<TNode>> run<TNode>(TNode start, TNode destination,
 			EdgeWalker<TNode> edgeWalker, bool stopWhenReachDestination = false)
@@ -51,14 +51,15 @@ namespace C7Engine.Pathing {
 			}
 
 			List<Tile> tilesInPath = new List<Tile>() { destination };
+			Tile tile = destination;
 			while (true) {
-				Edge<Tile> edge = walkingMap[destination];
-				if (edge.prev.Equals(destination)) {
+				Edge<Tile> edge = walkingMap[tile];
+				if (edge.prev.Equals(tile)) {
 					break;
 				}
 
-				destination = edge.prev;
-				tilesInPath.Add(destination);
+				tile = edge.prev;
+				tilesInPath.Add(tile);
 			}
 
 			tilesInPath.Reverse();

--- a/C7Engine/AI/Pathing/Edge.cs
+++ b/C7Engine/AI/Pathing/Edge.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace C7Engine.Pathing
+{
+	public class Edge<TNode>: IComparable<Edge<TNode>> {
+		public readonly TNode prev;
+		public readonly TNode current;
+		public float distanceToCurrent { get; private set; }
+
+		public Edge(TNode prev, TNode current, float distanceToCurrent) {
+			this.prev = prev;
+			this.current = current;
+			this.distanceToCurrent = distanceToCurrent;
+		}
+
+		public int CompareTo(Edge<TNode> other) {
+			return distanceToCurrent.CompareTo(other.distanceToCurrent);
+		}
+
+		internal void addDistance(Edge<TNode> previous) {
+			distanceToCurrent += previous.distanceToCurrent;
+		}
+	}
+}

--- a/C7Engine/AI/Pathing/EdgeWalker.cs
+++ b/C7Engine/AI/Pathing/EdgeWalker.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using C7GameData;
+
+namespace C7Engine.Pathing {
+	public abstract class EdgeWalker<TNode>
+	{
+		public abstract IEnumerable<Edge<TNode>> getEdges(TNode node);
+	}
+
+	public class WalkerOnLand: EdgeWalker<Tile> {
+		public override IEnumerable<Edge<Tile>> getEdges(Tile node) {
+			List<Edge<Tile>> result = new List<Edge<Tile>>();
+			foreach (KeyValuePair<TileDirection, Tile> pair in node.neighbors) {
+				TileDirection direction = pair.Key;
+				Tile neighbor = pair.Value;
+				if (neighbor.IsLand()) {
+					float movementCost = MapUnitExtensions.getMovementCost(neighbor, direction, neighbor);
+					result.Add(new Edge<Tile>(node, neighbor, movementCost));
+				}
+			}
+			return result;
+		}
+	}
+}

--- a/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
+++ b/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
@@ -7,7 +7,7 @@ namespace C7Engine.Pathing
 	 */
 	public class PathingAlgorithmChooser
 	{
-		private static PathingAlgorithm theAlgorithm = new DijkstrasLandAlgorithm();
+		private static PathingAlgorithm theAlgorithm = new DijkstrasAlgorithm(new WalkerOnLand());
 
 		public static PathingAlgorithm GetAlgorithm()
 		{

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -345,11 +345,19 @@ public static class MapUnitExtensions {
 			if (!unit.location.unitsOnTile.Remove(unit))
 				throw new System.Exception("Failed to remove unit from tile it's supposed to be on");
 			newLoc.unitsOnTile.Add(unit);
+			// todo switch to getMovementCost(loc, dir, newLoc)
 			unit.location = newLoc;
 			unit.movementPointsRemaining -= newLoc.overlayTerrainType.movementCost;
 			unit.OnEnterTile(newLoc);
 			unit.animate(MapUnit.AnimatedAction.RUN, wait);
 		}
+	}
+
+	public static float getMovementCost(Tile from, TileDirection dir, Tile newLocation) {
+		if (from.HasRiverCrossing(dir)) return newLocation.MovementCost();
+		if (newLocation.overlays.railroad) return 0;
+		if (newLocation.overlays.road) return 1.0f / 3;
+		return newLocation.MovementCost();
 	}
 
 	public static void moveAlongPath(this MapUnit unit)

--- a/EngineTests/AI/Pathing/BinaryMinHeapTest.cs
+++ b/EngineTests/AI/Pathing/BinaryMinHeapTest.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using C7Engine.Pathing;
+using Xunit;
+
+namespace EngineTests {
+	public class BinaryMinHeapTest {
+		private void checkBunchInsert<T>(List<T> list) where T:IComparable<T> {
+			BinaryMinHeap<T> heap = new BinaryMinHeap<T>();
+			foreach (T v in list) {
+				heap.insert(v);
+			}
+
+			Assert.Equal(list.Count, heap.count);
+
+			List<T> result = new List<T>();
+			while (heap.count > 0) {
+				result.Add(heap.extract());
+			}
+			Assert.Equal(list.Count, result.Count);
+
+			List<T> sortedCopy = new List<T>(list);
+			sortedCopy.Sort();
+			Assert.Equal(result, sortedCopy);
+		}
+
+		public List<int> generateLargeList() {
+			List<int> lst = new List<int>();
+			for (int i = 0; i < 1000; ++i) {
+				lst.Add(i);
+			}
+
+			Random random = new Random(0x1337);
+			for (int i = lst.Count - 1; i > 1 ; --i) {
+				var pos = random.Next(i - 1);
+				(lst[i], lst[pos]) = (lst[pos], lst[i]);
+			}
+
+			return lst;
+		}
+
+		[Fact]
+		public void testBinaryMinHeap() {
+			List<int> singleValue = new List<int>(){1};
+			List<int> fewValues = new List<int>() {9, 1, 3, 5, 6};
+			List<int> fewRepeatingValues = new List<int>() {1, 5, 6, 1, 5, 6};
+			List<float> floatValues = new List<float>() {float.MinValue, 0.1f, 0, 1, -1, 1000};
+
+			checkBunchInsert(singleValue);
+			checkBunchInsert(fewValues);
+			checkBunchInsert(fewRepeatingValues);
+			checkBunchInsert(floatValues);
+			checkBunchInsert(generateLargeList());
+		}
+	}
+}

--- a/EngineTests/AI/Pathing/DijkstrasAlgorithmTest.cs
+++ b/EngineTests/AI/Pathing/DijkstrasAlgorithmTest.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Linq;
+using C7Engine.Pathing;
+using Xunit;
+
+namespace EngineTests {
+	public class DijkstraAlgorithmTest {
+
+		[Fact]
+		void testOneVertexEmptyGraph() {
+			TestGraph graph = new TestGraph();
+
+			Dictionary<int, Edge<int>> result = DijkstrasAlgorithm.run(0, 0, graph);
+			Assert.Equal(result.Count, 1);
+			Assert.Equal(new Edge<int>(0, 0, 0.0f), result[0]);
+		}
+
+		[Fact]
+		void testOneVertexGraphWithEdges() {
+			TestGraph graph = new TestGraph();
+			graph.edges.Add(new Edge<int>(0, 0, 1.0f));
+
+			Dictionary<int, Edge<int>> result =
+				DijkstrasAlgorithm.run(0, 0, graph, stopWhenReachDestination: true);
+			Assert.Equal(result.Count, 1);
+			Assert.Equal(new Edge<int>(0, 0, 0.0f), result[0]);
+
+			result = DijkstrasAlgorithm.run(0, 0, graph, stopWhenReachDestination: false);
+			Assert.Equal(result.Count, 1);
+			Assert.Equal(new Edge<int>(0, 0, 0.0f), result[0]);
+		}
+
+		[Fact]
+		void testThreeVertexGraph() {
+			TestGraph graph = new TestGraph();
+			graph.addBidirectional(0, 1, 3.0f);
+			graph.addBidirectional(0, 2, 1.0f);
+			graph.addBidirectional(1, 2, 1.0f);
+
+			Dictionary<int, Edge<int>> result = DijkstrasAlgorithm.run(0, 1, graph);
+			Assert.Equal(3, result.Count);
+
+			Assert.Equal(new Edge<int>(0, 0, 0.0f), result[0]);
+			Assert.Equal(new Edge<int>(0, 1, 2.0f), result[1]);
+			Assert.Equal(new Edge<int>(1, 2, 1.0f), result[2]);
+		}
+
+		[Fact]
+		void testReachDestinationFlag() {
+			TestGraph graph = new TestGraph();
+			graph.addBidirectional(0, 1, 1.0f);
+			graph.addBidirectional(1, 2, 2.0f);
+			graph.addBidirectional(2, 3, 3.0f);
+
+			Dictionary<int, Edge<int>> withStop =
+				DijkstrasAlgorithm.run(0, 0, graph, stopWhenReachDestination: true);
+			Assert.Equal(1, withStop.Count);
+
+			Dictionary<int, Edge<int>> dontStop =
+				DijkstrasAlgorithm.run(0, 0, graph, stopWhenReachDestination: false);
+			Assert.Equal(4, dontStop.Count);
+		}
+	}
+
+	public class TestGraph: EdgeWalker<int> {
+		public readonly List<Edge<int>> edges = new List<Edge<int>>();
+
+		public void addBidirectional(int v1, int v2, float distance) {
+			edges.Add(new Edge<int>(v1, v2, distance));
+			edges.Add(new Edge<int>(v2, v1, distance));
+		}
+
+		public override IEnumerable<Edge<int>> getEdges(int node) {
+			return edges.Where(t => t.prev == node);
+		}
+	}
+}


### PR DESCRIPTION
Related to #191

Fractional movement points will be added in another pull request, because this is huge enough.

I rewrote dijkstra pathing algoritm for more abstract way. I decoupled it from game logic for movement possibility and costs.

DijkstrasAlgorithm.run(...) - pure algorithm, don't depend on game staff.
EdgeWalker interface passed to Dijkstra's algorithm and called back do determine movement costs between tiles.
WalkerOnLand - example of EdgeWalker imlementation for searching path on land.

BinaryMinHeap - custom data structure, needed for performance of Dijkstra's algorithm. "net472" doesn't have PriorityQueue, so I wrote it myself. Surprisingly the pathing algoritm turned out to be very simple.

I hope that existing BFSLandAlgorithm and DijkstrasLandAlgorithm could be replaced with new implementation and custom EdgeWalkers.

P.S. Algorithm already uses roads info when searching path, but units still untouched and they walk slow as without road.