### PR TITLE
[4.x] Default font size 14

### DIFF
--- a/C7/C7.csproj
+++ b/C7/C7.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.0.3">
+<Project Sdk="Godot.NET.Sdk/4.1.1">
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/C7/C7Theme.tres
+++ b/C7/C7Theme.tres
@@ -1,4 +1,6 @@
-[gd_resource type="Theme" load_steps=6 format=3 uid="uid://c1jpmssnhvodi"]
+[gd_resource type="Theme" load_steps=7 format=3 uid="uid://c1jpmssnhvodi"]
+
+[ext_resource type="FontFile" uid="uid://c1qd602n7xu3h" path="res://Fonts/NotoSans-Regular.ttf" id="1_6qeon"]
 
 [sub_resource type="StyleBoxEmpty" id="3"]
 
@@ -25,13 +27,19 @@ Button/colors/font_color = Color(0, 0, 0, 1)
 Button/colors/font_color_focus = Color(0, 0.45098, 0.741176, 1)
 Button/colors/font_color_hover = Color(0.709804, 0.352941, 0, 1)
 Button/colors/font_color_pressed = Color(0, 0.45098, 0.741176, 1)
+Button/font_sizes/font_size = 13
+Button/fonts/font = ExtResource("1_6qeon")
 Button/styles/focus = SubResource("3")
 Button/styles/hover = SubResource("4")
 Button/styles/normal = SubResource("6")
 Button/styles/pressed = SubResource("5")
 Label/colors/font_color = Color(0, 0, 0, 1)
+Label/font_sizes/font_size = 14
+Label/fonts/font = ExtResource("1_6qeon")
 LineEdit/colors/cursor_color = Color(0, 0, 0, 1)
 LineEdit/colors/font_color = Color(0, 0, 0, 1)
 LineEdit/colors/selection_color = Color(0.709804, 0.807843, 0.709804, 1)
+LineEdit/font_sizes/font_size = 14
+LineEdit/fonts/font = ExtResource("1_6qeon")
 LineEdit/styles/focus = SubResource("7")
 LineEdit/styles/normal = SubResource("7")

--- a/C7/project.godot
+++ b/C7/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="C7"
 run/main_scene="res://MainMenu.tscn"
-config/features=PackedStringArray("4.0", "C#")
+config/features=PackedStringArray("4.1", "C#")
 boot_splash/image="res://icon.png"
 config/icon="res://icon.png"
 


### PR DESCRIPTION
Sets the default font size to 14, and sets it to use Noto Sans.  14 was the default in Godot 3.x; this causes it to match existing functionality.  Downside, for some reason the overrides to font size for things like headers in dialogs aren't working; I verified that they weren't without these changes either.

See Popup.js, AddHeader method as an example of where we have an override that worked in 3.5 but doesn't in 4.x yet.

Also, switch to Godot 4.1.  We may not want to merge this until pcen has also signed-off on 4.1.