### PR TITLE
[Godot 4] Make ParameterWrapper type safe and remove memory leak

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -252,7 +252,7 @@ public partial class Game : Node2D {
 
 		// Also emit the signal for a new unit being selected, so other areas such as Game Status and Unit Buttons can update
 		if (CurrentlySelectedUnit != MapUnit.NONE) {
-			ParameterWrapper wrappedUnit = new ParameterWrapper(CurrentlySelectedUnit);
+			ParameterWrapper<MapUnit> wrappedUnit = new ParameterWrapper<MapUnit>(CurrentlySelectedUnit);
 			EmitSignal("NewAutoselectedUnit", wrappedUnit);
 		} else {
 			EmitSignal("NoMoreAutoselectableUnits");

--- a/C7/ParameterWrapper.cs
+++ b/C7/ParameterWrapper.cs
@@ -7,28 +7,19 @@ using Godot;
  * easily.
  * Taken from https://github.com/godotengine/godot/issues/16706#issuecomment-394605337
  * Example sending:
- * 		ParameterWrapper wrappedUnit = new ParameterWrapper(SelectedUnit);
- *      EmitSignal(nameof(NewAutoselectedUnit), wrappedUnit);
+ *     ParameterWrapper<MapUnit> wrappedUnit = new ParameterWrapper<MapUnit>(SelectedUnit);
+ *     EmitSignal(nameof(NewAutoselectedUnit), wrappedUnit);
  * Example receiving:
- *      public void OnNewUnitSelected(ParameterWrapper mapUnitThing) {
- *          MapUnit unwrappedUnit = mapUnitThing.GetValue<MapUnit>();
- *          //Do whatever you like with unwrappedUnit...
- *      }
+ *    public void OnNewUnitSelected(ParameterWrapper<MapUnit> mapUnitThing) {
+ *        MapUnit unwrappedUnit = mapUnitThing.Value;
+ *        // Do whatever you like with unwrappedUnit...
+ *    }
  **/
 
-// TODO(pcen): migrating to Godot 4 come back and check if this workaround is still needed
+public partial class ParameterWrapper<T> : RefCounted {
+	public T Value { get; private set; }
 
-public partial class ParameterWrapper : GodotObject
-{
-	private readonly object value;
-
-	public ParameterWrapper(object value)
-	{
-		this.value = value;
-	}
-
-	public T GetValue<T>()
-	{
-		return (T)this.value;
+	public ParameterWrapper(T value) {
+		Value = value;
 	}
 }

--- a/C7/UIElements/GameStatus/GameStatus.cs
+++ b/C7/UIElements/GameStatus/GameStatus.cs
@@ -21,9 +21,9 @@ public partial class GameStatus : MarginContainer
 		AddChild(LowerRightInfoBox);
 	}
 
-	public void OnNewUnitSelected(ParameterWrapper wrappedMapUnit)
+	public void OnNewUnitSelected(ParameterWrapper<MapUnit> wrappedMapUnit)
 	{
-		MapUnit newUnit = wrappedMapUnit.GetValue<MapUnit>();
+		MapUnit newUnit = wrappedMapUnit.Value;
 		log.Information("Selected unit: " + newUnit + " at " + newUnit.location);
 		LowerRightInfoBox.UpdateUnitInfo(newUnit, newUnit.location.overlayTerrainType);
 	}

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -81,8 +81,8 @@ public partial class UnitButtons : VBoxContainer {
 		this.Visible = false;
 	}
 
-	private void OnNewUnitSelected(ParameterWrapper wrappedMapUnit) {
-		MapUnit unit = wrappedMapUnit.GetValue<MapUnit>();
+	private void OnNewUnitSelected(ParameterWrapper<MapUnit> wrappedMapUnit) {
+		MapUnit unit = wrappedMapUnit.Value;
 		foreach (UnitControlButton button in buttonMap.Values) {
 			button.Visible = false;
 		}


### PR DESCRIPTION
- makes ParameterWrapper class take the type parameter instead of the value getter, making it impossible to attempt to cast `object value` to the wrong type
- makes ParameterWrapper inherit from `RefCounted` godot class so it does not leak memory