### PR TITLE
Add an Observer Mode

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -535,6 +535,22 @@ public class Game : Node2D
 			{
 				SetAnimationsEnabled(false);
 			}
+			else if (eventKeyDown.Scancode == (int)Godot.KeyList.O && eventKeyDown.Shift && eventKeyDown.Control && eventKeyDown.Alt) {
+				using (UIGameDataAccess gameDataAccess = new UIGameDataAccess()) {
+					gameDataAccess.gameData.observerMode = !gameDataAccess.gameData.observerMode;
+					if (gameDataAccess.gameData.observerMode) {
+						foreach (Player player in gameDataAccess.gameData.players) {
+							player.isHuman = false;
+						}
+					} else {
+						foreach (Player player in gameDataAccess.gameData.players) {
+							if (player.guid == EngineStorage.uiControllerID) {
+								player.isHuman = true;
+							}
+						}
+					}
+				}
+			}
 
 			// always turn off go to mode unless G key is pressed
 			// do this after processing esc key

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -1030,29 +1030,37 @@ public class LooseView : Node2D {
 				if (gD.map.isRowAt(y))
 					for (int x = visRegion.getRowStartX(y); x < visRegion.lowerRightX; x += 2) {
 						Tile tile = gD.map.tileAt(x, y);
-						if (tile != Tile.NONE && gameDataAccess.gameData.GetHumanPlayers()[0].tileKnowledge.isTileKnown(tile))
+						if (IsTileKnown(tile, gameDataAccess))
 							visibleTiles.Add(new VisibleTile { tile = tile, tileCenter = MapView.cellSize * new Vector2(x + 1, y + 1) });
 					}
 
-			foreach (LooseLayer layer in layers.FindAll(L => L.visible)) {
+			foreach (LooseLayer layer in layers.FindAll(L => L.visible && !(L is FogOfWarLayer))) {
 				layer.onBeginDraw(this, gD);
 				foreach (VisibleTile vT in visibleTiles)
 					layer.drawObject(this, gD, vT.tile, vT.tileCenter);
 				layer.onEndDraw(this, gD);
 			}
 
-			foreach (LooseLayer layer in layers.FindAll(layer => layer is FogOfWarLayer)) {
-				for (int y = visRegion.upperLeftY; y < visRegion.lowerRightY; y++)
-					if (gD.map.isRowAt(y))
-						for (int x = visRegion.getRowStartX(y); x < visRegion.lowerRightX; x += 2) {
-							Tile tile = gD.map.tileAt(x, y);
-							if (tile != Tile.NONE) {
-								VisibleTile invisibleTile = new VisibleTile { tile = tile, tileCenter = MapView.cellSize * new Vector2(x + 1, y + 1) };
-								layer.drawObject(this, gD, tile, invisibleTile.tileCenter);
+			if (!gD.observerMode) {
+				foreach (LooseLayer layer in layers.FindAll(layer => layer is FogOfWarLayer)) {
+					for (int y = visRegion.upperLeftY; y < visRegion.lowerRightY; y++)
+						if (gD.map.isRowAt(y))
+							for (int x = visRegion.getRowStartX(y); x < visRegion.lowerRightX; x += 2) {
+								Tile tile = gD.map.tileAt(x, y);
+								if (tile != Tile.NONE) {
+									VisibleTile invisibleTile = new VisibleTile { tile = tile, tileCenter = MapView.cellSize * new Vector2(x + 1, y + 1) };
+									layer.drawObject(this, gD, tile, invisibleTile.tileCenter);
+								}
 							}
-						}
+				}
 			}
 		}
+	}
+	private static bool IsTileKnown(Tile tile, UIGameDataAccess gameDataAccess) {
+		if (gameDataAccess.gameData.observerMode) {
+			return true;
+		}
+		return tile != Tile.NONE && gameDataAccess.gameData.GetHumanPlayers()[0].tileKnowledge.isTileKnown(tile);
 	}
 }
 

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -32,10 +32,7 @@ namespace C7Engine
 				foreach (Player player in gameData.players) {
 					if ((! player.hasPlayedThisTurn) &&
 					    ! (firstTurn && player.SitsOutFirstTurn())) {
-						if (player.guid == EngineStorage.uiControllerID) {
-							new MsgStartTurn().send();
-							return;
-						} else if (player.isBarbarians) {
+						if (player.isBarbarians) {
 							//Call the barbarian AI
 							//TODO: The AIs should be stored somewhere on the game state as some of them will store state (plans,
 							//strategy, etc.) For now, we only have a random AI, so that will be in a future commit
@@ -44,8 +41,13 @@ namespace C7Engine
 						} else if (! player.isHuman) {
 							PlayerAI.PlayTurn(player, GameData.rng);
 							player.hasPlayedThisTurn = true;
-						} else {
+						} else if (player.guid != EngineStorage.uiControllerID) {
 							player.hasPlayedThisTurn = true;
+						}
+						//Human player check.  Let the human see what's going on even if they are in observer mode.
+						if (player.guid == EngineStorage.uiControllerID) {
+							new MsgStartTurn().send();
+							return;
 						}
 					}
 				}

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -33,6 +33,8 @@ namespace C7GameData
 		public int healRateInHostileField;
 		public int healRateInCity;
 
+		public bool observerMode = false;
+
 		public GameData()
 		{
 			map = new GameMap();


### PR DESCRIPTION
Activated (and deactivated) with Ctrl+Shift+Alt+O.

This is slightly different than Civ3's Observer Mode, modeled more on Paradox's Observer Mode.  Specifically, it's different in that the AI will assume control of your civilization while you are in Observer Mode.

This makes it more useful for hands-off observation, and will be yet more useful, especially for testing how scenarios play out, or just if the player wants an advanced start, if an "autoplay" feature is added (which is featured in some Civ4 mods).

Known issue: If you enter Observation Mode immediately, before fortifying your units, each turn ended with the "Enter" key will cause two turns to happen.  If you fortify your units first, or use the NumPad enter key, that won't happen.

I've identified that the cause is at least in part that the Godot `BlinkyEndTurnButtonPressed` event we have is firing right after the Enter key event is processed in this case, but am not sure exactly why or why it happens only for Enter.  Presumably somehow it has the focus in that case?  But I suspect it's a deep enough rabbit hole that I don't really want to get into it, a good enough Observation Mode is good enough for Carthage.