### PR TITLE
EdgeWalker: fix the call to getMovementCost

### DIFF
--- a/C7Engine/AI/Pathing/EdgeWalker.cs
+++ b/C7Engine/AI/Pathing/EdgeWalker.cs
@@ -34,7 +34,7 @@ namespace C7Engine.Pathing {
 				// If the unit can't enter the city (for example an enemy city), we
 				// will path right next to it and then refuse to actually enter it.
 				if (neighbor.IsWater() || neighbor.HasCity) {
-					float movementCost = MapUnitExtensions.getMovementCost(neighbor, direction, neighbor);
+					float movementCost = MapUnitExtensions.getMovementCost(node, direction, neighbor);
 					result.Add(new Edge<Tile>(node, neighbor, movementCost));
 				}
 			}

--- a/C7Engine/AI/Pathing/EdgeWalker.cs
+++ b/C7Engine/AI/Pathing/EdgeWalker.cs
@@ -2,19 +2,18 @@ using System.Collections.Generic;
 using C7GameData;
 
 namespace C7Engine.Pathing {
-	public abstract class EdgeWalker<TNode>
-	{
+	public abstract class EdgeWalker<TNode> {
 		public abstract IEnumerable<Edge<TNode>> getEdges(TNode node);
 	}
 
-	public class WalkerOnLand: EdgeWalker<Tile> {
+	public class WalkerOnLand : EdgeWalker<Tile> {
 		public override IEnumerable<Edge<Tile>> getEdges(Tile node) {
 			List<Edge<Tile>> result = new List<Edge<Tile>>();
 			foreach (KeyValuePair<TileDirection, Tile> pair in node.neighbors) {
 				TileDirection direction = pair.Key;
 				Tile neighbor = pair.Value;
 				if (neighbor.IsLand()) {
-					float movementCost = MapUnitExtensions.getMovementCost(neighbor, direction, neighbor);
+					float movementCost = MapUnitExtensions.getMovementCost(node, direction, neighbor);
 					result.Add(new Edge<Tile>(node, neighbor, movementCost));
 				}
 			}
@@ -22,7 +21,7 @@ namespace C7Engine.Pathing {
 		}
 	}
 
-	public class WalkerOnWater: EdgeWalker<Tile> {
+	public class WalkerOnWater : EdgeWalker<Tile> {
 		public override IEnumerable<Edge<Tile>> getEdges(Tile node) {
 			List<Edge<Tile>> result = new List<Edge<Tile>>();
 			foreach (KeyValuePair<TileDirection, Tile> pair in node.neighbors) {

--- a/EngineTests/AI/Pathing/EdgeWalkerTest.cs
+++ b/EngineTests/AI/Pathing/EdgeWalkerTest.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+using System.Linq;
+using C7Engine.Pathing;
+using C7GameData;
+using Xunit;
+
+namespace EngineTests {
+	public class WalkerOnLandTest {
+		private WalkerOnLand walker = new();
+		private ID id = ID.None("test-tile");
+		private Tile mountain  = new(ID.None("")) {
+			baseTerrainType = new() {
+				Key = "mountains"
+			},
+			overlayTerrainType = new() {
+				Key = "mountains",
+				movementCost = 3
+			}
+		};
+		private Tile hill  = new(ID.None("")) {
+			baseTerrainType = new() {
+				Key = "hills"
+			},
+			overlayTerrainType = new() {
+				Key = "hills",
+				movementCost = 2
+			}
+		};
+		private Tile plains  = new(ID.None("")) {
+			baseTerrainType = new() {
+				Key = "plains"
+			},
+			overlayTerrainType = new() {
+				Key = "plains",
+				movementCost = 1
+			}
+		};
+		private Tile coast  = new(ID.None("")) {
+			baseTerrainType = new() {
+				Key = "coast"
+			},
+			overlayTerrainType = new() {
+				Key = "coast",
+				movementCost = 1
+			}
+		};
+
+		[Fact]
+		void testIgnoresWater() {
+			Tile start = hill;
+
+			// Add 3 neighbors, one of which is water.
+			start.neighbors[TileDirection.NORTH] = coast;
+			start.neighbors[TileDirection.SOUTH] = mountain;
+			start.neighbors[TileDirection.WEST] = plains;
+
+			// The water tile should be ignored, and the costs should be correct.
+			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
+			Assert.Equal(2, edges.Count());
+
+			Assert.Contains(edges, item => item.current == mountain && item.distanceToCurrent == 3);
+			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1);
+		}
+
+		[Fact]
+		void testRoadOnDestinationNotOnStart() {
+			Tile start = hill;
+
+			// Set up a neighbor with a road.
+			Tile end = plains;
+			end.overlays.road = true;
+			start.neighbors[TileDirection.NORTH] = end;
+
+			// The road shouldn't matter, since we don't have a road.
+			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
+			Assert.Single(edges);
+			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1);
+		}
+
+		[Fact]
+		void testRoadOnStartNotOnDestination() {
+			Tile start = hill;
+			start.overlays.road = true;
+
+			// Set up a neighbor without a road.
+			Tile end = plains;
+			start.neighbors[TileDirection.NORTH] = end;
+
+			// The road shouldn't matter, since the destination doesn't have a road.
+			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
+			Assert.Single(edges);
+			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1);
+		}
+
+		[Fact]
+		void testRoadOnStartAndDestination() {
+			Tile start = hill;
+			start.overlays.road = true;
+
+			// Set up a neighbor with a road.
+			Tile end = plains;
+			end.overlays.road = true;
+			start.neighbors[TileDirection.NORTH] = end;
+
+			// The cost should be adjusted because we both have a road.
+			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
+			Assert.Single(edges);
+			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1.0f / 3.0f);
+		}
+	}
+}


### PR DESCRIPTION
Using `neighbor` as both arguments means that river crossings and road usefulness was not always properly handled. I noticed this when I was incorrectly pathed over a river, despite being able to take a route all on a road. 

One of the added tests fails without this change, thinking that a move from <unroaded tile> to <roaded tile> only costs 1/3 of a movement point:

```
  Failed EngineTests.WalkerOnLandTest.testRoadOnDestinationNotOnStart [42 ms]
  Error Message:
   Assert.Contains() Failure
Not found: (filter expression)
In value:  List<Edge<Tile>> [Edge`1 { current = [0, 0] ( on ), distanceToCurrent = 0.33333334, prev = [0, 0] ( on ) }]
```
