### PR TITLE
[Godot 4] Fix Popup Bugs

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -27,7 +27,6 @@ public partial class Game : Node2D {
 	public AnimationManager civ3AnimData;
 	public AnimationTracker animTracker;
 
-	Hashtable Terrmask = new Hashtable();
 	GameState CurrentState = GameState.PreGame;
 
 	// CurrentlySelectedUnit is a reference directly into the game state so be careful of race conditions. TODO: Consider storing a GUID instead.
@@ -47,6 +46,8 @@ public partial class Game : Node2D {
 	Stopwatch loadTimer = new Stopwatch();
 	GlobalSingleton Global;
 
+	private PopupOverlay popupOverlay;
+
 	bool errorOnLoad = false;
 
 	public override void _EnterTree() {
@@ -58,6 +59,8 @@ public partial class Game : Node2D {
 	// that gives an error if we fail to load for some reason.
 	public override void _Ready() {
 		Global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
+		popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
+
 		try {
 			var animSoundPlayer = new AudioStreamPlayer();
 			AddChild(animSoundPlayer);
@@ -105,7 +108,6 @@ public partial class Game : Node2D {
 			log.Information("Game scene load time: " + Convert.ToInt32(stopwatchElapsed.TotalMilliseconds) + " ms");
 		} catch (Exception ex) {
 			errorOnLoad = true;
-			PopupOverlay popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
 			string message = ex.Message;
 			string[] stack = ex.StackTrace.Split("\r\n");   //for some reason it is returned with \r\n in the string as one line.  let's make it readable!
 			foreach (string line in stack) {
@@ -166,7 +168,7 @@ public partial class Game : Node2D {
 	}
 
 	public override void _Process(double delta) {
-		this.processActions();
+		processActions();
 
 		// TODO: Is it necessary to keep the game data mutex locked for this entire method?
 		using (var gameDataAccess = new UIGameDataAccess()) {
@@ -440,6 +442,15 @@ public partial class Game : Node2D {
 
 	// Handle Godot keybind actions
 	private void processActions() {
+		if (Input.IsActionJustPressed(C7Action.Escape) && popupOverlay.Visible) {
+			popupOverlay.OnHidePopup();
+			return;
+		}
+
+		// never poll for actions if UI elements are visible
+		if (popupOverlay.Visible) {
+			return;
+		}
 
 		if (Input.IsActionJustPressed(C7Action.EndTurn) && !this.HasCurrentlySelectedUnit()) {
 			log.Verbose("end_turn key pressed");
@@ -481,7 +492,6 @@ public partial class Game : Node2D {
 
 		if (Input.IsActionJustPressed(C7Action.Escape) && !this.inUnitGoToMode) {
 			log.Debug("Got request for escape/quit");
-			PopupOverlay popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
 			popupOverlay.ShowPopup(new EscapeQuitPopup(), PopupOverlay.PopupCategory.Info);
 		}
 
@@ -520,7 +530,6 @@ public partial class Game : Node2D {
 		}
 
 		if (Input.IsActionJustPressed(C7Action.UnitDisband)) {
-			PopupOverlay popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
 			popupOverlay.ShowPopup(new DisbandConfirmation(CurrentlySelectedUnit), PopupOverlay.PopupCategory.Advisor);
 		}
 
@@ -548,9 +557,7 @@ public partial class Game : Node2D {
 				MapUnit currentUnit = gameDataAccess.gameData.GetUnit(CurrentlySelectedUnit.guid);
 				log.Debug(currentUnit.Describe());
 				if (currentUnit.canBuildCity()) {
-					PopupOverlay popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
-					popupOverlay.ShowPopup(new BuildCityDialog(controller.GetNextCityName()),
-						PopupOverlay.PopupCategory.Advisor);
+					popupOverlay.ShowPopup(new BuildCityDialog(controller.GetNextCityName()), PopupOverlay.PopupCategory.Advisor);
 				}
 			}
 		}

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -442,7 +442,7 @@ public partial class Game : Node2D {
 
 	// Handle Godot keybind actions
 	private void processActions() {
-		if (Input.IsActionJustPressed(C7Action.Escape) && popupOverlay.Visible) {
+		if (Input.IsActionJustPressed(C7Action.Escape) && popupOverlay.ShowingPopup) {
 			popupOverlay.OnHidePopup();
 			return;
 		}

--- a/C7/UIElements/Popups/BuildCityDialog.cs
+++ b/C7/UIElements/Popups/BuildCityDialog.cs
@@ -100,17 +100,4 @@ public partial class BuildCityDialog : Popup
 		GetParent().EmitSignal("HidePopup");
 	}
 
-	public override void _UnhandledInput(InputEvent @event)
-	{
-		if (this.Visible) {
-			if (@event is InputEventKey eventKey && eventKey.Pressed)
-			{
-				if (eventKey.Keycode == Godot.Key.Escape)
-				{
-					GetViewport().SetInputAsHandled();
-					GetParent().EmitSignal("HidePopup");
-				}
-			}
-		}
-	}
 }

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -1,7 +1,4 @@
 using Godot;
-using ConvertCiv3Media;
-using System;
-using System.Diagnostics;
 using Serilog;
 
 public partial class PopupOverlay : HBoxContainer
@@ -16,7 +13,7 @@ public partial class PopupOverlay : HBoxContainer
 
 	Control currentChild = null;
 
-	public const string NodePath = "/root/C7Game/CanvasLayer/PopupOverlay";
+	public static readonly string NodePath = "/root/C7Game/CanvasLayer/PopupOverlay";
 
 	public enum PopupCategory {
 		Advisor,
@@ -24,17 +21,14 @@ public partial class PopupOverlay : HBoxContainer
 		Info	//Sounds similar to the above, but lower-pitched in the second half
 	}
 
-	public override void _Ready()
+	public void OnHidePopup()
 	{
-		base._Ready();
-	}
-
-	private void OnHidePopup()
-	{
-		log.Debug("Hiding popup");
 		RemoveChild(currentChild);
+		currentChild = null;
 		Hide();
 	}
+
+	public bool ShowingPopup() => currentChild is not null;
 
 	public void PlaySound(AudioStreamWav wav)
 	{
@@ -45,8 +39,8 @@ public partial class PopupOverlay : HBoxContainer
 
 	public void ShowPopup(Popup child, PopupCategory category)
 	{
-		if (child == null) // not necessary if we don't pass null?
-		{
+		if (child is null) {
+			// not necessary if we don't pass null?
 			log.Error("Received request to show null popup");
 			return;
 		}
@@ -60,24 +54,17 @@ public partial class PopupOverlay : HBoxContainer
 		AddChild(child);
 		currentChild = child;
 
-		string soundFile = "";
-		switch (category)
-		{
-			case PopupCategory.Advisor:
-				soundFile = "Sounds/PopupAdvisor.wav";
-				break;
-			case PopupCategory.Console:
-				soundFile = "Sounds/PopupConsole.wav";
-				break;
-			case PopupCategory.Info:
-				soundFile = "Sounds/PopupInfo.wav";
-				break;
-			default:
-				log.Error("Invalid popup category");
-				break;
+		string soundFile = category switch {
+			PopupCategory.Advisor => "Sounds/PopupAdvisor.wav",
+			PopupCategory.Console => "Sounds/PopupConsole.wav",
+			PopupCategory.Info => "Sounds/PopupInfo.wav",
+			_ => "",
+		};
+		if (soundFile == "") {
+			log.Error("Invalid popup category");
 		}
 		AudioStreamWav wav = Util.LoadWAVFromDisk(Util.Civ3MediaPath(soundFile));
-		Visible = true;
+		Show();
 		PlaySound(wav);
 	}
 

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -28,7 +28,7 @@ public partial class PopupOverlay : HBoxContainer
 		Hide();
 	}
 
-	public bool ShowingPopup() => currentChild is not null;
+	public bool ShowingPopup => currentChild is not null;
 
 	public void PlaySound(AudioStreamWav wav)
 	{


### PR DESCRIPTION
Incrementally removing bugs from the godot4 branch:

- prevents polling for input actions in Game.cs when a popup is visible
- fixes behaviour when the build city popup is open and esc. is pressed: before it would close the popup and show the exit game popup at the same time. now, the first esc. press will only close the current popup