### PR TITLE
godot4 fix: remove autoloaded nodes

### DIFF
--- a/C7/Credits.tscn
+++ b/C7/Credits.tscn
@@ -1,6 +1,6 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=2 format=3 uid="uid://ouangx1h81vh"]
 
-[ext_resource path="res://Credits.cs" type="Script" id=1]
+[ext_resource type="Script" path="res://Credits.cs" id="1"]
 
 [node name="Node2D" type="Node2D"]
-script = ExtResource( 1 )
+script = ExtResource("1")

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -45,7 +45,11 @@ public partial class Game : Node2D {
 	private Vector2 OldPosition;
 
 	Stopwatch loadTimer = new Stopwatch();
-	GlobalSingleton Global;
+	readonly GlobalSingleton Global = GlobalSingleton.Instance;
+
+	public override void _ExitTree() {
+		LogManager.ShutDown();
+	}
 
 	bool errorOnLoad = false;
 
@@ -57,7 +61,6 @@ public partial class Game : Node2D {
 	// The catch should always catch any error, as it's the general catch
 	// that gives an error if we fail to load for some reason.
 	public override void _Ready() {
-		Global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
 		try {
 			var animSoundPlayer = new AudioStreamPlayer();
 			AddChild(animSoundPlayer);

--- a/C7/GlobalSingleton.cs
+++ b/C7/GlobalSingleton.cs
@@ -1,12 +1,21 @@
+using System;
 using Godot;
 using QueryCiv3;
 
 /****
-    Need to pass values from one scene to another, particularly when loading
-    a game in main menu. This script is set to auto load in project settings.
-    See https://docs.godotengine.org/en/stable/getting_started/step_by_step/singletons_autoload.html
+	Need to pass values from one scene to another, particularly when loading
+	a game in main menu. This script is set to auto load in project settings.
+	See https://docs.godotengine.org/en/stable/getting_started/step_by_step/singletons_autoload.html
 ****/
-public partial class GlobalSingleton : Node {
+// TODO: document issue with Godot autoloader in 4.1 causing crashes
+public sealed class GlobalSingleton {
+	private static readonly Lazy<GlobalSingleton> lazy = new(() => new GlobalSingleton());
+
+	public static GlobalSingleton Instance { get => lazy.Value; }
+
+	// private to prevent GlobalSingleton from being instantiated directly
+	private GlobalSingleton() {}
+
 	// Will have main menu file picker set this and Game.cs pass it to C7Engine.createGame
 	// which then should blank it again to prevent reloading same if going back to main menu
 	// and back to game

--- a/C7/MainMenu.cs
+++ b/C7/MainMenu.cs
@@ -16,7 +16,7 @@ public partial class MainMenu : Node2D
 	Button SetCiv3Home;
 	FileDialog SetCiv3HomeDialog;
 	Util.Civ3FileDialog LoadScenarioDialog;
-	GlobalSingleton Global;
+	readonly GlobalSingleton Global = GlobalSingleton.Instance;
 
 	readonly int MENU_OFFSET_FROM_TOP = 180;
 	readonly int MENU_OFFSET_FROM_LEFT = 180;
@@ -28,13 +28,14 @@ public partial class MainMenu : Node2D
 		log.Debug("enter MainMenu._Ready");
 
 		// To pass data between scenes, putting path string in a global singleton and reading it later in createGame
-		Global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
 		Global.ResetLoadGamePath();
-		LoadDialog = new Util.Civ3FileDialog();
-		LoadDialog.RelPath = @"Conquests/Saves";
+		LoadDialog = new Util.Civ3FileDialog {
+			RelPath = @"Conquests/Saves"
+		};
 		LoadDialog.Connect("file_selected",new Callable(this,nameof(_on_FileDialog_file_selected)));
-		LoadScenarioDialog = new Util.Civ3FileDialog();
-		LoadScenarioDialog.RelPath = @"Conquests/Scenarios";
+		LoadScenarioDialog = new Util.Civ3FileDialog {
+			RelPath = @"Conquests/Scenarios"
+		};
 		LoadScenarioDialog.Connect("file_selected",new Callable(this,nameof(_on_FileDialog_file_selected)));
 		GetNode<CanvasLayer>("CanvasLayer").AddChild(LoadDialog);
 		SetCiv3Home = GetNode<Button>("CanvasLayer/SetCiv3Home");
@@ -133,6 +134,10 @@ public partial class MainMenu : Node2D
 	public void Preferences()
 	{
 		PlayButtonPressedSound();
+	}
+
+	public override void _ExitTree() {
+		LogManager.ShutDown();
 	}
 
 	public void _on_Exit_pressed()

--- a/C7/project.godot
+++ b/C7/project.godot
@@ -16,11 +16,6 @@ config/features=PackedStringArray("4.1", "C#")
 boot_splash/image="res://icon.png"
 config/icon="res://icon.png"
 
-[autoload]
-
-GlobalSingleton="*res://GlobalSingleton.cs"
-LogManager="*res://LogManager.cs"
-
 [display]
 
 window/size/window_width_override=1152


### PR DESCRIPTION
The reason for this change is that we are seeing issues opening the C7 project on the godot4 branch in the editor on linux:
![image](https://github.com/C7-Game/Prototype/assets/43939602/3c42fe97-52ad-4062-8622-db2bc8585829)
Which may potentially be the same as [this issue](https://github.com/godotengine/godot/issues/36787), which is reproducible in Godot 4.1 by creating a new project and adding an autoloaded C# node. This fix removes all autoloaded nodes:
GlobalSingleton becomes a singleton managed by C# using System.Lazy
LogManager becomes a purely static class with a static constructor running before methods are accessed, and currently LogManager.ShutDown() will need to be called whenever the application is closing in order to flush the log (ie. for every scene, have the top level node override _ExitTree and invoke LogManager.ShutDown, *if* exiting the tree implies the entire application is closing. Obviously we need a better solution for flushing the log in the future)