### PR TITLE
Boat pathing: Properly handle "goto" for water units

### DIFF
--- a/C7Engine/AI/Pathing/EdgeWalker.cs
+++ b/C7Engine/AI/Pathing/EdgeWalker.cs
@@ -21,4 +21,25 @@ namespace C7Engine.Pathing {
 			return result;
 		}
 	}
+
+	public class WalkerOnWater: EdgeWalker<Tile> {
+		public override IEnumerable<Edge<Tile>> getEdges(Tile node) {
+			List<Edge<Tile>> result = new List<Edge<Tile>>();
+			foreach (KeyValuePair<TileDirection, Tile> pair in node.neighbors) {
+				TileDirection direction = pair.Key;
+				Tile neighbor = pair.Value;
+
+				// Allow navigating to water tiles or tiles with a city, to support
+				// costal and canal cities.
+				//
+				// If the unit can't enter the city (for example an enemy city), we
+				// will path right next to it and then refuse to actually enter it.
+				if (neighbor.IsWater() || neighbor.HasCity) {
+					float movementCost = MapUnitExtensions.getMovementCost(neighbor, direction, neighbor);
+					result.Add(new Edge<Tile>(node, neighbor, movementCost));
+				}
+			}
+			return result;
+		}
+	}
 }

--- a/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
+++ b/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
@@ -7,11 +7,12 @@ namespace C7Engine.Pathing
 	 */
 	public class PathingAlgorithmChooser
 	{
-		private static PathingAlgorithm theAlgorithm = new DijkstrasAlgorithm(new WalkerOnLand());
+		private static PathingAlgorithm landAlgorithm = new DijkstrasAlgorithm(new WalkerOnLand());
+		private static PathingAlgorithm waterAlgorithm = new DijkstrasAlgorithm(new WalkerOnWater());
 
-		public static PathingAlgorithm GetAlgorithm()
+		public static PathingAlgorithm GetAlgorithm(bool isLandUnit)
 		{
-			return theAlgorithm;
+			return isLandUnit ? landAlgorithm : waterAlgorithm;
 		}
 	}
 }

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -84,7 +84,7 @@ namespace C7Engine
 						log.Information("Set AI for unit to JOIN_CITY due to lack of locations to settle");
 					}
 					else {
-						PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm();
+						PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit.IsLandUnit());
 						settlerAiData.pathToDestination = algorithm.PathFrom(unit.location, settlerAiData.destination);
 						log.Information("Set AI for unit to BUILD_CITY with destination of " + settlerAiData.destination);
 					}
@@ -170,7 +170,7 @@ namespace C7Engine
 						newUnitAIData.destination = nearestCityToDefend.location;
 						newUnitAIData.goal = DefenderAIData.DefenderGoal.DEFEND_CITY;
 
-						PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm();
+						PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit.IsLandUnit());
 						newUnitAIData.pathToDestination = algorithm.PathFrom(unit.location, newUnitAIData.destination);
 
 						log.Information($"Unit {unit} tasked with defending {nearestCityToDefend.name}");
@@ -201,7 +201,7 @@ namespace C7Engine
 			if (closestBarbDistance <= 3) {
 				CombatAIData caid = new CombatAIData();
 
-				PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm();
+				PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit.IsLandUnit());
 				caid.path = algorithm.PathFrom(unit.location, closestBarbCamp);
 				unit.currentAIData = caid;
 				return true;

--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -94,7 +94,7 @@ namespace C7Engine
 			int lowestDistance = int.MaxValue;
 			TilePath chosenPath = null;
 
-			PathingAlgorithm algo = PathingAlgorithmChooser.GetAlgorithm();
+			PathingAlgorithm algo = PathingAlgorithmChooser.GetAlgorithm(unit.IsLandUnit());
 			log.Debug("Explorer pathing from " + unit.location + " with " + unit.unitType);
 			foreach (Tile t in validExplorerTiles) {
 				if (t.distanceTo(unit.location) > lowestDistance) {

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -388,7 +388,7 @@ namespace C7Engine {
 		}
 
 		public static void setUnitPath(this MapUnit unit, Tile dest) {
-			unit.path = PathingAlgorithmChooser.GetAlgorithm().PathFrom(unit.location, dest);
+			unit.path = PathingAlgorithmChooser.GetAlgorithm(unit.IsLandUnit()).PathFrom(unit.location, dest);
 			if (unit.path == TilePath.NONE) {
 				log.Warning("Cannot move unit to " + dest + ", path is NONE!");
 			}

--- a/C7GameData/MapUnit.cs
+++ b/C7GameData/MapUnit.cs
@@ -53,6 +53,10 @@ namespace C7GameData {
 			return isFortified || (path != null && path.PathLength() > 0);
 		}
 
+		public bool IsLandUnit() {
+			return this.unitType.categories.Contains("Land");
+		}
+
 		public override string ToString() {
 			if (this != MapUnit.NONE) {
 				return this.owner + " " + unitType.name + "at (" + location.xCoordinate + ", " + location.yCoordinate + ") with " + movementPoints.getMixedNumber() + " MP and " + hitPointsRemaining + " HP, id = " + id;


### PR DESCRIPTION
I noticed that while I could move a boat around with the arrow keys, I couldn't move it with "G" or the "goto" button. Since my laptop doesn't have a numpad, this made it tricky to explore.

I think this is a fairly straightforward fix to the problem:

1. I added an implementation of the EdgeWalker interface that handles water tiles, including cities in the set of neighbors to allow canal cities, and pathing back into coastal cities.

2. Require specifying land vs water units when picking a pathing algorithm.

I did some manual testing, including building a canal city north of the default spawn, and confirmed I could path through it. I think building the city on a hill amusingly resulted in the boat movement cost being 2, but besides that it worked.