### PR TITLE
140 - Display Scenario-Specific Graphics

### DIFF
--- a/C7/Civ3Map/Civ3Map.cs
+++ b/C7/Civ3Map/Civ3Map.cs
@@ -81,7 +81,7 @@ public class Civ3Map : Node2D
 		// temp if
 		if(FileNameLookup[fileID] != null)
 		{
-		Pcx PcxTxtr = new Pcx(Util.Civ3MediaPath(FileNameLookup[fileID].ToString(), ModRelPath));
+		Pcx PcxTxtr = new Pcx(Util.Civ3MediaPath(FileNameLookup[fileID].ToString()));//, ModRelPath));
 		ImageTexture Txtr = PCXToGodot.getImageTextureFromPCX(PcxTxtr);
 
 		for (int y = 0; y < PcxTxtr.Height; y += 64) {

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -71,6 +71,7 @@ public class Game : Node2D
 
 			using (var gameDataAccess = new UIGameDataAccess()) {
 				GameMap map = gameDataAccess.gameData.map;
+				Util.setModPath(gameDataAccess.gameData.scenarioSearchPath);
 				log.Debug("RelativeModPath ", map.RelativeModPath);
 				mapView = new MapView(this, map.numTilesWide, map.numTilesTall, map.wrapHorizontally, map.wrapVertically);
 				AddChild(mapView);

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -109,17 +109,20 @@ public class Util
 	{
 		//First, check if the file exists via a scenario's mod path
 		//For now this is only checked relative to Civ3, not relative to C7.
-		if (modPath != "") {
-			string[] tryPaths = new string[] {
-				modPath,
-				// Needed for some reason as Steam version at least puts some mod art in Extras instead of Scenarios
-				//  Also, the case mismatch is intentional. C3C makes a capital C path, but it's lower-case on the filesystem
-				"Conquests/Conquests/" + modPath, "Conquests/Scenarios/" + modPath, "civ3PTW/Scenarios/" + modPath
-			};
-			for (int i = 0; i < tryPaths.Length; i++) {
-				string actualCasePath = CheckForMedia(mediaPath, tryPaths[i]);
-				if (actualCasePath != null)
-					return actualCasePath;
+		if (modPath != null) {
+			string[] paths = modPath.Split(";");
+			foreach (string path in paths) {
+				string[] tryPaths = new string[] {
+					path,
+					// Needed for some reason as Steam version at least puts some mod art in Extras instead of Scenarios
+					//  Also, the case mismatch is intentional. C3C makes a capital C path, but it's lower-case on the filesystem
+					"Conquests/Conquests/" + path, "Conquests/Scenarios/" + path, "civ3PTW/Scenarios/" + path
+				};
+				for (int i = 0; i < tryPaths.Length; i++) {
+					string actualCasePath = CheckForMedia(mediaPath, tryPaths[i]);
+					if (actualCasePath != null)
+						return actualCasePath;
+				}
 			}
 		}
 

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -85,6 +85,19 @@ public class Util
 	}
 
 	/// <summary>
+	/// Sets the Civ3 legacy mod path.
+	/// This is here so Civ3MediaPath can refer to it, without having to grab it from all the places we might need to call
+	/// it, which is in 25 places currently.
+	///
+	/// N.B. This needs to be enhanced to support semicolon-separated mod paths.  But Civ3MediaPath also
+	/// needs to be enhanced to support that.
+	/// </summary>
+	private static string modPath;
+	public static void setModPath(string modPathParam) {
+		modPath = modPathParam;
+	}
+
+	/// <summary>
 	/// Pass this function a relative path (e.g. Art/Terrain/xpgc.pcx) and it will grab the correct version
 	/// Assumes Conquests/Complete
 	/// </summary>
@@ -92,7 +105,7 @@ public class Util
 	/// <param name="modPath">The mod path for a scenario, e.g. RFRE</param>
 	/// <returns>The path to the media on the file system, or an exception if it cannot be found</returns>
 	/// <exception cref="ApplicationException"></exception>
-	public static string Civ3MediaPath(string mediaPath, string modPath = "")
+	public static string Civ3MediaPath(string mediaPath)
 	{
 		//First, check if the file exists via a scenario's mod path
 		//For now this is only checked relative to Civ3, not relative to C7.
@@ -101,7 +114,7 @@ public class Util
 				modPath,
 				// Needed for some reason as Steam version at least puts some mod art in Extras instead of Scenarios
 				//  Also, the case mismatch is intentional. C3C makes a capital C path, but it's lower-case on the filesystem
-				"Conquests/Conquests" + modPath, "Conquests/Scenarios" + modPath, "civ3PTW/Scenarios" + modPath
+				"Conquests/Conquests/" + modPath, "Conquests/Scenarios/" + modPath, "civ3PTW/Scenarios/" + modPath
 			};
 			for (int i = 0; i < tryPaths.Length; i++) {
 				string actualCasePath = CheckForMedia(mediaPath, tryPaths[i]);

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -88,9 +88,6 @@ public class Util
 	/// Sets the Civ3 legacy mod path.
 	/// This is here so Civ3MediaPath can refer to it, without having to grab it from all the places we might need to call
 	/// it, which is in 25 places currently.
-	///
-	/// N.B. This needs to be enhanced to support semicolon-separated mod paths.  But Civ3MediaPath also
-	/// needs to be enhanced to support that.
 	/// </summary>
 	private static string modPath;
 	public static void setModPath(string modPathParam) {

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -33,6 +33,8 @@ namespace C7GameData
 		public int healRateInHostileField;
 		public int healRateInCity;
 
+		public string scenarioSearchPath;	//legacy from Civ3, we'll probably have a more modern format someday but this keeps legacy compatibility
+
 		public GameData()
 		{
 			map = new GameMap();

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -38,6 +38,7 @@ namespace C7GameData
 			c7Save.GameData.healRateInNeutralField = 1;
 			c7Save.GameData.healRateInHostileField = 0;
 			c7Save.GameData.healRateInCity = 2;
+			c7Save.GameData.scenarioSearchPath = theBiq.Game[0].ScenarioSearchFolders;
 			ImportBarbarianInfo(theBiq, c7Save);
 		}
 


### PR DESCRIPTION
Based on the scenario search path.

I'd thought we had this before, but it was only in the legacy Civ3Map, and only when you tossed a string for the folder in the source code.

Now, it stores the search path in Util, and the Civ3MediaPath method uses that automatically.  From a pure OO standpoint, the old way of having to pass in the search path as an argument may be cleaner, but we already were calling that method from 25 places and it just didn't seem to make sense to have that cognitive overhead in 25 places when it's only going to change when a new game/scenario is loaded.

Please review #131 first!