### PR TITLE
#172 - City Scene

### DIFF
--- a/C7/Map/CityLabelScene.cs
+++ b/C7/Map/CityLabelScene.cs
@@ -1,0 +1,211 @@
+using System;
+using C7GameData;
+using ConvertCiv3Media;
+using Godot;
+using Serilog;
+using Serilog.Events;
+
+namespace C7.Map {
+	public class CityLabelScene : Node2D {
+		private ILogger log = LogManager.ForContext<CityLabelScene>();
+
+		private City city;
+		private Tile tile;
+		private Vector2 tileCenter;
+
+		private ImageTexture cityTexture;
+
+		private DynamicFont smallFont = new DynamicFont();
+		private DynamicFont midSizedFont = new DynamicFont();
+
+		private Pcx cityIcons = Util.LoadPCX("Art/Cities/city icons.pcx");
+		private Image nonEmbassyStar;
+
+		const int CITY_LABEL_HEIGHT = 23;
+		const int LEFT_RIGHT_BOXES_WIDTH = 24;
+		const int LEFT_RIGHT_BOXES_HEIGHT = CITY_LABEL_HEIGHT - 2;
+		const int TEXT_ROW_HEIGHT = 9;
+
+		ImageTexture cityLabel = new ImageTexture();
+
+		private TextureRect labelTextureRect = new TextureRect();
+		Label cityNameLabel = new Label();
+		Label productionLabel = new Label();
+		Label popSizeLabel = new Label();
+
+		Theme smallFontTheme = new Theme();
+		Theme popThemeRed = new Theme();
+		Theme popSizeTheme = new Theme();
+
+		private int lastLabelWidth = 0;
+
+		public CityLabelScene(City city, Tile tile, Vector2 tileCenter) {
+			this.city = city;
+			this.tile = tile;
+			this.tileCenter = tileCenter;
+
+			smallFontTheme.DefaultFont = smallFont;
+			smallFontTheme.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
+			popSizeTheme.DefaultFont = midSizedFont;
+			popSizeTheme.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
+			popThemeRed.DefaultFont = midSizedFont;
+			popThemeRed.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
+
+			smallFont.FontData = ResourceLoader.Load<DynamicFontData>("res://Fonts/NotoSans-Regular.ttf");
+			smallFont.Size = 11;
+
+			midSizedFont.FontData = ResourceLoader.Load<DynamicFontData>("res://Fonts/NotoSans-Regular.ttf");
+			midSizedFont.Size = 18;
+
+			nonEmbassyStar = PCXToGodot.getImageFromPCX(cityIcons, 20, 1, 18, 18);
+
+			labelTextureRect.MouseFilter = Control.MouseFilterEnum.Ignore;
+			cityNameLabel.MouseFilter = Control.MouseFilterEnum.Ignore;
+			productionLabel.MouseFilter = Control.MouseFilterEnum.Ignore;
+			popSizeLabel.MouseFilter = Control.MouseFilterEnum.Ignore;
+
+			AddChild(labelTextureRect);
+			AddChild(cityNameLabel);
+			AddChild(productionLabel);
+			AddChild(popSizeLabel);
+		}
+
+		public override void _Draw() {
+			base._Draw();
+
+			int turnsUntilGrowth = city.TurnsUntilGrowth();
+			string turnsUntilGrowthText = turnsUntilGrowth == int.MaxValue || turnsUntilGrowth < 0 ? "- -" : "" + turnsUntilGrowth;
+			string cityNameAndGrowth = $"{city.name} : {turnsUntilGrowthText}";
+			string productionDescription = city.itemBeingProduced.name + " : " + city.TurnsUntilProductionFinished();
+
+			int cityNameAndGrowthWidth = (int)smallFont.GetStringSize(cityNameAndGrowth).x;
+			int productionDescriptionWidth = (int)smallFont.GetStringSize(productionDescription).x;
+			int maxTextWidth = Math.Max(cityNameAndGrowthWidth, productionDescriptionWidth);
+
+			int cityLabelWidth = maxTextWidth + (city.IsCapital()? 70 : 45);	//TODO: Is 65 right?  70?  Will depend on whether it's capital, too
+			int textAreaWidth = cityLabelWidth - (city.IsCapital() ? 50 : 25);
+			if (log.IsEnabled(LogEventLevel.Verbose)) {
+				log.Verbose("Width of city name = " + maxTextWidth);
+				log.Verbose("City label width: " + cityLabelWidth);
+				log.Verbose("Text area width: " + textAreaWidth);
+			}
+
+			if (cityLabelWidth != lastLabelWidth) {
+				Image labelBackground = CreateLabelBackground(cityLabelWidth, city, textAreaWidth);
+				cityLabel.CreateFromImage(labelBackground, 0);
+				lastLabelWidth = cityLabelWidth;
+			}
+
+			DrawLabelOnScreen(tileCenter, cityLabelWidth, city, cityLabel);
+			DrawTextOnLabel(tileCenter, cityNameAndGrowthWidth, productionDescriptionWidth, city, cityNameAndGrowth, productionDescription, cityLabelWidth);
+		}
+
+		private void DrawLabelOnScreen(Vector2 tileCenter, int cityLabelWidth, City city, ImageTexture cityLabel)
+		{
+			labelTextureRect.MarginLeft = tileCenter.x + (cityLabelWidth / -2);
+			labelTextureRect.MarginTop = tileCenter.y + 24;
+			labelTextureRect.Texture = cityLabel;
+		}
+
+		private void DrawTextOnLabel(Vector2 tileCenter, int cityNameAndGrowthWidth, int productionDescriptionWidth, City city, string cityNameAndGrowth, string productionDescription, int cityLabelWidth) {
+
+			//Destination for font is based on lower-left of baseline of font, not upper left as for blitted rectangles
+			int cityNameOffset = cityNameAndGrowthWidth / -2;
+			int prodDescriptionOffset = productionDescriptionWidth / -2;
+			if (!city.IsCapital()) {
+				cityNameOffset += 12;
+				prodDescriptionOffset += 12;
+			}
+
+			cityNameLabel.Theme = smallFontTheme;
+			cityNameLabel.Text = cityNameAndGrowth;
+			cityNameLabel.MarginLeft = tileCenter.x + cityNameOffset;
+			cityNameLabel.MarginTop = tileCenter.y + 22;
+
+			productionLabel.Theme = smallFontTheme;
+			productionLabel.Text = productionDescription;
+			productionLabel.MarginLeft = tileCenter.x + prodDescriptionOffset;
+			productionLabel.MarginTop = tileCenter.y + 32;
+
+			//City pop size
+			string popSizeString = "" + city.size;
+			int popSizeWidth = (int)midSizedFont.GetStringSize(popSizeString).x;
+			int popSizeOffset = LEFT_RIGHT_BOXES_WIDTH / 2 - popSizeWidth / 2;
+			Vector2 popSizeDestination = new Vector2(tileCenter + new Vector2(cityLabelWidth / -2, 24) + new Vector2(popSizeOffset, 18));
+			Color popColor = Color.Color8(255, 255, 255, 255);
+			if (city.TurnsUntilGrowth() < 0) {
+				popColor = Color.Color8(255, 0, 0, 255);
+			}
+
+			popSizeLabel.Theme = popSizeTheme;
+
+			if (city.TurnsUntilGrowth() < 0) {
+				popSizeLabel.Theme = popThemeRed;
+			}
+
+			popSizeLabel.Text = popSizeString;
+			popSizeLabel.MarginLeft = tileCenter.x + cityLabelWidth / -2 + popSizeOffset;
+			popSizeLabel.MarginTop = tileCenter.y + 22;
+		}
+
+		private Image CreateLabelBackground(int cityLabelWidth, City city, int textAreaWidth)
+		{
+			//Label/name/producing area
+			Image labelImage = new Image();
+			labelImage.Create(cityLabelWidth, CITY_LABEL_HEIGHT, false, Image.Format.Rgba8);
+			labelImage.Fill(Color.Color8(0, 0, 0, 0));
+			byte transparencyLevel = 192; //25%
+			Color civColor = new Color(city.owner.color);
+			civColor = new Color(civColor, transparencyLevel);
+			Color civColorDarker = Color.Color8(0, 0, 138, transparencyLevel); //todo: automate the darker() function.  maybe less transparency?
+			Color topRowGrey = Color.Color8(32, 32, 32, transparencyLevel);
+			Color bottomRowGrey = Color.Color8(48, 48, 48, transparencyLevel);
+			Color backgroundGrey = Color.Color8(64, 64, 64, transparencyLevel);
+			Color borderGrey = Color.Color8(80, 80, 80, transparencyLevel);
+
+			Image horizontalBorder = new Image();
+			horizontalBorder.Create(cityLabelWidth - 2, 1, false, Image.Format.Rgba8);
+			horizontalBorder.Fill(borderGrey);
+			labelImage.BlitRect(horizontalBorder, new Rect2(0, 0, new Vector2(cityLabelWidth - 2, 1)), new Vector2(1, 0));
+			labelImage.BlitRect(horizontalBorder, new Rect2(0, 0, new Vector2(cityLabelWidth - 2, 1)), new Vector2(1, 22));
+
+			Image verticalBorder = new Image();
+			verticalBorder.Create(1, CITY_LABEL_HEIGHT - 2, false, Image.Format.Rgba8);
+			verticalBorder.Fill(borderGrey);
+			labelImage.BlitRect(verticalBorder, new Rect2(0, 0, new Vector2(1, 23)), new Vector2(0, 1));
+			labelImage.BlitRect(verticalBorder, new Rect2(0, 0, new Vector2(1, 23)), new Vector2(cityLabelWidth - 1, 1));
+
+			Image bottomRow = new Image();
+			bottomRow.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
+			bottomRow.Fill(bottomRowGrey);
+			labelImage.BlitRect(bottomRow, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 21));
+
+			Image topRow = new Image();
+			topRow.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
+			topRow.Fill(topRowGrey);
+			labelImage.BlitRect(topRow, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 1));
+
+			Image background = new Image();
+			background.Create(textAreaWidth, TEXT_ROW_HEIGHT, false, Image.Format.Rgba8);
+			background.Fill(backgroundGrey);
+			labelImage.BlitRect(background, new Rect2(0, 0, new Vector2(textAreaWidth, 9)), new Vector2(25, 2));
+			labelImage.BlitRect(background, new Rect2(0, 0, new Vector2(textAreaWidth, 9)), new Vector2(25, 12));
+
+			Image centerDivider = new Image();
+			centerDivider.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
+			centerDivider.Fill(civColor);
+			labelImage.BlitRect(centerDivider, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 11));
+
+			Image leftAndRightBoxes = new Image();
+			leftAndRightBoxes.Create(LEFT_RIGHT_BOXES_WIDTH, LEFT_RIGHT_BOXES_HEIGHT, false, Image.Format.Rgba8);
+			leftAndRightBoxes.Fill(civColor);
+			labelImage.BlitRect(leftAndRightBoxes, new Rect2(0, 0, new Vector2(24, 21)), new Vector2(1, 1));
+			if (city.IsCapital()) {
+				labelImage.BlitRect(leftAndRightBoxes, new Rect2(0, 0, new Vector2(24, 21)), new Vector2(cityLabelWidth - 25, 1));
+				labelImage.BlendRect(nonEmbassyStar, new Rect2(0, 0, new Vector2(18, 18)), new Vector2(cityLabelWidth - 24, 2));
+			}
+			//todo: darker shades of civ color around edges
+			return labelImage;
+		}
+	}
+}

