### PR TITLE
139 - Smarter Barbarians

### DIFF
--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -41,7 +41,7 @@ namespace C7Engine {
 
 							//Check if there are any undefended units that can be taken!
 							foreach (Tile tile in validTiles) {
-								if (tile.unitsOnTile.Exists(mapUnit => UndefendedUnit(mapUnit))) {
+								if (tile.unitsOnTile.Exists(mapUnit => IsUndefendedUnit(mapUnit))) {
 									bool alive = unit.move(unit.location.directionTo(tile));
 									// TODO: Restructure so we can avoid gotos.
 									goto nextMovementPoint;
@@ -85,7 +85,7 @@ nextUnit: ;
 			}
 		}
 
-		private static bool UndefendedUnit(MapUnit unit) {
+		private static bool IsUndefendedUnit(MapUnit unit) {
 			if (unit.owner.isBarbarians) {
 				return false;
 			}

--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -34,6 +34,15 @@ namespace C7Engine {
 								break;
 							}
 
+							//Check if there are any undefended units that can be taken!
+							foreach (Tile tile in validTiles) {
+								if (tile.unitsOnTile.Exists(mapUnit => UndefendedUnit(mapUnit))) {
+									unit.move(unit.location.directionTo(tile));
+									// TODO: Restructure so we can avoid gotos.
+									goto nextMovementPoint;
+								}
+							}
+
 							Tile newLocation = validTiles[GameData.rng.Next(validTiles.Count)];
 							//Because it chooses a semi-cardinal direction at random, not accounting for map, it could get none
 							//if it tries to move e.g. north from the north pole.  Hence, this check.
@@ -46,10 +55,21 @@ namespace C7Engine {
 								//Avoid potential infinite loop.
 								break;
 							}
+nextMovementPoint: ;
 						}
 					}
 				}
 			}
+		}
+
+		private static bool UndefendedUnit(MapUnit unit) {
+			if (unit.owner.isBarbarians) {
+				return false;
+			}
+
+			return unit.location.unitsOnTile.Count(mapUnit => {
+				return mapUnit.unitType.defense > 0;
+			}) == 0;
 		}
 
 		private static bool UnitIsFreeToMove(MapUnit unit)

--- a/C7Engine/AI/UnitAI/CombatOdds.cs
+++ b/C7Engine/AI/UnitAI/CombatOdds.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using C7GameData;
+
+namespace C7Engine.AI.UnitAI {
+	/**
+	 * This is the start of a combat odds calculator.
+	 * Its primary purpose is to make the AI well-informed about the risks it is taking, so it can defeat the human
+	 * more easily.
+	 * Its secondary purpose is to allow an eventual Civ4-style UI giving the human a helpful tooltip about the odds,
+	 * thus no longer placing the human at a disadvantage relative to the AI.
+	 * This class will start out very simple, but over time we will add more complex scenarios, such as calculating
+	 * odds per round of combat, and calculating the likely results of whole-stack combat, which will allow the AI
+	 * to make smart decisions about how many units it needs to defeat human defenses.
+	 */
+	public class CombatOdds {
+		public static double OddsOfVictory(MapUnit attacker, MapUnit defender) {
+			//Yanked from MapUnitExtension's `fight` method
+			IEnumerable<StrengthBonus> attackBonuses  = attacker.ListStrengthBonusesVersus(defender, CombatRole.Attack , attacker.facingDirection),
+				defenseBonuses = defender.ListStrengthBonusesVersus(attacker, CombatRole.Defense, attacker.facingDirection);
+
+			double attackerStrength = attacker.unitType.attack  * StrengthBonus.ListToMultiplier(attackBonuses),
+				defenderStrength = defender.unitType.defense * StrengthBonus.ListToMultiplier(defenseBonuses);
+
+			return attackerStrength / (attackerStrength + defenderStrength);
+		}
+	}
+}

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -87,7 +87,7 @@ namespace C7Engine
 					//7% chance of a new barbarian.  Probably should scale based on barbarian activity.
 					int result = GameData.rng.Next(100);
 					log.Verbose("Random barb result = " + result);
