### PR TITLE
Prevent mouse interactions with map and other UI elements when popup is open

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -180,7 +180,6 @@ anchors_preset = 11
 anchor_left = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -108.0
 offset_top = 80.0
 offset_right = -108.0
 offset_bottom = -170.0

--- a/C7/Credits.tscn
+++ b/C7/Credits.tscn
@@ -1,6 +1,6 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=2 format=3 uid="uid://pfefjvwiljdp"]
 
-[ext_resource path="res://Credits.cs" type="Script" id=1]
+[ext_resource type="Script" path="res://Credits.cs" id="1"]
 
 [node name="Node2D" type="Node2D"]
-script = ExtResource( 1 )
+script = ExtResource("1")

--- a/C7/GlobalSingleton.cs
+++ b/C7/GlobalSingleton.cs
@@ -2,9 +2,9 @@ using Godot;
 using QueryCiv3;
 
 /****
-    Need to pass values from one scene to another, particularly when loading
-    a game in main menu. This script is set to auto load in project settings.
-    See https://docs.godotengine.org/en/stable/getting_started/step_by_step/singletons_autoload.html
+	Need to pass values from one scene to another, particularly when loading
+	a game in main menu. This script is set to auto load in project settings.
+	See https://docs.godotengine.org/en/stable/getting_started/step_by_step/singletons_autoload.html
 ****/
 public partial class GlobalSingleton : Node {
 	// Will have main menu file picker set this and Game.cs pass it to C7Engine.createGame

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -54,21 +54,21 @@ public partial class LowerRightInfoBox : TextureRect
 		lblUnitSelected.HorizontalAlignment = HorizontalAlignment.Right;
 		lblUnitSelected.SetPosition(new Vector2(0, 20));
 		lblUnitSelected.AnchorRight = 1.0f;
-		lblUnitSelected.OffsetRight = -35;
+		lblUnitSelected.OffsetRight = -30;
 		boxRightRectangle.AddChild(lblUnitSelected);
 
 		attackDefenseMovement.Text = "0.0. 1/1";
 		attackDefenseMovement.HorizontalAlignment = HorizontalAlignment.Right;
 		attackDefenseMovement.SetPosition(new Vector2(0, 35));
 		attackDefenseMovement.AnchorRight = 1.0f;
-		attackDefenseMovement.OffsetRight = -35;
+		attackDefenseMovement.OffsetRight = -30;
 		boxRightRectangle.AddChild(attackDefenseMovement);
 
 		terrainType.Text = "Grassland";
 		terrainType.HorizontalAlignment = HorizontalAlignment.Right;
 		terrainType.SetPosition(new Vector2(0, 50));
 		terrainType.AnchorRight = 1.0f;
-		terrainType.OffsetRight = -35;
+		terrainType.OffsetRight = -30;
 		boxRightRectangle.AddChild(terrainType);
 
 		//For the centered labels, we anchor them center, with equal weight on each side.

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -19,7 +19,7 @@ public partial class LowerRightInfoBox : TextureRect
 	Label yearAndGold = new Label();
 
 	Timer blinkingTimer = new Timer();
-	Boolean timerStarted = false;	//This "isStopped" returns false if it's never been started.  So we need this to know if we've ever started it.
+	bool timerStarted = false;	//This "isStopped" returns false if it's never been started.  So we need this to know if we've ever started it.
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Godot;
 using Serilog;
 
@@ -15,6 +16,8 @@ public partial class PopupOverlay : HBoxContainer
 
 	public static readonly string NodePath = "/root/C7Game/CanvasLayer/PopupOverlay";
 
+	private static readonly string ControlNodePath = "/root/C7Game/CanvasLayer/Control";
+
 	public enum PopupCategory {
 		Advisor,
 		Console,
@@ -26,6 +29,8 @@ public partial class PopupOverlay : HBoxContainer
 		RemoveChild(currentChild);
 		currentChild = null;
 		Hide();
+		Control control = getControlNode();
+		control.ProcessMode = ProcessModeEnum.Inherit;
 	}
 
 	public bool ShowingPopup => currentChild is not null;
@@ -35,6 +40,10 @@ public partial class PopupOverlay : HBoxContainer
 		AudioStreamPlayer player = GetNode<AudioStreamPlayer>("PopupSound");
 		player.Stream = wav;
 		player.Play();
+	}
+
+	private Control getControlNode() {
+		return GetNode<Control>(ControlNodePath);
 	}
 
 	public void ShowPopup(Popup child, PopupCategory category)
