### PR TITLE
use MovementPoints with float value instead of plain int

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -172,7 +172,7 @@ public class Game : Node2D
 					// Advance off the currently selected unit to the next one if it's out of moves or HP and not playing an
 					// animation we want to watch, or if it's fortified and we aren't set to keep fortified units selected.
 					if ((CurrentlySelectedUnit != MapUnit.NONE) &&
-						(((CurrentlySelectedUnit.movementPointsRemaining <= 0 || CurrentlySelectedUnit.hitPointsRemaining <= 0) &&
+						(((!CurrentlySelectedUnit.movementPoints.canMove || CurrentlySelectedUnit.hitPointsRemaining <= 0) &&
 						  ! animTracker.getUnitAppearance(CurrentlySelectedUnit).DeservesPlayerAttention()) ||
 						 (CurrentlySelectedUnit.isFortified && ! KeepCSUWhenFortified)))
 						GetNextAutoselectedUnit(gameData);
@@ -360,7 +360,7 @@ public class Game : Node2D
 						using (var gameDataAccess = new UIGameDataAccess()) {
 							var tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
 							if (tile != null) {
-								MapUnit to_select = tile.unitsOnTile.Find(u => u.movementPointsRemaining > 0);
+								MapUnit to_select = tile.unitsOnTile.Find(u => u.movementPoints.canMove);
 								if (to_select != null && to_select.owner == controller)
 									setSelectedUnit(to_select);
 							}

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -690,8 +690,7 @@ public class UnitLayer : LooseLayer {
 
 		Vector2 indicatorLoc = tileCenter - new Vector2(26, 40) + animOffset;
 
-		int mp = unit.movementPointsRemaining;
-		int moveIndIndex = (mp <= 0) ? 4 : ((mp >= unit.unitType.movement) ? 0 : 2);
+		int moveIndIndex = (!unit.movementPoints.canMove) ? 4 : ((unit.movementPoints.remaining >= unit.unitType.movement) ? 0 : 2);
 		Vector2 moveIndUpperLeft = new Vector2(1 + 7 * moveIndIndex, 1);
 		Rect2 moveIndRect = new Rect2(moveIndUpperLeft, new Vector2(6, 6));
 		var screenRect = new Rect2(indicatorLoc, new Vector2(6, 6));

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -145,7 +145,7 @@ public class LowerRightInfoBox : TextureRect
 		terrainType.Visible = true;
 		lblUnitSelected.Text = NewUnit.unitType.name;
 		lblUnitSelected.Visible = true;
-		string movementPointsRemaining = NewUnit.movementPointsRemaining > 0 ? "" + NewUnit.movementPointsRemaining : "0";
+		string movementPointsRemaining = NewUnit.movementPoints.canMove ? "" + NewUnit.movementPoints.remaining : "0";
 		string bombardText = "";
 		if (NewUnit.unitType.bombard > 0)
 		{

--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -21,7 +21,7 @@ namespace C7Engine {
 			// issue for the barbs but will be for similar loops elsewhere in the AI logic.
 			foreach (MapUnit unit in player.units.ToArray()) {
 				if (UnitIsFreeToMove(unit)) {
-					while (unit.movementPointsRemaining > 0) {
+					while (unit.movementPoints.canMove) {
 						//Move randomly
 						List<Tile> validTiles = unit.unitType.categories.Contains("Sea") ? unit.location.GetCoastNeighbors() : unit.location.GetLandNeighbors();
 						if (validTiles.Count == 0) {
@@ -35,7 +35,7 @@ namespace C7Engine {
 						if (newLocation != Tile.NONE) {
 							log.Debug("Moving barbarian at " + unit.location + " to " + newLocation);
 							unit.move(unit.location.directionTo(newLocation));
-							unit.movementPointsRemaining -= newLocation.MovementCost();
+							unit.movementPoints.onUnitMove(newLocation.MovementCost());
 						} else {
 							//Avoid potential infinite loop.
 							break;

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -21,7 +21,7 @@ namespace C7Engine
 				//than the old limit of one non-barbarian player.
 				if (player.isHuman) {
 					foreach (MapUnit unit in player.units) {
-						if (unit.movementPointsRemaining > 0 && !unit.IsBusy()) {
+						if (unit.movementPoints.canMove && !unit.IsBusy()) {
 							if (!waitQueue.Contains(unit)) {
 								return unit;
 							}

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -243,7 +243,7 @@ public static class MapUnitExtensions {
 			return;
 
 		unit.animate(MapUnit.AnimatedAction.ATTACK1, true);
-		unit.movementPointsRemaining -= 1;
+		unit.movementPoints.onUnitMove(1);
 		if (GameData.rng.NextDouble() < attackerOdds) {
 			target.hitPointsRemaining -= 1;
 			tile.Animate(AnimatedEffect.Hit3, false);
@@ -275,14 +275,14 @@ public static class MapUnitExtensions {
 	public static void OnBeginTurn(this MapUnit unit)
 	{
 		int maxMP = unit.unitType.movement;
-		if (unit.movementPointsRemaining >= maxMP) {
+		if (unit.movementPoints.remaining >= maxMP) {
 			int maxHP = unit.maxHitPoints;
 			if (unit.hitPointsRemaining < maxHP)
 				unit.hitPointsRemaining += unit.HealRateAt(unit.location);
 			if (unit.hitPointsRemaining > maxHP)
 				unit.hitPointsRemaining = maxHP;
 		}
-		unit.movementPointsRemaining = maxMP;
+		unit.movementPoints.reset(maxMP);
 		unit.defensiveBombardsRemaining = 1;
 	}
 
@@ -331,7 +331,7 @@ public static class MapUnitExtensions {
 	{
 		(int dx, int dy) = dir.toCoordDiff();
 		var newLoc = EngineStorage.gameData.map.tileAt(dx + unit.location.xCoordinate, dy + unit.location.yCoordinate);
-		if ((newLoc != Tile.NONE) && unit.CanEnterTile(newLoc, true) && (unit.movementPointsRemaining > 0)) {
+		if ((newLoc != Tile.NONE) && unit.CanEnterTile(newLoc, true) && (unit.movementPoints.canMove)) {
 			unit.facingDirection = dir;
 			unit.wake();
 
@@ -349,13 +349,13 @@ public static class MapUnitExtensions {
 					// but still pay one movement point for the combat.
 					else if (combatResult == CombatResult.DefenderKilled || combatResult == CombatResult.DefenderRetreated) {
 						if (!unit.CanEnterTile(newLoc, false)) {
-							unit.movementPointsRemaining -= 1;
+							unit.movementPoints.onUnitMove(1);
 							return;
 						}
 
 					// Similarly if we retreated, pay one MP for the combat but don't move.
 					} else if (combatResult == CombatResult.AttackerRetreated) {
-						unit.movementPointsRemaining -= 1;
+						unit.movementPoints.onUnitMove(1);
 						return;
 					}
 				} else if (unit.unitType.bombard > 0) {
@@ -366,13 +366,13 @@ public static class MapUnitExtensions {
 				}
 			}
 
+			float movementCost = getMovementCost(unit.location, dir, newLoc);
 			if (!unit.location.unitsOnTile.Remove(unit))
 				throw new System.Exception("Failed to remove unit from tile it's supposed to be on");
 			unit.OnEnterTile(newLoc);
 			newLoc.unitsOnTile.Add(unit);
-			// todo switch to getMovementCost(loc, dir, newLoc)
 			unit.location = newLoc;
-			unit.movementPointsRemaining -= newLoc.overlayTerrainType.movementCost;
+			unit.movementPoints.onUnitMove(movementCost);
 			unit.animate(MapUnit.AnimatedAction.RUN, wait);
 		}
 	}
@@ -386,7 +386,7 @@ public static class MapUnitExtensions {
 
 	public static void moveAlongPath(this MapUnit unit)
 	{
-		while (unit.movementPointsRemaining > 0 && unit.path?.PathLength() > 0) {
+		while (unit.movementPoints.canMove && unit.path?.PathLength() > 0) {
 			var dir = unit.location.directionTo(unit.path.Next());
 			unit.move(dir, true); //TODO: don't wait on last move animation?
 		}
@@ -403,12 +403,7 @@ public static class MapUnitExtensions {
 
 	public static void skipTurn(this MapUnit unit)
 	{
-		/**
-		* I'd like to enhance this so it's like Civ4, where the skip turn action takes the unit out of the rotation, but you can change your
-		* mind if need be.  But for now it'll be like Civ3, where you're out of luck if you realize that unit was needed for something; that
-		* also simplifies things here.
-		**/
-		unit.movementPointsRemaining = 0;
+		unit.movementPoints.skipTurn();
 	}
 
 	public static void disband(this MapUnit unit)
@@ -471,7 +466,7 @@ public static class MapUnitExtensions {
 
 		// TODO add animation and long process of building
 		unit.location.overlays.road = true;
-		unit.movementPointsRemaining = 0;
+		unit.movementPoints.onConsumeAll();
 	}
 
 	}

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -251,7 +251,7 @@ namespace C7GameData
 				unit.experienceLevelKey = defaultExperienceLevelKey;
 				unit.experienceLevel = defaultExperienceLevel;
 				unit.facingDirection = TileDirection.SOUTHWEST;
-				unit.movementPointsRemaining = proto.movement;
+				unit.movementPoints.reset(proto.movement);
 				unit.hitPointsRemaining = 3;
 				tile.unitsOnTile.Add(unit);
 				//TODO: Probably remove mapUnits

--- a/C7GameData/MapUnit.cs
+++ b/C7GameData/MapUnit.cs
@@ -23,7 +23,7 @@ public class MapUnit
 	[JsonIgnore]
 	public ExperienceLevel experienceLevel {get; set;}
 
-	public int movementPointsRemaining {get; set;}
+	public MovementPoints movementPoints = new MovementPoints();
 	public int hitPointsRemaining {get; set;}
 	public int maxHitPoints {
 		get {
@@ -52,7 +52,7 @@ public class MapUnit
 	public override string ToString()
 	{
 		if (this != MapUnit.NONE) {
-			return unitType.name + " with " + movementPointsRemaining + " movement points and " + hitPointsRemaining + " hit points, guid = " + guid;
+			return unitType.name + " with " + movementPoints.remaining + " movement points and " + hitPointsRemaining + " hit points, guid = " + guid;
 		}
 		else {
 			return "This is the NONE unit";
@@ -64,7 +64,7 @@ public class MapUnit
 		UnitPrototype type = this.unitType;
 		string hPDesc = ((type.attack > 0) || (type.defense > 0)) ? $" ({hitPointsRemaining}/{maxHitPoints})" : "";
 		string attackDesc = (type.bombard > 0) ? $"{type.attack}({type.bombard})" : type.attack.ToString();
-		return $"{experienceLevel.displayName}{hPDesc} {type.name} ({attackDesc}.{type.defense}.{movementPointsRemaining}/{type.movement})";
+		return $"{experienceLevel.displayName}{hPDesc} {type.name} ({attackDesc}.{type.defense}.{movementPoints.remaining}/{type.movement})";
 	}
 
 	// TODO: The contents of this enum are copy-pasted from UnitAction in Civ3UnitSprite.cs. We should unify these so we don't have two different

--- a/C7GameData/MovementPoints.cs
+++ b/C7GameData/MovementPoints.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace C7GameData
+{
+	/**
+	 * Struct for representing unit movement points values, such as 2, 1/3, 1/10 etc
+	 * epsilon required for avoiding rounding errors
+	 */
+	public struct MovementPoints {
+		private const float epsilon = 0.0001f;
+
+		public float remaining { get; private set; }
+
+		public bool canMove { get => remaining > epsilon; }
+
+		public void onUnitMove(float v) {
+			remaining = Math.Max(0.0f, remaining - v);
+		}
+
+		public void onConsumeAll() {
+			remaining = 0.0f;
+		}
+
+		public void reset(float maxMovementPoints) {
+			remaining = maxMovementPoints;
+		}
+
+		/**
+		* I'd like to enhance this so it's like Civ4, where the skip turn action takes the unit out of the rotation, but you can change your
+		* mind if need be.  But for now it'll be like Civ3, where you're out of luck if you realize that unit was needed for something; that
+		* also simplifies things here.
+		**/
+		public void skipTurn() {
+			remaining = 0.0f;
+		}
+	}
+}

--- a/C7GameData/UnitPrototype.cs
+++ b/C7GameData/UnitPrototype.cs
@@ -48,7 +48,7 @@ namespace C7GameData
 			MapUnit instance = new MapUnit();
 			instance.unitType = this;
 			instance.hitPointsRemaining = 3;    //todo: make this configurable
-			instance.movementPointsRemaining = movement;
+			instance.movementPoints.reset(movement);
 			return instance;
 		}
 	}


### PR DESCRIPTION
Closes #191

Roads allow values like 1/3.
I replaced int values with MovementPoints struct. It uses float and has helper methods for avoiding rounding errors.