-					if (result < 4) {
+					if (result < 5) {
 						MapUnit newUnit = new MapUnit();
 						newUnit.location = tile;
 						newUnit.owner = barbPlayer;
@@ -101,7 +101,7 @@ namespace C7Engine
 						gameData.mapUnits.Add(newUnit);
 						tribe.AddUnit(newUnit);
 						log.Debug("New barbarian added at " + tile);
-					} else if (tile.NeighborsWater() && result < 6) {
+					} else if (tile.NeighborsWater() && result < 7) {
 						MapUnit newUnit = new MapUnit();
 						newUnit.location = tile;
 						newUnit.owner = barbPlayer;

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -81,40 +81,41 @@ namespace C7Engine
 		private static void SpawnBarbarians(GameData gameData)
 		{
 			//Generate new barbarian units.
-			Player barbPlayer = gameData.players.Find(player => player.isBarbarians);
-			foreach (Tile tile in gameData.map.barbarianCamps) {
-				//7% chance of a new barbarian.  Probably should scale based on barbarian activity.
-				int result = GameData.rng.Next(100);
-				log.Verbose("Random barb result = " + result);
-				if (result < 4) {
-					MapUnit newUnit = new MapUnit();
-					newUnit.location = tile;
-					newUnit.owner = gameData.players[0];
-					newUnit.unitType = gameData.barbarianInfo.basicBarbarian;
-					newUnit.experienceLevelKey = gameData.defaultExperienceLevelKey;
-					newUnit.experienceLevel = gameData.defaultExperienceLevel;
-					newUnit.hitPointsRemaining = 3;
-					newUnit.isFortified = true; //todo: hack for unit selection
+			BarbarianPlayer barbPlayer = (BarbarianPlayer)gameData.players.Find(player => player.isBarbarians);
+			foreach (BarbarianTribe tribe in barbPlayer.getTribes()) {
+				foreach (Tile tile in tribe.GetCamps()) {
+					//7% chance of a new barbarian.  Probably should scale based on barbarian activity.
+					int result = GameData.rng.Next(100);
+					log.Verbose("Random barb result = " + result);
+					if (result < 4) {
+						MapUnit newUnit = new MapUnit();
+						newUnit.location = tile;
+						newUnit.owner = barbPlayer;
+						newUnit.unitType = gameData.barbarianInfo.basicBarbarian;
+						newUnit.experienceLevelKey = gameData.defaultExperienceLevelKey;
+						newUnit.experienceLevel = gameData.defaultExperienceLevel;
+						newUnit.hitPointsRemaining = 3;
+						newUnit.isFortified = true; //todo: hack for unit selection
 
-					tile.unitsOnTile.Add(newUnit);
-					gameData.mapUnits.Add(newUnit);
-					barbPlayer.units.Add(newUnit);
-					log.Debug("New barbarian added at " + tile);
-				}
-				else if (tile.NeighborsWater() && result < 6) {
-					MapUnit newUnit = new MapUnit();
-					newUnit.location = tile;
-					newUnit.owner = gameData.players[0]; //todo: make this reliably point to the barbs
-					newUnit.unitType = gameData.barbarianInfo.barbarianSeaUnit;
-					newUnit.experienceLevelKey = gameData.defaultExperienceLevelKey;
-					newUnit.experienceLevel = gameData.defaultExperienceLevel;
-					newUnit.hitPointsRemaining = 3;
-					newUnit.isFortified = true; //todo: hack for unit selection
+						tile.unitsOnTile.Add(newUnit);
+						gameData.mapUnits.Add(newUnit);
+						tribe.AddUnit(newUnit);
+						log.Debug("New barbarian added at " + tile);
+					} else if (tile.NeighborsWater() && result < 6) {
+						MapUnit newUnit = new MapUnit();
+						newUnit.location = tile;
+						newUnit.owner = barbPlayer;
+						newUnit.unitType = gameData.barbarianInfo.barbarianSeaUnit;
+						newUnit.experienceLevelKey = gameData.defaultExperienceLevelKey;
+						newUnit.experienceLevel = gameData.defaultExperienceLevel;
+						newUnit.hitPointsRemaining = 3;
+						newUnit.isFortified = true; //todo: hack for unit selection
 
-					tile.unitsOnTile.Add(newUnit);
-					gameData.mapUnits.Add(newUnit);
-					barbPlayer.units.Add(newUnit);
-					log.Debug("New barbarian galley added at " + tile);
+						tile.unitsOnTile.Add(newUnit);
+						gameData.mapUnits.Add(newUnit);
+						tribe.AddUnit(newUnit);
+						log.Debug("New barbarian galley added at " + tile);
+					}
 				}
 			}
 		}

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -430,12 +430,23 @@ public static class MapUnitExtensions {
 		// EngineStorage.animTracker.endAnimation(unit, false);   TODO: Must send message instead of call directly
 		unit.location.unitsOnTile.Remove(unit);
 		gameData.mapUnits.Remove(unit);
-		foreach(Player player in gameData.players)
+		foreach (Player player in gameData.players)
 		{
-			if (player.units.Contains(unit)) {
-				player.units.Remove(unit);
+			if (!player.isBarbarians) {
+				if (player.units.Contains(unit)) {
+					player.units.Remove(unit);
+					break;
+				}
+			} else {
+				foreach (BarbarianTribe tribe in ((BarbarianPlayer)(player)).getTribes()) {
+					if (tribe.GetUnits().Contains(unit)) {
+						tribe.RemoveUnit(unit);
+						goto endDisband;
+					}
+				}
 			}
 		}
+endDisband: ;
 	}
 
 	public static bool canBuildCity(this MapUnit unit)

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -436,23 +436,7 @@ public static class MapUnitExtensions {
 		// EngineStorage.animTracker.endAnimation(unit, false);   TODO: Must send message instead of call directly
 		unit.location.unitsOnTile.Remove(unit);
 		gameData.mapUnits.Remove(unit);
-		foreach (Player player in gameData.players)
-		{
-			if (!player.isBarbarians) {
-				if (player.units.Contains(unit)) {
-					player.units.Remove(unit);
-					break;
-				}
-			} else {
-				foreach (BarbarianTribe tribe in ((BarbarianPlayer)(player)).getTribes()) {
-					if (tribe.GetUnits().Contains(unit)) {
-						tribe.RemoveUnit(unit);
-						goto endDisband;
-					}
-				}
-			}
-		}
-endDisband: ;
+		unit.owner.RemoveUnit(unit);
 	}
 
 	public static bool canBuildCity(this MapUnit unit)

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -295,6 +295,12 @@ public static class MapUnitExtensions {
 		if (tile.hasBarbarianCamp && (!unit.owner.isBarbarians)) {
 			tile.DisbandNonDefendingUnits();
 			EngineStorage.gameData.map.barbarianCamps.Remove(tile);
+			BarbarianPlayer barbarians = (BarbarianPlayer)EngineStorage.gameData.players.Find(player => player.isBarbarians);
+			foreach (BarbarianTribe tribe in barbarians.getTribes()) {
+				if (tribe.GetCamps().Contains(tile)) {
+					tribe.RemoveCamp(tile);
+				}
+			}
 			tile.hasBarbarianCamp = false;
 		}
 

--- a/C7GameData/BarbarianPlayer.cs
+++ b/C7GameData/BarbarianPlayer.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+
+namespace C7GameData {
+	/**
+	 * Special class for the barbarian player.
+	 * They have some unique behavior, notably being organized by tribe.
+	 */
+	public class BarbarianPlayer : Player {
+		private List<BarbarianTribe> tribes = new List<BarbarianTribe>();
+
+		public BarbarianPlayer(uint color) {
+			guid = Guid.NewGuid().ToString();
+			this.color = (int)(color & 0xFFFFFFFF);
+			this.isBarbarians = true;
+		}
+
+		public void AddTribe(Tile tile, MapUnit startingUnit) {
+			tribes.Add(new BarbarianTribe(tile, startingUnit));
+		}
+	}
+}

--- a/C7GameData/BarbarianPlayer.cs
+++ b/C7GameData/BarbarianPlayer.cs
@@ -23,5 +23,14 @@ namespace C7GameData {
 		public ReadOnlyCollection<BarbarianTribe> getTribes() {
 			return tribes.AsReadOnly();
 		}
+
+		public override void RemoveUnit(MapUnit unit) {
+			foreach (BarbarianTribe tribe in tribes) {
+				if (tribe.GetUnits().Contains(unit)) {
+					tribe.RemoveUnit(unit);
+					break;
+				}
+			}
+		}
 	}
 }

--- a/C7GameData/BarbarianPlayer.cs
+++ b/C7GameData/BarbarianPlayer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace C7GameData {
 	/**
@@ -17,6 +18,10 @@ namespace C7GameData {
 
 		public void AddTribe(Tile tile, MapUnit startingUnit) {
 			tribes.Add(new BarbarianTribe(tile, startingUnit));
+		}
+
+		public ReadOnlyCollection<BarbarianTribe> getTribes() {
+			return tribes.AsReadOnly();
 		}
 	}
 }

--- a/C7GameData/BarbarianTribe.cs
+++ b/C7GameData/BarbarianTribe.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace C7GameData {
+	public class BarbarianTribe {
+		private string name = "Vandals";
+		private List<Tile> campLocations = new List<Tile>();
+		private TileKnowledge tileKnowledge = new TileKnowledge();
+		private List<MapUnit> units = new List<MapUnit>();
+
+		public BarbarianTribe(Tile startingCamp, MapUnit startingUnit) {
+			campLocations.Add(startingCamp);
+			units.Add(startingUnit);
+		}
+	}
+}

--- a/C7GameData/BarbarianTribe.cs
+++ b/C7GameData/BarbarianTribe.cs
@@ -29,5 +29,9 @@ namespace C7GameData {
 		public ReadOnlyCollection<Tile> GetCamps() {
 			return campLocations.AsReadOnly();
 		}
+
+		public void RemoveCamp(Tile tile) {
+			this.campLocations.Remove(tile);
+		}
 	}
 }

--- a/C7GameData/BarbarianTribe.cs
+++ b/C7GameData/BarbarianTribe.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace C7GameData {
 	public class BarbarianTribe {
@@ -9,7 +10,24 @@ namespace C7GameData {
 
 		public BarbarianTribe(Tile startingCamp, MapUnit startingUnit) {
 			campLocations.Add(startingCamp);
+			tileKnowledge.AddTilesToKnown(startingCamp);
 			units.Add(startingUnit);
+		}
+
+		public ReadOnlyCollection<MapUnit> GetUnits() {
+			return units.AsReadOnly();
+		}
+
+		public void AddUnit(MapUnit unit) {
+			this.units.Add(unit);
+		}
+
+		public void RemoveUnit(MapUnit unit) {
+			this.units.Remove(unit);
+		}
+
+		public ReadOnlyCollection<Tile> GetCamps() {
+			return campLocations.AsReadOnly();
 		}
 	}
 }

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -99,8 +99,7 @@ namespace C7GameData
 			this.turn = 0;
 
 			uint white = 0xFFFFFFFF;
-			Player barbarianPlayer = new Player(white);
-			barbarianPlayer.isBarbarians = true;
+			BarbarianPlayer barbarianPlayer = new BarbarianPlayer(white);
 			players.Add(barbarianPlayer);
 
 			Civilization carthage = new Civilization();
@@ -235,6 +234,7 @@ namespace C7GameData
 					barbarian.facingDirection = TileDirection.SOUTHEAST;
 					barbarian.location.hasBarbarianCamp = true;
 					map.barbarianCamps.Add(barbCampLocation);
+					barbarianPlayer.AddTribe(barbCampLocation, barbarian);
 				}
 			}
 

--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -83,6 +83,12 @@ public class Player
 		return true;
 	}
 
+	public virtual void RemoveUnit(MapUnit unit) {
+		if (units.Contains(unit)) {
+			units.Remove(unit);
+		}
+	}
+
 	public override string ToString() {
 		if (civilization != null)
 			return civilization.cityNames.First();


### PR DESCRIPTION
Closes #139 

This is a set of changes to make the barbarians more dangerous.  More changes can be added to make them more dangerous, and may be as part of this PR, or later.

It also organizes them into tribes, with the idea of various tribes having different priorities.

So far the changes center around making them more opportunistic:

 - If a barbarian unit starts its turn next to an undefended non-combat unit, goodbye undefended unit
 - If a barbarian unit starts its turn next to a non-barbarian unit it thinks it has a chance of beating, it will attack

Corollary, the barbarians aren't the best at figuring out if they think they have a chance of winning yet.  I added a very simple risk calculator that takes into account defensive bonuses, but not the round-based nature of combat, meaning the barbarians will be more optimistic than they should be.

Long-term, I envision adding a more accurate combat odds calculator, and perhaps a multi-unit combat calculator (do my five units have a chance of taking that city?).  Which combat odds calculator the barbarians (and AI) use could vary based on difficulty level.