### PR TITLE
Godot4: Use Godot Action System for Input

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://cldl5nk4n61m2"]
+[gd_scene load_steps=15 format=3 uid="uid://cldl5nk4n61m2"]
 
 [ext_resource type="Script" path="res://Game.cs" id="1"]
 [ext_resource type="Script" path="res://UIElements/Advisors/Advisors.cs" id="3"]
@@ -9,6 +9,7 @@
 [ext_resource type="Script" path="res://UIElements/UnitButtons/RenameButton.cs" id="8"]
 [ext_resource type="Script" path="res://UIElements/Popups/PopupOverlay.cs" id="9"]
 [ext_resource type="Theme" uid="uid://c1jpmssnhvodi" path="res://C7Theme.tres" id="10"]
+[ext_resource type="Script" path="res://PlayerController.gd" id="11_fjijt"]
 [ext_resource type="Script" path="res://UIElements/UnitButtons/UnitButtons.cs" id="12"]
 
 [sub_resource type="Animation" id="2"]
@@ -79,9 +80,9 @@ anchors_preset = 11
 anchor_left = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 1024.0
+offset_left = -128.0
 offset_top = 80.0
-offset_right = 1024.0
+offset_right = -128.0
 offset_bottom = 9520.0
 grow_horizontal = 0
 grow_vertical = 2
@@ -224,9 +225,10 @@ script = ExtResource("9")
 
 [node name="PopupSound" type="AudioStreamPlayer" parent="CanvasLayer/PopupOverlay"]
 
-[node name="CharacterBody2D" type="CharacterBody2D" parent="."]
+[node name="PlayerController" type="CharacterBody2D" parent="."]
+script = ExtResource("11_fjijt")
 
-[node name="Camera2D" type="Camera2D" parent="CharacterBody2D"]
+[node name="Camera2D" type="Camera2D" parent="PlayerController"]
 anchor_mode = 0
 
 [connection signal="NewAutoselectedUnit" from="." to="CanvasLayer/GameStatus" method="OnNewUnitSelected"]

--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://cldl5nk4n61m2"]
+[gd_scene load_steps=14 format=3 uid="uid://cldl5nk4n61m2"]
 
 [ext_resource type="Script" path="res://Game.cs" id="1"]
 [ext_resource type="Script" path="res://UIElements/Advisors/Advisors.cs" id="3"]
@@ -9,7 +9,6 @@
 [ext_resource type="Script" path="res://UIElements/UnitButtons/RenameButton.cs" id="8"]
 [ext_resource type="Script" path="res://UIElements/Popups/PopupOverlay.cs" id="9"]
 [ext_resource type="Theme" uid="uid://c1jpmssnhvodi" path="res://C7Theme.tres" id="10"]
-[ext_resource type="Script" path="res://PlayerController.gd" id="11_fjijt"]
 [ext_resource type="Script" path="res://UIElements/UnitButtons/UnitButtons.cs" id="12"]
 
 [sub_resource type="Animation" id="2"]
@@ -225,12 +224,6 @@ script = ExtResource("9")
 
 [node name="PopupSound" type="AudioStreamPlayer" parent="CanvasLayer/PopupOverlay"]
 
-[node name="PlayerController" type="CharacterBody2D" parent="."]
-script = ExtResource("11_fjijt")
-
-[node name="Camera2D" type="Camera2D" parent="PlayerController"]
-anchor_mode = 0
-
 [connection signal="NewAutoselectedUnit" from="." to="CanvasLayer/GameStatus" method="OnNewUnitSelected"]
 [connection signal="NewAutoselectedUnit" from="." to="CanvasLayer/UnitButtons" method="OnNewUnitSelected"]
 [connection signal="NoMoreAutoselectableUnits" from="." to="CanvasLayer/GameStatus" method="OnNoMoreAutoselectableUnits"]
@@ -248,7 +241,6 @@ anchor_mode = 0
 [connection signal="pressed" from="CanvasLayer/SlideOutBar/VBoxContainer/QuitButton" to="." method="_on_QuitButton_pressed"]
 [connection signal="pressed" from="CanvasLayer/ToolBar/MarginContainer/HBoxContainer/AdvisorButton" to="CanvasLayer/Advisor" method="ShowLatestAdvisor"]
 [connection signal="pressed" from="CanvasLayer/ToolBar/MarginContainer/HBoxContainer/UiBarEndTurnButton" to="." method="_onEndTurnButtonPressed"]
-[connection signal="UnitButtonPressed" from="CanvasLayer/UnitButtons" to="." method="UnitButtonPressed"]
 [connection signal="BuildCity" from="CanvasLayer/PopupOverlay" to="." method="OnBuildCity"]
 [connection signal="HidePopup" from="CanvasLayer/PopupOverlay" to="CanvasLayer/PopupOverlay" method="OnHidePopup"]
 [connection signal="Quit" from="CanvasLayer/PopupOverlay" to="." method="OnQuitTheGame"]

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -93,7 +93,7 @@ public partial class Game : Node2D
 			}
 
 			Toolbar = GetNode<Control>("CanvasLayer/ToolBar/MarginContainer/HBoxContainer");
-			Player = GetNode<CharacterBody2D>("CharacterBody2D");
+			// Player = GetNode<CharacterBody2D>("CharacterBody2D");
 			//TODO: What was this supposed to do?  It throws errors and occasinally causes crashes now, because _OnViewportSizeChanged doesn't exist
 			// GetTree().Root.Connect("size_changed",new Callable(this,"_OnViewportSizeChanged"));
 

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -382,26 +382,25 @@ public partial class Game : Node2D {
 							new RightClickTileMenu(this, tile).Open(eventMouseButton.Position);
 
 						string yield = tile.YieldString(controller);
-						//These GD.Print statements are debugging prints for developers to see info about the tile
-						//For now I'm leaving them as GD.Print.  Could revisit this later.
-						GD.Print($"({tile.xCoordinate}, {tile.yCoordinate}): {tile.overlayTerrainType.DisplayName} {yield}");
+						log.Debug($"({tile.xCoordinate}, {tile.yCoordinate}): {tile.overlayTerrainType.DisplayName} {yield}");
 
 						if (tile.cityAtTile != null) {
 							City city = tile.cityAtTile;
-							GD.Print($"  {city.name}, production {city.shieldsStored} of {city.itemBeingProduced.shieldCost}");
+							log.Debug($"  {city.name}, production {city.shieldsStored} of {city.itemBeingProduced.shieldCost}");
 							foreach (CityResident resident in city.residents) {
-								GD.Print($"  Resident working at {resident.tileWorked}");
+								log.Debug($"  Resident working at {resident.tileWorked}");
 							}
 						}
 
 						if (tile.unitsOnTile.Count > 0) {
 							foreach (MapUnit unit in tile.unitsOnTile) {
-								GD.Print("  Unit on tile: " + unit);
-								GD.Print("  Strategy: " + unit.currentAIData);
+								log.Debug("  Unit on tile: " + unit);
+								log.Debug("  Strategy: " + unit.currentAIData);
 							}
 						}
-					} else
-						GD.Print("Didn't click on any tile");
+					} else {
+						log.Debug("Didn't click on any tile");
+					}
 				}
 			}
 		} else if (@event is InputEventMouseMotion eventMouseMotion && IsMovingCamera) {
@@ -425,10 +424,6 @@ public partial class Game : Node2D {
 					}
 				}
 			}