--- a/C7/Map/CityLabelScene.cs
+++ b/C7/Map/CityLabelScene.cs
@@ -15,12 +15,6 @@ namespace C7.Map {
 
 		private ImageTexture cityTexture;
 
-		private DynamicFont smallFont = new DynamicFont();
-		private DynamicFont midSizedFont = new DynamicFont();
-
-		private Pcx cityIcons = Util.LoadPCX("Art/Cities/city icons.pcx");
-		private Image nonEmbassyStar;
-
 		const int CITY_LABEL_HEIGHT = 23;
 		const int LEFT_RIGHT_BOXES_WIDTH = 24;
 		const int LEFT_RIGHT_BOXES_HEIGHT = CITY_LABEL_HEIGHT - 2;
@@ -33,17 +27,18 @@ namespace C7.Map {
 		Label productionLabel = new Label();
 		Label popSizeLabel = new Label();
 
-		Theme smallFontTheme = new Theme();
-		Theme popThemeRed = new Theme();
-		Theme popSizeTheme = new Theme();
+		private static DynamicFont smallFont = new DynamicFont();
+		private static DynamicFont midSizedFont = new DynamicFont();
+
+		private static Pcx cityIcons = Util.LoadPCX("Art/Cities/city icons.pcx");
+		private static Image nonEmbassyStar;
+		private static Theme smallFontTheme = new Theme();
+		private static Theme popThemeRed = new Theme();
+		private static Theme popSizeTheme = new Theme();
 
 		private int lastLabelWidth = 0;
 
-		public CityLabelScene(City city, Tile tile, Vector2 tileCenter) {
-			this.city = city;
-			this.tile = tile;
-			this.tileCenter = tileCenter;
-
+		static CityLabelScene() {
 			smallFontTheme.DefaultFont = smallFont;
 			smallFontTheme.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
 			popSizeTheme.DefaultFont = midSizedFont;
@@ -58,6 +53,13 @@ namespace C7.Map {
 			midSizedFont.Size = 18;
 
 			nonEmbassyStar = PCXToGodot.getImageFromPCX(cityIcons, 20, 1, 18, 18);
+		}
+
+		public CityLabelScene(City city, Tile tile, Vector2 tileCenter) {
+			this.city = city;
+			this.tile = tile;
+			this.tileCenter = tileCenter;
+
 
 			labelTextureRect.MouseFilter = Control.MouseFilterEnum.Ignore;
 			cityNameLabel.MouseFilter = Control.MouseFilterEnum.Ignore;
@@ -131,11 +133,6 @@ namespace C7.Map {
 			string popSizeString = "" + city.size;
 			int popSizeWidth = (int)midSizedFont.GetStringSize(popSizeString).x;
 			int popSizeOffset = LEFT_RIGHT_BOXES_WIDTH / 2 - popSizeWidth / 2;
-			Vector2 popSizeDestination = new Vector2(tileCenter + new Vector2(cityLabelWidth / -2, 24) + new Vector2(popSizeOffset, 18));
-			Color popColor = Color.Color8(255, 255, 255, 255);
-			if (city.TurnsUntilGrowth() < 0) {
-				popColor = Color.Color8(255, 0, 0, 255);
-			}
 
 			popSizeLabel.Theme = popSizeTheme;
 

--- a/C7/Map/CityLayer.cs
+++ b/C7/Map/CityLayer.cs
@@ -9,30 +9,18 @@ using Serilog.Events;
 namespace C7.Map {
 	public class CityLayer : LooseLayer {
 
-		private ILogger log = LogManager.ForContext<Game>();
+		private ILogger log = LogManager.ForContext<CityLayer>();
 
 		private ImageTexture cityTexture;
 		private Dictionary<string, ImageTexture> cityLabels = new Dictionary<string, ImageTexture>();
 
-		private DynamicFont smallFont = new DynamicFont();
-		private DynamicFont midSizedFont = new DynamicFont();
-		private Pcx cityIcons = Util.LoadPCX("Art/Cities/city icons.pcx");
-		private Image nonEmbassyStar;
 
-		const int CITY_LABEL_HEIGHT = 23;
-		const int LEFT_RIGHT_BOXES_WIDTH = 24;
-		const int LEFT_RIGHT_BOXES_HEIGHT = CITY_LABEL_HEIGHT - 2;
-		const int TEXT_ROW_HEIGHT = 9;
+
 
 		public CityLayer()
 		{
-			smallFont.FontData = ResourceLoader.Load<DynamicFontData>("res://Fonts/NotoSans-Regular.ttf");
-			smallFont.Size = 11;
 
-			midSizedFont.FontData = ResourceLoader.Load<DynamicFontData>("res://Fonts/NotoSans-Regular.ttf");
-			midSizedFont.Size = 18;
 
-			nonEmbassyStar = PCXToGodot.getImageFromPCX(cityIcons, 20, 1, 18, 18);
 		}
 
 		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)

--- a/C7/Map/CityLayer.cs
+++ b/C7/Map/CityLayer.cs
@@ -13,7 +13,7 @@ namespace C7.Map {
 
 		private ImageTexture cityTexture;
 		private Dictionary<string, ImageTexture> cityLabels = new Dictionary<string, ImageTexture>();
-		private Vector2 citySpriteSize;
+
 		private DynamicFont smallFont = new DynamicFont();
 		private DynamicFont midSizedFont = new DynamicFont();
 		private Pcx cityIcons = Util.LoadPCX("Art/Cities/city icons.pcx");
@@ -26,12 +26,6 @@ namespace C7.Map {
 
 		public CityLayer()
 		{
-			//TODO: Generalize, support multiple city types, etc.
-			Pcx pcx = Util.LoadPCX("Art/Cities/rMIDEAST.PCX");
-			int height = pcx.Height/4;
-			int width = pcx.Width/3;
-			cityTexture = Util.LoadTextureFromPCX("Art/Cities/rMIDEAST.PCX", 0, 0, width, height);
-			citySpriteSize = new Vector2(width, height);
 			smallFont.FontData = ResourceLoader.Load<DynamicFontData>("res://Fonts/NotoSans-Regular.ttf");
 			smallFont.Size = 11;
 
@@ -48,127 +42,9 @@ namespace C7.Map {
 			}
 
 			City city = tile.cityAtTile;
-			Rect2 screenRect = new Rect2(tileCenter - (float)0.5 * citySpriteSize, citySpriteSize);
-			Rect2 textRect = new Rect2(new Vector2(0, 0), citySpriteSize);
-			looseView.DrawTextureRectRegion(cityTexture, screenRect, textRect);
 
-			int turnsUntilGrowth = city.TurnsUntilGrowth();
-			string turnsUntilGrowthText = turnsUntilGrowth == int.MaxValue || turnsUntilGrowth < 0 ? "- -" : "" + turnsUntilGrowth;
-			string cityNameAndGrowth = $"{city.name} : {turnsUntilGrowthText}";
-			string productionDescription = city.itemBeingProduced.name + " : " + city.TurnsUntilProductionFinished();
-
-			int cityNameAndGrowthWidth = (int)smallFont.GetStringSize(cityNameAndGrowth).x;
-			int productionDescriptionWidth = (int)smallFont.GetStringSize(productionDescription).x;
-			int maxTextWidth = Math.Max(cityNameAndGrowthWidth, productionDescriptionWidth);
-
-			int cityLabelWidth = maxTextWidth + (city.IsCapital()? 70 : 45);	//TODO: Is 65 right?  70?  Will depend on whether it's capital, too
-			int textAreaWidth = cityLabelWidth - (city.IsCapital() ? 50 : 25);
-			if (log.IsEnabled(LogEventLevel.Verbose)) {
-				log.Verbose("Width of city name = " + maxTextWidth);
-				log.Verbose("City label width: " + cityLabelWidth);
-				log.Verbose("Text area width: " + textAreaWidth);
-			}
-
-			Image labelBackground = CreateLabelBackground(cityLabelWidth, city, textAreaWidth);
-			ImageTexture cityLabel = new ImageTexture();
-			cityLabel.CreateFromImage(labelBackground, 0);
-
-			DrawLabelOnScreen(looseView, tileCenter, cityLabelWidth, city, cityLabel);
-			DrawTextOnLabel(looseView, tileCenter, cityNameAndGrowthWidth, productionDescriptionWidth, city, cityNameAndGrowth, productionDescription, cityLabelWidth);
-		}
-		private void DrawLabelOnScreen(LooseView looseView, Vector2 tileCenter, int cityLabelWidth, City city, ImageTexture cityLabel)
-		{
-
-			Rect2 labelDestination = new Rect2(tileCenter + new Vector2(cityLabelWidth / -2, 24), new Vector2(cityLabelWidth, CITY_LABEL_HEIGHT)); //24 is a swag
-			Rect2 allOfTheLabel = new Rect2(new Vector2(0, 0), new Vector2(cityLabelWidth, CITY_LABEL_HEIGHT));
-			cityLabels[city.name] = cityLabel;
-			looseView.DrawTextureRectRegion(cityLabel, labelDestination, allOfTheLabel);
-		}
-
-		private void DrawTextOnLabel(LooseView looseView, Vector2 tileCenter, int cityNameAndGrowthWidth, int productionDescriptionWidth, City city, string cityNameAndGrowth, string productionDescription, int cityLabelWidth)
-		{
-			//Destination for font is based on lower-left of baseline of font, not upper left as for blitted rectangles
-			int cityNameOffset = cityNameAndGrowthWidth / -2;
-			int prodDescriptionOffset = productionDescriptionWidth / -2;
-			if (!city.IsCapital()) {
-				cityNameOffset += 12;
-				prodDescriptionOffset += 12;
-			}
-			Vector2 cityNameDestination = new Vector2(tileCenter + new Vector2(cityNameOffset, 24) + new Vector2(0, 10));
-			looseView.DrawString(smallFont, cityNameDestination, cityNameAndGrowth, Color.Color8(255, 255, 255, 255));
-			Vector2 productionDestination = new Vector2(tileCenter + new Vector2(prodDescriptionOffset, 24) + new Vector2(0, 20));
-			looseView.DrawString(smallFont, productionDestination, productionDescription, Color.Color8(255, 255, 255, 255));
-
-			//City pop size
-			string popSizeString = "" + city.size;
-			int popSizeWidth = (int)midSizedFont.GetStringSize(popSizeString).x;
-			int popSizeOffset = LEFT_RIGHT_BOXES_WIDTH / 2 - popSizeWidth / 2;
-			Vector2 popSizeDestination = new Vector2(tileCenter + new Vector2(cityLabelWidth / -2, 24) + new Vector2(popSizeOffset, 18));
-			Color popColor = Color.Color8(255, 255, 255, 255);
-			if (city.TurnsUntilGrowth() < 0) {
-				popColor = Color.Color8(255, 0, 0, 255);
-			}
-			looseView.DrawString(midSizedFont, popSizeDestination, popSizeString, popColor);
-		}
-
-		private Image CreateLabelBackground(int cityLabelWidth, City city, int textAreaWidth)
-		{
-			//Label/name/producing area
-			Image labelImage = new Image();
-			labelImage.Create(cityLabelWidth, CITY_LABEL_HEIGHT, false, Image.Format.Rgba8);
-			labelImage.Fill(Color.Color8(0, 0, 0, 0));
-			byte transparencyLevel = 192; //25%
-			Color civColor = new Color(city.owner.color);
-			civColor = new Color(civColor, transparencyLevel);
-			Color civColorDarker = Color.Color8(0, 0, 138, transparencyLevel); //todo: automate the darker() function.  maybe less transparency?
-			Color topRowGrey = Color.Color8(32, 32, 32, transparencyLevel);
-			Color bottomRowGrey = Color.Color8(48, 48, 48, transparencyLevel);
-			Color backgroundGrey = Color.Color8(64, 64, 64, transparencyLevel);
-			Color borderGrey = Color.Color8(80, 80, 80, transparencyLevel);
-
-			Image horizontalBorder = new Image();
-			horizontalBorder.Create(cityLabelWidth - 2, 1, false, Image.Format.Rgba8);
-			horizontalBorder.Fill(borderGrey);
-			labelImage.BlitRect(horizontalBorder, new Rect2(0, 0, new Vector2(cityLabelWidth - 2, 1)), new Vector2(1, 0));
-			labelImage.BlitRect(horizontalBorder, new Rect2(0, 0, new Vector2(cityLabelWidth - 2, 1)), new Vector2(1, 22));
-
-			Image verticalBorder = new Image();
-			verticalBorder.Create(1, CITY_LABEL_HEIGHT - 2, false, Image.Format.Rgba8);
-			verticalBorder.Fill(borderGrey);
-			labelImage.BlitRect(verticalBorder, new Rect2(0, 0, new Vector2(1, 23)), new Vector2(0, 1));
-			labelImage.BlitRect(verticalBorder, new Rect2(0, 0, new Vector2(1, 23)), new Vector2(cityLabelWidth - 1, 1));
-
-			Image bottomRow = new Image();
-			bottomRow.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
-			bottomRow.Fill(bottomRowGrey);
-			labelImage.BlitRect(bottomRow, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 21));
-
-			Image topRow = new Image();
-			topRow.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
-			topRow.Fill(topRowGrey);
-			labelImage.BlitRect(topRow, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 1));
-
-			Image background = new Image();
-			background.Create(textAreaWidth, TEXT_ROW_HEIGHT, false, Image.Format.Rgba8);
-			background.Fill(backgroundGrey);
-			labelImage.BlitRect(background, new Rect2(0, 0, new Vector2(textAreaWidth, 9)), new Vector2(25, 2));
-			labelImage.BlitRect(background, new Rect2(0, 0, new Vector2(textAreaWidth, 9)), new Vector2(25, 12));
-
-			Image centerDivider = new Image();
-			centerDivider.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
-			centerDivider.Fill(civColor);
-			labelImage.BlitRect(centerDivider, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 11));
-
-			Image leftAndRightBoxes = new Image();
-			leftAndRightBoxes.Create(LEFT_RIGHT_BOXES_WIDTH, LEFT_RIGHT_BOXES_HEIGHT, false, Image.Format.Rgba8);
-			leftAndRightBoxes.Fill(civColor);
-			labelImage.BlitRect(leftAndRightBoxes, new Rect2(0, 0, new Vector2(24, 21)), new Vector2(1, 1));
-			if (city.IsCapital()) {
-				labelImage.BlitRect(leftAndRightBoxes, new Rect2(0, 0, new Vector2(24, 21)), new Vector2(cityLabelWidth - 25, 1));
-				labelImage.BlendRect(nonEmbassyStar, new Rect2(0, 0, new Vector2(18, 18)), new Vector2(cityLabelWidth - 24, 2));
-			}
-			//todo: darker shades of civ color around edges
-			return labelImage;
+			CityScene cityScene = new CityScene(city, tile, tileCenter);
+			looseView.AddChild(cityScene);
 		}
 	}
 }

--- a/C7/Map/CityLayer.cs
+++ b/C7/Map/CityLayer.cs
@@ -14,12 +14,8 @@ namespace C7.Map {
 		private ImageTexture cityTexture;
 		private Dictionary<string, ImageTexture> cityLabels = new Dictionary<string, ImageTexture>();
 
-
-
-
 		public CityLayer()
 		{
-
 
 		}
 
@@ -33,6 +29,7 @@ namespace C7.Map {
 
 			CityScene cityScene = new CityScene(city, tile, tileCenter);
 			looseView.AddChild(cityScene);
+			GD.Print("Child count " + looseView.GetChildren().Count);
 		}
 	}
 }

--- a/C7/Map/CityLayer.cs
+++ b/C7/Map/CityLayer.cs
@@ -14,6 +14,9 @@ namespace C7.Map {
 		private ImageTexture cityTexture;
 		private Dictionary<string, ImageTexture> cityLabels = new Dictionary<string, ImageTexture>();
 
+		private List<City> citiesWithScenes = new List<City>();
+		private Dictionary<City, CityScene> citySceneLookup = new Dictionary<City, CityScene>();
+
 		public CityLayer()
 		{
 
@@ -26,10 +29,14 @@ namespace C7.Map {
 			}
 
 			City city = tile.cityAtTile;
-
-			CityScene cityScene = new CityScene(city, tile, tileCenter);
-			looseView.AddChild(cityScene);
-			GD.Print("Child count " + looseView.GetChildren().Count);
+			if (!citySceneLookup.ContainsKey(city)) {
+				CityScene cityScene = new CityScene(city, tile, tileCenter);
+				looseView.AddChild(cityScene);
+				citySceneLookup[city] = cityScene;
+			} else {
+				CityScene scene = citySceneLookup[city];
+				scene._Draw();
+			}
 		}
 	}
 }

--- a/C7/Map/CityScene.cs
+++ b/C7/Map/CityScene.cs
@@ -1,9 +1,13 @@
+using System;
 using C7GameData;
 using ConvertCiv3Media;
 using Godot;
+using Serilog;
+using Serilog.Events;
 
 namespace C7.Map {
 	public class CityScene : Node2D {
+		private ILogger log = LogManager.ForContext<CityScene>();
 
 		private City city;
 		private Tile tile;
@@ -12,6 +16,19 @@ namespace C7.Map {
 		private Vector2 citySpriteSize;
 
 		private ImageTexture cityTexture;
+
+		private DynamicFont smallFont = new DynamicFont();
+		private DynamicFont midSizedFont = new DynamicFont();
+
+		private Pcx cityIcons = Util.LoadPCX("Art/Cities/city icons.pcx");
+		private Image nonEmbassyStar;
+
+		const int CITY_LABEL_HEIGHT = 23;
+		const int LEFT_RIGHT_BOXES_WIDTH = 24;
+		const int LEFT_RIGHT_BOXES_HEIGHT = CITY_LABEL_HEIGHT - 2;
+		const int TEXT_ROW_HEIGHT = 9;
+
+		ImageTexture cityLabel = new ImageTexture();
 
 		public CityScene(City city, Tile tile, Vector2 tileCenter) {
 			this.city = city;
@@ -25,6 +42,14 @@ namespace C7.Map {
 			cityTexture = Util.LoadTextureFromPCX("Art/Cities/rMIDEAST.PCX", 0, 0, width, height);
 			citySpriteSize = new Vector2(width, height);
 
+
+			smallFont.FontData = ResourceLoader.Load<DynamicFontData>("res://Fonts/NotoSans-Regular.ttf");
+			smallFont.Size = 11;
+
+			midSizedFont.FontData = ResourceLoader.Load<DynamicFontData>("res://Fonts/NotoSans-Regular.ttf");
+			midSizedFont.Size = 18;
+
+			nonEmbassyStar = PCXToGodot.getImageFromPCX(cityIcons, 20, 1, 18, 18);
 		}
 
 		public override void _Draw() {
@@ -33,124 +58,121 @@ namespace C7.Map {
 			Rect2 textRect = new Rect2(new Vector2(0, 0), citySpriteSize);
 			this.DrawTextureRectRegion(cityTexture, screenRect, textRect);
 
-			// int turnsUntilGrowth = city.TurnsUntilGrowth();
-			// string turnsUntilGrowthText = turnsUntilGrowth == int.MaxValue || turnsUntilGrowth < 0 ? "- -" : "" + turnsUntilGrowth;
-			// string cityNameAndGrowth = $"{city.name} : {turnsUntilGrowthText}";
-			// string productionDescription = city.itemBeingProduced.name + " : " + city.TurnsUntilProductionFinished();
-			//
-			// int cityNameAndGrowthWidth = (int)smallFont.GetStringSize(cityNameAndGrowth).x;
-			// int productionDescriptionWidth = (int)smallFont.GetStringSize(productionDescription).x;
-			// int maxTextWidth = Math.Max(cityNameAndGrowthWidth, productionDescriptionWidth);
-			//
-			// int cityLabelWidth = maxTextWidth + (city.IsCapital()? 70 : 45);	//TODO: Is 65 right?  70?  Will depend on whether it's capital, too
-			// int textAreaWidth = cityLabelWidth - (city.IsCapital() ? 50 : 25);
-			// if (log.IsEnabled(LogEventLevel.Verbose)) {
-			// 	log.Verbose("Width of city name = " + maxTextWidth);
-			// 	log.Verbose("City label width: " + cityLabelWidth);
-			// 	log.Verbose("Text area width: " + textAreaWidth);
-			// }
-			//
-			// Image labelBackground = CreateLabelBackground(cityLabelWidth, city, textAreaWidth);
-			// ImageTexture cityLabel = new ImageTexture();
-			// cityLabel.CreateFromImage(labelBackground, 0);
-			//
-			// DrawLabelOnScreen(looseView, tileCenter, cityLabelWidth, city, cityLabel);
-			// DrawTextOnLabel(looseView, tileCenter, cityNameAndGrowthWidth, productionDescriptionWidth, city, cityNameAndGrowth, productionDescription, cityLabelWidth);
+			int turnsUntilGrowth = city.TurnsUntilGrowth();
+			string turnsUntilGrowthText = turnsUntilGrowth == int.MaxValue || turnsUntilGrowth < 0 ? "- -" : "" + turnsUntilGrowth;
+			string cityNameAndGrowth = $"{city.name} : {turnsUntilGrowthText}";
+			string productionDescription = city.itemBeingProduced.name + " : " + city.TurnsUntilProductionFinished();
+
+			int cityNameAndGrowthWidth = (int)smallFont.GetStringSize(cityNameAndGrowth).x;
+			int productionDescriptionWidth = (int)smallFont.GetStringSize(productionDescription).x;
+			int maxTextWidth = Math.Max(cityNameAndGrowthWidth, productionDescriptionWidth);
+
+			int cityLabelWidth = maxTextWidth + (city.IsCapital()? 70 : 45);	//TODO: Is 65 right?  70?  Will depend on whether it's capital, too
+			int textAreaWidth = cityLabelWidth - (city.IsCapital() ? 50 : 25);
+			if (log.IsEnabled(LogEventLevel.Verbose)) {
+				log.Verbose("Width of city name = " + maxTextWidth);
+				log.Verbose("City label width: " + cityLabelWidth);
+				log.Verbose("Text area width: " + textAreaWidth);
+			}
+
+			Image labelBackground = CreateLabelBackground(cityLabelWidth, city, textAreaWidth);
+			cityLabel.CreateFromImage(labelBackground, 0);
+
+			DrawLabelOnScreen(tileCenter, cityLabelWidth, city, cityLabel);
+			DrawTextOnLabel(tileCenter, cityNameAndGrowthWidth, productionDescriptionWidth, city, cityNameAndGrowth, productionDescription, cityLabelWidth);
 		}
 
-		// private void DrawLabelOnScreen(LooseView looseView, Vector2 tileCenter, int cityLabelWidth, City city, ImageTexture cityLabel)
-		// {
-		//
-		// 	Rect2 labelDestination = new Rect2(tileCenter + new Vector2(cityLabelWidth / -2, 24), new Vector2(cityLabelWidth, CITY_LABEL_HEIGHT)); //24 is a swag
-		// 	Rect2 allOfTheLabel = new Rect2(new Vector2(0, 0), new Vector2(cityLabelWidth, CITY_LABEL_HEIGHT));
-		// 	cityLabels[city.name] = cityLabel;
-		// 	looseView.DrawTextureRectRegion(cityLabel, labelDestination, allOfTheLabel);
-		// }
-		//
-		// private void DrawTextOnLabel(LooseView looseView, Vector2 tileCenter, int cityNameAndGrowthWidth, int productionDescriptionWidth, City city, string cityNameAndGrowth, string productionDescription, int cityLabelWidth)
-		// {
-		// 	//Destination for font is based on lower-left of baseline of font, not upper left as for blitted rectangles
-		// 	int cityNameOffset = cityNameAndGrowthWidth / -2;
-		// 	int prodDescriptionOffset = productionDescriptionWidth / -2;
-		// 	if (!city.IsCapital()) {
-		// 		cityNameOffset += 12;
-		// 		prodDescriptionOffset += 12;
-		// 	}
-		// 	Vector2 cityNameDestination = new Vector2(tileCenter + new Vector2(cityNameOffset, 24) + new Vector2(0, 10));
-		// 	looseView.DrawString(smallFont, cityNameDestination, cityNameAndGrowth, Color.Color8(255, 255, 255, 255));
-		// 	Vector2 productionDestination = new Vector2(tileCenter + new Vector2(prodDescriptionOffset, 24) + new Vector2(0, 20));
-		// 	looseView.DrawString(smallFont, productionDestination, productionDescription, Color.Color8(255, 255, 255, 255));
-		//
-		// 	//City pop size
-		// 	string popSizeString = "" + city.size;
-		// 	int popSizeWidth = (int)midSizedFont.GetStringSize(popSizeString).x;
-		// 	int popSizeOffset = LEFT_RIGHT_BOXES_WIDTH / 2 - popSizeWidth / 2;
-		// 	Vector2 popSizeDestination = new Vector2(tileCenter + new Vector2(cityLabelWidth / -2, 24) + new Vector2(popSizeOffset, 18));
-		// 	Color popColor = Color.Color8(255, 255, 255, 255);
-		// 	if (city.TurnsUntilGrowth() < 0) {
-		// 		popColor = Color.Color8(255, 0, 0, 255);
-		// 	}
-		// 	looseView.DrawString(midSizedFont, popSizeDestination, popSizeString, popColor);
-		// }
-		//
-		// private Image CreateLabelBackground(int cityLabelWidth, City city, int textAreaWidth)
-		// {
-		// 	//Label/name/producing area
-		// 	Image labelImage = new Image();
-		// 	labelImage.Create(cityLabelWidth, CITY_LABEL_HEIGHT, false, Image.Format.Rgba8);
-		// 	labelImage.Fill(Color.Color8(0, 0, 0, 0));
-		// 	byte transparencyLevel = 192; //25%
-		// 	Color civColor = new Color(city.owner.color);
-		// 	civColor = new Color(civColor, transparencyLevel);
-		// 	Color civColorDarker = Color.Color8(0, 0, 138, transparencyLevel); //todo: automate the darker() function.  maybe less transparency?
-		// 	Color topRowGrey = Color.Color8(32, 32, 32, transparencyLevel);
-		// 	Color bottomRowGrey = Color.Color8(48, 48, 48, transparencyLevel);
-		// 	Color backgroundGrey = Color.Color8(64, 64, 64, transparencyLevel);
-		// 	Color borderGrey = Color.Color8(80, 80, 80, transparencyLevel);
-		//
-		// 	Image horizontalBorder = new Image();
-		// 	horizontalBorder.Create(cityLabelWidth - 2, 1, false, Image.Format.Rgba8);
-		// 	horizontalBorder.Fill(borderGrey);
-		// 	labelImage.BlitRect(horizontalBorder, new Rect2(0, 0, new Vector2(cityLabelWidth - 2, 1)), new Vector2(1, 0));
-		// 	labelImage.BlitRect(horizontalBorder, new Rect2(0, 0, new Vector2(cityLabelWidth - 2, 1)), new Vector2(1, 22));
-		//
-		// 	Image verticalBorder = new Image();
-		// 	verticalBorder.Create(1, CITY_LABEL_HEIGHT - 2, false, Image.Format.Rgba8);
-		// 	verticalBorder.Fill(borderGrey);
-		// 	labelImage.BlitRect(verticalBorder, new Rect2(0, 0, new Vector2(1, 23)), new Vector2(0, 1));
-		// 	labelImage.BlitRect(verticalBorder, new Rect2(0, 0, new Vector2(1, 23)), new Vector2(cityLabelWidth - 1, 1));
-		//
-		// 	Image bottomRow = new Image();
-		// 	bottomRow.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
-		// 	bottomRow.Fill(bottomRowGrey);
-		// 	labelImage.BlitRect(bottomRow, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 21));
-		//
-		// 	Image topRow = new Image();
-		// 	topRow.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
-		// 	topRow.Fill(topRowGrey);
-		// 	labelImage.BlitRect(topRow, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 1));
-		//
-		// 	Image background = new Image();
-		// 	background.Create(textAreaWidth, TEXT_ROW_HEIGHT, false, Image.Format.Rgba8);
-		// 	background.Fill(backgroundGrey);
-		// 	labelImage.BlitRect(background, new Rect2(0, 0, new Vector2(textAreaWidth, 9)), new Vector2(25, 2));
-		// 	labelImage.BlitRect(background, new Rect2(0, 0, new Vector2(textAreaWidth, 9)), new Vector2(25, 12));
-		//
-		// 	Image centerDivider = new Image();
-		// 	centerDivider.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
-		// 	centerDivider.Fill(civColor);
-		// 	labelImage.BlitRect(centerDivider, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 11));
-		//
-		// 	Image leftAndRightBoxes = new Image();
-		// 	leftAndRightBoxes.Create(LEFT_RIGHT_BOXES_WIDTH, LEFT_RIGHT_BOXES_HEIGHT, false, Image.Format.Rgba8);
-		// 	leftAndRightBoxes.Fill(civColor);
-		// 	labelImage.BlitRect(leftAndRightBoxes, new Rect2(0, 0, new Vector2(24, 21)), new Vector2(1, 1));
-		// 	if (city.IsCapital()) {
-		// 		labelImage.BlitRect(leftAndRightBoxes, new Rect2(0, 0, new Vector2(24, 21)), new Vector2(cityLabelWidth - 25, 1));
-		// 		labelImage.BlendRect(nonEmbassyStar, new Rect2(0, 0, new Vector2(18, 18)), new Vector2(cityLabelWidth - 24, 2));
-		// 	}
-		// 	//todo: darker shades of civ color around edges
-		// 	return labelImage;
-		// }
+		private void DrawLabelOnScreen(Vector2 tileCenter, int cityLabelWidth, City city, ImageTexture cityLabel)
+		{
+			Rect2 labelDestination = new Rect2(tileCenter + new Vector2(cityLabelWidth / -2, 24), new Vector2(cityLabelWidth, CITY_LABEL_HEIGHT)); //24 is a swag
+			Rect2 allOfTheLabel = new Rect2(new Vector2(0, 0), new Vector2(cityLabelWidth, CITY_LABEL_HEIGHT));
+			DrawTextureRectRegion(cityLabel, labelDestination, allOfTheLabel);
+		}
+
+		private void DrawTextOnLabel(Vector2 tileCenter, int cityNameAndGrowthWidth, int productionDescriptionWidth, City city, string cityNameAndGrowth, string productionDescription, int cityLabelWidth)
+		{
+			//Destination for font is based on lower-left of baseline of font, not upper left as for blitted rectangles
+			int cityNameOffset = cityNameAndGrowthWidth / -2;
+			int prodDescriptionOffset = productionDescriptionWidth / -2;
+			if (!city.IsCapital()) {
+				cityNameOffset += 12;
+				prodDescriptionOffset += 12;
+			}
+			Vector2 cityNameDestination = new Vector2(tileCenter + new Vector2(cityNameOffset, 24) + new Vector2(0, 10));
+			DrawString(smallFont, cityNameDestination, cityNameAndGrowth, Color.Color8(255, 255, 255, 255));
+			Vector2 productionDestination = new Vector2(tileCenter + new Vector2(prodDescriptionOffset, 24) + new Vector2(0, 20));
+			DrawString(smallFont, productionDestination, productionDescription, Color.Color8(255, 255, 255, 255));
+
+			//City pop size
+			string popSizeString = "" + city.size;
+			int popSizeWidth = (int)midSizedFont.GetStringSize(popSizeString).x;
+			int popSizeOffset = LEFT_RIGHT_BOXES_WIDTH / 2 - popSizeWidth / 2;
+			Vector2 popSizeDestination = new Vector2(tileCenter + new Vector2(cityLabelWidth / -2, 24) + new Vector2(popSizeOffset, 18));
+			Color popColor = Color.Color8(255, 255, 255, 255);
+			if (city.TurnsUntilGrowth() < 0) {
+				popColor = Color.Color8(255, 0, 0, 255);
+			}
+			DrawString(midSizedFont, popSizeDestination, popSizeString, popColor);
+		}
+
+		private Image CreateLabelBackground(int cityLabelWidth, City city, int textAreaWidth)
+		{
+			//Label/name/producing area
+			Image labelImage = new Image();
+			labelImage.Create(cityLabelWidth, CITY_LABEL_HEIGHT, false, Image.Format.Rgba8);
+			labelImage.Fill(Color.Color8(0, 0, 0, 0));
+			byte transparencyLevel = 192; //25%
+			Color civColor = new Color(city.owner.color);
+			civColor = new Color(civColor, transparencyLevel);
+			Color civColorDarker = Color.Color8(0, 0, 138, transparencyLevel); //todo: automate the darker() function.  maybe less transparency?
+			Color topRowGrey = Color.Color8(32, 32, 32, transparencyLevel);
+			Color bottomRowGrey = Color.Color8(48, 48, 48, transparencyLevel);
+			Color backgroundGrey = Color.Color8(64, 64, 64, transparencyLevel);
+			Color borderGrey = Color.Color8(80, 80, 80, transparencyLevel);
+
+			Image horizontalBorder = new Image();
+			horizontalBorder.Create(cityLabelWidth - 2, 1, false, Image.Format.Rgba8);
+			horizontalBorder.Fill(borderGrey);
+			labelImage.BlitRect(horizontalBorder, new Rect2(0, 0, new Vector2(cityLabelWidth - 2, 1)), new Vector2(1, 0));
+			labelImage.BlitRect(horizontalBorder, new Rect2(0, 0, new Vector2(cityLabelWidth - 2, 1)), new Vector2(1, 22));
+
+			Image verticalBorder = new Image();
+			verticalBorder.Create(1, CITY_LABEL_HEIGHT - 2, false, Image.Format.Rgba8);
+			verticalBorder.Fill(borderGrey);
+			labelImage.BlitRect(verticalBorder, new Rect2(0, 0, new Vector2(1, 23)), new Vector2(0, 1));
+			labelImage.BlitRect(verticalBorder, new Rect2(0, 0, new Vector2(1, 23)), new Vector2(cityLabelWidth - 1, 1));
+
+			Image bottomRow = new Image();
+			bottomRow.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
+			bottomRow.Fill(bottomRowGrey);
+			labelImage.BlitRect(bottomRow, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 21));
+
+			Image topRow = new Image();
+			topRow.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
+			topRow.Fill(topRowGrey);
+			labelImage.BlitRect(topRow, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 1));
+
+			Image background = new Image();
+			background.Create(textAreaWidth, TEXT_ROW_HEIGHT, false, Image.Format.Rgba8);
+			background.Fill(backgroundGrey);
+			labelImage.BlitRect(background, new Rect2(0, 0, new Vector2(textAreaWidth, 9)), new Vector2(25, 2));
+			labelImage.BlitRect(background, new Rect2(0, 0, new Vector2(textAreaWidth, 9)), new Vector2(25, 12));
+
+			Image centerDivider = new Image();
+			centerDivider.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
+			centerDivider.Fill(civColor);
+			labelImage.BlitRect(centerDivider, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 11));
+
+			Image leftAndRightBoxes = new Image();
+			leftAndRightBoxes.Create(LEFT_RIGHT_BOXES_WIDTH, LEFT_RIGHT_BOXES_HEIGHT, false, Image.Format.Rgba8);
+			leftAndRightBoxes.Fill(civColor);
+			labelImage.BlitRect(leftAndRightBoxes, new Rect2(0, 0, new Vector2(24, 21)), new Vector2(1, 1));
+			if (city.IsCapital()) {
+				labelImage.BlitRect(leftAndRightBoxes, new Rect2(0, 0, new Vector2(24, 21)), new Vector2(cityLabelWidth - 25, 1));
+				labelImage.BlendRect(nonEmbassyStar, new Rect2(0, 0, new Vector2(18, 18)), new Vector2(cityLabelWidth - 24, 2));
+			}
+			//todo: darker shades of civ color around edges
+			return labelImage;
+		}
 	}
 }

--- a/C7/Map/CityScene.cs
+++ b/C7/Map/CityScene.cs
@@ -36,10 +36,21 @@ namespace C7.Map {
 		Label productionLabel = new Label();
 		Label popSizeLabel = new Label();
 
+		Theme smallFontTheme = new Theme();
+		Theme popThemeRed = new Theme();
+		Theme popSizeTheme = new Theme();
+
 		public CityScene(City city, Tile tile, Vector2 tileCenter) {
 			this.city = city;
 			this.tile = tile;
 			this.tileCenter = tileCenter;
+
+			smallFontTheme.DefaultFont = smallFont;
+			smallFontTheme.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
+			popSizeTheme.DefaultFont = midSizedFont;
+			popSizeTheme.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
+			popThemeRed.DefaultFont = midSizedFont;
+			popThemeRed.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
 
 			//TODO: Generalize, support multiple city types, etc.
 			Pcx pcx = Util.LoadPCX("Art/Cities/rMIDEAST.PCX");
@@ -102,9 +113,6 @@ namespace C7.Map {
 		}
 
 		private void DrawTextOnLabel(Vector2 tileCenter, int cityNameAndGrowthWidth, int productionDescriptionWidth, City city, string cityNameAndGrowth, string productionDescription, int cityLabelWidth) {
-			Theme smallFontTheme = new Theme();
-			smallFontTheme.DefaultFont = smallFont;
-			smallFontTheme.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
 
 			//Destination for font is based on lower-left of baseline of font, not upper left as for blitted rectangles
 			int cityNameOffset = cityNameAndGrowthWidth / -2;
@@ -134,14 +142,12 @@ namespace C7.Map {
 				popColor = Color.Color8(255, 0, 0, 255);
 			}
 
-			Theme popSizeTheme = new Theme();
-			popSizeTheme.DefaultFont = midSizedFont;
-			popSizeTheme.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
+			popSizeLabel.Theme = popSizeTheme;
+
 			if (city.TurnsUntilGrowth() < 0) {
-				popSizeTheme.SetColor("font_color", "Label", Color.Color8(255, 0, 0, 255));
+				popSizeLabel.Theme = popThemeRed;
 			}
 
-			popSizeLabel.Theme = popSizeTheme;
 			popSizeLabel.Text = popSizeString;
 			popSizeLabel.MarginLeft = tileCenter.x + cityLabelWidth / -2 + popSizeOffset;
 			popSizeLabel.MarginTop = tileCenter.y + 22;

--- a/C7/Map/CityScene.cs
+++ b/C7/Map/CityScene.cs
@@ -99,11 +99,19 @@ namespace C7.Map {
 		{
 			Rect2 labelDestination = new Rect2(tileCenter + new Vector2(cityLabelWidth / -2, 24), new Vector2(cityLabelWidth, CITY_LABEL_HEIGHT)); //24 is a swag
 			Rect2 allOfTheLabel = new Rect2(new Vector2(0, 0), new Vector2(cityLabelWidth, CITY_LABEL_HEIGHT));
-			// DrawTextureRectRegion(cityLabel, labelDestination, allOfTheLabel);
+
+			TextureRect label = new TextureRect();
+			label.MarginLeft = tileCenter.x + (cityLabelWidth / -2);
+			label.MarginTop = tileCenter.y + 24;
+			label.Texture = cityLabel;
+			AddChild(label);
 		}
 
-		private void DrawTextOnLabel(Vector2 tileCenter, int cityNameAndGrowthWidth, int productionDescriptionWidth, City city, string cityNameAndGrowth, string productionDescription, int cityLabelWidth)
-		{
+		private void DrawTextOnLabel(Vector2 tileCenter, int cityNameAndGrowthWidth, int productionDescriptionWidth, City city, string cityNameAndGrowth, string productionDescription, int cityLabelWidth) {
+			Theme smallFontTheme = new Theme();
+			smallFontTheme.DefaultFont = smallFont;
+			smallFontTheme.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
+
 			//Destination for font is based on lower-left of baseline of font, not upper left as for blitted rectangles
 			int cityNameOffset = cityNameAndGrowthWidth / -2;
 			int prodDescriptionOffset = productionDescriptionWidth / -2;
@@ -112,8 +120,21 @@ namespace C7.Map {
 				prodDescriptionOffset += 12;
 			}
 			Vector2 cityNameDestination = new Vector2(tileCenter + new Vector2(cityNameOffset, 24) + new Vector2(0, 10));
+			Label cityNameLabel = new Label();
+			cityNameLabel.Theme = smallFontTheme;
+			cityNameLabel.Text = cityNameAndGrowth;
+			cityNameLabel.MarginLeft = tileCenter.x + cityNameOffset;
+			cityNameLabel.MarginTop = tileCenter.y + 22;
+			AddChild(cityNameLabel);
 			// theTexture.DrawString(smallFont, cityNameDestination, cityNameAndGrowth, Color.Color8(255, 255, 255, 255));
+
 			Vector2 productionDestination = new Vector2(tileCenter + new Vector2(prodDescriptionOffset, 24) + new Vector2(0, 20));
+			Label productionLabel = new Label();
+			productionLabel.Theme = smallFontTheme;
+			productionLabel.Text = productionDescription;
+			productionLabel.MarginLeft = tileCenter.x + prodDescriptionOffset;
+			productionLabel.MarginTop = tileCenter.y + 32;
+			AddChild(productionLabel);
 			// theTexture.DrawString(smallFont, productionDestination, productionDescription, Color.Color8(255, 255, 255, 255));
 
 			//City pop size
@@ -125,6 +146,20 @@ namespace C7.Map {
 			if (city.TurnsUntilGrowth() < 0) {
 				popColor = Color.Color8(255, 0, 0, 255);
 			}
+
+			Theme popSizeTheme = new Theme();
+			popSizeTheme.DefaultFont = midSizedFont;
+			popSizeTheme.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
+			if (city.TurnsUntilGrowth() < 0) {
+				popSizeTheme.SetColor("font_color", "Label", Color.Color8(255, 0, 0, 255));
+			}
+
+			Label popSizeLabel = new Label();
+			popSizeLabel.Theme = popSizeTheme;
+			popSizeLabel.Text = popSizeString;
+			popSizeLabel.MarginLeft = tileCenter.x + cityLabelWidth / -2 + popSizeOffset;
+			popSizeLabel.MarginTop = tileCenter.y + 22;
+			AddChild(popSizeLabel);
 			// theTexture.DrawString(midSizedFont, popSizeDestination, popSizeString, popColor);
 		}
 

--- a/C7/Map/CityScene.cs
+++ b/C7/Map/CityScene.cs
@@ -40,6 +40,8 @@ namespace C7.Map {
 		Theme popThemeRed = new Theme();
 		Theme popSizeTheme = new Theme();
 
+		private int lastLabelWidth = 0;
+
 		public CityScene(City city, Tile tile, Vector2 tileCenter) {
 			this.city = city;
 			this.tile = tile;
@@ -98,8 +100,11 @@ namespace C7.Map {
 				log.Verbose("Text area width: " + textAreaWidth);
 			}
 
-			Image labelBackground = CreateLabelBackground(cityLabelWidth, city, textAreaWidth);
-			cityLabel.CreateFromImage(labelBackground, 0);
+			if (cityLabelWidth != lastLabelWidth) {
+				Image labelBackground = CreateLabelBackground(cityLabelWidth, city, textAreaWidth);
+				cityLabel.CreateFromImage(labelBackground, 0);
+				lastLabelWidth = cityLabelWidth;
+			}
 
 			DrawLabelOnScreen(tileCenter, cityLabelWidth, city, cityLabel);
 			DrawTextOnLabel(tileCenter, cityNameAndGrowthWidth, productionDescriptionWidth, city, cityNameAndGrowth, productionDescription, cityLabelWidth);

--- a/C7/Map/CityScene.cs
+++ b/C7/Map/CityScene.cs
@@ -30,6 +30,8 @@ namespace C7.Map {
 
 		ImageTexture cityLabel = new ImageTexture();
 
+		private TextureRect theTexture = new TextureRect();
+
 		public CityScene(City city, Tile tile, Vector2 tileCenter) {
 			this.city = city;
 			this.tile = tile;
@@ -50,13 +52,23 @@ namespace C7.Map {
 			midSizedFont.Size = 18;
 
 			nonEmbassyStar = PCXToGodot.getImageFromPCX(cityIcons, 20, 1, 18, 18);
+			this.AddChild(theTexture);
 		}
 
 		public override void _Draw() {
-			base._Draw();
+			// base._Draw();
+
 			Rect2 screenRect = new Rect2(tileCenter - (float)0.5 * citySpriteSize, citySpriteSize);
 			Rect2 textRect = new Rect2(new Vector2(0, 0), citySpriteSize);
-			this.DrawTextureRectRegion(cityTexture, screenRect, textRect);
+			theTexture.MarginLeft = tileCenter.x - (float)0.5 * citySpriteSize.x;
+			theTexture.MarginTop = tileCenter.y - (float)0.5 * citySpriteSize.y;
+			theTexture.Texture = cityTexture;
+			//Drawing text gives this error:
+			//ERROR: Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.
+			//  theTexture.DrawString(smallFont, new Vector2(0, 0), "Test String", Color.Color8(255, 0, 0))
+			//Even though we're in the _Draw() method (which is the C# capitalization of it).  For some reason it works in LooseLayer, which is also a Node2D with public override void _Draw().
+			//We'll have to either figure that out or figure out an alternative in order to be able to use this modus operandi effectively.
+
 
 			int turnsUntilGrowth = city.TurnsUntilGrowth();
 			string turnsUntilGrowthText = turnsUntilGrowth == int.MaxValue || turnsUntilGrowth < 0 ? "- -" : "" + turnsUntilGrowth;
@@ -80,13 +92,14 @@ namespace C7.Map {
 
 			DrawLabelOnScreen(tileCenter, cityLabelWidth, city, cityLabel);
 			DrawTextOnLabel(tileCenter, cityNameAndGrowthWidth, productionDescriptionWidth, city, cityNameAndGrowth, productionDescription, cityLabelWidth);
+
 		}
 
 		private void DrawLabelOnScreen(Vector2 tileCenter, int cityLabelWidth, City city, ImageTexture cityLabel)
 		{
 			Rect2 labelDestination = new Rect2(tileCenter + new Vector2(cityLabelWidth / -2, 24), new Vector2(cityLabelWidth, CITY_LABEL_HEIGHT)); //24 is a swag
 			Rect2 allOfTheLabel = new Rect2(new Vector2(0, 0), new Vector2(cityLabelWidth, CITY_LABEL_HEIGHT));
-			DrawTextureRectRegion(cityLabel, labelDestination, allOfTheLabel);
+			// DrawTextureRectRegion(cityLabel, labelDestination, allOfTheLabel);
 		}
 
 		private void DrawTextOnLabel(Vector2 tileCenter, int cityNameAndGrowthWidth, int productionDescriptionWidth, City city, string cityNameAndGrowth, string productionDescription, int cityLabelWidth)
@@ -99,9 +112,9 @@ namespace C7.Map {
 				prodDescriptionOffset += 12;
 			}
 			Vector2 cityNameDestination = new Vector2(tileCenter + new Vector2(cityNameOffset, 24) + new Vector2(0, 10));
-			DrawString(smallFont, cityNameDestination, cityNameAndGrowth, Color.Color8(255, 255, 255, 255));
+			// theTexture.DrawString(smallFont, cityNameDestination, cityNameAndGrowth, Color.Color8(255, 255, 255, 255));
 			Vector2 productionDestination = new Vector2(tileCenter + new Vector2(prodDescriptionOffset, 24) + new Vector2(0, 20));
-			DrawString(smallFont, productionDestination, productionDescription, Color.Color8(255, 255, 255, 255));
+			// theTexture.DrawString(smallFont, productionDestination, productionDescription, Color.Color8(255, 255, 255, 255));
 
 			//City pop size
 			string popSizeString = "" + city.size;
@@ -112,7 +125,7 @@ namespace C7.Map {
 			if (city.TurnsUntilGrowth() < 0) {
 				popColor = Color.Color8(255, 0, 0, 255);
 			}
-			DrawString(midSizedFont, popSizeDestination, popSizeString, popColor);
+			// theTexture.DrawString(midSizedFont, popSizeDestination, popSizeString, popColor);
 		}
 
 		private Image CreateLabelBackground(int cityLabelWidth, City city, int textAreaWidth)

--- a/C7/Map/CityScene.cs
+++ b/C7/Map/CityScene.cs
@@ -1,0 +1,156 @@
+using C7GameData;
+using ConvertCiv3Media;
+using Godot;
+
+namespace C7.Map {
+	public class CityScene : Node2D {
+
+		private City city;
+		private Tile tile;
+		private Vector2 tileCenter;
+
+		private Vector2 citySpriteSize;
+
+		private ImageTexture cityTexture;
+
+		public CityScene(City city, Tile tile, Vector2 tileCenter) {
+			this.city = city;
+			this.tile = tile;
+			this.tileCenter = tileCenter;
+
+			//TODO: Generalize, support multiple city types, etc.
+			Pcx pcx = Util.LoadPCX("Art/Cities/rMIDEAST.PCX");
+			int height = pcx.Height/4;
+			int width = pcx.Width/3;
+			cityTexture = Util.LoadTextureFromPCX("Art/Cities/rMIDEAST.PCX", 0, 0, width, height);
+			citySpriteSize = new Vector2(width, height);
+
+		}
+
+		public override void _Draw() {
+			base._Draw();
+			Rect2 screenRect = new Rect2(tileCenter - (float)0.5 * citySpriteSize, citySpriteSize);
+			Rect2 textRect = new Rect2(new Vector2(0, 0), citySpriteSize);
+			this.DrawTextureRectRegion(cityTexture, screenRect, textRect);
+
+			// int turnsUntilGrowth = city.TurnsUntilGrowth();
+			// string turnsUntilGrowthText = turnsUntilGrowth == int.MaxValue || turnsUntilGrowth < 0 ? "- -" : "" + turnsUntilGrowth;
+			// string cityNameAndGrowth = $"{city.name} : {turnsUntilGrowthText}";
+			// string productionDescription = city.itemBeingProduced.name + " : " + city.TurnsUntilProductionFinished();
+			//
+			// int cityNameAndGrowthWidth = (int)smallFont.GetStringSize(cityNameAndGrowth).x;
+			// int productionDescriptionWidth = (int)smallFont.GetStringSize(productionDescription).x;
+			// int maxTextWidth = Math.Max(cityNameAndGrowthWidth, productionDescriptionWidth);
+			//
+			// int cityLabelWidth = maxTextWidth + (city.IsCapital()? 70 : 45);	//TODO: Is 65 right?  70?  Will depend on whether it's capital, too
+			// int textAreaWidth = cityLabelWidth - (city.IsCapital() ? 50 : 25);
+			// if (log.IsEnabled(LogEventLevel.Verbose)) {
+			// 	log.Verbose("Width of city name = " + maxTextWidth);
+			// 	log.Verbose("City label width: " + cityLabelWidth);
+			// 	log.Verbose("Text area width: " + textAreaWidth);
+			// }
+			//
+			// Image labelBackground = CreateLabelBackground(cityLabelWidth, city, textAreaWidth);
+			// ImageTexture cityLabel = new ImageTexture();
+			// cityLabel.CreateFromImage(labelBackground, 0);
+			//
+			// DrawLabelOnScreen(looseView, tileCenter, cityLabelWidth, city, cityLabel);
+			// DrawTextOnLabel(looseView, tileCenter, cityNameAndGrowthWidth, productionDescriptionWidth, city, cityNameAndGrowth, productionDescription, cityLabelWidth);
+		}
+
+		// private void DrawLabelOnScreen(LooseView looseView, Vector2 tileCenter, int cityLabelWidth, City city, ImageTexture cityLabel)
+		// {
+		//
+		// 	Rect2 labelDestination = new Rect2(tileCenter + new Vector2(cityLabelWidth / -2, 24), new Vector2(cityLabelWidth, CITY_LABEL_HEIGHT)); //24 is a swag
+		// 	Rect2 allOfTheLabel = new Rect2(new Vector2(0, 0), new Vector2(cityLabelWidth, CITY_LABEL_HEIGHT));
+		// 	cityLabels[city.name] = cityLabel;
+		// 	looseView.DrawTextureRectRegion(cityLabel, labelDestination, allOfTheLabel);
+		// }
+		//
+		// private void DrawTextOnLabel(LooseView looseView, Vector2 tileCenter, int cityNameAndGrowthWidth, int productionDescriptionWidth, City city, string cityNameAndGrowth, string productionDescription, int cityLabelWidth)
+		// {
+		// 	//Destination for font is based on lower-left of baseline of font, not upper left as for blitted rectangles
+		// 	int cityNameOffset = cityNameAndGrowthWidth / -2;
+		// 	int prodDescriptionOffset = productionDescriptionWidth / -2;
+		// 	if (!city.IsCapital()) {
+		// 		cityNameOffset += 12;
+		// 		prodDescriptionOffset += 12;
+		// 	}
+		// 	Vector2 cityNameDestination = new Vector2(tileCenter + new Vector2(cityNameOffset, 24) + new Vector2(0, 10));
+		// 	looseView.DrawString(smallFont, cityNameDestination, cityNameAndGrowth, Color.Color8(255, 255, 255, 255));
+		// 	Vector2 productionDestination = new Vector2(tileCenter + new Vector2(prodDescriptionOffset, 24) + new Vector2(0, 20));
+		// 	looseView.DrawString(smallFont, productionDestination, productionDescription, Color.Color8(255, 255, 255, 255));
+		//
+		// 	//City pop size
+		// 	string popSizeString = "" + city.size;
+		// 	int popSizeWidth = (int)midSizedFont.GetStringSize(popSizeString).x;
+		// 	int popSizeOffset = LEFT_RIGHT_BOXES_WIDTH / 2 - popSizeWidth / 2;
+		// 	Vector2 popSizeDestination = new Vector2(tileCenter + new Vector2(cityLabelWidth / -2, 24) + new Vector2(popSizeOffset, 18));
+		// 	Color popColor = Color.Color8(255, 255, 255, 255);
+		// 	if (city.TurnsUntilGrowth() < 0) {
+		// 		popColor = Color.Color8(255, 0, 0, 255);
+		// 	}
+		// 	looseView.DrawString(midSizedFont, popSizeDestination, popSizeString, popColor);
+		// }
+		//
+		// private Image CreateLabelBackground(int cityLabelWidth, City city, int textAreaWidth)
+		// {
+		// 	//Label/name/producing area
+		// 	Image labelImage = new Image();
+		// 	labelImage.Create(cityLabelWidth, CITY_LABEL_HEIGHT, false, Image.Format.Rgba8);
+		// 	labelImage.Fill(Color.Color8(0, 0, 0, 0));
+		// 	byte transparencyLevel = 192; //25%
+		// 	Color civColor = new Color(city.owner.color);
+		// 	civColor = new Color(civColor, transparencyLevel);
+		// 	Color civColorDarker = Color.Color8(0, 0, 138, transparencyLevel); //todo: automate the darker() function.  maybe less transparency?
+		// 	Color topRowGrey = Color.Color8(32, 32, 32, transparencyLevel);
+		// 	Color bottomRowGrey = Color.Color8(48, 48, 48, transparencyLevel);
+		// 	Color backgroundGrey = Color.Color8(64, 64, 64, transparencyLevel);
+		// 	Color borderGrey = Color.Color8(80, 80, 80, transparencyLevel);
+		//
+		// 	Image horizontalBorder = new Image();
+		// 	horizontalBorder.Create(cityLabelWidth - 2, 1, false, Image.Format.Rgba8);
+		// 	horizontalBorder.Fill(borderGrey);
+		// 	labelImage.BlitRect(horizontalBorder, new Rect2(0, 0, new Vector2(cityLabelWidth - 2, 1)), new Vector2(1, 0));
+		// 	labelImage.BlitRect(horizontalBorder, new Rect2(0, 0, new Vector2(cityLabelWidth - 2, 1)), new Vector2(1, 22));
+		//
+		// 	Image verticalBorder = new Image();
+		// 	verticalBorder.Create(1, CITY_LABEL_HEIGHT - 2, false, Image.Format.Rgba8);
+		// 	verticalBorder.Fill(borderGrey);
+		// 	labelImage.BlitRect(verticalBorder, new Rect2(0, 0, new Vector2(1, 23)), new Vector2(0, 1));
+		// 	labelImage.BlitRect(verticalBorder, new Rect2(0, 0, new Vector2(1, 23)), new Vector2(cityLabelWidth - 1, 1));
+		//
+		// 	Image bottomRow = new Image();
+		// 	bottomRow.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
+		// 	bottomRow.Fill(bottomRowGrey);
+		// 	labelImage.BlitRect(bottomRow, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 21));
+		//
+		// 	Image topRow = new Image();
+		// 	topRow.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
+		// 	topRow.Fill(topRowGrey);
+		// 	labelImage.BlitRect(topRow, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 1));
+		//
+		// 	Image background = new Image();
+		// 	background.Create(textAreaWidth, TEXT_ROW_HEIGHT, false, Image.Format.Rgba8);
+		// 	background.Fill(backgroundGrey);
+		// 	labelImage.BlitRect(background, new Rect2(0, 0, new Vector2(textAreaWidth, 9)), new Vector2(25, 2));
+		// 	labelImage.BlitRect(background, new Rect2(0, 0, new Vector2(textAreaWidth, 9)), new Vector2(25, 12));
+		//
+		// 	Image centerDivider = new Image();
+		// 	centerDivider.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
+		// 	centerDivider.Fill(civColor);
+		// 	labelImage.BlitRect(centerDivider, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 11));
+		//
+		// 	Image leftAndRightBoxes = new Image();
+		// 	leftAndRightBoxes.Create(LEFT_RIGHT_BOXES_WIDTH, LEFT_RIGHT_BOXES_HEIGHT, false, Image.Format.Rgba8);
+		// 	leftAndRightBoxes.Fill(civColor);
+		// 	labelImage.BlitRect(leftAndRightBoxes, new Rect2(0, 0, new Vector2(24, 21)), new Vector2(1, 1));
+		// 	if (city.IsCapital()) {
+		// 		labelImage.BlitRect(leftAndRightBoxes, new Rect2(0, 0, new Vector2(24, 21)), new Vector2(cityLabelWidth - 25, 1));
+		// 		labelImage.BlendRect(nonEmbassyStar, new Rect2(0, 0, new Vector2(18, 18)), new Vector2(cityLabelWidth - 24, 2));
+		// 	}
+		// 	//todo: darker shades of civ color around edges
+		// 	return labelImage;
+		// }
+	}
+}

--- a/C7/Map/CityScene.cs
+++ b/C7/Map/CityScene.cs
@@ -69,6 +69,13 @@ namespace C7.Map {
 			midSizedFont.Size = 18;
 
 			nonEmbassyStar = PCXToGodot.getImageFromPCX(cityIcons, 20, 1, 18, 18);
+
+			theTexture.MouseFilter = Control.MouseFilterEnum.Ignore;
+			labelTextureRect.MouseFilter = Control.MouseFilterEnum.Ignore;
+			cityNameLabel.MouseFilter = Control.MouseFilterEnum.Ignore;
+			productionLabel.MouseFilter = Control.MouseFilterEnum.Ignore;
+			popSizeLabel.MouseFilter = Control.MouseFilterEnum.Ignore;
+
 			AddChild(theTexture);
 			AddChild(labelTextureRect);
 			AddChild(cityNameLabel);

--- a/C7/Map/CityScene.cs
+++ b/C7/Map/CityScene.cs
@@ -9,50 +9,14 @@ namespace C7.Map {
 	public class CityScene : Node2D {
 		private ILogger log = LogManager.ForContext<CityScene>();
 
-		private City city;
-		private Tile tile;
-		private Vector2 tileCenter;
-
-		private Vector2 citySpriteSize;
+		private readonly Vector2 citySpriteSize;
 
 		private ImageTexture cityTexture;
-
-		private DynamicFont smallFont = new DynamicFont();
-		private DynamicFont midSizedFont = new DynamicFont();
-
-		private Pcx cityIcons = Util.LoadPCX("Art/Cities/city icons.pcx");
-		private Image nonEmbassyStar;
-
-		const int CITY_LABEL_HEIGHT = 23;
-		const int LEFT_RIGHT_BOXES_WIDTH = 24;
-		const int LEFT_RIGHT_BOXES_HEIGHT = CITY_LABEL_HEIGHT - 2;
-		const int TEXT_ROW_HEIGHT = 9;
-
-		ImageTexture cityLabel = new ImageTexture();
-
-		private TextureRect theTexture = new TextureRect();
-		private TextureRect labelTextureRect = new TextureRect();
-		Label cityNameLabel = new Label();
-		Label productionLabel = new Label();
-		Label popSizeLabel = new Label();
-
-		Theme smallFontTheme = new Theme();
-		Theme popThemeRed = new Theme();
-		Theme popSizeTheme = new Theme();
-
-		private int lastLabelWidth = 0;
+		private TextureRect cityGraphics = new TextureRect();
+		private CityLabelScene cityLabelScene;
 
 		public CityScene(City city, Tile tile, Vector2 tileCenter) {
-			this.city = city;
-			this.tile = tile;
-			this.tileCenter = tileCenter;
-
-			smallFontTheme.DefaultFont = smallFont;
-			smallFontTheme.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
-			popSizeTheme.DefaultFont = midSizedFont;
-			popSizeTheme.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
-			popThemeRed.DefaultFont = midSizedFont;
-			popThemeRed.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
+			cityLabelScene = new CityLabelScene(city, tile, tileCenter);
 
 			//TODO: Generalize, support multiple city types, etc.
 			Pcx pcx = Util.LoadPCX("Art/Cities/rMIDEAST.PCX");
@@ -61,168 +25,18 @@ namespace C7.Map {
 			cityTexture = Util.LoadTextureFromPCX("Art/Cities/rMIDEAST.PCX", 0, 0, width, height);
 			citySpriteSize = new Vector2(width, height);
 
+			cityGraphics.MarginLeft = tileCenter.x - (float)0.5 * citySpriteSize.x;
+			cityGraphics.MarginTop = tileCenter.y - (float)0.5 * citySpriteSize.y;
+			cityGraphics.MouseFilter = Control.MouseFilterEnum.Ignore;
+			cityGraphics.Texture = cityTexture;
 
-			smallFont.FontData = ResourceLoader.Load<DynamicFontData>("res://Fonts/NotoSans-Regular.ttf");
-			smallFont.Size = 11;
-
-			midSizedFont.FontData = ResourceLoader.Load<DynamicFontData>("res://Fonts/NotoSans-Regular.ttf");
-			midSizedFont.Size = 18;
-
-			nonEmbassyStar = PCXToGodot.getImageFromPCX(cityIcons, 20, 1, 18, 18);
-
-			theTexture.MouseFilter = Control.MouseFilterEnum.Ignore;
-			labelTextureRect.MouseFilter = Control.MouseFilterEnum.Ignore;
-			cityNameLabel.MouseFilter = Control.MouseFilterEnum.Ignore;
-			productionLabel.MouseFilter = Control.MouseFilterEnum.Ignore;
-			popSizeLabel.MouseFilter = Control.MouseFilterEnum.Ignore;
-
-			AddChild(theTexture);
-			AddChild(labelTextureRect);
-			AddChild(cityNameLabel);
-			AddChild(productionLabel);
-			AddChild(popSizeLabel);
+			AddChild(cityGraphics);
+			AddChild(cityLabelScene);
 		}
 
 		public override void _Draw() {
 			base._Draw();
-
-			theTexture.MarginLeft = tileCenter.x - (float)0.5 * citySpriteSize.x;
-			theTexture.MarginTop = tileCenter.y - (float)0.5 * citySpriteSize.y;
-			theTexture.Texture = cityTexture;
-
-			int turnsUntilGrowth = city.TurnsUntilGrowth();
-			string turnsUntilGrowthText = turnsUntilGrowth == int.MaxValue || turnsUntilGrowth < 0 ? "- -" : "" + turnsUntilGrowth;
-			string cityNameAndGrowth = $"{city.name} : {turnsUntilGrowthText}";
-			string productionDescription = city.itemBeingProduced.name + " : " + city.TurnsUntilProductionFinished();
-
-			int cityNameAndGrowthWidth = (int)smallFont.GetStringSize(cityNameAndGrowth).x;
-			int productionDescriptionWidth = (int)smallFont.GetStringSize(productionDescription).x;
-			int maxTextWidth = Math.Max(cityNameAndGrowthWidth, productionDescriptionWidth);
-
-			int cityLabelWidth = maxTextWidth + (city.IsCapital()? 70 : 45);	//TODO: Is 65 right?  70?  Will depend on whether it's capital, too
-			int textAreaWidth = cityLabelWidth - (city.IsCapital() ? 50 : 25);
-			if (log.IsEnabled(LogEventLevel.Verbose)) {
-				log.Verbose("Width of city name = " + maxTextWidth);
-				log.Verbose("City label width: " + cityLabelWidth);
-				log.Verbose("Text area width: " + textAreaWidth);
-			}
-
-			if (cityLabelWidth != lastLabelWidth) {
-				Image labelBackground = CreateLabelBackground(cityLabelWidth, city, textAreaWidth);
-				cityLabel.CreateFromImage(labelBackground, 0);
-				lastLabelWidth = cityLabelWidth;
-			}
-
-			DrawLabelOnScreen(tileCenter, cityLabelWidth, city, cityLabel);
-			DrawTextOnLabel(tileCenter, cityNameAndGrowthWidth, productionDescriptionWidth, city, cityNameAndGrowth, productionDescription, cityLabelWidth);
-		}
-
-		private void DrawLabelOnScreen(Vector2 tileCenter, int cityLabelWidth, City city, ImageTexture cityLabel)
-		{
-			labelTextureRect.MarginLeft = tileCenter.x + (cityLabelWidth / -2);
-			labelTextureRect.MarginTop = tileCenter.y + 24;
-			labelTextureRect.Texture = cityLabel;
-		}
-
-		private void DrawTextOnLabel(Vector2 tileCenter, int cityNameAndGrowthWidth, int productionDescriptionWidth, City city, string cityNameAndGrowth, string productionDescription, int cityLabelWidth) {
-
-			//Destination for font is based on lower-left of baseline of font, not upper left as for blitted rectangles
-			int cityNameOffset = cityNameAndGrowthWidth / -2;
-			int prodDescriptionOffset = productionDescriptionWidth / -2;
-			if (!city.IsCapital()) {
-				cityNameOffset += 12;
-				prodDescriptionOffset += 12;
-			}
-
-			cityNameLabel.Theme = smallFontTheme;
-			cityNameLabel.Text = cityNameAndGrowth;
-			cityNameLabel.MarginLeft = tileCenter.x + cityNameOffset;
-			cityNameLabel.MarginTop = tileCenter.y + 22;
-
-			productionLabel.Theme = smallFontTheme;
-			productionLabel.Text = productionDescription;
-			productionLabel.MarginLeft = tileCenter.x + prodDescriptionOffset;
-			productionLabel.MarginTop = tileCenter.y + 32;
-
-			//City pop size
-			string popSizeString = "" + city.size;
-			int popSizeWidth = (int)midSizedFont.GetStringSize(popSizeString).x;
-			int popSizeOffset = LEFT_RIGHT_BOXES_WIDTH / 2 - popSizeWidth / 2;
-			Vector2 popSizeDestination = new Vector2(tileCenter + new Vector2(cityLabelWidth / -2, 24) + new Vector2(popSizeOffset, 18));
-			Color popColor = Color.Color8(255, 255, 255, 255);
-			if (city.TurnsUntilGrowth() < 0) {
-				popColor = Color.Color8(255, 0, 0, 255);
-			}
-
-			popSizeLabel.Theme = popSizeTheme;
-
-			if (city.TurnsUntilGrowth() < 0) {
-				popSizeLabel.Theme = popThemeRed;
-			}
-
-			popSizeLabel.Text = popSizeString;
-			popSizeLabel.MarginLeft = tileCenter.x + cityLabelWidth / -2 + popSizeOffset;
-			popSizeLabel.MarginTop = tileCenter.y + 22;
-		}
-
-		private Image CreateLabelBackground(int cityLabelWidth, City city, int textAreaWidth)
-		{
-			//Label/name/producing area
-			Image labelImage = new Image();
-			labelImage.Create(cityLabelWidth, CITY_LABEL_HEIGHT, false, Image.Format.Rgba8);
-			labelImage.Fill(Color.Color8(0, 0, 0, 0));
-			byte transparencyLevel = 192; //25%
-			Color civColor = new Color(city.owner.color);
-			civColor = new Color(civColor, transparencyLevel);
-			Color civColorDarker = Color.Color8(0, 0, 138, transparencyLevel); //todo: automate the darker() function.  maybe less transparency?
-			Color topRowGrey = Color.Color8(32, 32, 32, transparencyLevel);
-			Color bottomRowGrey = Color.Color8(48, 48, 48, transparencyLevel);
-			Color backgroundGrey = Color.Color8(64, 64, 64, transparencyLevel);
-			Color borderGrey = Color.Color8(80, 80, 80, transparencyLevel);
-
-			Image horizontalBorder = new Image();
-			horizontalBorder.Create(cityLabelWidth - 2, 1, false, Image.Format.Rgba8);
-			horizontalBorder.Fill(borderGrey);
-			labelImage.BlitRect(horizontalBorder, new Rect2(0, 0, new Vector2(cityLabelWidth - 2, 1)), new Vector2(1, 0));
-			labelImage.BlitRect(horizontalBorder, new Rect2(0, 0, new Vector2(cityLabelWidth - 2, 1)), new Vector2(1, 22));
-
-			Image verticalBorder = new Image();
-			verticalBorder.Create(1, CITY_LABEL_HEIGHT - 2, false, Image.Format.Rgba8);
-			verticalBorder.Fill(borderGrey);
-			labelImage.BlitRect(verticalBorder, new Rect2(0, 0, new Vector2(1, 23)), new Vector2(0, 1));
-			labelImage.BlitRect(verticalBorder, new Rect2(0, 0, new Vector2(1, 23)), new Vector2(cityLabelWidth - 1, 1));
-
-			Image bottomRow = new Image();
-			bottomRow.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
-			bottomRow.Fill(bottomRowGrey);
-			labelImage.BlitRect(bottomRow, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 21));
-
-			Image topRow = new Image();
-			topRow.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
-			topRow.Fill(topRowGrey);
-			labelImage.BlitRect(topRow, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 1));
-
-			Image background = new Image();
-			background.Create(textAreaWidth, TEXT_ROW_HEIGHT, false, Image.Format.Rgba8);
-			background.Fill(backgroundGrey);
-			labelImage.BlitRect(background, new Rect2(0, 0, new Vector2(textAreaWidth, 9)), new Vector2(25, 2));
-			labelImage.BlitRect(background, new Rect2(0, 0, new Vector2(textAreaWidth, 9)), new Vector2(25, 12));
-
-			Image centerDivider = new Image();
-			centerDivider.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
-			centerDivider.Fill(civColor);
-			labelImage.BlitRect(centerDivider, new Rect2(0, 0, new Vector2(textAreaWidth, 1)), new Vector2(25, 11));
-
-			Image leftAndRightBoxes = new Image();
-			leftAndRightBoxes.Create(LEFT_RIGHT_BOXES_WIDTH, LEFT_RIGHT_BOXES_HEIGHT, false, Image.Format.Rgba8);
-			leftAndRightBoxes.Fill(civColor);
-			labelImage.BlitRect(leftAndRightBoxes, new Rect2(0, 0, new Vector2(24, 21)), new Vector2(1, 1));
-			if (city.IsCapital()) {
-				labelImage.BlitRect(leftAndRightBoxes, new Rect2(0, 0, new Vector2(24, 21)), new Vector2(cityLabelWidth - 25, 1));
-				labelImage.BlendRect(nonEmbassyStar, new Rect2(0, 0, new Vector2(18, 18)), new Vector2(cityLabelWidth - 24, 2));
-			}
-			//todo: darker shades of civ color around edges
-			return labelImage;
+			cityLabelScene._Draw();
 		}
 	}
 }

--- a/C7/Map/CityScene.cs
+++ b/C7/Map/CityScene.cs
@@ -31,6 +31,10 @@ namespace C7.Map {
 		ImageTexture cityLabel = new ImageTexture();
 
 		private TextureRect theTexture = new TextureRect();
+		private TextureRect labelTextureRect = new TextureRect();
+		Label cityNameLabel = new Label();
+		Label productionLabel = new Label();
+		Label popSizeLabel = new Label();
 
 		public CityScene(City city, Tile tile, Vector2 tileCenter) {
 			this.city = city;
@@ -52,23 +56,19 @@ namespace C7.Map {
 			midSizedFont.Size = 18;
 
 			nonEmbassyStar = PCXToGodot.getImageFromPCX(cityIcons, 20, 1, 18, 18);
-			this.AddChild(theTexture);
+			AddChild(theTexture);
+			AddChild(labelTextureRect);
+			AddChild(cityNameLabel);
+			AddChild(productionLabel);
+			AddChild(popSizeLabel);
 		}
 
 		public override void _Draw() {
-			// base._Draw();
+			base._Draw();
 
-			Rect2 screenRect = new Rect2(tileCenter - (float)0.5 * citySpriteSize, citySpriteSize);
-			Rect2 textRect = new Rect2(new Vector2(0, 0), citySpriteSize);
 			theTexture.MarginLeft = tileCenter.x - (float)0.5 * citySpriteSize.x;
 			theTexture.MarginTop = tileCenter.y - (float)0.5 * citySpriteSize.y;
 			theTexture.Texture = cityTexture;
-			//Drawing text gives this error:
-			//ERROR: Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.
-			//  theTexture.DrawString(smallFont, new Vector2(0, 0), "Test String", Color.Color8(255, 0, 0))
-			//Even though we're in the _Draw() method (which is the C# capitalization of it).  For some reason it works in LooseLayer, which is also a Node2D with public override void _Draw().
-			//We'll have to either figure that out or figure out an alternative in order to be able to use this modus operandi effectively.
-
 
 			int turnsUntilGrowth = city.TurnsUntilGrowth();
 			string turnsUntilGrowthText = turnsUntilGrowth == int.MaxValue || turnsUntilGrowth < 0 ? "- -" : "" + turnsUntilGrowth;
@@ -92,19 +92,13 @@ namespace C7.Map {
 
 			DrawLabelOnScreen(tileCenter, cityLabelWidth, city, cityLabel);
 			DrawTextOnLabel(tileCenter, cityNameAndGrowthWidth, productionDescriptionWidth, city, cityNameAndGrowth, productionDescription, cityLabelWidth);
-
 		}
 
 		private void DrawLabelOnScreen(Vector2 tileCenter, int cityLabelWidth, City city, ImageTexture cityLabel)
 		{
-			Rect2 labelDestination = new Rect2(tileCenter + new Vector2(cityLabelWidth / -2, 24), new Vector2(cityLabelWidth, CITY_LABEL_HEIGHT)); //24 is a swag
-			Rect2 allOfTheLabel = new Rect2(new Vector2(0, 0), new Vector2(cityLabelWidth, CITY_LABEL_HEIGHT));
-
-			TextureRect label = new TextureRect();
-			label.MarginLeft = tileCenter.x + (cityLabelWidth / -2);
-			label.MarginTop = tileCenter.y + 24;
-			label.Texture = cityLabel;
-			AddChild(label);
+			labelTextureRect.MarginLeft = tileCenter.x + (cityLabelWidth / -2);
+			labelTextureRect.MarginTop = tileCenter.y + 24;
+			labelTextureRect.Texture = cityLabel;
 		}
 
 		private void DrawTextOnLabel(Vector2 tileCenter, int cityNameAndGrowthWidth, int productionDescriptionWidth, City city, string cityNameAndGrowth, string productionDescription, int cityLabelWidth) {
@@ -119,23 +113,16 @@ namespace C7.Map {
 				cityNameOffset += 12;
 				prodDescriptionOffset += 12;
 			}
-			Vector2 cityNameDestination = new Vector2(tileCenter + new Vector2(cityNameOffset, 24) + new Vector2(0, 10));
-			Label cityNameLabel = new Label();
+
 			cityNameLabel.Theme = smallFontTheme;
 			cityNameLabel.Text = cityNameAndGrowth;
 			cityNameLabel.MarginLeft = tileCenter.x + cityNameOffset;
 			cityNameLabel.MarginTop = tileCenter.y + 22;
-			AddChild(cityNameLabel);
-			// theTexture.DrawString(smallFont, cityNameDestination, cityNameAndGrowth, Color.Color8(255, 255, 255, 255));
 
-			Vector2 productionDestination = new Vector2(tileCenter + new Vector2(prodDescriptionOffset, 24) + new Vector2(0, 20));
-			Label productionLabel = new Label();
 			productionLabel.Theme = smallFontTheme;
 			productionLabel.Text = productionDescription;
 			productionLabel.MarginLeft = tileCenter.x + prodDescriptionOffset;
 			productionLabel.MarginTop = tileCenter.y + 32;
-			AddChild(productionLabel);
-			// theTexture.DrawString(smallFont, productionDestination, productionDescription, Color.Color8(255, 255, 255, 255));
 
 			//City pop size
 			string popSizeString = "" + city.size;
@@ -154,13 +141,10 @@ namespace C7.Map {
 				popSizeTheme.SetColor("font_color", "Label", Color.Color8(255, 0, 0, 255));
 			}
 
-			Label popSizeLabel = new Label();
 			popSizeLabel.Theme = popSizeTheme;
 			popSizeLabel.Text = popSizeString;
 			popSizeLabel.MarginLeft = tileCenter.x + cityLabelWidth / -2 + popSizeOffset;
 			popSizeLabel.MarginTop = tileCenter.y + 22;
-			AddChild(popSizeLabel);
-			// theTexture.DrawString(midSizedFont, popSizeDestination, popSizeString, popColor);
 		}
 
 		private Image CreateLabelBackground(int cityLabelWidth, City city, int textAreaWidth)

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -16,6 +16,9 @@ namespace C7Engine
 			CityResident firstResident = new CityResident();
 			CityTileAssignmentAI.AssignNewCitizenToTile(newCity, firstResident);
 			newCity.SetItemBeingProduced(CityProductionAI.GetNextItemToBeProduced(newCity, null));
+			if (owner.cities.Count == 0) {
+				newCity.capital = true;
+			}
 			gameData.cities.Add(newCity);
 			owner.cities.Add(newCity);
 			tileWithNewCity.cityAtTile = newCity;

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using C7Engine.AI;
 using Serilog;
 
@@ -22,15 +23,19 @@ namespace C7Engine
 		}
 
 		// Implements the game loop. This method is called when the game is started and when the player signals that they're done moving.
-		internal static void AdvanceTurn()
-		{
+		internal static void AdvanceTurn() {
+			Stopwatch stopwatch = new Stopwatch();
+			stopwatch.Start();
 			GameData gameData = EngineStorage.gameData;
 			while (true) { // Loop ends with a function return once we reach the UI controller during the movement phase
 				bool firstTurn = GetTurnNumber() == 0;
 
 				// Movement phase
-				if (PlayPlayerTurns(gameData, firstTurn))
+				if (PlayPlayerTurns(gameData, firstTurn)) {
+					stopwatch.Stop();
+					log.Information("Turn time took " + stopwatch.ElapsedMilliseconds + " milliseconds");
 					return;
+				}
 
 				//Clear all wait queue, so if a player ended the turn without handling all waited units, they are selected
 				//at the same place in the order.  Confirmed this is what Civ3 does.

--- a/C7GameData/City.cs
+++ b/C7GameData/City.cs
@@ -18,6 +18,7 @@ namespace C7GameData
         public int foodStored = 0;
         public int foodNeededToGrow = 20;
 
+        public bool capital = false;
         public Player owner {get; set;}
         public List<CityResident> residents = new List<CityResident>();
 
@@ -38,8 +39,7 @@ namespace C7GameData
 
         public bool IsCapital()
         {
-            //TODO: Look through built cities, figure out if it is or not
-            return true;
+            return capital;
         }
 
         public bool CanBuildUnit(UnitPrototype proto)

--- a/C7GameData/MapUnit.cs
+++ b/C7GameData/MapUnit.cs
@@ -61,7 +61,7 @@ public class MapUnit
 	public override string ToString()
 	{
 		if (this != MapUnit.NONE) {
-			return this.owner + " " + unitType.name + "at (" + location.xCoordinate + ", " + location.yCoordinate + ") with " + movementPoints.remaining + " MP and " + hitPointsRemaining + " HP, guid = " + guid;
+			return this.owner + " " + unitType.name + " at (" + location.xCoordinate + ", " + location.yCoordinate + ") with " + movementPoints.remaining + " MP and " + hitPointsRemaining + " HP, guid = " + guid;
 		}
 		else {
 			return "This is the NONE unit";


### PR DESCRIPTION
Closes #172 

These changes break our city-drawing code into its own scene, and also break out the city label into its own scene.

Along the way I added a couple small optimizations, such as only redrawing the label background (which involves a lot of operations) if the label background has changed.

I also added in making it so only the capital has the capital star, and logging of turn times.