### PR TITLE
Fix Godot 4 City Graphics Regressions

### DIFF
--- a/C7/Map/CityLabelScene.cs
+++ b/C7/Map/CityLabelScene.cs
@@ -47,9 +47,13 @@ namespace C7.Map {
 			popThemeRed.DefaultFont = midSizedFont;
 			popThemeRed.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
 
-			smallFont = ResourceLoader.Load<FontFile>("res://Fonts/NotoSans-Regular.ttf");
-
+			//Mid-Size font uses the cache
 			midSizedFont = ResourceLoader.Load<FontFile>("res://Fonts/NotoSans-Regular.ttf");
+
+			//Small font doesn't, because otherwise it makes everything small
+			smallFont = ResourceLoader.Load<FontFile>("res://Fonts/NotoSans-Regular.ttf", null, ResourceLoader.CacheMode.Ignore);
+			//Must set the FixedSize so Godot can calculate the width of the font for city labels
+			smallFont.FixedSize = 11;
 
 			nonEmbassyStar = PCXToGodot.getImageFromPCX(cityIcons, 20, 1, 18, 18);
 		}

--- a/C7/Map/CityLabelScene.cs
+++ b/C7/Map/CityLabelScene.cs
@@ -44,10 +44,12 @@ namespace C7.Map {
 			smallFontTheme.SetFontSize("font_size", "Label", 11);
 			popSizeTheme.DefaultFont = midSizedFont;
 			popSizeTheme.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
+			popSizeTheme.SetFontSize("font_size", "Label", 18);
 			popThemeRed.DefaultFont = midSizedFont;
 			popThemeRed.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
+			popThemeRed.SetFontSize("font_size", "Label", 18);
 
-			//Mid-Size font uses the cache
+			//Mid-Size font skips the cache as it sets a custom size
 			midSizedFont = ResourceLoader.Load<FontFile>("res://Fonts/NotoSans-Regular.ttf");
 
 			//Small font doesn't, because otherwise it makes everything small

--- a/C7/Map/CityScene.cs
+++ b/C7/Map/CityScene.cs
@@ -20,7 +20,7 @@ namespace C7.Map {
 			Pcx pcx = Util.LoadPCX("Art/Cities/rMIDEAST.PCX");
 			int height = pcx.Height/4;
 			int width = pcx.Width/3;
-			cityTexture = Util.LoadTextureFromPCX("Art/Cities/rMIDEAST.PCX", 0, 0, width, height);
+			cityTexture = Util.LoadTextureFromPCX("Art/Cities/rMIDEAST.PCX", 0, 0, width, height, false);
 			citySpriteSize = new Vector2(width, height);
 
 			cityGraphics.OffsetLeft = tileCenter.X - (float)0.5 * citySpriteSize.X;

--- a/C7/PCXToGodot.cs
+++ b/C7/PCXToGodot.cs
@@ -11,16 +11,17 @@ public partial class PCXToGodot : GodotObject
 		return getImageTextureFromImage(ImgTxtr);
 	}
 
-	public static ImageTexture getImageTextureFromPCX(Pcx pcx, int leftStart, int topStart, int croppedWidth, int croppedHeight) {
-		Image image = getImageFromPCX(pcx, leftStart, topStart, croppedWidth, croppedHeight);
+	public static ImageTexture getImageTextureFromPCX(Pcx pcx, int leftStart, int topStart, int croppedWidth, int croppedHeight, bool shadows = true) {
+		Image image = getImageFromPCX(pcx, leftStart, topStart, croppedWidth, croppedHeight, shadows);
 		return getImageTextureFromImage(image);
 	}
 
 	/**
 	 * This method is for cases where we want to use components of multiple PCXs in a texture, such as for the popup background.
 	 **/
-	public static Image getImageFromPCX(Pcx pcx, int leftStart, int topStart, int croppedWidth, int croppedHeight) {
-		int[] ColorData = loadPalette(pcx.Palette, true);
+	public static Image getImageFromPCX(Pcx pcx, int leftStart, int topStart, int croppedWidth, int croppedHeight, bool shadows = true) {
+
+		int[] ColorData = loadPalette(pcx.Palette, shadows);
 		int[] BufferData = new int[croppedWidth * croppedHeight];
 
 		int DataIndex = 0;

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -210,13 +210,13 @@ public partial class Util {
 	private static Dictionary<string, ImageTexture> textureCache = new Dictionary<string, ImageTexture>();
 	//Send this function a path (e.g. Art/exitBox-backgroundStates.pcx), and the coordinates of the extracted image you need from that PCX
 	//file, and it'll load it up and return you what you need.
-	static public ImageTexture LoadTextureFromPCX(string relPath, int leftStart, int topStart, int width, int height) {
+	static public ImageTexture LoadTextureFromPCX(string relPath, int leftStart, int topStart, int width, int height, bool shadows = true) {
 		string key = relPath + "-" + leftStart + "-" + topStart + "-" + width + "-" + height;
 		if (textureCache.ContainsKey(key)) {
 			return textureCache[key];
 		}
 		Pcx NewPCX = LoadPCX(relPath);
-		ImageTexture texture = PCXToGodot.getImageTextureFromPCX(NewPCX, leftStart, topStart, width, height);
+		ImageTexture texture = PCXToGodot.getImageTextureFromPCX(NewPCX, leftStart, topStart, width, height, shadows);
 		textureCache[key] = texture;
 		return texture;
 	}


### PR DESCRIPTION
These fixes bring the city graphics/label up to equality with Godot 3.5.

1. City label being too wide.  This is fixed by specifying the size of the font used for the label so Godot can calculate it correctly.  (Note it doesn't use the cache, as otherwise it would change the size everywhere).
2. Remove the square box around the city graphics.  This was caused by using shadows when they shouldn't have been used; this is now configurable. (Not 100% sure why this only affected Godot 4)
3. Pop size label now is the correct size