### PR TITLE
343 - Cities that grow negatively will now shrink back down to the next size

### DIFF
--- a/C7/Map/CityLayer.cs
+++ b/C7/Map/CityLayer.cs
@@ -50,7 +50,7 @@ namespace C7.Map {
 			looseView.DrawTextureRectRegion(cityTexture, screenRect, textRect);
 
 			int turnsUntilGrowth = city.TurnsUntilGrowth();
-			string turnsUntilGrowthText = turnsUntilGrowth == int.MaxValue ? "- -" : "" + turnsUntilGrowth;
+			string turnsUntilGrowthText = turnsUntilGrowth == int.MaxValue || turnsUntilGrowth < 0 ? "- -" : "" + turnsUntilGrowth;
 			string cityNameAndGrowth = $"{city.name} : {turnsUntilGrowthText}";
 			string productionDescription = city.itemBeingProduced.name + " : " + city.TurnsUntilProductionFinished();
 
@@ -101,7 +101,11 @@ namespace C7.Map {
 			int popSizeWidth = (int)midSizedFont.GetStringSize(popSizeString).x;
 			int popSizeOffset = LEFT_RIGHT_BOXES_WIDTH / 2 - popSizeWidth / 2;
 			Vector2 popSizeDestination = new Vector2(tileCenter + new Vector2(cityLabelWidth / -2, 24) + new Vector2(popSizeOffset, 18));
-			looseView.DrawString(midSizedFont, popSizeDestination, popSizeString, Color.Color8(255, 255, 255, 255));
+			Color popColor = Color.Color8(255, 255, 255, 255);
+			if (city.TurnsUntilGrowth() < 0) {
+				popColor = Color.Color8(255, 0, 0, 255);
+			}
+			looseView.DrawString(midSizedFont, popSizeDestination, popSizeString, popColor);
 		}
 
 		private Image CreateLabelBackground(int cityLabelWidth, City city, int textAreaWidth)

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -43,6 +43,13 @@ namespace C7Engine
 				OnBeginTurn();
 			}
 		}
+
+		/// <summary>
+		/// Plays the turns for all the players in the game (including barbarians).
+		/// </summary>
+		/// <param name="gameData"></param>
+		/// <param name="firstTurn"></param>
+		/// <returns>true when it is time for the human to take control again</returns>
 		private static bool PlayPlayerTurns(GameData gameData, bool firstTurn)
 		{
 			foreach (Player player in gameData.players) {

--- a/C7GameData/City.cs
+++ b/C7GameData/City.cs
@@ -85,6 +85,10 @@ namespace C7GameData
 		        size++;
 		        foodStored = 0;
 	        }
+	        else if (foodStored < 0) {
+		        size--;
+		        foodStored = 0;
+	        }
         }
 
         /**


### PR DESCRIPTION
Closes #343 

This is part of the bug-squashing effort.  You can use seed 643368717 to test this; move your Settler a few tiles SW so it can build a city surrounded by desert and one Plains tile, and after 20 turns it'll grow to size 2, when it should show -- city growth and a red pop size in the UI, and the next turn it will shrink back down to size 1 and start growing again.

The last commit is a minor refactor of TurnHandling.cs to break a large method into a few logical parts.  Other than extracting methods, it's the same.  I didn't have to change anything there but it was my first port of call when investigating this and I was reminded that I'd been wanting to split that method up for some time.

Note that if you keep playing 643368717, you'll soon encounter the zombies of #323 .  They seem to be more ravenous as Halloween approaches.