### PR TITLE
Search for Civ3 Folder in Steam Folder on Linux/Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .import/
 export.cfg
 logs/
+
 ### This is excluded because Android builds may have secrets in export_presets.cfg ; see https://github.com/godotengine/godot-demo-projects/issues/329
 # re-ignoring it so manual exports don't mess with the to-be-finely-honed settings; can manually add if needs updating
 export_presets.cfg
@@ -24,7 +25,6 @@ sav/
 *.flc
 *.mp4
 *.webp
-.vscode/
 *.bin
 
 *.swp
@@ -34,7 +34,7 @@ project.lock.json
 *.pyc
 
 # Visual Studio Code
-# .vscode
+.vscode
 
 # User-specific files
 *.suo
@@ -42,6 +42,7 @@ project.lock.json
 *.userosscache
 *.sln.docstates
 C7.ini
+log.txt
 
 # Build results
 [Dd]ebug/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .import/
 export.cfg
 logs/
+.godot
 
 ### This is excluded because Android builds may have secrets in export_presets.cfg ; see https://github.com/godotengine/godot-demo-projects/issues/329
 # re-ignoring it so manual exports don't mess with the to-be-finely-honed settings; can manually add if needs updating

--- a/C7/MainMenu.tscn
+++ b/C7/MainMenu.tscn
@@ -79,6 +79,7 @@ __meta__ = {
 [node name="SetCiv3HomeDialog" type="FileDialog" parent="CanvasLayer"]
 margin_right = 550.0
 margin_bottom = 750.0
+rect_min_size = Vector2( 400, 140 )
 window_title = "Open a File or Directory"
 resizable = true
 mode = 3

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -47,8 +47,7 @@ public class Util {
 			if (path != null) { return path; }
 		} else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
 			// Check for a civ3 folder in steamapps/common
-			// TODO: should this method only be used at dev time?
-			var root = new System.IO.DirectoryInfo(Util.SteamCommonDir());
+			System.IO.DirectoryInfo root = new System.IO.DirectoryInfo(Util.SteamCommonDir());
 			foreach (System.IO.DirectoryInfo di in root.GetDirectories()) {
 				if (Util.FolderIsCiv3(di)) {
 					return di.FullName;

--- a/C7/project.godot
+++ b/C7/project.godot
@@ -37,6 +37,10 @@ limits=false
 
 theme/custom="res://C7Theme.tres"
 
+[mono]
+
+project/assembly_name="C7"
+
 [network]
 
 limits/debugger_stdout/max_chars_per_second=65535


### PR DESCRIPTION
- tested on mac
- cannot currently test on linux
- whitespace dif from running formatter on Utils.cs based on .editorconfig
- prevents Godot from crashing like in https://github.com/C7-Game/Prototype/issues/385 by not attempting to read from windows registry when not running on windows