### PR TITLE
90 - Bonus Grassland Overlay and Production Effect

### DIFF
--- a/C7/Map/TntLayer.cs
+++ b/C7/Map/TntLayer.cs
@@ -1,0 +1,42 @@
+using C7GameData;
+using Godot;
+using Resource = C7GameData.Resource;
+using Serilog;
+
+namespace C7.Map
+{
+	/// <summary>
+	/// Displays terrain yield overlays (from the tnt.pcx file).  These are most well known for letting you know where
+	/// there are bonus grasslands.
+	/// Note: I don't know why it's called tnt.
+	/// </summary>
+	public class TntLayer : LooseLayer
+	{
+		private ILogger log = LogManager.ForContext<ResourceLayer>();
+
+		private static readonly Vector2 tntSize = new Vector2(128, 64);
+		private ImageTexture txtTexture;
+
+		//Each row corresponds to a terrain.  For now we're only adding one, maybe someday we'll add full TNT support
+		private readonly int GRASSLAND_ROW = 0;
+		private readonly int BONUS_GRASSLAND_ROW = 1;
+		private readonly int PLAINS_ROW = 2;
+		private readonly int DESERT_ROW = 3;
+		private readonly int BONUS_GRASSLAND_TNT_OFF_ROW = 3;
+		private readonly int TUNDRA_ROW = 4;
+		private readonly int FLOOD_PLAIN_ROW = 5;
+
+		public TntLayer()
+		{
+			txtTexture = Util.LoadTextureFromPCX("Art/Terrain/tnt.pcx");
+		}
+		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
+		{
+			if (tile.overlayTerrainType.Key == "grassland" && tile.isBonusShield) {
+				Rect2 tntRectangle = new Rect2(0 * tntSize.x, BONUS_GRASSLAND_TNT_OFF_ROW * tntSize.y, tntSize);
+				Rect2 screenTarget = new Rect2(tileCenter - 0.5f * tntSize, tntSize);
+				looseView.DrawTextureRectRegion(txtTexture, screenTarget, tntRectangle);
+			}
+		}
+	}
+}

--- a/C7/Map/TntLayer.cs
+++ b/C7/Map/TntLayer.cs
@@ -12,10 +12,10 @@ namespace C7.Map
 	/// </summary>
 	public class TntLayer : LooseLayer
 	{
-		private ILogger log = LogManager.ForContext<ResourceLayer>();
+		private ILogger log = LogManager.ForContext<TntLayer>();
 
 		private static readonly Vector2 tntSize = new Vector2(128, 64);
-		private ImageTexture txtTexture;
+		private ImageTexture tntTexture;
 
 		//Each row corresponds to a terrain.  For now we're only adding one, maybe someday we'll add full TNT support
 		private readonly int GRASSLAND_ROW = 0;
@@ -28,14 +28,14 @@ namespace C7.Map
 
 		public TntLayer()
 		{
-			txtTexture = Util.LoadTextureFromPCX("Art/Terrain/tnt.pcx");
+			tntTexture = Util.LoadTextureFromPCX("Art/Terrain/tnt.pcx");
 		}
 		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
 		{
 			if (tile.overlayTerrainType.Key == "grassland" && tile.isBonusShield) {
-				Rect2 tntRectangle = new Rect2(0 * tntSize.x, BONUS_GRASSLAND_TNT_OFF_ROW * tntSize.y, tntSize);
+				Rect2 tntRectangle = new Rect2(0, BONUS_GRASSLAND_TNT_OFF_ROW * tntSize.y, tntSize);
 				Rect2 screenTarget = new Rect2(tileCenter - 0.5f * tntSize, tntSize);
-				looseView.DrawTextureRectRegion(txtTexture, screenTarget, tntRectangle);
+				looseView.DrawTextureRectRegion(tntTexture, screenTarget, tntRectangle);
 			}
 		}
 	}

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -1120,6 +1120,7 @@ public class MapView : Node2D {
 		looseView.layers.Add(new ForestLayer());
 		looseView.layers.Add(new MarshLayer());
 		looseView.layers.Add(new HillsLayer());
+		looseView.layers.Add(new TntLayer());
 		looseView.layers.Add(new RoadLayer());
 		looseView.layers.Add(new ResourceLayer());
 		gridLayer = new GridLayer();

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -179,7 +179,10 @@ namespace C7GameData
 		public int productionYield(Player player)
 		{
 			int yield = overlayTerrainType.baseShieldProduction;
-			if (this.Resource != Resource.NONE && player.KnowsAboutResource(Resource)) {
+			if (overlayTerrainType.Key == "grassland" && this.isBonusShield) {
+				yield++;
+			}
+			if (Resource != Resource.NONE && player.KnowsAboutResource(Resource)) {
 				yield += this.Resource.ShieldsBonus;
 			}
 			return yield;


### PR DESCRIPTION
Bonus grasslands now show up, and production from the bonus is accounted for.

I added the check for grassland as the tile key because in Civ3 SAV files, tiles other than grassland can apparently have the bonus flag checked.  Either that or our import process has an error in it, but I checked that and it looks right to me.