### PR TITLE
[godot 4] make caret color black by default

### DIFF
--- a/C7/UIElements/Popups/BuildCityDialog.cs
+++ b/C7/UIElements/Popups/BuildCityDialog.cs
@@ -11,6 +11,8 @@ public partial class BuildCityDialog : Popup
 
 	public BuildCityDialog(string defaultName)
 	{
+		cityName.Theme = ThemeFactory.DefaultTheme;
+		cityName.CaretBlink = true;
 		this.defaultName = defaultName;
 		alignment = BoxContainer.AlignmentMode.End;
 		margins = new Margins(right: -10); // 10px margin from the right

--- a/C7/UIElements/Theme.cs
+++ b/C7/UIElements/Theme.cs
@@ -1,0 +1,15 @@
+using Godot;
+
+public static class ThemeFactory {
+
+	static ThemeFactory() {
+		defaultTheme = new Theme();
+		defaultTheme.SetColor("caret_color", "LineEdit", Colors.Black);
+	}
+
+	private static Theme defaultTheme;
+
+	public static Theme DefaultTheme {
+		get => defaultTheme;
+	}
+}


### PR DESCRIPTION
Fixes the caret color being white on the godot 4 branch, as described in https://github.com/C7-Game/Prototype/issues/441.