### PR TITLE
323 - Fix zombie units causing crashes

### DIFF
--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -21,7 +21,7 @@ namespace C7Engine {
 			// issue for the barbs but will be for similar loops elsewhere in the AI logic.
 			foreach (MapUnit unit in player.units.ToArray()) {
 				if (UnitIsFreeToMove(unit)) {
-					while (unit.movementPoints.canMove) {
+					while (unit.hitPointsRemaining > 0 && unit.movementPoints.canMove) {
 						//Move randomly
 						List<Tile> validTiles = unit.unitType.categories.Contains("Sea") ? unit.location.GetCoastNeighbors() : unit.location.GetLandNeighbors();
 						if (validTiles.Count == 0) {

--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -21,7 +21,7 @@ namespace C7Engine {
 			// issue for the barbs but will be for similar loops elsewhere in the AI logic.
 			foreach (MapUnit unit in player.units.ToArray()) {
 				if (UnitIsFreeToMove(unit)) {
-					while (unit.hitPointsRemaining > 0 && unit.movementPoints.canMove) {
+					while (unit.movementPoints.canMove) {
 						//Move randomly
 						List<Tile> validTiles = unit.unitType.categories.Contains("Sea") ? unit.location.GetCoastNeighbors() : unit.location.GetLandNeighbors();
 						if (validTiles.Count == 0) {
@@ -34,7 +34,9 @@ namespace C7Engine {
 						//if it tries to move e.g. north from the north pole.  Hence, this check.
 						if (newLocation != Tile.NONE) {
 							log.Debug("Moving barbarian at " + unit.location + " to " + newLocation);
-							unit.move(unit.location.directionTo(newLocation));
+							if (!unit.move(unit.location.directionTo(newLocation))) {
+								break;
+							}
 						} else {
 							//Avoid potential infinite loop.
 							break;

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -330,7 +330,7 @@ public static class MapUnitExtensions {
 	public static void move(this MapUnit unit, TileDirection dir, bool wait = false)
 	{
 		(int dx, int dy) = dir.toCoordDiff();
-		var newLoc = EngineStorage.gameData.map.tileAt(dx + unit.location.xCoordinate, dy + unit.location.yCoordinate);
+		Tile newLoc = EngineStorage.gameData.map.tileAt(dx + unit.location.xCoordinate, dy + unit.location.yCoordinate);
 		if ((newLoc != Tile.NONE) && unit.CanEnterTile(newLoc, true) && (unit.movementPoints.canMove)) {
 			unit.facingDirection = dir;
 			unit.wake();

--- a/C7GameData/MapUnit.cs
+++ b/C7GameData/MapUnit.cs
@@ -61,7 +61,7 @@ public class MapUnit
 	public override string ToString()
 	{
 		if (this != MapUnit.NONE) {
-			return this.owner + " " + unitType.name + " with " + movementPoints.remaining + " movement points and " + hitPointsRemaining + " hit points, guid = " + guid;
+			return this.owner + " " + unitType.name + "at (" + location.xCoordinate + ", " + location.yCoordinate + ") with " + movementPoints.remaining + " MP and " + hitPointsRemaining + " HP, guid = " + guid;
 		}
 		else {
 			return "This is the NONE unit";


### PR DESCRIPTION
This fixes a longstanding mysterious crash, which thanks to improved logging and the ability to set a fixed seed, was determined to be caused by zombie units.

These units no longer move around and cause crashes, and should be properly garbage collected the next turn now that they don't cause crashes.

You can use fixed seed 1626442457 to test this solving a crash that happens after turn 18.  See the issue card for full notes.

Please review 357 first!  The reproducible case for this depends on the changes made there.