### PR TITLE
241 - Remove citizens from tiles when a city is destroyed.

### DIFF
--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -21,5 +21,16 @@ namespace C7Engine
 			tileWithNewCity.cityAtTile = newCity;
 			tileWithNewCity.overlays.road = true;
 		}
+
+		public static void DestroyCity(int x, int y) {
+			Tile tile = EngineStorage.gameData.map.tileAt(x, y);
+			tile.DisbandNonDefendingUnits();
+			while (tile.cityAtTile.size > 0) {
+				tile.cityAtTile.RemoveCitizen();
+			}
+			tile.cityAtTile.owner.cities.Remove(tile.cityAtTile);
+			EngineStorage.gameData.cities.Remove(tile.cityAtTile);
+			tile.cityAtTile = null;
+		}
 	}
 }

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -25,9 +25,7 @@ namespace C7Engine
 		public static void DestroyCity(int x, int y) {
 			Tile tile = EngineStorage.gameData.map.tileAt(x, y);
 			tile.DisbandNonDefendingUnits();
-			while (tile.cityAtTile.size > 0) {
-				tile.cityAtTile.RemoveCitizen();
-			}
+			tile.cityAtTile.RemoveAllCitizens();
 			tile.cityAtTile.owner.cities.Remove(tile.cityAtTile);
 			EngineStorage.gameData.cities.Remove(tile.cityAtTile);
 			tile.cityAtTile = null;

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -116,7 +116,7 @@ namespace C7Engine
 							log.Error($"Attempting to remove the last resident from {city}");
 						} else {
 							for (int i = 0; i < diff; i++) {
-								city.removeCitizen();
+								city.RemoveCitizen();
 							}
 						}
 					}
@@ -138,7 +138,7 @@ namespace C7Engine
 
 							if (newUnit.unitType.populationCost > 0) {
 								for (int i = 0; i < newUnit.unitType.populationCost; i++) {
-									city.removeCitizen();
+									city.RemoveCitizen();
 								}
 							}
 						}

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -115,9 +115,7 @@ namespace C7Engine
 						if (newSize <= 0) {
 							log.Error($"Attempting to remove the last resident from {city}");
 						} else {
-							for (int i = 0; i < diff; i++) {
-								city.RemoveCitizen();
-							}
+							city.RemoveCitizens(diff);
 						}
 					}
 
@@ -137,9 +135,7 @@ namespace C7Engine
 							city.owner.AddUnit(newUnit);
 
 							if (newUnit.unitType.populationCost > 0) {
-								for (int i = 0; i < newUnit.unitType.populationCost; i++) {
-									city.RemoveCitizen();
-								}
+								city.RemoveCitizens(newUnit.unitType.populationCost);
 							}
 						}
 						city.SetItemBeingProduced(CityProductionAI.GetNextItemToBeProduced(city, producedItem));

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -300,10 +300,7 @@ public static class MapUnitExtensions {
 
 		// Destroy enemy city on tile
 		if (tile.HasCity && !unit.owner.IsAtPeaceWith(tile.cityAtTile.owner)) {
-			tile.DisbandNonDefendingUnits();
-			tile.cityAtTile.owner.cities.Remove(tile.cityAtTile);
-			EngineStorage.gameData.cities.Remove(tile.cityAtTile);
-			tile.cityAtTile = null;
+			CityInteractions.DestroyCity(tile.xCoordinate, tile.yCoordinate);
 		}
 	}
 

--- a/C7GameData/City.cs
+++ b/C7GameData/City.cs
@@ -135,7 +135,7 @@ namespace C7GameData
 			return CurrentFoodYield() - size * 2;
 		}
 
-		public void removeCitizen() {
+		public void RemoveCitizen() {
 			residents[residents.Count - 1].tileWorked.personWorkingTile = null;
 			residents.RemoveAt(residents.Count - 1);
 		}

--- a/C7GameData/City.cs
+++ b/C7GameData/City.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Serilog;
 
 namespace C7GameData
 {
@@ -135,9 +136,26 @@ namespace C7GameData
 			return CurrentFoodYield() - size * 2;
 		}
 
-		public void RemoveCitizen() {
+		private void RemoveCitizen() {
 			residents[residents.Count - 1].tileWorked.personWorkingTile = null;
 			residents.RemoveAt(residents.Count - 1);
+		}
+
+		public void RemoveCitizens(int number) {
+			for (int i = 0; i < number; i++) {
+				if (residents.Count > 0) {
+					RemoveCitizen();
+				} else {
+					Log.Warning("Trying to remove last citizen from " + name);
+					break;
+				}
+			}
+		}
+
+		public void RemoveAllCitizens() {
+			while (residents.Count > 0) {
+				RemoveCitizen();
+			}
 		}
 
 		public override string ToString() {


### PR DESCRIPTION
Also renamed method to conform with C# standards, and move the destroy logic out to CityInteractions so it can be reused when we add voluntary (right click menu) city destruction.