### PR TITLE
Add-change-production-button

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -378,10 +378,16 @@ public partial class Game : Node2D {
 					var tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
 					if (tile != null) {
 						bool shiftDown = Input.IsKeyPressed(Godot.Key.Shift);
+
+						// Handle the shortcut of shift+right clicking a city to get the change production menu.
 						if (shiftDown && tile.cityAtTile?.owner == controller)
 							new RightClickChooseProductionMenu(this, tile.cityAtTile).Open(eventMouseButton.Position);
 						else if ((!shiftDown) && tile.unitsOnTile.Count > 0)
+						    // There are units on this title, so open that menu.
 							new RightClickTileMenu(this, tile).Open(eventMouseButton.Position);
+						else if ((!shiftDown) && tile.cityAtTile?.owner == controller)
+						    // There are no units, but this is the player's city.
+							new RightClickCityMenu(this, tile).Open(eventMouseButton.Position);
 
 						string yield = tile.YieldString(controller);
 						log.Debug($"({tile.xCoordinate}, {tile.yCoordinate}): {tile.overlayTerrainType.DisplayName} {yield}");

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -138,6 +138,13 @@ public partial class RightClickTileMenu : RightClickMenu {
 		if (unfortifiedCount > 1) {
 			AddItem($"Fortify All ({unfortifiedCount} units)", () => ForAll(tile.xCoordinate, tile.yCoordinate, true));
 		}
+		if (tile.cityAtTile?.owner == game.controller) {
+			AddItem("Change Production (Shift+right click)", () => {
+				// Close the first menu before opening the second menu.
+				this.CloseAndDelete();
+				new RightClickChooseProductionMenu(game, tile.cityAtTile).Open(this.GetPosition());
+			});
+		}
 	}
 
 	public void SelectUnit(ID id) {
@@ -175,7 +182,25 @@ public partial class RightClickTileMenu : RightClickMenu {
 			CloseAndDelete();
 		}
 	}
+}
 
+// A right click menu for the player's city when there are no units.
+public partial class RightClickCityMenu : RightClickMenu {
+	public RightClickCityMenu(Game game, Tile tile) : base(game) {
+		ResetItems(tile);
+	}
+
+	public void ResetItems(Tile tile) {
+		RemoveAll();
+
+		if (tile.cityAtTile?.owner == game.controller) {
+			AddItem("Change Production (Shift+right click)", () => {
+				// Close the first menu before opening the second menu.
+				this.CloseAndDelete();
+				new RightClickChooseProductionMenu(game, tile.cityAtTile).Open(this.GetPosition());
+			});
+		}
+	}
 }
 
 public partial class RightClickChooseProductionMenu : RightClickMenu {

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -5,6 +5,7 @@ using C7Engine;
 
 public partial class RightClickMenu : VBoxContainer {
 	protected Game game;
+	protected Vector2 position;
 
 	protected RightClickMenu(Game game) : base() {
 		this.game = game;
@@ -43,6 +44,9 @@ public partial class RightClickMenu : VBoxContainer {
 			position.Y = Mathf.Max(0, position.Y - offScreen.Y);
 		}
 		this.SetPosition(position);
+
+		// Godot 4.2.1 does not have an accessor for the position, so store it ourselves.
+		this.position = position;
 	}
 
 	public void CloseAndDelete() {
@@ -138,6 +142,13 @@ public partial class RightClickTileMenu : RightClickMenu {
 		if (unfortifiedCount > 1) {
 			AddItem($"Fortify All ({unfortifiedCount} units)", () => ForAll(tile.xCoordinate, tile.yCoordinate, true));
 		}
+		if (tile.cityAtTile?.owner == game.controller) {
+			AddItem("Change Production (Shift+right click)", () => {
+				// Close the first menu before opening the second menu.
+				this.CloseAndDelete();
+				new RightClickChooseProductionMenu(game, tile.cityAtTile).Open(this.position);
+			});
+		}
 	}
 
 	public void SelectUnit(ID id) {
@@ -175,7 +186,25 @@ public partial class RightClickTileMenu : RightClickMenu {
 			CloseAndDelete();
 		}
 	}
+}
 
+// A right click menu for the player's city when there are no units.
+public partial class RightClickCityMenu : RightClickMenu {
+	public RightClickCityMenu(Game game, Tile tile) : base(game) {
+		ResetItems(tile);
+	}
+
+	public void ResetItems(Tile tile) {
+		RemoveAll();
+
+		if (tile.cityAtTile?.owner == game.controller) {
+			AddItem("Change Production (Shift+right click)", () => {
+				// Close the first menu before opening the second menu.
+				this.CloseAndDelete();
+				new RightClickChooseProductionMenu(game, tile.cityAtTile).Open(this.position);
+			});
+		}
+	}
 }
 
 public partial class RightClickChooseProductionMenu : RightClickMenu {

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -87,12 +87,11 @@ public partial class UnitButtons : VBoxContainer {
 			button.Visible = false;
 		}
 
-		// pcen (may 2023) - switched this to use the prototype's actions, not
-		// sure I understand the commented goal. Before, was commented:
-		//     TODO: This is technically right, since the unit's available actions have been attached,
-		//     but is unintuitive since they typically are on the prototype.
-		//     Goal: Send the actions as a list.
-		foreach (string action in unit.unitType.actions) {
+		// Mark all the buttons corresponding to the unit's available actions
+		// as visible. We do this rather than using the unit prototype's actions
+		// so that we don't display buttons that do nothing - we don't want to
+		// show the "road" button if we can't build a road, etc.
+		foreach (string action in unit.availableActions) {
 			if (buttonMap.ContainsKey(action)) {
 				buttonMap[action].Visible = true;
 			} else {


### PR DESCRIPTION
This avoids the player having to know about the "shift+right click" shortcut to
change production.

Despite playing a fair bit of civ3, I didn't know about this shortcut and had to
figure it out by looking at the c7 code. These extra menu items make this basic
game functionality more discoverable for new players.