### PR TITLE
[godot4] Advisor menu fixes

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -63,15 +63,6 @@ script = ExtResource("1")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 
-[node name="Advisor" type="CenterContainer" parent="CanvasLayer"]
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme = ExtResource("10")
-script = ExtResource("3")
-
 [node name="PopupOverlay" type="HBoxContainer" parent="CanvasLayer"]
 visible = false
 anchors_preset = 15
@@ -242,6 +233,15 @@ text = "Quit"
 libraries = {
 "": SubResource("AnimationLibrary_bowxq")
 }
+
+[node name="Advisor" type="CenterContainer" parent="CanvasLayer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("10")
+script = ExtResource("3")
 
 [connection signal="NewAutoselectedUnit" from="." to="CanvasLayer/Control/GameStatus" method="OnNewUnitSelected"]
 [connection signal="NewAutoselectedUnit" from="." to="CanvasLayer/Control/UnitButtons" method="OnNewUnitSelected"]

--- a/C7/UIElements/Advisors/DomesticAdvisor.cs
+++ b/C7/UIElements/Advisors/DomesticAdvisor.cs
@@ -51,6 +51,6 @@ public partial class DomesticAdvisor : TextureRect
 
 	private void ReturnToMenu()
 	{
-		GetParent().EmitSignal("hide");
+		GetParent<Advisors>().Hide();
 	}
 }


### PR DESCRIPTION
- Exiting the advisor screen now correctly navigates to the main screen.
- Game UI elements are no longer painted on top of the advisor screen on small resolutions.