### PR TITLE
142 - Remove the nuisance variables.

### DIFF
--- a/C7/MainMenu.tscn
+++ b/C7/MainMenu.tscn
@@ -83,8 +83,6 @@ window_title = "Open a File or Directory"
 resizable = true
 mode = 3
 access = 2
-current_dir = "/Development/Civ Related Projects/Prototype/C7"
-current_path = "/Development/Civ Related Projects/Prototype/C7/"
 
 [connection signal="pressed" from="CanvasLayer/SetCiv3Home" to="." method="_on_SetCiv3Home_pressed"]
 [connection signal="dir_selected" from="CanvasLayer/SetCiv3HomeDialog" to="." method="_on_SetCiv3HomeDialog_dir_selected"]


### PR DESCRIPTION
The Godot fix for this has been added to Godot 3.5, and after unsetting my Civ3_Home variable and my registry's Civ3 entries, I am now confident in saying these stay away now.

Closes #142 

So long as everyone is on Godot 3.5 or greater now, these should not re-appear.