### PR TITLE
320 - Fix the overloaded NeighborsWater method.

### DIFF
--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System;
+using System.Linq;
 using C7.Map;
 using Godot;
 using ConvertCiv3Media;
@@ -309,7 +310,7 @@ public class ForestLayer : LooseLayer {
 			int randomJungleRow = tile.yCoordinate % 2;
 			int randomJungleColumn;
 			ImageTexture jungleTexture;
-			if (tile.NeighborsWater()) {
+			if (tile.getEdgeNeighbors().Any(t => t.IsWater())) {
 				randomJungleColumn = tile.xCoordinate % 6;
 				jungleTexture = smallJungleTexture;
 			}
@@ -340,7 +341,7 @@ public class ForestLayer : LooseLayer {
 			}
 			else {
 				forestRow = tile.yCoordinate % 2;
-				if (tile.NeighborsWater()) {
+				if (tile.getEdgeNeighbors().Any(t => t.IsWater())) {
 					forestColumn = tile.xCoordinate % 5;
 					if (tile.baseTerrainType.Key == "grassland") {
 						forestTexture = smallForestTexture;
@@ -390,7 +391,7 @@ public class MarshLayer : LooseLayer {
 			int randomJungleRow = tile.yCoordinate % 2;
 			int randomMarshColumn;
 			ImageTexture marshTexture;
-			if (tile.NeighborsWater()) {
+			if (tile.getEdgeNeighbors().Any(t => t.IsWater())) {
 				randomMarshColumn = tile.xCoordinate % 5;
 				marshTexture = smallMarshTexture;
 			}

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -79,7 +79,7 @@ namespace C7GameData
 		//Sometimes we care *specifically* about the Coast terrain, e.g. galleys can only move on that terrain, not Sea or Ocean
 		//Those cases should not use this method.
 		public bool NeighborsWater() {
-			foreach (Tile neighbor in getDiagonalNeighbors()) {
+			foreach (Tile neighbor in neighbors.Values) {
 				if (neighbor.baseTerrainType.isWater()) {
 					return true;
 				}
@@ -87,9 +87,14 @@ namespace C7GameData
 			return false;
 		}
 
-		public Tile[] getDiagonalNeighbors() {
-			Tile[] diagonalNeighbors =  { neighbors[TileDirection.NORTHEAST], neighbors[TileDirection.NORTHWEST], neighbors[TileDirection.SOUTHEAST], neighbors[TileDirection.SOUTHWEST]};
-			return diagonalNeighbors;
+		/// <summary>
+		/// Returns neighbors along edges only.
+		/// This is used by some graphics algorithms.
+		/// </summary>
+		/// <returns></returns>
+		public Tile[] getEdgeNeighbors() {
+			Tile[] edgeNeighbors =  { neighbors[TileDirection.NORTHEAST], neighbors[TileDirection.NORTHWEST], neighbors[TileDirection.SOUTHEAST], neighbors[TileDirection.SOUTHWEST]};
+			return edgeNeighbors;
 		}
 
 		public override string ToString()
@@ -129,6 +134,10 @@ namespace C7GameData
 		public bool IsLand()
 		{
 			return !baseTerrainType.isWater();
+		}
+
+		public bool IsWater() {
+			return baseTerrainType.isWater();
 		}
 
 		public bool IsAllowCities() {


### PR DESCRIPTION
This fixes the bug where cities/barb camps that were connected to water only along a vertex could not build water units.

Closes #320 