### PR TITLE
Fix Game Menu Spawning Multiple Popups

### DIFF
--- a/C7/UIElements/Advisors/Advisors.cs
+++ b/C7/UIElements/Advisors/Advisors.cs
@@ -20,12 +20,6 @@ public partial class Advisors : CenterContainer
 		this.Hide();
 	}
 
-//  // Called every frame. 'delta' is the elapsed time since the previous frame.
-//  public override void _Process(float delta)
-//  {
-//
-//  }
-
 	private void ShowLatestAdvisor()
 	{
 		log.Debug("Received request to show latest advisor");

--- a/C7/UIElements/Popups/GameMenu.cs
+++ b/C7/UIElements/Popups/GameMenu.cs
@@ -1,9 +1,9 @@
+using System;
 using Godot;
 
 public partial class GameMenu : Popup
 {
-
-	private static GameMenu instance = null;
+	private static readonly Lazy<GameMenu> lazy = new Lazy<GameMenu>(() => new GameMenu());
 
 	private GameMenu() {
 		alignment = BoxContainer.AlignmentMode.Center;
@@ -23,12 +23,7 @@ public partial class GameMenu : Popup
 		AddButton("Quit Game (ESC)", 210, "quit");
 	}
 
-	public static GameMenu Get() {
-		if (GameMenu.instance == null) {
-			GameMenu.instance = new GameMenu();
-		}
-		return GameMenu.instance;
-	}
+	public static GameMenu Instance { get => lazy.Value; }
 
 	public override void _Ready()
 	{
@@ -44,5 +39,4 @@ public partial class GameMenu : Popup
 	{
 		GetParent().EmitSignal("HidePopup");
 	}
-
 }

--- a/C7/UIElements/Popups/GameMenu.cs
+++ b/C7/UIElements/Popups/GameMenu.cs
@@ -3,14 +3,11 @@ using Godot;
 public partial class GameMenu : Popup
 {
 
-	public GameMenu() {
+	private static GameMenu instance = null;
+
+	private GameMenu() {
 		alignment = BoxContainer.AlignmentMode.Center;
 		margins = new Margins(top: 100);
-	}
-
-	public override void _Ready()
-	{
-		base._Ready();
 
 		AddTexture(370, 300);
 		AddBackground(370, 300);
@@ -24,6 +21,18 @@ public partial class GameMenu : Popup
 		AddButton("Retire (Ctrl-Q)", 160, "retire");
 		AddButton("Save Game (Ctrl-S)", 185, "save");
 		AddButton("Quit Game (ESC)", 210, "quit");
+	}
+
+	public static GameMenu Get() {
+		if (GameMenu.instance == null) {
+			GameMenu.instance = new GameMenu();
+		}
+		return GameMenu.instance;
+	}
+
+	public override void _Ready()
+	{
+		base._Ready();
 	}
 
 	private void quit()

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -51,6 +51,10 @@ public partial class PopupOverlay : HBoxContainer
 			return;
 		}
 
+		if (child == currentChild) {
+			return; // already being displayed
+		}
+
 		Alignment = child.alignment;
 		OffsetTop = child.margins.top;
 		OffsetBottom = child.margins.bottom;

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -1,7 +1,4 @@
 using Godot;
-using ConvertCiv3Media;
-using System;
-using System.Diagnostics;
 using Serilog;
 
 public partial class PopupOverlay : HBoxContainer
@@ -34,6 +31,7 @@ public partial class PopupOverlay : HBoxContainer
 		log.Debug("Hiding popup");
 		RemoveChild(currentChild);
 		Hide();
+		currentChild = null;
 	}
 
 	public void PlaySound(AudioStreamWav wav)
@@ -43,16 +41,17 @@ public partial class PopupOverlay : HBoxContainer
 		player.Play();
 	}
 
-	public void ShowPopup(Popup child, PopupCategory category)
+	public bool ShowPopup(Popup child, PopupCategory category)
 	{
-		if (child == null) // not necessary if we don't pass null?
-		{
+		if (child is null) {
+			// not necessary if we don't pass null? / always pass in new Popup explicitly
 			log.Error("Received request to show null popup");
-			return;
+			return false;
 		}
 
-		if (child == currentChild) {
-			return; // already being displayed
+		if (currentChild is not null) {
+			log.Debug("cannot show popup since current child is not null");
+			return false; // already showing a popup
 		}
 
 		Alignment = child.alignment;
@@ -83,6 +82,7 @@ public partial class PopupOverlay : HBoxContainer
 		AudioStreamWav wav = Util.LoadWAVFromDisk(Util.Civ3MediaPath(soundFile));
 		Visible = true;
 		PlaySound(wav);
+		return true;
 	}
 
 	/**

--- a/C7/UIElements/UpperLeftNav/MenuButton.cs
+++ b/C7/UIElements/UpperLeftNav/MenuButton.cs
@@ -17,7 +17,7 @@ public partial class MenuButton : TextureButton
 	public override void _Pressed()
 	{
 		PopupOverlay popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
-		popupOverlay.ShowPopup(new GameMenu(), PopupOverlay.PopupCategory.Info);
+		popupOverlay.ShowPopup(GameMenu.Get(), PopupOverlay.PopupCategory.Info);
 	}
 
 }

--- a/C7/UIElements/UpperLeftNav/MenuButton.cs
+++ b/C7/UIElements/UpperLeftNav/MenuButton.cs
@@ -17,7 +17,7 @@ public partial class MenuButton : TextureButton
 	public override void _Pressed()
 	{
 		PopupOverlay popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
-		popupOverlay.ShowPopup(GameMenu.Get(), PopupOverlay.PopupCategory.Info);
+		popupOverlay.ShowPopup(GameMenu.Instance, PopupOverlay.PopupCategory.Info);
 	}
 
 }


### PR DESCRIPTION
fixes #123 for opening game menu multiple times by only allowing popup overlay to show a popup when current child is null