### PR TITLE
349 - Fix cheap road/rail transport

### DIFF
--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -27,7 +27,7 @@ namespace C7Engine {
 						if (validTiles.Count == 0) {
 							//This can happen if a barbarian galley spawns next to a 1-tile lake, moves there, and doesn't have anywhere else to go.
 							log.Warning("WARNING: No valid tiles for barbarian to move to");
-							continue;
+							break;
 						}
 						Tile newLocation = validTiles[GameData.rng.Next(validTiles.Count)];
 						//Because it chooses a semi-cardinal direction at random, not accounting for map, it could get none

--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -35,7 +35,6 @@ namespace C7Engine {
 						if (newLocation != Tile.NONE) {
 							log.Debug("Moving barbarian at " + unit.location + " to " + newLocation);
 							unit.move(unit.location.directionTo(newLocation));
-							unit.movementPoints.onUnitMove(newLocation.MovementCost());
 						} else {
 							//Avoid potential infinite loop.
 							break;

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -382,8 +382,8 @@ public static class MapUnitExtensions {
 
 	public static float getMovementCost(Tile from, TileDirection dir, Tile newLocation) {
 		if (from.HasRiverCrossing(dir)) return newLocation.MovementCost();
-		if (newLocation.overlays.railroad) return 0;
-		if (newLocation.overlays.road) return 1.0f / 3;
+		if (from.overlays.railroad && newLocation.overlays.railroad) return 0;
+		if ((from.overlays.railroad || from.overlays.road) && newLocation.overlays.road) return 1.0f / 3;
 		return newLocation.MovementCost();
 	}
 

--- a/C7GameData/AIData/DefenderAIData.cs
+++ b/C7GameData/AIData/DefenderAIData.cs
@@ -15,14 +15,14 @@ namespace C7GameData.AIData
 			ESTABLISH_BEACHHEAD,	//e.g. on a new continent
 			PILLAGE_ENEMY_LANDS
 		}
-		
+
 		public DefenderGoal goal;
 		public Tile destination;
 		public TilePath pathToDestination;
-		
+
 		public override string ToString()
 		{
-			string cityName = destination.cityAtTile.name;
+			string cityName = destination.HasCity ? destination.cityAtTile.name : " at " + destination.ToString();
 			return goal + " " + cityName;
 		}
 	}


### PR DESCRIPTION
Moving onto rails is no longer free, and moving onto roads is no longer discounted, unless the source tile also has rail/(roads or rail), respectively.

Also fix barbarians being charged for base terrain cost regardless of roads/rails, and a crash caused by right-clicking on a unit with a defend strategy on a non-city tile (which currently happens for catapults in scenarios that don't support Settlers).