-		} else if (@event is InputEventKey eventKeyUp && !eventKeyUp.Pressed) {
-			if (eventKeyUp.Keycode == Godot.Key.Shift) {
-				SetAnimationsEnabled(true);
-			}
 		} else if (@event is InputEventMagnifyGesture magnifyGesture) {
 			// UI slider has the min/max zoom settings for now
 			VSlider slider = GetNode<VSlider>("CanvasLayer/SlideOutBar/VBoxContainer/Zoom");
@@ -446,7 +441,7 @@ public partial class Game : Node2D {
 	// Handle Godot keybind actions
 	private void processActions() {
 
-		if (Input.IsActionJustPressed("end_turn") && !this.HasCurrentlySelectedUnit()) {
+		if (Input.IsActionJustPressed(C7Action.EndTurn) && !this.HasCurrentlySelectedUnit()) {
 			log.Verbose("end_turn key pressed");
 			this.OnPlayerEndTurn();
 		}
@@ -551,7 +546,7 @@ public partial class Game : Node2D {
 		if (Input.IsActionJustPressed(C7Action.UnitBuildCity) && CurrentlySelectedUnit.canBuildCity()) {
 			using (var gameDataAccess = new UIGameDataAccess()) {
 				MapUnit currentUnit = gameDataAccess.gameData.GetUnit(CurrentlySelectedUnit.guid);
-				GD.Print(currentUnit.Describe());
+				log.Debug(currentUnit.Describe());
 				if (currentUnit.canBuildCity()) {
 					PopupOverlay popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
 					popupOverlay.ShowPopup(new BuildCityDialog(controller.GetNextCityName()),

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -450,21 +450,21 @@ public partial class Game : Node2D {
 			// TODO: replace bool with an invalid TileDirection enum
 			TileDirection dir = TileDirection.NORTH;
 			bool moveUnit = true;
-			if (Input.IsActionJustPressed("move_unit_southwest")) {
+			if (Input.IsActionJustPressed(C7Action.MoveUnitSouthwest)) {
 				dir = TileDirection.SOUTHWEST;
-			} else if (Input.IsActionJustPressed("move_unit_south")) {
+			} else if (Input.IsActionJustPressed(C7Action.MoveUnitSouth)) {
 				dir = TileDirection.SOUTH;
-			} else if (Input.IsActionJustPressed("move_unit_southeast")) {
+			} else if (Input.IsActionJustPressed(C7Action.MoveUnitSoutheast)) {
 				dir = TileDirection.SOUTHEAST;
-			} else if (Input.IsActionJustPressed("move_unit_west")) {
+			} else if (Input.IsActionJustPressed(C7Action.MoveUnitWest)) {
 				dir = TileDirection.WEST;
-			} else if (Input.IsActionJustPressed("move_unit_east")) {
+			} else if (Input.IsActionJustPressed(C7Action.MoveUnitEast)) {
 				dir = TileDirection.EAST;
-			} else if (Input.IsActionJustPressed("move_unit_northwest")) {
+			} else if (Input.IsActionJustPressed(C7Action.MoveUnitNorthwest)) {
 				dir = TileDirection.NORTHWEST;
-			} else if (Input.IsActionJustPressed("move_unit_north")) {
+			} else if (Input.IsActionJustPressed(C7Action.MoveUnitNorth)) {
 				dir = TileDirection.NORTH;
-			} else if (Input.IsActionJustPressed("move_unit_northeast")) {
+			} else if (Input.IsActionJustPressed(C7Action.MoveUnitNortheast)) {
 				dir = TileDirection.NORTHEAST;
 			} else {
 				moveUnit = false;
@@ -475,17 +475,17 @@ public partial class Game : Node2D {
 			}
 		}
 
-		if (Input.IsActionJustPressed("toggle_grid")) {
+		if (Input.IsActionJustPressed(C7Action.ToggleGrid)) {
 			this.mapView.gridLayer.visible = !this.mapView.gridLayer.visible;
 		}
 
-		if (Input.IsActionJustPressed("escape") && !this.inUnitGoToMode) {
+		if (Input.IsActionJustPressed(C7Action.Escape) && !this.inUnitGoToMode) {
 			log.Debug("Got request for escape/quit");
 			PopupOverlay popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
 			popupOverlay.ShowPopup(new EscapeQuitPopup(), PopupOverlay.PopupCategory.Info);
 		}
 
-		if (Input.IsActionJustPressed("toggle_zoom")) {
+		if (Input.IsActionJustPressed(C7Action.ToggleZoom)) {
 			if (mapView.cameraZoom != 1) {
 				mapView.setCameraZoomFromMiddle(1.0f);
 				VSlider slider = GetNode<VSlider>("CanvasLayer/SlideOutBar/VBoxContainer/Zoom");
@@ -497,9 +497,9 @@ public partial class Game : Node2D {
 			}
 		}
 
-		if (Input.IsActionJustPressed("toggle_animations")) {
+		if (Input.IsActionJustPressed(C7Action.ToggleAnimations)) {
 			SetAnimationsEnabled(false);
-		} else if (Input.IsActionJustReleased("toggle_animations")) {
+		} else if (Input.IsActionJustReleased(C7Action.ToggleAnimations)) {
 			SetAnimationsEnabled(true);
 		}
 

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -6,8 +6,7 @@ using C7Engine;
 using C7GameData;
 using Serilog;
 
-public partial class Game : Node2D
-{
+public partial class Game : Node2D {
 	[Signal] public delegate void TurnStartedEventHandler();
 	[Signal] public delegate void TurnEndedEventHandler();
 	[Signal] public delegate void ShowSpecificAdvisorEventHandler();
@@ -33,6 +32,8 @@ public partial class Game : Node2D
 
 	// CurrentlySelectedUnit is a reference directly into the game state so be careful of race conditions. TODO: Consider storing a GUID instead.
 	public MapUnit CurrentlySelectedUnit = MapUnit.NONE; //The selected unit.  May be changed by clicking on a unit or the next unit being auto-selected after orders are given for the current one.
+	private bool HasCurrentlySelectedUnit() => CurrentlySelectedUnit != MapUnit.NONE;
+
 	private bool inUnitGoToMode = false;
 
 	// Normally if the currently selected unit (CSU) becomes fortified, we advance to the next autoselected unit. If this flag is set, we won't do
@@ -42,23 +43,20 @@ public partial class Game : Node2D
 	Control Toolbar;
 	private bool IsMovingCamera;
 	private Vector2 OldPosition;
-	private CharacterBody2D Player;
 
 	Stopwatch loadTimer = new Stopwatch();
 	GlobalSingleton Global;
 
 	bool errorOnLoad = false;
 
-	public override void _EnterTree()
-	{
+	public override void _EnterTree() {
 		loadTimer.Start();
 	}
 
 	// Called when the node enters the scene tree for the first time.
 	// The catch should always catch any error, as it's the general catch
 	// that gives an error if we fail to load for some reason.
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		Global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
 		try {
 			var animSoundPlayer = new AudioStreamPlayer();
@@ -86,14 +84,14 @@ public partial class Game : Node2D
 					if (capital != null)
 						mapView.centerCameraOnTile(capital.location);
 				} else {
-					MapUnit startingSettler = controller.units.Find(u => u.unitType.actions.Contains("buildCity"));
+					MapUnit startingSettler = controller.units.Find(u => u.unitType.actions.Contains(C7Action.UnitBuildCity));
 					if (startingSettler != null)
 						mapView.centerCameraOnTile(startingSettler.location);
 				}
 			}
 
 			Toolbar = GetNode<Control>("CanvasLayer/ToolBar/MarginContainer/HBoxContainer");
-			// Player = GetNode<CharacterBody2D>("CharacterBody2D");
+
 			//TODO: What was this supposed to do?  It throws errors and occasinally causes crashes now, because _OnViewportSizeChanged doesn't exist
 			// GetTree().Root.Connect("size_changed",new Callable(this,"_OnViewportSizeChanged"));
 
@@ -105,12 +103,11 @@ public partial class Game : Node2D
 			loadTimer.Stop();
 			TimeSpan stopwatchElapsed = loadTimer.Elapsed;
 			log.Information("Game scene load time: " + Convert.ToInt32(stopwatchElapsed.TotalMilliseconds) + " ms");
-		}
-		catch(Exception ex) {
+		} catch (Exception ex) {
 			errorOnLoad = true;
 			PopupOverlay popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
 			string message = ex.Message;
-			string[] stack = ex.StackTrace.Split("\r\n");	//for some reason it is returned with \r\n in the string as one line.  let's make it readable!
+			string[] stack = ex.StackTrace.Split("\r\n");   //for some reason it is returned with \r\n in the string as one line.  let's make it readable!
 			foreach (string line in stack) {
 				message = message + "\r\n" + line;
 			}
@@ -121,41 +118,40 @@ public partial class Game : Node2D
 	}
 
 	// Must only be called while holding the game data mutex
-	public void processEngineMessages(GameData gameData)
-	{
+	public void processEngineMessages(GameData gameData) {
 		MessageToUI msg;
 		while (EngineStorage.messagesToUI.TryDequeue(out msg)) {
 			switch (msg) {
-			case MsgStartUnitAnimation mSUA:
-				MapUnit unit = gameData.GetUnit(mSUA.unitGUID);
-				if (unit != null && (controller.tileKnowledge.isTileKnown(unit.location) || controller.tileKnowledge.isTileKnown(unit.previousLocation))) {
-					// TODO: This needs to be extended so that the player is shown when AIs found cities, when they move units
-					// (optionally, depending on preferences) and generalized so that modders can specify whether custom
-					// animations should be shown to the player.
-					if (mSUA.action == MapUnit.AnimatedAction.ATTACK1)
-						ensureLocationIsInView(unit.location);
+				case MsgStartUnitAnimation mSUA:
+					MapUnit unit = gameData.GetUnit(mSUA.unitGUID);
+					if (unit != null && (controller.tileKnowledge.isTileKnown(unit.location) || controller.tileKnowledge.isTileKnown(unit.previousLocation))) {
+						// TODO: This needs to be extended so that the player is shown when AIs found cities, when they move units
+						// (optionally, depending on preferences) and generalized so that modders can specify whether custom
+						// animations should be shown to the player.
+						if (mSUA.action == MapUnit.AnimatedAction.ATTACK1)
+							ensureLocationIsInView(unit.location);
 
-					animTracker.startAnimation(unit, mSUA.action, mSUA.completionEvent, mSUA.ending);
-				} else {
-					if (mSUA.completionEvent != null) {
-						mSUA.completionEvent.Set();
+						animTracker.startAnimation(unit, mSUA.action, mSUA.completionEvent, mSUA.ending);
+					} else {
+						if (mSUA.completionEvent != null) {
+							mSUA.completionEvent.Set();
+						}
 					}
-				}
-				break;
-			case MsgStartEffectAnimation mSEA:
-				int x, y;
-				gameData.map.tileIndexToCoords(mSEA.tileIndex, out x, out y);
-				Tile tile = gameData.map.tileAt(x, y);
-				if (tile != Tile.NONE && controller.tileKnowledge.isTileKnown(tile))
-					animTracker.startAnimation(tile, mSEA.effect, mSEA.completionEvent, mSEA.ending);
-				else {
-					if (mSEA.completionEvent != null)
-						mSEA.completionEvent.Set();
-				}
-				break;
-			case MsgStartTurn mST:
-				OnPlayerStartTurn();
-				break;
+					break;
+				case MsgStartEffectAnimation mSEA:
+					int x, y;
+					gameData.map.tileIndexToCoords(mSEA.tileIndex, out x, out y);
+					Tile tile = gameData.map.tileAt(x, y);
+					if (tile != Tile.NONE && controller.tileKnowledge.isTileKnown(tile))
+						animTracker.startAnimation(tile, mSEA.effect, mSEA.completionEvent, mSEA.ending);
+					else {
+						if (mSEA.completionEvent != null)
+							mSEA.completionEvent.Set();
+					}
+					break;
+				case MsgStartTurn mST:
+					OnPlayerStartTurn();
+					break;
 			}
 		}
 	}
@@ -164,14 +160,14 @@ public partial class Game : Node2D
 	// the animations up to date. Right now it's called from UnitLayer right before it draws the units on the map. This method also processes all
 	// waiting messages b/c some of them might pertain to animations. TODO: Consider processing only the animation messages here.
 	// Must only be called while holding the game data mutex
-	public void updateAnimations(GameData gameData)
-	{
+	public void updateAnimations(GameData gameData) {
 		processEngineMessages(gameData);
 		animTracker.update();
 	}
 
-	public override void _Process(double delta)
-	{
+	public override void _Process(double delta) {
+		this.processActions();
+
 		// TODO: Is it necessary to keep the game data mutex locked for this entire method?
 		using (var gameDataAccess = new UIGameDataAccess()) {
 			GameData gameData = gameDataAccess.gameData;
@@ -181,15 +177,15 @@ public partial class Game : Node2D
 			if (!errorOnLoad) {
 				if (CurrentState == GameState.PlayerTurn) {
 					// If the selected unit is unfortified, prepare to autoselect the next one if it becomes fortified
-					if ((CurrentlySelectedUnit != MapUnit.NONE) && (! CurrentlySelectedUnit.isFortified))
+					if ((CurrentlySelectedUnit != MapUnit.NONE) && (!CurrentlySelectedUnit.isFortified))
 						KeepCSUWhenFortified = false;
 
 					// Advance off the currently selected unit to the next one if it's out of moves or HP and not playing an
 					// animation we want to watch, or if it's fortified and we aren't set to keep fortified units selected.
 					if ((CurrentlySelectedUnit != MapUnit.NONE) &&
 						(((!CurrentlySelectedUnit.movementPoints.canMove || CurrentlySelectedUnit.hitPointsRemaining <= 0) &&
-						  ! animTracker.getUnitAppearance(CurrentlySelectedUnit).DeservesPlayerAttention()) ||
-						 (CurrentlySelectedUnit.isFortified && ! KeepCSUWhenFortified)))
+						  !animTracker.getUnitAppearance(CurrentlySelectedUnit).DeservesPlayerAttention()) ||
+						 (CurrentlySelectedUnit.isFortified && !KeepCSUWhenFortified)))
 						GetNextAutoselectedUnit(gameData);
 				}
 				//Listen to keys.  There is a C# Mono Godot bug where e.g. Godot.Key.F1 (etc.) doesn't work
@@ -205,8 +201,7 @@ public partial class Game : Node2D
 	// This is the terrain generator that used to be part of TerrainAsTileMap. Now it gets passed to and called from generateDummyGameMap so that
 	// function can be more in charge of terrain generation. Eventually we'll want generation to be part of the engine not the UI but we can't
 	// simply move this function there right now since we don't want the engine to depend on Godot.
-	public int[,] genBasicTerrainNoiseMap(int seed, int mapWidth, int mapHeight)
-	{
+	public int[,] genBasicTerrainNoiseMap(int seed, int mapWidth, int mapHeight) {
 		var tr = new int[mapWidth,mapHeight];
 		Godot.FastNoiseLite noise = new Godot.FastNoiseLite();
 		noise.Seed = seed;
@@ -215,15 +210,14 @@ public partial class Game : Node2D
 			for (int x = 0; x < mapWidth; x++) {
 				// Multiplying x & y for noise coordinate sampling
 				float n = noise.GetNoise2D(x*2,y*2);
-				tr[x,y] = n < 0.1 ? 2 : n < 0.4? 1 : 0;
+				tr[x, y] = n < 0.1 ? 2 : n < 0.4 ? 1 : 0;
 			}
 		}
 		return tr;
 	}
 
 	// If "location" is not already near the center of the screen, moves the camera to bring it into view.
-	public void ensureLocationIsInView(Tile location)
-	{
+	public void ensureLocationIsInView(Tile location) {
 		if (controller.tileKnowledge.isTileKnown(location) && location != Tile.NONE) {
 			Vector2 relativeScreenLocation = mapView.screenLocationOfTile(location, true) / mapView.getVisibleAreaSize();
 			if (relativeScreenLocation.DistanceTo(new Vector2((float)0.5, (float)0.5)) > 0.30)
@@ -231,10 +225,9 @@ public partial class Game : Node2D
 		}
 	}
 
-	public void SetAnimationsEnabled(bool enabled)
-	{
+	public void SetAnimationsEnabled(bool enabled) {
 		new MsgSetAnimationsEnabled(enabled).send();
-		animTracker.endAllImmediately = ! enabled;
+		animTracker.endAllImmediately = !enabled;
 	}
 
 	/**
@@ -242,8 +235,7 @@ public partial class Game : Node2D
 	 * Both code paths are in Game.cs for now, so it's local, but we may
 	 * want to change it event driven.
 	 **/
-	public void setSelectedUnit(MapUnit unit)
-	{
+	public void setSelectedUnit(MapUnit unit) {
 		unit = UnitInteractions.UnitWithAvailableActions(unit);
 
 		if ((unit.path?.PathLength() ?? -1) > 0) {
@@ -258,30 +250,24 @@ public partial class Game : Node2D
 			ensureLocationIsInView(unit.location);
 		}
 
-		//Also emit the signal for a new unit being selected, so other areas such as Game Status and Unit Buttons can update
+		// Also emit the signal for a new unit being selected, so other areas such as Game Status and Unit Buttons can update
 		if (CurrentlySelectedUnit != MapUnit.NONE) {
 			ParameterWrapper wrappedUnit = new ParameterWrapper(CurrentlySelectedUnit);
 			EmitSignal("NewAutoselectedUnit", wrappedUnit);
-		}
-		else {
+		} else {
 			EmitSignal("NoMoreAutoselectableUnits");
 		}
 	}
 
-	private void _onEndTurnButtonPressed()
-	{
-		if (CurrentState == GameState.PlayerTurn)
-		{
+	private void _onEndTurnButtonPressed() {
+		if (CurrentState == GameState.PlayerTurn) {
 			OnPlayerEndTurn();
-		}
-		else
-		{
+		} else {
 			log.Information("It's not your turn!");
 		}
 	}
 
-	private void OnPlayerStartTurn()
-	{
+	private void OnPlayerStartTurn() {
 		log.Information("Starting player turn");
 		int turnNumber = TurnHandling.GetTurnNumber();
 		EmitSignal("TurnStarted", turnNumber);
@@ -292,10 +278,8 @@ public partial class Game : Node2D
 		}
 	}
 
-	private void OnPlayerEndTurn()
-	{
-		if (CurrentState == GameState.PlayerTurn)
-		{
+	private void OnPlayerEndTurn() {
+		if (CurrentState == GameState.PlayerTurn) {
 			log.Information("Ending player turn");
 			EmitSignal("TurnEnded");
 			log.Information("Starting computer turn");
@@ -304,8 +288,7 @@ public partial class Game : Node2D
 		}
 	}
 
-	public void _on_QuitButton_pressed()
-	{
+	public void _on_QuitButton_pressed() {
 		// This apparently exits the whole program
 		// GetTree().Quit();
 
@@ -313,13 +296,11 @@ public partial class Game : Node2D
 		GetTree().ChangeSceneToFile("res://MainMenu.tscn");
 	}
 
-	public void _on_Zoom_value_changed(float value)
-	{
+	public void _on_Zoom_value_changed(float value) {
 		mapView.setCameraZoomFromMiddle(value);
 	}
 
-	public void AdjustZoomSlider(int numSteps, Vector2 zoomCenter)
-	{
+	public void AdjustZoomSlider(int numSteps, Vector2 zoomCenter) {
 		VSlider slider = GetNode<VSlider>("CanvasLayer/SlideOutBar/VBoxContainer/Zoom");
 		double newScale = slider.Value + slider.Step * (double)numSteps;
 		if (newScale < slider.MinValue)
@@ -333,34 +314,31 @@ public partial class Game : Node2D
 		slider.Value = newScale;
 	}
 
-	public void _on_RightButton_pressed()
-	{
+	public void _on_RightButton_pressed() {
 		mapView.cameraLocation += new Vector2(128, 0);
 	}
-	public void _on_LeftButton_pressed()
-	{
+	public void _on_LeftButton_pressed() {
 		mapView.cameraLocation += new Vector2(-128, 0);
 	}
-	public void _on_UpButton_pressed()
-	{
+	public void _on_UpButton_pressed() {
 		mapView.cameraLocation += new Vector2(0, -64);
 	}
-	public void _on_DownButton_pressed()
-	{
+	public void _on_DownButton_pressed() {
 		mapView.cameraLocation += new Vector2(0, 64);
 	}
 
-	public override void _UnhandledInput(InputEvent @event)
-	{
-		// Scrolls map by repositioning "Player" when clicking & dragging mouse
+	public override void _Input(InputEvent @event) {
+		if (@event is InputEventKey e && e.Pressed && !e.IsAction(C7Action.UnitGoto)) {
+			this.setGoToMode(false);
+		}
+	}
+
+	public override void _UnhandledInput(InputEvent @event) {
 		// Control node must not be in the way and/or have mouse pass enabled
-		if(@event is InputEventMouseButton eventMouseButton)
-		{
-			if(eventMouseButton.ButtonIndex == MouseButton.Left)
-			{
+		if (@event is InputEventMouseButton eventMouseButton) {
+			if (eventMouseButton.ButtonIndex == MouseButton.Left) {
 				GetViewport().SetInputAsHandled();
-				if(eventMouseButton.IsPressed())
-				{
+				if (eventMouseButton.IsPressed()) {
 					if (inUnitGoToMode) {
 						setGoToMode(false);
 						using (var gameDataAccess = new UIGameDataAccess()) {
@@ -369,9 +347,7 @@ public partial class Game : Node2D
 								new MsgSetUnitPath(CurrentlySelectedUnit.guid, tile).send();
 							}
 						}
-					}
-					else
-					{
+					} else {
 						// Select unit on tile at mouse location
 						using (var gameDataAccess = new UIGameDataAccess()) {
 							var tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
@@ -385,24 +361,16 @@ public partial class Game : Node2D
 						OldPosition = eventMouseButton.Position;
 						IsMovingCamera = true;
 					}
-				}
-				else
-				{
+				} else {
 					IsMovingCamera = false;
 				}
-			}
-			else if(eventMouseButton.ButtonIndex == MouseButton.WheelUp)
-			{
+			} else if (eventMouseButton.ButtonIndex == MouseButton.WheelUp) {
 				GetViewport().SetInputAsHandled();
 				AdjustZoomSlider(1, GetViewport().GetMousePosition());
-			}
-			else if(eventMouseButton.ButtonIndex == MouseButton.WheelDown)
-			{
+			} else if (eventMouseButton.ButtonIndex == MouseButton.WheelDown) {
 				GetViewport().SetInputAsHandled();
 				AdjustZoomSlider(-1, GetViewport().GetMousePosition());
-			}
-			else if ((eventMouseButton.ButtonIndex == MouseButton.Right) && (!eventMouseButton.IsPressed()))
-			{
+			} else if ((eventMouseButton.ButtonIndex == MouseButton.Right) && (!eventMouseButton.IsPressed())) {
 				setGoToMode(false);
 				using (var gameDataAccess = new UIGameDataAccess()) {
 					var tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
@@ -410,7 +378,7 @@ public partial class Game : Node2D
 						bool shiftDown = Input.IsKeyPressed(Godot.Key.Shift);
 						if (shiftDown && tile.cityAtTile?.owner == controller)
 							new RightClickChooseProductionMenu(this, tile.cityAtTile).Open(eventMouseButton.Position);
-						else if ((! shiftDown) && tile.unitsOnTile.Count > 0)
+						else if ((!shiftDown) && tile.unitsOnTile.Count > 0)
 							new RightClickTileMenu(this, tile).Open(eventMouseButton.Position);
 
 						string yield = tile.YieldString(controller);
@@ -436,108 +404,12 @@ public partial class Game : Node2D
 						GD.Print("Didn't click on any tile");
 				}
 			}
-		}
-		else if(@event is InputEventMouseMotion eventMouseMotion)
-		{
-			if(IsMovingCamera)
-			{
-				GetViewport().SetInputAsHandled();
-				mapView.cameraLocation += OldPosition - eventMouseMotion.Position;
-				OldPosition = eventMouseMotion.Position;
-			}
-		}
-		else if (@event is InputEventKey eventKeyDown && eventKeyDown.Pressed)
-		{
-			if (eventKeyDown.Keycode == Godot.Key.Enter)
-			{
-				log.Verbose("Enter pressed");
-				if (CurrentlySelectedUnit == MapUnit.NONE)
-				{
-					this.OnPlayerEndTurn();
-				}
-				else {
-					log.Debug("There is a " + CurrentlySelectedUnit.unitType.name + " selected; not ending turn");
-				}
-			}
-			else if (eventKeyDown.Keycode == Godot.Key.Space)
-			{
-				log.Verbose("Space pressed");
-				if (CurrentlySelectedUnit == MapUnit.NONE)
-				{
-					this.OnPlayerEndTurn();
-				}
-			}
-			else if ((eventKeyDown.Keycode >= Godot.Key.Kp1) && (eventKeyDown.Keycode <= Godot.Key.Kp9))
-			{ // Move units with the numpad keys
-				if (CurrentlySelectedUnit != MapUnit.NONE)
-				{
-					TileDirection dir;
-					switch (eventKeyDown.Keycode - Godot.Key.Kp0) {
-					case 1: dir = TileDirection.SOUTHWEST; break;
-					case 2: dir = TileDirection.SOUTH;     break;
-					case 3: dir = TileDirection.SOUTHEAST; break;
-					case 4: dir = TileDirection.WEST;      break;
-					case 5: return; // Key pad 5 => don't move
-					case 6: dir = TileDirection.EAST;      break;
-					case 7: dir = TileDirection.NORTHWEST; break;
-					case 8: dir = TileDirection.NORTH;     break;
-					case 9: dir = TileDirection.NORTHEAST; break;
-					default: return; // Impossible
-					}
-					new MsgMoveUnit(CurrentlySelectedUnit.guid, dir).send();
-					setSelectedUnit(CurrentlySelectedUnit);	//also triggers updating the lower-left info box
-				}
-			}
-			else if ((eventKeyDown.Keycode >= Godot.Key.Home) && (eventKeyDown.Keycode <= Godot.Key.Pagedown))
-			{ // Move units with the arrow and fn keys
-				if (CurrentlySelectedUnit != MapUnit.NONE)
-				{
-					TileDirection dir;
-					switch (eventKeyDown.Keycode) {
-					case Godot.Key.Home:     dir = TileDirection.NORTHWEST; break; // fn-left arrow
-					case Godot.Key.End:      dir = TileDirection.SOUTHWEST; break; // fn-right arrow
-					case Godot.Key.Left:     dir = TileDirection.WEST;      break;
-					case Godot.Key.Up:       dir = TileDirection.NORTH;     break;
-					case Godot.Key.Right:    dir = TileDirection.EAST;      break;
-					case Godot.Key.Down:     dir = TileDirection.SOUTH;     break;
-					case Godot.Key.Pageup:   dir = TileDirection.NORTHEAST; break; // fn-up arrow
-					case Godot.Key.Pagedown: dir = TileDirection.SOUTHEAST; break; // fn-down arrow
-					default: return; // Impossible
-					}
-					new MsgMoveUnit(CurrentlySelectedUnit.guid, dir).send();
-					setSelectedUnit(CurrentlySelectedUnit);	//also triggers updating the lower-left info box
-				}
-			}
-			else if (eventKeyDown.Keycode == Godot.Key.G && eventKeyDown.IsCommandOrControlPressed())
-			{
-				mapView.gridLayer.visible = !mapView.gridLayer.visible;
-			}
-			else if (eventKeyDown.Keycode == Godot.Key.Escape)
-			{
-				if (!inUnitGoToMode) {
-					log.Debug("Got request for escape/quit");
-					PopupOverlay popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
-					popupOverlay.ShowPopup(new EscapeQuitPopup(), PopupOverlay.PopupCategory.Info);
-				}
-			}
-			else if (eventKeyDown.Keycode == Godot.Key.Z)
-			{
-				if (mapView.cameraZoom != 1) {
-					mapView.setCameraZoomFromMiddle(1.0f);
-					VSlider slider = GetNode<VSlider>("CanvasLayer/SlideOutBar/VBoxContainer/Zoom");
-					slider.Value = 1.0f;
-				}
-				else {
-					mapView.setCameraZoomFromMiddle(0.5f);
-					VSlider slider = GetNode<VSlider>("CanvasLayer/SlideOutBar/VBoxContainer/Zoom");
-					slider.Value = 0.5f;
-				}
-			}
-			else if (eventKeyDown.Keycode == Godot.Key.Shift && ! eventKeyDown.Echo)
-			{
-				SetAnimationsEnabled(false);
-			}
-			else if (eventKeyDown.Keycode == Godot.Key.O && eventKeyDown.ShiftPressed && eventKeyDown.IsCommandOrControlPressed() && eventKeyDown.AltPressed) {
+		} else if (@event is InputEventMouseMotion eventMouseMotion && IsMovingCamera) {
+			GetViewport().SetInputAsHandled();
+			mapView.cameraLocation += OldPosition - eventMouseMotion.Position;
+			OldPosition = eventMouseMotion.Position;
+		} else if (@event is InputEventKey eventKeyDown && eventKeyDown.Pressed) {
+			if (eventKeyDown.Keycode == Godot.Key.O && eventKeyDown.ShiftPressed && eventKeyDown.IsCommandOrControlPressed() && eventKeyDown.AltPressed) {
 				using (UIGameDataAccess gameDataAccess = new UIGameDataAccess()) {
 					gameDataAccess.gameData.observerMode = !gameDataAccess.gameData.observerMode;
 					if (gameDataAccess.gameData.observerMode) {
@@ -553,20 +425,11 @@ public partial class Game : Node2D
 					}
 				}
 			}
-
-			// always turn off go to mode unless G key is pressed
-			// do this after processing esc key
-			setGoToMode(eventKeyDown.Keycode == Godot.Key.G);
-		}
-		else if (@event is InputEventKey eventKeyUp && ! eventKeyUp.Pressed)
-		{
-			if (eventKeyUp.Keycode == Godot.Key.Shift)
-			{
+		} else if (@event is InputEventKey eventKeyUp && !eventKeyUp.Pressed) {
+			if (eventKeyUp.Keycode == Godot.Key.Shift) {
 				SetAnimationsEnabled(true);
 			}
-		}
-		else if (@event is InputEventMagnifyGesture magnifyGesture)
-		{
+		} else if (@event is InputEventMagnifyGesture magnifyGesture) {
 			// UI slider has the min/max zoom settings for now
 			VSlider slider = GetNode<VSlider>("CanvasLayer/SlideOutBar/VBoxContainer/Zoom");
 			double newScale = mapView.cameraZoom * magnifyGesture.Factor;
@@ -580,107 +443,159 @@ public partial class Game : Node2D
 		}
 	}
 
-	private void GetNextAutoselectedUnit(GameData gameData)
-	{
-		this.setSelectedUnit(UnitInteractions.getNextSelectedUnit(gameData));
-	}
+	// Handle Godot keybind actions
+	private void processActions() {
 
-	private void setGoToMode(bool isOn)
-	{
-		inUnitGoToMode = isOn;
-	}
+		if (Input.IsActionJustPressed("end_turn") && !this.HasCurrentlySelectedUnit()) {
+			log.Verbose("end_turn key pressed");
+			this.OnPlayerEndTurn();
+		}
 
-	///This is our global handler for unit buttons being pressed.  Both the mouse clicks and
-	///the keyboard shortcuts should wind up here.
-	///Eventually, we should quite possibly put this somewhere other than Game.cs, or at
-	///least the logic should be somewhere else.  I want to see how it looks with a couple
-	///more things going on before figuring out what the 'right' thing is, though.
-	private void UnitButtonPressed(string buttonName)
-	{
-		// this will detoggle goTo when clicking unit buttons
-		// other than goTo
-		setGoToMode(buttonName == "goTo");
+		if (this.HasCurrentlySelectedUnit()) {
+			// TODO: replace bool with an invalid TileDirection enum
+			TileDirection dir = TileDirection.NORTH;
+			bool moveUnit = true;
+			if (Input.IsActionJustPressed("move_unit_southwest")) {
+				dir = TileDirection.SOUTHWEST;
+			} else if (Input.IsActionJustPressed("move_unit_south")) {
+				dir = TileDirection.SOUTH;
+			} else if (Input.IsActionJustPressed("move_unit_southeast")) {
+				dir = TileDirection.SOUTHEAST;
+			} else if (Input.IsActionJustPressed("move_unit_west")) {
+				dir = TileDirection.WEST;
+			} else if (Input.IsActionJustPressed("move_unit_east")) {
+				dir = TileDirection.EAST;
+			} else if (Input.IsActionJustPressed("move_unit_northwest")) {
+				dir = TileDirection.NORTHWEST;
+			} else if (Input.IsActionJustPressed("move_unit_north")) {
+				dir = TileDirection.NORTH;
+			} else if (Input.IsActionJustPressed("move_unit_northeast")) {
+				dir = TileDirection.NORTHEAST;
+			} else {
+				moveUnit = false;
+			}
+			if (moveUnit) {
+				new MsgMoveUnit(CurrentlySelectedUnit.guid, dir).send();
+				setSelectedUnit(CurrentlySelectedUnit); //also triggers updating the lower-left info box
+			}
+		}
 
-		log.Verbose("The " + buttonName + " button was pressed");
-		switch (buttonName) {
-		case "hold":
+		if (Input.IsActionJustPressed("toggle_grid")) {
+			this.mapView.gridLayer.visible = !this.mapView.gridLayer.visible;
+		}
+
+		if (Input.IsActionJustPressed("escape") && !this.inUnitGoToMode) {
+			log.Debug("Got request for escape/quit");
+			PopupOverlay popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
+			popupOverlay.ShowPopup(new EscapeQuitPopup(), PopupOverlay.PopupCategory.Info);
+		}
+
+		if (Input.IsActionJustPressed("toggle_zoom")) {
+			if (mapView.cameraZoom != 1) {
+				mapView.setCameraZoomFromMiddle(1.0f);
+				VSlider slider = GetNode<VSlider>("CanvasLayer/SlideOutBar/VBoxContainer/Zoom");
+				slider.Value = 1.0f;
+			} else {
+				mapView.setCameraZoomFromMiddle(0.5f);
+				VSlider slider = GetNode<VSlider>("CanvasLayer/SlideOutBar/VBoxContainer/Zoom");
+				slider.Value = 0.5f;
+			}
+		}
+
+		if (Input.IsActionJustPressed("toggle_animations")) {
+			SetAnimationsEnabled(false);
+		} else if (Input.IsActionJustReleased("toggle_animations")) {
+			SetAnimationsEnabled(true);
+		}
+
+		// actions with unit buttons
+		if (Input.IsActionJustPressed(C7Action.UnitHold)) {
 			new MsgSkipUnitTurn(CurrentlySelectedUnit.guid).send();
-			break;
+		}
 
-		case "fortify":
-			new MsgSetFortification(CurrentlySelectedUnit.guid, true).send();
-			break;
-
-		case "wait":
+		if (Input.IsActionJustPressed(C7Action.UnitWait)) {
 			using (var gameDataAccess = new UIGameDataAccess()) {
 				UnitInteractions.waitUnit(gameDataAccess.gameData, CurrentlySelectedUnit.guid);
 				GetNextAutoselectedUnit(gameDataAccess.gameData);
 			}
-			break;
+		}
 
-		case "disband":
-			{
-				PopupOverlay popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
-				popupOverlay.ShowPopup(new DisbandConfirmation(CurrentlySelectedUnit), PopupOverlay.PopupCategory.Advisor);
-			}
-			break;
+		if (Input.IsActionJustPressed(C7Action.UnitFortify)) {
+			new MsgSetFortification(CurrentlySelectedUnit.guid, true).send();
+		}
 
-		case "buildCity":
+		if (Input.IsActionJustPressed(C7Action.UnitDisband)) {
+			PopupOverlay popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
+			popupOverlay.ShowPopup(new DisbandConfirmation(CurrentlySelectedUnit), PopupOverlay.PopupCategory.Advisor);
+		}
+
+		// unit_goto's behavior is more complicated than other actions - it
+		// toggles the go to state, but must be detoggled in _*Input methods if
+		// it is not the input being pressed.
+		if (Input.IsActionJustPressed(C7Action.UnitGoto)) {
+			setGoToMode(true);
+		}
+
+		if (Input.IsActionJustPressed(C7Action.UnitExplore)) {
+			// unimplemented
+		}
+
+		if (Input.IsActionJustPressed(C7Action.UnitSentry)) {
+			// unimplemented
+		}
+
+		if (Input.IsActionJustPressed(C7Action.UnitSentryEnemyOnly)) {
+			// unimplemented
+		}
+
+		if (Input.IsActionJustPressed(C7Action.UnitBuildCity) && CurrentlySelectedUnit.canBuildCity()) {
 			using (var gameDataAccess = new UIGameDataAccess()) {
 				MapUnit currentUnit = gameDataAccess.gameData.GetUnit(CurrentlySelectedUnit.guid);
+				GD.Print(currentUnit.Describe());
 				if (currentUnit.canBuildCity()) {
 					PopupOverlay popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
 					popupOverlay.ShowPopup(new BuildCityDialog(controller.GetNextCityName()),
 						PopupOverlay.PopupCategory.Advisor);
 				}
 			}
-			break;
-
-		case "buildRoad":
-			if (CurrentlySelectedUnit.canBuildRoad()) {
-				new MsgBuildRoad(CurrentlySelectedUnit.guid).send();
-			}
-			break;
-
-		case "goTo":
-			break;
-
-		default:
-			//A nice sanity check if I use a different name here than where I created it...
-			log.Warning("An unrecognized button " + buttonName + " was pressed");
-			break;
 		}
+
+		if (Input.IsActionJustPressed(C7Action.UnitBuildRoad) && CurrentlySelectedUnit.canBuildRoad()) {
+			new MsgBuildRoad(CurrentlySelectedUnit.guid).send();
+		}
+
 	}
 
-	private void _on_SlideToggle_toggled(bool buttonPressed)
-	{
-		if (buttonPressed)
-		{
+	private void GetNextAutoselectedUnit(GameData gameData) {
+		this.setSelectedUnit(UnitInteractions.getNextSelectedUnit(gameData));
+	}
+
+	private void setGoToMode(bool isOn) {
+		inUnitGoToMode = isOn;
+	}
+
+	private void _on_SlideToggle_toggled(bool buttonPressed) {
+		if (buttonPressed) {
 			GetNode<AnimationPlayer>("CanvasLayer/SlideOutBar/AnimationPlayer").PlayBackwards("SlideOutAnimation");
-		}
-		else
-		{
+		} else {
 			GetNode<AnimationPlayer>("CanvasLayer/SlideOutBar/AnimationPlayer").Play("SlideOutAnimation");
 		}
 	}
 
 	// Called by the disband popup
-	private void OnUnitDisbanded()
-	{
+	private void OnUnitDisbanded() {
 		new MsgDisbandUnit(CurrentlySelectedUnit.guid).send();
 	}
 
 	/**
 	 * User quit.  We *may* want to do some things here like make a back-up save, or call the server and let it know we're bailing (esp. in MP).
 	 **/
-	private void OnQuitTheGame()
-	{
+	private void OnQuitTheGame() {
 		log.Information("Goodbye!");
 		GetTree().Quit();
 	}
 
-	private void OnBuildCity(string name)
-	{
+	private void OnBuildCity(string name) {
 		new MsgBuildCity(CurrentlySelectedUnit.guid, name).send();
 	}
 }

--- a/C7/PlayerController.gd
+++ b/C7/PlayerController.gd
@@ -1,6 +1,0 @@
-extends CharacterBody2D
-
-var game = get_owner()
-
-func _physics_process(_delta):
-	pass

--- a/C7/PlayerController.gd
+++ b/C7/PlayerController.gd
@@ -1,0 +1,6 @@
+extends CharacterBody2D
+
+var game = get_owner()
+
+func _physics_process(_delta):
+	pass

--- a/C7/UIElements/UnitButtons/RenameButton.cs
+++ b/C7/UIElements/UnitButtons/RenameButton.cs
@@ -10,6 +10,6 @@ public partial class RenameButton : TextureButton
 		Pcx buttonPcx = new Pcx(Util.Civ3MediaPath("Conquests/Art/interface/NormButtons.PCX"));
 		Pcx buttonPcxAlpha = new Pcx(Util.Civ3MediaPath("Conquests/Art/interface/ButtonAlpha.pcx"));
 		ImageTexture menuTexture = PCXToGodot.getImageFromPCXWithAlphaBlend(buttonPcx, buttonPcxAlpha, 64, 224, 32, 32);
-		this.TextureNormal = menuTexture;		
+		this.TextureNormal = menuTexture;
 	}
 }

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -74,8 +74,6 @@ public partial class UnitButtons : VBoxContainer {
 	}
 
 	private void onButtonPressed(string action) {
-		GD.Print("pressed " + action);
-		log.Debug("pressed button " + action);
 		Input.ActionPress(action);
 	}
 

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -3,12 +3,15 @@ using System.Collections.Generic;
 using C7GameData;
 using Serilog;
 
-public partial class UnitButtons : VBoxContainer
-{
+/*
+ UnitButtons contains the buttons at the bottom of the game UI when viewing the
+ map, and control unit actions. Clicking buttons triggers Input.ActionPress
+ calls which are checked and handled in Game.processActions.
+*/
+
+public partial class UnitButtons : VBoxContainer {
 
 	private ILogger log = LogManager.ForContext<UnitButtons>();
-
-	[Signal] public delegate void UnitButtonPressedEventHandler(string button);
 
 	private Dictionary<string, UnitControlButton> buttonMap = new Dictionary<string, UnitControlButton>();
 	HBoxContainer primaryControls;
@@ -16,23 +19,22 @@ public partial class UnitButtons : VBoxContainer
 	HBoxContainer advancedControls;
 
 	// Called when the node enters the scene tree for the first time.
-	public override void _Ready()
-	{
-		//You can hide buttons like this.  This will come in handy later!
-		//Remember to re-calc the margin after hiding/unhiding buttons, as that may affect the width.
-		//this.GetNode<FortifyButton>("PrimaryUnitControls/FortifyButton").Hide();
+	public override void _Ready() {
+		// You can hide buttons like this.  This will come in handy later!
+		// Remember to re-calc the margin after hiding/unhiding buttons, as that may affect the width.
+		// this.GetNode<FortifyButton>("PrimaryUnitControls/FortifyButton").Hide();
 
 		primaryControls = GetNode<HBoxContainer>("PrimaryUnitControls");
 		specializedControls = GetNode<HBoxContainer>("SpecializedUnitControls");
 
-		AddNewButton(primaryControls, new UnitControlButton("hold", Godot.Key.Space, 0, 0, onButtonPressed));
-		AddNewButton(primaryControls, new UnitControlButton("wait", Godot.Key.W,  1, 0, onButtonPressed));
-		AddNewButton(primaryControls, new UnitControlButton("fortify", Godot.Key.F,  2, 0, onButtonPressed));
-		AddNewButton(primaryControls, new UnitControlButton("disband", Godot.Key.D, 3, 0, onButtonPressed));
-		AddNewButton(primaryControls, new UnitControlButton("goTo", Godot.Key.G, 4, 0, onButtonPressed));
-		AddNewButton(primaryControls, new UnitControlButton("explore", 5, 0, onButtonPressed));
-		AddNewButton(primaryControls, new UnitControlButton("sentry", 6, 0, onButtonPressed));
-		AddNewButton(primaryControls, new UnitControlButton("sentryEnemyOnly", 2, 5, onButtonPressed));
+		AddNewButton(primaryControls, new UnitControlButton(C7Action.UnitHold, 0, 0, onButtonPressed));
+		AddNewButton(primaryControls, new UnitControlButton(C7Action.UnitWait, 1, 0, onButtonPressed));
+		AddNewButton(primaryControls, new UnitControlButton(C7Action.UnitFortify, 2, 0, onButtonPressed));
+		AddNewButton(primaryControls, new UnitControlButton(C7Action.UnitDisband, 3, 0, onButtonPressed));
+		AddNewButton(primaryControls, new UnitControlButton(C7Action.UnitGoto, 4, 0, onButtonPressed));
+		AddNewButton(primaryControls, new UnitControlButton(C7Action.UnitExplore, 5, 0, onButtonPressed));
+		AddNewButton(primaryControls, new UnitControlButton(C7Action.UnitSentry, 6, 0, onButtonPressed));
+		AddNewButton(primaryControls, new UnitControlButton(C7Action.UnitSentryEnemyOnly, 2, 5, onButtonPressed));
 
 		//   ******* SPECIALIZED CONTROLS *************
 		AddNewButton(specializedControls, new UnitControlButton("load", 7, 0, onButtonPressed));
@@ -47,10 +49,10 @@ public partial class UnitButtons : VBoxContainer
 
 		//TODO: The first two buttons in row index 2, and validate science age/colony are correct
 		AddNewButton(specializedControls, new UnitControlButton("sacrifice", 3, 2, onButtonPressed));
-		AddNewButton(specializedControls, new UnitControlButton("scienceAge", 3, 2, onButtonPressed));	//validate
-		AddNewButton(specializedControls, new UnitControlButton("buildColony", 4, 2, onButtonPressed));	//validate
-		AddNewButton(specializedControls, new UnitControlButton("buildCity", Godot.Key.B, 5, 2, onButtonPressed));
-		AddNewButton(specializedControls, new UnitControlButton("buildRoad", Godot.Key.R, 6, 2, onButtonPressed));
+		AddNewButton(specializedControls, new UnitControlButton("scienceAge", 3, 2, onButtonPressed));  //validate
+		AddNewButton(specializedControls, new UnitControlButton("buildColony", 4, 2, onButtonPressed)); //validate
+		AddNewButton(specializedControls, new UnitControlButton(C7Action.UnitBuildCity, 5, 2, onButtonPressed));
+		AddNewButton(specializedControls, new UnitControlButton(C7Action.UnitBuildRoad, 6, 2, onButtonPressed));
 		AddNewButton(specializedControls, new UnitControlButton("buildRailroad", 7, 2, onButtonPressed));
 
 		AddNewButton(specializedControls, new UnitControlButton("fortress", 0, 3, onButtonPressed));
@@ -63,62 +65,43 @@ public partial class UnitButtons : VBoxContainer
 		AddNewButton(specializedControls, new UnitControlButton("clearDamage", 6, 3, onButtonPressed));
 		AddNewButton(specializedControls, new UnitControlButton("automate", 7, 3, onButtonPressed));
 
-		//Row index 4 and later not yet added
+		// Row index 4 and later not yet added
 	}
 
-	private void AddNewButton(HBoxContainer row, UnitControlButton button)
-	{
+	private void AddNewButton(HBoxContainer row, UnitControlButton button) {
 		row.AddChild(button);
-		buttonMap[button.key] = button;
+		buttonMap[button.action] = button;
 	}
 
-	private void onButtonPressed(string buttonKey)
-	{
-		EmitSignal("UnitButtonPressed", buttonKey);
+	private void onButtonPressed(string action) {
+		GD.Print("pressed " + action);
+		log.Debug("pressed button " + action);
+		Input.ActionPress(action);
 	}
 
-	private void OnNoMoreAutoselectableUnits()
-	{
+	private void OnNoMoreAutoselectableUnits() {
 		this.Visible = false;
 	}
 
-	private void OnNewUnitSelected(ParameterWrapper wrappedMapUnit)
-	{
+	private void OnNewUnitSelected(ParameterWrapper wrappedMapUnit) {
 		MapUnit unit = wrappedMapUnit.GetValue<MapUnit>();
 		foreach (UnitControlButton button in buttonMap.Values) {
 			button.Visible = false;
 		}
 
-		//TODO: This is technically right, since the unit's available actions have been attached,
-		//but is unintuitive since they typically are on the prototype.
-		//Goal: Send the actions as a list.
-		foreach (string buttonKey in unit.availableActions) {
-			if (buttonMap.ContainsKey(buttonKey)) {
-				buttonMap[buttonKey].Visible = true;
-			}
-			else {
-				log.Warning("Could not find button " + buttonKey);
+		// pcen (may 2023) - switched this to use the prototype's actions, not
+		// sure I understand the commented goal. Before, was commented:
+		//     TODO: This is technically right, since the unit's available actions have been attached,
+		//     but is unintuitive since they typically are on the prototype.
+		//     Goal: Send the actions as a list.
+		foreach (string action in unit.unitType.actions) {
+			if (buttonMap.ContainsKey(action)) {
+				buttonMap[action].Visible = true;
+			} else {
+				log.Warning("Could not find button " + action);
 			}
 		}
 
 		this.Visible = true;
-	}
-
-	public override void _UnhandledInput(InputEvent @event) {
-		if (this.Visible)
-		{
-			if (@event is InputEventKey eventKey && eventKey.Pressed)
-			{
-				foreach (UnitControlButton button in buttonMap.Values)
-				{
-					if (button.Visible == true) {
-						if (eventKey.Keycode == button.shortcutKey && !eventKey.ShiftPressed && !eventKey.IsCommandOrControlPressed() && !eventKey.AltPressed) {
-							this.onButtonPressed(button.key);
-							GetViewport().SetInputAsHandled();
-						}
-					}
-				}
-			}
-		}
 	}
 }

--- a/C7/UIElements/UnitButtons/UnitControlButton.cs
+++ b/C7/UIElements/UnitButtons/UnitControlButton.cs
@@ -2,53 +2,39 @@ using Godot;
 using ConvertCiv3Media;
 using System;
 
-public partial class UnitControlButton : TextureButton
-{
+public partial class UnitControlButton : TextureButton {
 
-	public string key;
-	private int graphicsX;
-	private int graphicsY;
+	public string action; // corresponding Godot action (keybinding)
+	private int x;
+	private int y;
 	private Action<string> onPressedAction;
-	public Godot.Key shortcutKey;
 
-	public static int scale = 32;   //how many pixels each button is in each direction
+	public static int scale = 32; // how many pixels each button is in each direction
 
-	public UnitControlButton(string key, int graphicsX, int graphicsY, Action<string> onPressedAction)
-	{
-		this.key = key;
-		this.graphicsX = graphicsX;
-		this.graphicsY = graphicsY;
-		this.onPressedAction = onPressedAction;
-	}
-
-	public UnitControlButton(string key, Godot.Key shortcut, int graphicsX, int graphicsY, Action<string> onPressedAction) {
-		this.key = key;
-		this.shortcutKey = shortcut;
-		this.graphicsX = graphicsX;
-		this.graphicsY = graphicsY;
+	public UnitControlButton(string action, int x, int y, Action<string> onPressedAction) {
+		this.action = action;
+		this.x = x;
+		this.y = y;
 		this.onPressedAction = onPressedAction;
 	}
 
 	// Called when the node enters the scene tree for the first time.
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		Pcx buttonPcx = new Pcx(Util.Civ3MediaPath("Conquests/Art/interface/NormButtons.PCX"));
 		Pcx buttonPcxRollover = new Pcx(Util.Civ3MediaPath("Conquests/Art/interface/rolloverbuttons.PCX"));
 		Pcx buttonPcxPressed = new Pcx(Util.Civ3MediaPath("Conquests/Art/interface/highlightedbuttons.PCX"));
 		Pcx buttonPcxAlpha = new Pcx(Util.Civ3MediaPath("Conquests/Art/interface/ButtonAlpha.pcx"));
-		ImageTexture menuTexture = PCXToGodot.getImageFromPCXWithAlphaBlend(buttonPcx, buttonPcxAlpha, graphicsX * scale, graphicsY * scale, scale, scale);
-		ImageTexture rolloverTexture = PCXToGodot.getImageFromPCXWithAlphaBlend(buttonPcxRollover, buttonPcxAlpha, graphicsX * scale, graphicsY * scale, scale, scale);
-		ImageTexture pressedTexture = PCXToGodot.getImageFromPCXWithAlphaBlend(buttonPcxPressed, buttonPcxAlpha, graphicsX * scale, graphicsY * scale, scale, scale);
+		ImageTexture menuTexture = PCXToGodot.getImageFromPCXWithAlphaBlend(buttonPcx, buttonPcxAlpha, x * scale, y * scale, scale, scale);
+		ImageTexture rolloverTexture = PCXToGodot.getImageFromPCXWithAlphaBlend(buttonPcxRollover, buttonPcxAlpha, x * scale, y * scale, scale, scale);
+		ImageTexture pressedTexture = PCXToGodot.getImageFromPCXWithAlphaBlend(buttonPcxPressed, buttonPcxAlpha, x * scale, y * scale, scale, scale);
 		this.TextureNormal = menuTexture;
 		this.TextureHover = rolloverTexture;
 		this.TexturePressed = pressedTexture;
 
-		this.Connect("pressed", new Callable(this, "ButtonPressed"));
+		this.Connect("pressed", new Callable(this, "onButtonPress"));
 	}
 
-	// TODO: check hides inherited warning
-	private void ButtonPressed()
-	{
-		onPressedAction(this.key);
+	private void onButtonPress() {
+		onPressedAction(this.action);
 	}
 }

--- a/C7/project.godot
+++ b/C7/project.godot
@@ -39,6 +39,30 @@ limits=false
 
 theme/custom="res://C7Theme.tres"
 
+[input]
+
+left={
+"deadzone": 0.5,
+"events": []
+}
+right={
+"deadzone": 0.5,
+"events": []
+}
+up={
+"deadzone": 0.5,
+"events": []
+}
+down={
+"deadzone": 0.5,
+"events": []
+}
+unit_goto={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":71,"key_label":0,"unicode":103,"echo":false,"script":null)
+]
+}
+
 [mono]
 
 project/assembly_name="C7"

--- a/C7/project.godot
+++ b/C7/project.godot
@@ -62,6 +62,126 @@ unit_goto={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":71,"key_label":0,"unicode":103,"echo":false,"script":null)
 ]
 }
+end_turn={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194309,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)
+]
+}
+move_unit_north={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194446,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+move_unit_northeast={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194447,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194323,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+move_unit_northwest={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194445,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194317,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+move_unit_east={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194444,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+move_unit_west={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194442,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+move_unit_south={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194440,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194322,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+move_unit_southeast={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194441,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194324,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+move_unit_southwest={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194439,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194318,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+toggle_grid={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":true,"pressed":false,"keycode":0,"physical_keycode":71,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":71,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+escape={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+toggle_zoom={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":90,"key_label":0,"unicode":122,"echo":false,"script":null)
+]
+}
+toggle_animations={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+unit_hold={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)
+]
+}
+unit_wait={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"echo":false,"script":null)
+]
+}
+unit_fortify={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"echo":false,"script":null)
+]
+}
+unit_disband={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
+]
+}
+unit_explore={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"echo":false,"script":null)
+]
+}
+unit_sentry={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":89,"key_label":0,"unicode":121,"echo":false,"script":null)
+]
+}
+unit_sentry_enemy_only={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":true,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":89,"key_label":0,"unicode":89,"echo":false,"script":null)
+]
+}
+unit_build_city={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":66,"key_label":0,"unicode":98,"echo":false,"script":null)
+]
+}
+unit_build_road={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":114,"echo":false,"script":null)
+]
+}
 
 [mono]
 

--- a/C7Engine/AI/StrategicAI/ExpansionPriority.cs
+++ b/C7Engine/AI/StrategicAI/ExpansionPriority.cs
@@ -32,7 +32,7 @@ namespace C7GameData.AIData {
 
 		public override float GetProductionItemFlatAdjuster(IProducible producible) {
 			if (producible is UnitPrototype prototype) {
-				if (prototype.actions.Contains("buildCity")) {
+				if (prototype.actions.Contains(C7Action.UnitBuildCity)) {
 					//Offset the shield cost and pop cost maluses, and add a flat 30 value to be equivalent to an early-game unit
 					int adjustment = prototype.shieldCost + 10 * prototype.populationCost + SETTLER_FLAT_APPEAL;
 					log.Debug($"ExpansionPriority adjusting {producible} by {adjustment}");
@@ -49,7 +49,7 @@ namespace C7GameData.AIData {
 		/// <returns></returns>
 		public override float GetProductionItemPreferenceWeight(IProducible producible) {
 			if (producible is UnitPrototype prototype) {
-				if (prototype.actions.Contains("buildCity")) {
+				if (prototype.actions.Contains(C7Action.UnitBuildCity)) {
 					return SETTLER_WEIGHTED_APPEAL;
 				}
 			}

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -49,7 +49,7 @@ namespace C7Engine
 
 			// Eventually, we should look this up somewhere to see what all actions we have (and mods might add more)
 			// For now, this is still an improvement over the last iteration.
-			string[] implementedActions = { "hold", "wait", "fortify", "disband", "goTo", "bombard"};
+			string[] implementedActions = { C7Action.UnitHold, C7Action.UnitWait, C7Action.UnitFortify, C7Action.UnitDisband, C7Action.UnitGoto, C7Action.UnitBombard };
 			foreach (string action in implementedActions) {
 				if (unit.unitType.actions.Contains(action)) {
 					unit.availableActions.Add(action);
@@ -57,11 +57,11 @@ namespace C7Engine
 			}
 
 			if (unit.canBuildCity()) {
-				unit.availableActions.Add("buildCity");
+				unit.availableActions.Add(C7Action.UnitBuildCity);
 			}
 
 			if (unit.canBuildRoad()) {
-				unit.availableActions.Add("buildRoad");
+				unit.availableActions.Add(C7Action.UnitBuildRoad);
 			}
 
 			// Eventually we will have advanced actions too, whose availability will rely on their base actions' availability.

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -1,485 +1,462 @@
 using Serilog;
 
-namespace C7Engine
-{
+namespace C7Engine {
 	using System;
-using System.Collections.Generic;
-using System.Linq;
-using Pathing;
-using C7GameData;
+	using System.Collections.Generic;
+	using System.Linq;
+	using Pathing;
+	using C7GameData;
 
-//We should document why we're putting things in the extensions methods.  We discussed it a month or so ago, but I forget why at this point.
-//Coming from an OO background, I'm wondering why these aren't on the MapUnit class... data access?  Modding?  Some other benefit?
-public static class MapUnitExtensions {
+	//We should document why we're putting things in the extensions methods.  We discussed it a month or so ago, but I forget why at this point.
+	//Coming from an OO background, I'm wondering why these aren't on the MapUnit class... data access?  Modding?  Some other benefit?
+	public static class MapUnitExtensions {
 
-	private static ILogger log = Log.ForContext<MapUnit>();
+		private static ILogger log = Log.ForContext<MapUnit>();
 
-	public static void animate(this MapUnit unit, MapUnit.AnimatedAction action, bool wait, AnimationEnding ending = AnimationEnding.Stop)
-	{
-		if (EngineStorage.animationsEnabled) {
-			new MsgStartUnitAnimation(unit, action, wait ? EngineStorage.uiEvent : null, ending).send();
-			if (wait) {
-				EngineStorage.gameDataMutex.ReleaseMutex();
-				EngineStorage.uiEvent.WaitOne();
-				EngineStorage.gameDataMutex.WaitOne();
+		public static void animate(this MapUnit unit, MapUnit.AnimatedAction action, bool wait, AnimationEnding ending = AnimationEnding.Stop) {
+			if (EngineStorage.animationsEnabled) {
+				new MsgStartUnitAnimation(unit, action, wait ? EngineStorage.uiEvent : null, ending).send();
+				if (wait) {
+					EngineStorage.gameDataMutex.ReleaseMutex();
+					EngineStorage.uiEvent.WaitOne();
+					EngineStorage.gameDataMutex.WaitOne();
+				}
 			}
 		}
-	}
 
-	public static void fortify(this MapUnit unit)
-	{
-		unit.facingDirection = TileDirection.SOUTHEAST;
-		unit.isFortified = true;
-		unit.animate(MapUnit.AnimatedAction.FORTIFY, false);
-	}
-
-	public static void wake(this MapUnit unit)
-	{
-		unit.isFortified = false;
-	}
-
-	public static IEnumerable<StrengthBonus> ListStrengthBonusesVersus(this MapUnit unit, MapUnit opponent, CombatRole role, TileDirection? attackDirection)
-	{
-		GameData gD = EngineStorage.gameData;
-
-		if (role.Defending()) {
-			if (unit.isFortified)
-				yield return gD.fortificationBonus;
-
-			yield return unit.location.overlayTerrainType.defenseBonus;
-
-			if ((! role.Bombarding()) && (attackDirection is TileDirection dir) && unit.location.HasRiverCrossing(dir.reversed()))
-				yield return gD.riverCrossingBonus;
-
-			// TODO: Bonus should vary depending on city level. First we must load the thresholds for level 2/3 into the scenario data.
-			if (unit.location.cityAtTile != null)
-				yield return gD.cityLevel2DefenseBonus;
+		public static void fortify(this MapUnit unit) {
+			unit.facingDirection = TileDirection.SOUTHEAST;
+			unit.isFortified = true;
+			unit.animate(MapUnit.AnimatedAction.FORTIFY, false);
 		}
-	}
 
-	public static double StrengthVersus(this MapUnit unit, MapUnit opponent, CombatRole role, TileDirection? attackDirection)
-	{
-		return unit.unitType.BaseStrength(role) * StrengthBonus.ListToMultiplier(unit.ListStrengthBonusesVersus(opponent, role, attackDirection));
-	}
+		public static void wake(this MapUnit unit) {
+			unit.isFortified = false;
+		}
 
-	public static bool CanDefendAgainst(this MapUnit unit, MapUnit attacker) {
-		//Basically, unit type must match.  Sea/air units in a city/airfield can't defend against land units.
-		//Land units on a boat or planes on a carrier can't defend against boats.  Anti-air is another category that should be checked before the direct combat.
-		//Potential future hybrid units that have multiple categories (e.g. amphibious vehicles) may contain more than one category.
-		if (attacker.unitType.categories.Contains("Land") && !unit.unitType.categories.Contains("Land")) {
-			return false;
-		}
-		if (attacker.unitType.categories.Contains("Sea") && !unit.unitType.categories.Contains("Sea")) {
-			return false;
-		}
-		if (attacker.unitType.categories.Contains("Air") && !unit.unitType.categories.Contains("Air")) {
-			return false;
-		}
-		return true;
-	}
+		public static IEnumerable<StrengthBonus> ListStrengthBonusesVersus(this MapUnit unit, MapUnit opponent, CombatRole role, TileDirection? attackDirection) {
+			GameData gD = EngineStorage.gameData;
 
-	// Answers the question: if "opponent" is attacking the tile that this unit is standing on, does this unit defend instead of "otherDefender"?
-	// Note that otherDefender does not necessarily belong to the same civ as this unit. Under standard Civ 3 rules you can't have units belonging
-	// to two different civs on the same tile, but we don't want to assume that. In that case, whoever is an enemy of "opponent" should get
-	// priority. Otherwise it's just whoever is stronger on defense.
-	public static bool HasPriorityAsDefender(this MapUnit unit, MapUnit otherDefender, MapUnit opponent)
-	{
-		Player opponentPlayer = opponent.owner;
-		bool weAreEnemy           = (opponentPlayer != null) ? ! opponentPlayer.IsAtPeaceWith(unit.owner)          : false;
-		bool otherDefenderIsEnemy = (opponentPlayer != null) ? ! opponentPlayer.IsAtPeaceWith(otherDefender.owner) : false;
-		if (weAreEnemy && ! otherDefenderIsEnemy)
+			if (role.Defending()) {
+				if (unit.isFortified)
+					yield return gD.fortificationBonus;
+
+				yield return unit.location.overlayTerrainType.defenseBonus;
+
+				if ((!role.Bombarding()) && (attackDirection is TileDirection dir) && unit.location.HasRiverCrossing(dir.reversed()))
+					yield return gD.riverCrossingBonus;
+
+				// TODO: Bonus should vary depending on city level. First we must load the thresholds for level 2/3 into the scenario data.
+				if (unit.location.cityAtTile != null)
+					yield return gD.cityLevel2DefenseBonus;
+			}
+		}
+
+		public static double StrengthVersus(this MapUnit unit, MapUnit opponent, CombatRole role, TileDirection? attackDirection) {
+			return unit.unitType.BaseStrength(role) * StrengthBonus.ListToMultiplier(unit.ListStrengthBonusesVersus(opponent, role, attackDirection));
+		}
+
+		public static bool CanDefendAgainst(this MapUnit unit, MapUnit attacker) {
+			//Basically, unit type must match.  Sea/air units in a city/airfield can't defend against land units.
+			//Land units on a boat or planes on a carrier can't defend against boats.  Anti-air is another category that should be checked before the direct combat.
+			//Potential future hybrid units that have multiple categories (e.g. amphibious vehicles) may contain more than one category.
+			if (attacker.unitType.categories.Contains("Land") && !unit.unitType.categories.Contains("Land")) {
+				return false;
+			}
+			if (attacker.unitType.categories.Contains("Sea") && !unit.unitType.categories.Contains("Sea")) {
+				return false;
+			}
+			if (attacker.unitType.categories.Contains("Air") && !unit.unitType.categories.Contains("Air")) {
+				return false;
+			}
 			return true;
-		else if (otherDefenderIsEnemy && ! weAreEnemy)
-			return false;
-		else {
-			double ourTotalStrength   = unit         .StrengthVersus(opponent, CombatRole.Defense, null) * unit         .hitPointsRemaining,
-			       theirTotalStrength = otherDefender.StrengthVersus(opponent, CombatRole.Defense, null) * otherDefender.hitPointsRemaining;
-			return ourTotalStrength > theirTotalStrength;
 		}
-	}
 
-
-	public static void RollToPromote(this MapUnit unit, MapUnit opponent, bool waitForAnimation)
-	{
-		double promotionChance = unit.experienceLevel.promotionChance;
-		if (opponent.owner.isBarbarians)
-			promotionChance /= 2.0;
-		// TODO: Double promotionChance if unit is owned by a militaristic civ
-
-		if (GameData.rng.NextDouble() < promotionChance) {
-			ExperienceLevel nextLevel = EngineStorage.gameData.GetExperienceLevelAfter(unit.experienceLevel);
-			if (nextLevel != null) {
-				unit.experienceLevelKey = nextLevel.key;
-				unit.experienceLevel = nextLevel;
-				unit.hitPointsRemaining++;
-				unit.animate(MapUnit.AnimatedAction.VICTORY, waitForAnimation);
+		// Answers the question: if "opponent" is attacking the tile that this unit is standing on, does this unit defend instead of "otherDefender"?
+		// Note that otherDefender does not necessarily belong to the same civ as this unit. Under standard Civ 3 rules you can't have units belonging
+		// to two different civs on the same tile, but we don't want to assume that. In that case, whoever is an enemy of "opponent" should get
+		// priority. Otherwise it's just whoever is stronger on defense.
+		public static bool HasPriorityAsDefender(this MapUnit unit, MapUnit otherDefender, MapUnit opponent) {
+			Player opponentPlayer = opponent.owner;
+			bool weAreEnemy           = (opponentPlayer != null) ? ! opponentPlayer.IsAtPeaceWith(unit.owner)          : false;
+			bool otherDefenderIsEnemy = (opponentPlayer != null) ? ! opponentPlayer.IsAtPeaceWith(otherDefender.owner) : false;
+			if (weAreEnemy && !otherDefenderIsEnemy)
+				return true;
+			else if (otherDefenderIsEnemy && !weAreEnemy)
+				return false;
+			else {
+				double ourTotalStrength   = unit         .StrengthVersus(opponent, CombatRole.Defense, null) * unit         .hitPointsRemaining,
+				   theirTotalStrength = otherDefender.StrengthVersus(opponent, CombatRole.Defense, null) * otherDefender.hitPointsRemaining;
+				return ourTotalStrength > theirTotalStrength;
 			}
 		}
-	}
 
-	public static double RetreatChance(this MapUnit unit, MapUnit opponent, bool isAttacking)
-	{
-		return ((unit.unitType.movement > 1) && (opponent.unitType.movement <= 1)) ? unit.experienceLevel.retreatChance : 0.0;
-	}
 
-	public static CombatResult fight(this MapUnit attacker, MapUnit defender)
-	{
-		// Rotate defender to face its attacker. We'll restore the original facing direction at the end of the battle.
-		var defenderOriginalDirection = defender.facingDirection;
-		defender.facingDirection = attacker.facingDirection.reversed();
+		public static void RollToPromote(this MapUnit unit, MapUnit opponent, bool waitForAnimation) {
+			double promotionChance = unit.experienceLevel.promotionChance;
+			if (opponent.owner.isBarbarians)
+				promotionChance /= 2.0;
+			// TODO: Double promotionChance if unit is owned by a militaristic civ
 
-		IEnumerable<StrengthBonus> attackBonuses  = attacker.ListStrengthBonusesVersus(defender, CombatRole.Attack , attacker.facingDirection),
-		                           defenseBonuses = defender.ListStrengthBonusesVersus(attacker, CombatRole.Defense, attacker.facingDirection);
-
-		double attackerStrength = attacker.unitType.attack  * StrengthBonus.ListToMultiplier(attackBonuses),
-		       defenderStrength = defender.unitType.defense * StrengthBonus.ListToMultiplier(defenseBonuses);
-
-		log.Information($"Combat log: {attacker.unitType.name} ({attackerStrength}) attacking {defender.unitType.name} ({defenderStrength})");
-		log.Information($"\tAttacker: {attacker.unitType.name}, base strength {attacker.unitType.BaseStrength(CombatRole.Attack)}");
-		foreach (StrengthBonus bonus in attackBonuses)
-			log.Information($"\t\t+{100.0*bonus.amount}%\t{bonus.description}");
-		log.Information($"\tDefender: {defender.unitType.name}, base strength {defender.unitType.BaseStrength(CombatRole.Defense)}");
-		foreach (StrengthBonus bonus in defenseBonuses)
-			log.Information($"\t\t+{100.0*bonus.amount}%\t{bonus.description}");
-
-		CombatResult result = CombatResult.Impossible;
-
-		double attackerOdds = attackerStrength / (attackerStrength + defenderStrength);
-		if (Double.IsNaN(attackerOdds))
-			return result;
-
-		// Defensive bombard
-		MapUnit defensiveBombarder = MapUnit.NONE;
-		double defensiveBombarderStrength = 0.0;
-		foreach (MapUnit candidate in defender.location.unitsOnTile.Where(u => u != defender && ! u.owner.IsAtPeaceWith(attacker.owner) && u.defensiveBombardsRemaining > 0)) {
-			double strength = candidate.StrengthVersus(attacker, CombatRole.DefensiveBombard, attacker.facingDirection.reversed());
-			if (strength > defensiveBombarderStrength) {
-				defensiveBombarder = candidate;
-				defensiveBombarderStrength = strength;
+			if (GameData.rng.NextDouble() < promotionChance) {
+				ExperienceLevel nextLevel = EngineStorage.gameData.GetExperienceLevelAfter(unit.experienceLevel);
+				if (nextLevel != null) {
+					unit.experienceLevelKey = nextLevel.key;
+					unit.experienceLevel = nextLevel;
+					unit.hitPointsRemaining++;
+					unit.animate(MapUnit.AnimatedAction.VICTORY, waitForAnimation);
+				}
 			}
 		}
-		// In the original game, defensive bombard does not trigger against attackers with 1 HP. See:
-		// https://github.com/C7-Game/Prototype/pull/250#discussion_r893051111
-		if (defensiveBombarder != MapUnit.NONE && attacker.hitPointsRemaining > 1) {
-			var dBOriginalDirection = defensiveBombarder.facingDirection;
-			defensiveBombarder.facingDirection = defender.facingDirection;
 
-			defensiveBombarder.animate(MapUnit.AnimatedAction.ATTACK1, true);
-
-			// dADB = defense Against Defensive Bombard
-			double dADB = attacker.StrengthVersus(defensiveBombarder, CombatRole.DefensiveBombardDefense, defensiveBombarder.facingDirection);
-			if (GameData.rng.NextDouble() < defensiveBombarderStrength / (defensiveBombarderStrength + dADB))
-				attacker.hitPointsRemaining -= 1;
-
-			defensiveBombarder.defensiveBombardsRemaining -= 1;
-			defensiveBombarder.facingDirection = dBOriginalDirection;
+		public static double RetreatChance(this MapUnit unit, MapUnit opponent, bool isAttacking) {
+			return ((unit.unitType.movement > 1) && (opponent.unitType.movement <= 1)) ? unit.experienceLevel.retreatChance : 0.0;
 		}
 
-		bool defenderEligibleToRetreat = defender.hitPointsRemaining > 1 && ! defender.location.HasCity;
+		public static CombatResult fight(this MapUnit attacker, MapUnit defender) {
+			// Rotate defender to face its attacker. We'll restore the original facing direction at the end of the battle.
+			var defenderOriginalDirection = defender.facingDirection;
+			defender.facingDirection = attacker.facingDirection.reversed();
 
-		// Do combat rounds
-		while (true) {
-			defender.animate(MapUnit.AnimatedAction.ATTACK1, false);
-			attacker.animate(MapUnit.AnimatedAction.ATTACK1, true );
-			if (GameData.rng.NextDouble() < attackerOdds) {
-				if (defenderEligibleToRetreat &&
-				    defender.hitPointsRemaining == 1 &&
-				    GameData.rng.NextDouble() < defender.RetreatChance(attacker, false)) {
-					// TODO: Defender retreat behavior requires some more work. There's an issue for it here:
-					// https://github.com/C7-Game/Prototype/issues/274
-					Tile retreatDestination = defender.location.neighbors[attacker.facingDirection];
-					if ((retreatDestination != Tile.NONE) && defender.CanEnterTile(retreatDestination, false)) {
-						defender.move(attacker.facingDirection, true);
-						result = CombatResult.DefenderRetreated;
+			IEnumerable<StrengthBonus> attackBonuses  = attacker.ListStrengthBonusesVersus(defender, CombatRole.Attack , attacker.facingDirection),
+								   defenseBonuses = defender.ListStrengthBonusesVersus(attacker, CombatRole.Defense, attacker.facingDirection);
+
+			double attackerStrength = attacker.unitType.attack  * StrengthBonus.ListToMultiplier(attackBonuses),
+			   defenderStrength = defender.unitType.defense * StrengthBonus.ListToMultiplier(defenseBonuses);
+
+			log.Information($"Combat log: {attacker.unitType.name} ({attackerStrength}) attacking {defender.unitType.name} ({defenderStrength})");
+			log.Information($"\tAttacker: {attacker.unitType.name}, base strength {attacker.unitType.BaseStrength(CombatRole.Attack)}");
+			foreach (StrengthBonus bonus in attackBonuses)
+				log.Information($"\t\t+{100.0 * bonus.amount}%\t{bonus.description}");
+			log.Information($"\tDefender: {defender.unitType.name}, base strength {defender.unitType.BaseStrength(CombatRole.Defense)}");
+			foreach (StrengthBonus bonus in defenseBonuses)
+				log.Information($"\t\t+{100.0 * bonus.amount}%\t{bonus.description}");
+
+			CombatResult result = CombatResult.Impossible;
+
+			double attackerOdds = attackerStrength / (attackerStrength + defenderStrength);
+			if (Double.IsNaN(attackerOdds))
+				return result;
+
+			// Defensive bombard
+			MapUnit defensiveBombarder = MapUnit.NONE;
+			double defensiveBombarderStrength = 0.0;
+			foreach (MapUnit candidate in defender.location.unitsOnTile.Where(u => u != defender && !u.owner.IsAtPeaceWith(attacker.owner) && u.defensiveBombardsRemaining > 0)) {
+				double strength = candidate.StrengthVersus(attacker, CombatRole.DefensiveBombard, attacker.facingDirection.reversed());
+				if (strength > defensiveBombarderStrength) {
+					defensiveBombarder = candidate;
+					defensiveBombarderStrength = strength;
+				}
+			}
+			// In the original game, defensive bombard does not trigger against attackers with 1 HP. See:
+			// https://github.com/C7-Game/Prototype/pull/250#discussion_r893051111
+			if (defensiveBombarder != MapUnit.NONE && attacker.hitPointsRemaining > 1) {
+				var dBOriginalDirection = defensiveBombarder.facingDirection;
+				defensiveBombarder.facingDirection = defender.facingDirection;
+
+				defensiveBombarder.animate(MapUnit.AnimatedAction.ATTACK1, true);
+
+				// dADB = defense Against Defensive Bombard
+				double dADB = attacker.StrengthVersus(defensiveBombarder, CombatRole.DefensiveBombardDefense, defensiveBombarder.facingDirection);
+				if (GameData.rng.NextDouble() < defensiveBombarderStrength / (defensiveBombarderStrength + dADB))
+					attacker.hitPointsRemaining -= 1;
+
+				defensiveBombarder.defensiveBombardsRemaining -= 1;
+				defensiveBombarder.facingDirection = dBOriginalDirection;
+			}
+
+			bool defenderEligibleToRetreat = defender.hitPointsRemaining > 1 && ! defender.location.HasCity;
+
+			// Do combat rounds
+			while (true) {
+				defender.animate(MapUnit.AnimatedAction.ATTACK1, false);
+				attacker.animate(MapUnit.AnimatedAction.ATTACK1, true);
+				if (GameData.rng.NextDouble() < attackerOdds) {
+					if (defenderEligibleToRetreat &&
+						defender.hitPointsRemaining == 1 &&
+						GameData.rng.NextDouble() < defender.RetreatChance(attacker, false)) {
+						// TODO: Defender retreat behavior requires some more work. There's an issue for it here:
+						// https://github.com/C7-Game/Prototype/issues/274
+						Tile retreatDestination = defender.location.neighbors[attacker.facingDirection];
+						if ((retreatDestination != Tile.NONE) && defender.CanEnterTile(retreatDestination, false)) {
+							defender.move(attacker.facingDirection, true);
+							result = CombatResult.DefenderRetreated;
+							break;
+						}
+					}
+					defender.hitPointsRemaining -= 1;
+					if (defender.hitPointsRemaining <= 0) {
+						result = CombatResult.DefenderKilled;
+						break;
+					}
+				} else {
+					if (attacker.hitPointsRemaining == 1 &&
+						GameData.rng.NextDouble() < attacker.RetreatChance(defender, true)) {
+						result = CombatResult.AttackerRetreated;
+						break;
+					}
+					attacker.hitPointsRemaining -= 1;
+					if (attacker.hitPointsRemaining <= 0) {
+						result = CombatResult.AttackerKilled;
 						break;
 					}
 				}
-				defender.hitPointsRemaining -= 1;
-				if (defender.hitPointsRemaining <= 0) {
-					result = CombatResult.DefenderKilled;
-					break;
-				}
-			} else {
-				if (attacker.hitPointsRemaining == 1 &&
-				    GameData.rng.NextDouble() < attacker.RetreatChance(defender, true)) {
-					result = CombatResult.AttackerRetreated;
-					break;
-				}
-				attacker.hitPointsRemaining -= 1;
-				if (attacker.hitPointsRemaining <= 0) {
-					result = CombatResult.AttackerKilled;
-					break;
-				}
+			}
+
+			if ((result == CombatResult.AttackerKilled) || (result == CombatResult.DefenderKilled)) {
+				var (dead, alive) = (result == CombatResult.AttackerKilled) ? (attacker, defender) : (defender, attacker);
+				alive.RollToPromote(dead, false);
+				dead.animate(MapUnit.AnimatedAction.DEATH, true);
+				dead.disband();
+			}
+
+			if (result.DefenderWon())
+				defender.facingDirection = defenderOriginalDirection;
+
+			return result;
+		}
+
+		public static void bombard(this MapUnit unit, Tile tile) {
+			MapUnit target = tile.FindTopDefender(unit);
+			if ((unit.unitType.bombard == 0) || (target == MapUnit.NONE))
+				return; // Do nothing if we don't have a unit to attack. TODO: Attack city or tile improv if possible
+
+			var unitOriginalOrientation = unit.facingDirection;
+			unit.facingDirection = unit.location.directionTo(tile);
+
+			double bombardStrength  = unit  .StrengthVersus(target, CombatRole.Bombard       , unit.facingDirection);
+			double defenderStrength = target.StrengthVersus(unit  , CombatRole.BombardDefense, unit.facingDirection);
+			double attackerOdds = bombardStrength / (bombardStrength + defenderStrength);
+			if (Double.IsNaN(attackerOdds))
+				return;
+
+			unit.animate(MapUnit.AnimatedAction.ATTACK1, true);
+			unit.movementPoints.onUnitMove(1);
+			if (GameData.rng.NextDouble() < attackerOdds) {
+				target.hitPointsRemaining -= 1;
+				tile.Animate(AnimatedEffect.Hit3, false);
+			} else
+				tile.Animate(AnimatedEffect.Miss, false);
+
+			if (target.hitPointsRemaining <= 0) {
+				unit.RollToPromote(target, false);
+				target.animate(MapUnit.AnimatedAction.DEATH, true);
+				target.disband();
+			}
+
+			unit.facingDirection = unitOriginalOrientation;
+		}
+
+		public static int HealRateAt(this MapUnit unit, Tile location) {
+			GameData gD = EngineStorage.gameData;
+			City city = location.cityAtTile;
+			bool inFriendlyCity = (city != null) && (city != City.NONE) && unit.owner.IsAtPeaceWith(city.owner);
+			if (inFriendlyCity)
+				return gD.healRateInCity;
+			if (unit.unitType.categories.Contains("Sea"))
+				return 0;
+			return gD.healRateInNeutralField;
+			// TODO: Consider friendly/neutral/enemy territory once that's implemented, barracks, the Red Cross
+		}
+
+		public static void OnBeginTurn(this MapUnit unit) {
+			int maxMP = unit.unitType.movement;
+			if (unit.movementPoints.remaining >= maxMP) {
+				int maxHP = unit.maxHitPoints;
+				if (unit.hitPointsRemaining < maxHP)
+					unit.hitPointsRemaining += unit.HealRateAt(unit.location);
+				if (unit.hitPointsRemaining > maxHP)
+					unit.hitPointsRemaining = maxHP;
+			}
+			unit.movementPoints.reset(maxMP);
+			unit.defensiveBombardsRemaining = 1;
+		}
+
+		public static void OnEnterTile(this MapUnit unit, Tile tile) {
+			//Add to player knowledge of tiles
+			unit.owner.tileKnowledge.AddTilesToKnown(tile);
+
+			// Disperse barb camp
+			if (tile.hasBarbarianCamp && (!unit.owner.isBarbarians)) {
+				tile.DisbandNonDefendingUnits();
+				EngineStorage.gameData.map.barbarianCamps.Remove(tile);
+				tile.hasBarbarianCamp = false;
+			}
+
+			// Destroy enemy city on tile
+			if (tile.HasCity && !unit.owner.IsAtPeaceWith(tile.cityAtTile.owner)) {
+				CityInteractions.DestroyCity(tile.xCoordinate, tile.yCoordinate);
 			}
 		}
 
-		if ((result == CombatResult.AttackerKilled) || (result == CombatResult.DefenderKilled)) {
-			var (dead, alive) = (result == CombatResult.AttackerKilled) ? (attacker, defender) : (defender, attacker);
-			alive.RollToPromote(dead, false);
-			dead.animate(MapUnit.AnimatedAction.DEATH, true);
-			dead.disband();
-		}
+		public static bool CanEnterTile(this MapUnit unit, Tile tile, bool allowCombat) {
+			// Keep land units on land and sea units on water
+			if (unit.unitType.categories.Contains("Sea") && tile.IsLand()) {
+				if (tile.HasCity && tile.cityAtTile.owner == unit.owner) {
+					return true;
+				}
+				return false;
+			} else if (unit.unitType.categories.Contains("Land") && !tile.IsLand())
+				return false;
 
-		if (result.DefenderWon())
-			defender.facingDirection = defenderOriginalDirection;
-
-		return result;
-	}
-
-	public static void bombard(this MapUnit unit, Tile tile)
-	{
-		MapUnit target = tile.FindTopDefender(unit);
-		if ((unit.unitType.bombard == 0) || (target == MapUnit.NONE))
-			return; // Do nothing if we don't have a unit to attack. TODO: Attack city or tile improv if possible
-
-		var unitOriginalOrientation = unit.facingDirection;
-		unit.facingDirection = unit.location.directionTo(tile);
-
-		double bombardStrength  = unit  .StrengthVersus(target, CombatRole.Bombard       , unit.facingDirection);
-		double defenderStrength = target.StrengthVersus(unit  , CombatRole.BombardDefense, unit.facingDirection);
-		double attackerOdds = bombardStrength / (bombardStrength + defenderStrength);
-		if (Double.IsNaN(attackerOdds))
-			return;
-
-		unit.animate(MapUnit.AnimatedAction.ATTACK1, true);
-		unit.movementPoints.onUnitMove(1);
-		if (GameData.rng.NextDouble() < attackerOdds) {
-			target.hitPointsRemaining -= 1;
-			tile.Animate(AnimatedEffect.Hit3, false);
-		} else
-			tile.Animate(AnimatedEffect.Miss, false);
-
-		if (target.hitPointsRemaining <= 0) {
-			unit.RollToPromote(target, false);
-			target.animate(MapUnit.AnimatedAction.DEATH, true);
-			target.disband();
-		}
-
-		unit.facingDirection = unitOriginalOrientation;
-	}
-
-	public static int HealRateAt(this MapUnit unit, Tile location)
-	{
-		GameData gD = EngineStorage.gameData;
-		City city = location.cityAtTile;
-		bool inFriendlyCity = (city != null) && (city != City.NONE) && unit.owner.IsAtPeaceWith(city.owner);
-		if (inFriendlyCity)
-			return gD.healRateInCity;
-		if (unit.unitType.categories.Contains("Sea"))
-			return 0;
-		return gD.healRateInNeutralField;
-		// TODO: Consider friendly/neutral/enemy territory once that's implemented, barracks, the Red Cross
-	}
-
-	public static void OnBeginTurn(this MapUnit unit)
-	{
-		int maxMP = unit.unitType.movement;
-		if (unit.movementPoints.remaining >= maxMP) {
-			int maxHP = unit.maxHitPoints;
-			if (unit.hitPointsRemaining < maxHP)
-				unit.hitPointsRemaining += unit.HealRateAt(unit.location);
-			if (unit.hitPointsRemaining > maxHP)
-				unit.hitPointsRemaining = maxHP;
-		}
-		unit.movementPoints.reset(maxMP);
-		unit.defensiveBombardsRemaining = 1;
-	}
-
-	public static void OnEnterTile(this MapUnit unit, Tile tile)
-	{
-		//Add to player knowledge of tiles
-		unit.owner.tileKnowledge.AddTilesToKnown(tile);
-
-		// Disperse barb camp
-		if (tile.hasBarbarianCamp && (!unit.owner.isBarbarians)) {
-			tile.DisbandNonDefendingUnits();
-			EngineStorage.gameData.map.barbarianCamps.Remove(tile);
-			tile.hasBarbarianCamp = false;
-		}
-
-		// Destroy enemy city on tile
-		if (tile.HasCity && !unit.owner.IsAtPeaceWith(tile.cityAtTile.owner)) {
-			CityInteractions.DestroyCity(tile.xCoordinate, tile.yCoordinate);
-		}
-	}
-
-	public static bool CanEnterTile(this MapUnit unit, Tile tile, bool allowCombat)
-	{
-		// Keep land units on land and sea units on water
-		if (unit.unitType.categories.Contains("Sea") && tile.IsLand()) {
-			if (tile.HasCity && tile.cityAtTile.owner == unit.owner) {
-				return true;
-			}
-			return false;
-		} else if (unit.unitType.categories.Contains("Land") && ! tile.IsLand())
-			return false;
-
-		// Check for units belonging to other civs
-		foreach (MapUnit other in tile.unitsOnTile)
-			if (other.owner != unit.owner) {
-				if (!other.owner.IsAtPeaceWith(unit.owner))
-					return allowCombat;
-				else
-					return false;
-			}
-
-		return true;
-	}
-
-	/// <summary>
-	/// Moves the unit in the given direction
-	/// </summary>
-	/// <param name="unit"></param>
-	/// <param name="dir">Which direction to move, e.g. northeast, west, etc.</param>
-	/// <param name="wait">Whether the method should wait to return until animations complete</param>
-	/// <returns>True if the unit is alive after the movement, false otherwise</returns>
-	/// <exception cref="Exception"></exception>
-	public static bool move(this MapUnit unit, TileDirection dir, bool wait = false)
-	{
-		(int dx, int dy) = dir.toCoordDiff();
-		Tile newLoc = EngineStorage.gameData.map.tileAt(dx + unit.location.xCoordinate, dy + unit.location.yCoordinate);
-		if ((newLoc != Tile.NONE) && unit.CanEnterTile(newLoc, true) && (unit.movementPoints.canMove)) {
-			unit.facingDirection = dir;
-			unit.wake();
-
-			// Trigger combat if the tile we're moving into has an enemy unit. Or if this unit can't fight, do nothing.
-			MapUnit defender = newLoc.FindTopDefender(unit);
-			if (defender != MapUnit.NONE && !unit.owner.IsAtPeaceWith(defender.owner)) {
-				if (unit.unitType.attack > 0) {
-					CombatResult combatResult = unit.fight(defender);
-					// If we were killed then of course there's nothing more to do. If the combat couldn't happen for whatever
-					// reason, just give up on trying to move.
-					if (combatResult == CombatResult.AttackerKilled) {
+			// Check for units belonging to other civs
+			foreach (MapUnit other in tile.unitsOnTile)
+				if (other.owner != unit.owner) {
+					if (!other.owner.IsAtPeaceWith(unit.owner))
+						return allowCombat;
+					else
 						return false;
-					}
-					if (combatResult == CombatResult.Impossible) {
-						return true;
-					}
+				}
 
-					// If the enemy was defeated, check if there is another enemy on the tile. If so we can't complete the move
-					// but still pay one movement point for the combat.
-					else if (combatResult == CombatResult.DefenderKilled || combatResult == CombatResult.DefenderRetreated) {
-						if (!unit.CanEnterTile(newLoc, false)) {
-							unit.movementPoints.onUnitMove(1);
+			return true;
+		}
+
+		/// <summary>
+		/// Moves the unit in the given direction
+		/// </summary>
+		/// <param name="unit"></param>
+		/// <param name="dir">Which direction to move, e.g. northeast, west, etc.</param>
+		/// <param name="wait">Whether the method should wait to return until animations complete</param>
+		/// <returns>True if the unit is alive after the movement, false otherwise</returns>
+		/// <exception cref="Exception"></exception>
+		public static bool move(this MapUnit unit, TileDirection dir, bool wait = false) {
+			(int dx, int dy) = dir.toCoordDiff();
+			Tile newLoc = EngineStorage.gameData.map.tileAt(dx + unit.location.xCoordinate, dy + unit.location.yCoordinate);
+			if ((newLoc != Tile.NONE) && unit.CanEnterTile(newLoc, true) && (unit.movementPoints.canMove)) {
+				unit.facingDirection = dir;
+				unit.wake();
+
+				// Trigger combat if the tile we're moving into has an enemy unit. Or if this unit can't fight, do nothing.
+				MapUnit defender = newLoc.FindTopDefender(unit);
+				if (defender != MapUnit.NONE && !unit.owner.IsAtPeaceWith(defender.owner)) {
+					if (unit.unitType.attack > 0) {
+						CombatResult combatResult = unit.fight(defender);
+						// If we were killed then of course there's nothing more to do. If the combat couldn't happen for whatever
+						// reason, just give up on trying to move.
+						if (combatResult == CombatResult.AttackerKilled) {
+							return false;
+						}
+						if (combatResult == CombatResult.Impossible) {
 							return true;
 						}
 
-					// Similarly if we retreated, pay one MP for the combat but don't move.
-					} else if (combatResult == CombatResult.AttackerRetreated) {
-						unit.movementPoints.onUnitMove(1);
+						// If the enemy was defeated, check if there is another enemy on the tile. If so we can't complete the move
+						// but still pay one movement point for the combat.
+						else if (combatResult == CombatResult.DefenderKilled || combatResult == CombatResult.DefenderRetreated) {
+							if (!unit.CanEnterTile(newLoc, false)) {
+								unit.movementPoints.onUnitMove(1);
+								return true;
+							}
+
+							// Similarly if we retreated, pay one MP for the combat but don't move.
+						} else if (combatResult == CombatResult.AttackerRetreated) {
+							unit.movementPoints.onUnitMove(1);
+							return true;
+						}
+					} else if (unit.unitType.bombard > 0) {
+						unit.bombard(newLoc);
+						return true;
+					} else {
 						return true;
 					}
-				} else if (unit.unitType.bombard > 0) {
-					unit.bombard(newLoc);
-					return true;
-				} else {
-					return true;
+				}
+
+				float movementCost = getMovementCost(unit.location, dir, newLoc);
+				if (!unit.location.unitsOnTile.Remove(unit))
+					throw new System.Exception("Failed to remove unit from tile it's supposed to be on");
+				unit.OnEnterTile(newLoc);
+				newLoc.unitsOnTile.Add(unit);
+				unit.location = newLoc;
+				unit.movementPoints.onUnitMove(movementCost);
+				unit.animate(MapUnit.AnimatedAction.RUN, wait);
+			}
+			return true;
+		}
+
+		public static float getMovementCost(Tile from, TileDirection dir, Tile newLocation) {
+			if (from.HasRiverCrossing(dir)) return newLocation.MovementCost();
+			if (from.overlays.railroad && newLocation.overlays.railroad) return 0;
+			if ((from.overlays.railroad || from.overlays.road) && newLocation.overlays.road) return 1.0f / 3;
+			return newLocation.MovementCost();
+		}
+
+		public static void moveAlongPath(this MapUnit unit) {
+			while (unit.movementPoints.canMove && unit.path?.PathLength() > 0) {
+				TileDirection dir = unit.location.directionTo(unit.path.Next());
+				unit.move(dir, true); //TODO: don't wait on last move animation?
+			}
+		}
+
+		public static void setUnitPath(this MapUnit unit, Tile dest) {
+			unit.path = PathingAlgorithmChooser.GetAlgorithm().PathFrom(unit.location, dest);
+			if (unit.path == TilePath.NONE) {
+				log.Warning("Cannot move unit to " + dest + ", path is NONE!");
+			}
+			unit.moveAlongPath();
+		}
+
+		public static void skipTurn(this MapUnit unit) {
+			unit.movementPoints.skipTurn();
+		}
+
+		public static void disband(this MapUnit unit) {
+			GameData gameData = EngineStorage.gameData;
+
+			// Set unit's hit points to zero to indicate that it's no longer alive. Ultimately we may not want to do this. I'm only doing it right
+			// now since this way all the UI needs to do to check if the selected unit has been destroyed is to check its hit points.
+			unit.hitPointsRemaining = 0;
+
+			// EngineStorage.animTracker.endAnimation(unit, false);   TODO: Must send message instead of call directly
+			unit.location.unitsOnTile.Remove(unit);
+			gameData.mapUnits.Remove(unit);
+			foreach (Player player in gameData.players) {
+				if (player.units.Contains(unit)) {
+					player.units.Remove(unit);
 				}
 			}
-
-			float movementCost = getMovementCost(unit.location, dir, newLoc);
-			if (!unit.location.unitsOnTile.Remove(unit))
-				throw new System.Exception("Failed to remove unit from tile it's supposed to be on");
-			unit.OnEnterTile(newLoc);
-			newLoc.unitsOnTile.Add(unit);
-			unit.location = newLoc;
-			unit.movementPoints.onUnitMove(movementCost);
-			unit.animate(MapUnit.AnimatedAction.RUN, wait);
 		}
-		return true;
-	}
 
-	public static float getMovementCost(Tile from, TileDirection dir, Tile newLocation) {
-		if (from.HasRiverCrossing(dir)) return newLocation.MovementCost();
-		if (from.overlays.railroad && newLocation.overlays.railroad) return 0;
-		if ((from.overlays.railroad || from.overlays.road) && newLocation.overlays.road) return 1.0f / 3;
-		return newLocation.MovementCost();
-	}
-
-	public static void moveAlongPath(this MapUnit unit)
-	{
-		while (unit.movementPoints.canMove && unit.path?.PathLength() > 0) {
-			TileDirection dir = unit.location.directionTo(unit.path.Next());
-			unit.move(dir, true); //TODO: don't wait on last move animation?
-		}
-	}
-
-	public static void setUnitPath(this MapUnit unit, Tile dest)
-	{
-		unit.path = PathingAlgorithmChooser.GetAlgorithm().PathFrom(unit.location, dest);
-		if (unit.path == TilePath.NONE) {
-			log.Warning("Cannot move unit to " + dest + ", path is NONE!");
-		}
-		unit.moveAlongPath();
-	}
-
-	public static void skipTurn(this MapUnit unit)
-	{
-		unit.movementPoints.skipTurn();
-	}
-
-	public static void disband(this MapUnit unit)
-	{
-		GameData gameData = EngineStorage.gameData;
-
-		// Set unit's hit points to zero to indicate that it's no longer alive. Ultimately we may not want to do this. I'm only doing it right
-		// now since this way all the UI needs to do to check if the selected unit has been destroyed is to check its hit points.
-		unit.hitPointsRemaining = 0;
-
-		// EngineStorage.animTracker.endAnimation(unit, false);   TODO: Must send message instead of call directly
-		unit.location.unitsOnTile.Remove(unit);
-		gameData.mapUnits.Remove(unit);
-		foreach(Player player in gameData.players)
-		{
-			if (player.units.Contains(unit)) {
-				player.units.Remove(unit);
+		public static bool canBuildCity(this MapUnit unit) {
+			if (!unit.unitType.actions.Contains(C7Action.UnitBuildCity)) {
+				return false;
 			}
-		}
-	}
-
-	public static bool canBuildCity(this MapUnit unit)
-	{
-		if (!unit.unitType.actions.Contains(C7Action.UnitBuildCity)) {
-			return false;
-		}
-		if (unit.location.HasCity || !unit.location.IsAllowCities()) {
-			return false;
-		}
-		return unit.location.neighbors.Values.All(tile => !tile.HasCity);
-	}
-
-	public static void buildCity(this MapUnit unit, string cityName)
-	{
-		if (!unit.canBuildCity()) {
-			log.Warning($"can't build city at {unit.location}");
-			return;
+			if (unit.location.HasCity || !unit.location.IsAllowCities()) {
+				return false;
+			}
+			return unit.location.neighbors.Values.All(tile => !tile.HasCity);
 		}
 
-		unit.animate(MapUnit.AnimatedAction.BUILD, true);
+		public static void buildCity(this MapUnit unit, string cityName) {
+			if (!unit.canBuildCity()) {
+				log.Warning($"can't build city at {unit.location}");
+				return;
+			}
 
-		// TODO: Need to check somewhere that this unit is allowed to build a city on its current tile. Either do that here or in every caller
-		// (probably best to just do it here).
-		CityInteractions.BuildCity(unit.location.xCoordinate, unit.location.yCoordinate, unit.owner.guid, cityName);
+			unit.animate(MapUnit.AnimatedAction.BUILD, true);
 
-		// TODO: Should directly delete the unit instead of disbanding it. Disbanding in a city will eventually award shields, which we
-		// obviously don't want to do here.
-		unit.disband();
-	}
+			// TODO: Need to check somewhere that this unit is allowed to build a city on its current tile. Either do that here or in every caller
+			// (probably best to just do it here).
+			CityInteractions.BuildCity(unit.location.xCoordinate, unit.location.yCoordinate, unit.owner.guid, cityName);
 
-	public static bool canBuildRoad(this MapUnit unit) {
-		return unit.unitType.actions.Contains(C7Action.UnitBuildRoad) && unit.location.IsLand() && !unit.location.overlays.road;
-	}
-
-	public static void buildRoad(this MapUnit unit) {
-		if (!unit.canBuildRoad()) {
-			log.Warning($"can't build road by {unit}");
-			return;
+			// TODO: Should directly delete the unit instead of disbanding it. Disbanding in a city will eventually award shields, which we
+			// obviously don't want to do here.
+			unit.disband();
 		}
 
-		// TODO add animation and long process of building
-		unit.location.overlays.road = true;
-		unit.movementPoints.onConsumeAll();
-	}
+		public static bool canBuildRoad(this MapUnit unit) {
+			return unit.unitType.actions.Contains(C7Action.UnitBuildRoad) && unit.location.IsLand() && !unit.location.overlays.road;
+		}
+
+		public static void buildRoad(this MapUnit unit) {
+			if (!unit.canBuildRoad()) {
+				log.Warning($"can't build road by {unit}");
+				return;
+			}
+
+			// TODO add animation and long process of building
+			unit.location.overlays.road = true;
+			unit.movementPoints.onConsumeAll();
+		}
 
 	}
 }

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -2,8 +2,7 @@ using Serilog;
 
 namespace C7Engine
 {
-
-using System;
+	using System;
 using System.Collections.Generic;
 using System.Linq;
 using Pathing;
@@ -440,7 +439,7 @@ public static class MapUnitExtensions {
 
 	public static bool canBuildCity(this MapUnit unit)
 	{
-		if (!unit.unitType.actions.Contains("buildCity")) {
+		if (!unit.unitType.actions.Contains(C7Action.UnitBuildCity)) {
 			return false;
 		}
 		if (unit.location.HasCity || !unit.location.IsAllowCities()) {
@@ -468,7 +467,7 @@ public static class MapUnitExtensions {
 	}
 
 	public static bool canBuildRoad(this MapUnit unit) {
-		return unit.unitType.actions.Contains("buildRoad") && unit.location.IsLand() && !unit.location.overlays.road;
+		return unit.unitType.actions.Contains(C7Action.UnitBuildRoad) && unit.location.IsLand() && !unit.location.overlays.road;
 	}
 
 	public static void buildRoad(this MapUnit unit) {

--- a/C7GameData/Actions.cs
+++ b/C7GameData/Actions.cs
@@ -1,5 +1,6 @@
 namespace C7GameData {
 	public static class C7Action {
+		public static readonly string EndTurn = "end_turn";
 		public static readonly string UnitBombard = "unit_bombard";
 		public static readonly string UnitBuildCity = "unit_build_city";
 		public static readonly string UnitBuildRoad = "unit_build_road";

--- a/C7GameData/Actions.cs
+++ b/C7GameData/Actions.cs
@@ -1,0 +1,15 @@
+namespace C7GameData {
+	public static class C7Action {
+		public static readonly string UnitBombard = "unit_bombard";
+		public static readonly string UnitBuildCity = "unit_build_city";
+		public static readonly string UnitBuildRoad = "unit_build_road";
+		public static readonly string UnitDisband = "unit_disband";
+		public static readonly string UnitExplore = "unit_explore";
+		public static readonly string UnitFortify = "unit_fortify";
+		public static readonly string UnitGoto = "unit_goto";
+		public static readonly string UnitHold = "unit_hold";
+		public static readonly string UnitSentry = "unit_sentry";
+		public static readonly string UnitSentryEnemyOnly = "unit_sentry_enemy_only";
+		public static readonly string UnitWait = "unit_wait";
+	}
+}

--- a/C7GameData/Actions.cs
+++ b/C7GameData/Actions.cs
@@ -1,6 +1,18 @@
 namespace C7GameData {
 	public static class C7Action {
 		public static readonly string EndTurn = "end_turn";
+		public static readonly string Escape = "escape";
+		public static readonly string MoveUnitSouthwest = "move_unit_southwest";
+		public static readonly string MoveUnitSouth = "move_unit_south";
+		public static readonly string MoveUnitSoutheast = "move_unit_southeast";
+		public static readonly string MoveUnitWest = "move_unit_west";
+		public static readonly string MoveUnitEast = "move_unit_east";
+		public static readonly string MoveUnitNorthwest = "move_unit_northwest";
+		public static readonly string MoveUnitNorth = "move_unit_north";
+		public static readonly string MoveUnitNortheast = "move_unit_northeast";
+		public static readonly string ToggleAnimations = "toggle_animations";
+		public static readonly string ToggleGrid = "toggle_grid";
+		public static readonly string ToggleZoom = "toggle_zoom";
 		public static readonly string UnitBombard = "unit_bombard";
 		public static readonly string UnitBuildCity = "unit_build_city";
 		public static readonly string UnitBuildRoad = "unit_build_road";

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -244,28 +244,28 @@ namespace C7GameData
 				prototype.bombard = prto.BombardStrength;
 				prototype.iconIndex = prto.IconIndex;
 				if (prto.BuildCity) {
-					prototype.actions.Add("buildCity");
+					prototype.actions.Add(C7Action.UnitBuildCity);
 				}
 				if (prto.BuildRoad) {
-					prototype.actions.Add("buildRoad");
+					prototype.actions.Add(C7Action.UnitBuildRoad);
 				}
 				if (prto.Bombard) {
-					prototype.actions.Add("bombard");
+					prototype.actions.Add(C7Action.UnitBombard);
 				}
 				if (prto.SkipTurn) {
-					prototype.actions.Add("hold");
+					prototype.actions.Add(C7Action.UnitHold);
 				}
 				if (prto.Wait) {
-					prototype.actions.Add("wait");
+					prototype.actions.Add(C7Action.UnitWait);
 				}
 				if (prto.Fortify) {
-					prototype.actions.Add("fortify");
+					prototype.actions.Add(C7Action.UnitFortify);
 				}
 				if (prto.Disband) {
-					prototype.actions.Add("disband");
+					prototype.actions.Add(C7Action.UnitDisband);
 				}
 				if (prto.GoTo) {
-					prototype.actions.Add("goTo");
+					prototype.actions.Add(C7Action.UnitGoto);
 				}
 				//Temporary check until #329/#330 are finished
 				if (!c7SaveFormat.GameData.unitPrototypes.ContainsKey(prototype.name)) {


### PR DESCRIPTION
the actual dif is ~500 lines (change rewrites the sample save file and 400 lines of whitespace changes in 1 file)

# use Godot action keybindings for input:
- before input buttons were hardcoded to Godot.Key.<key>, now actions triggered by input are determined by action keybindings in Godot (Project -> Project Settings... -> Input Map) queried by Godot `Input.` methods
- simplifies Unit Buttons: instead of sending a signal that calls into Game, Unit Buttons trigger actions also through Godot `Input` class
- for consistency, unit actions use the same names as corresponding Godot keybinding action names, defined in C7GameData/Actions.cs (ie. r key is mapped to the "unit_build_road" action in Godot, and now the worker prototype actions contains "unit_build_road" instead of "buildRoad")