@@ -64,6 +73,9 @@ public partial class PopupOverlay : HBoxContainer
 			log.Error("Invalid popup category");
 		}
 		AudioStreamWav wav = Util.LoadWAVFromDisk(Util.Civ3MediaPath(soundFile));
+		Control control = getControlNode();
+		control.ProcessMode = ProcessModeEnum.Disabled;
+
 		Show();
 		PlaySound(wav);
 	}

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using Godot;
 using Serilog;
 
@@ -26,10 +25,17 @@ public partial class PopupOverlay : HBoxContainer
 
 	public void OnHidePopup()
 	{
+		// 1. enable mouse interaction with non-UI nodes
+		MouseFilter = MouseFilterEnum.Pass;
 		RemoveChild(currentChild);
 		currentChild = null;
 		Hide();
+
 		Control control = getControlNode();
+		// 2. enable mouse interactions with other UI elements
+		setMouseFilter(control, MouseFilterEnum.Pass);
+
+		// 3. enable clicking other UI elements
 		control.ProcessMode = ProcessModeEnum.Inherit;
 	}
 
@@ -44,6 +50,15 @@ public partial class PopupOverlay : HBoxContainer
 
 	private Control getControlNode() {
 		return GetNode<Control>(ControlNodePath);
+	}
+
+	private void setMouseFilter(Node n, MouseFilterEnum filter) {
+		foreach (Node child in n?.GetChildren()) {
+			setMouseFilter(child, filter);
+		}
+		if (n is Control control) {
+			control.MouseFilter = filter;
+		}
 	}
 
 	public void ShowPopup(Popup child, PopupCategory category)
@@ -73,8 +88,17 @@ public partial class PopupOverlay : HBoxContainer
 			log.Error("Invalid popup category");
 		}
 		AudioStreamWav wav = Util.LoadWAVFromDisk(Util.Civ3MediaPath(soundFile));
+
+		// 1. prevent mouse interaction with non-UI elements (ie. the map)
+		MouseFilter = MouseFilterEnum.Stop;
+
 		Control control = getControlNode();
+
+		// 2. prevent clicking other UI elements
 		control.ProcessMode = ProcessModeEnum.Disabled;
+
+		// 3. ignore all mouse input on other UI elements (ie. button color changes on hover)
+		setMouseFilter(control, MouseFilterEnum.Ignore);
 
 		Show();
 		PlaySound(wav);
@@ -89,17 +113,11 @@ public partial class PopupOverlay : HBoxContainer
 	 **/
 	public override void _UnhandledInput(InputEvent @event)
 	{
-		if (this.Visible) {
-			if (@event is InputEventKey eventKey)
-			{
-				//As I've added more shortcuts, I've realized checking all of them here could be irksome.
-				//For now, I'm thinking it would make more sense to process or allow through the ones that should go through,
-				//as most of the global ones should *not* go through here.
-				if (eventKey.Pressed)
-				{
-					GetViewport().SetInputAsHandled();
-				}
-			}
+		if (Visible && @event is InputEventKey eventKey && eventKey.Pressed) {
+			// As I've added more shortcuts, I've realized checking all of them here could be irksome.
+			// For now, I'm thinking it would make more sense to process or allow through the ones that should go through,
+			// as most of the global ones should *not* go through here.
+			GetViewport().SetInputAsHandled();
 		}
 	}
 }


### PR DESCRIPTION
Fixes the issue with popups described in https://github.com/C7-Game/Prototype/issues/441. Also adjusts the spacing of the "ENTER or SPACEBAR for next turn" so it doesn't start too close to left edge.