### PR TITLE
[godot4] Manage node paths with export properties

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -58,8 +58,12 @@ _data = {
 "SlideOutAnimation": SubResource("1")
 }
 
-[node name="C7Game" type="Node2D"]
+[node name="C7Game" type="Node2D" node_paths=PackedStringArray("Toolbar", "popupOverlay", "slider", "animationPlayer")]
 script = ExtResource("1")
+Toolbar = NodePath("CanvasLayer/Control/ToolBar/MarginContainer/HBoxContainer")
+popupOverlay = NodePath("CanvasLayer/PopupOverlay")
+slider = NodePath("CanvasLayer/Control/SlideOutBar/VBoxContainer/Zoom")
+animationPlayer = NodePath("CanvasLayer/Control/SlideOutBar/AnimationPlayer")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 
@@ -72,7 +76,7 @@ grow_vertical = 2
 theme = ExtResource("10")
 script = ExtResource("3")
 
-[node name="PopupOverlay" type="HBoxContainer" parent="CanvasLayer"]
+[node name="PopupOverlay" type="HBoxContainer" parent="CanvasLayer" node_paths=PackedStringArray("control")]
 visible = false
 anchors_preset = 15
 anchor_right = 1.0
@@ -81,6 +85,7 @@ grow_horizontal = 0
 size_flags_horizontal = 3
 alignment = 2
 script = ExtResource("9")
+control = NodePath("../Control")
 
 [node name="PopupSound" type="AudioStreamPlayer" parent="CanvasLayer/PopupOverlay"]
 
@@ -159,9 +164,10 @@ grow_horizontal = 2
 [node name="HBoxContainer" type="HBoxContainer" parent="CanvasLayer/Control/ToolBar/MarginContainer"]
 layout_mode = 2
 
-[node name="MenuButton" type="TextureButton" parent="CanvasLayer/Control/ToolBar/MarginContainer/HBoxContainer"]
+[node name="MenuButton" type="TextureButton" parent="CanvasLayer/Control/ToolBar/MarginContainer/HBoxContainer" node_paths=PackedStringArray("popupOverlay")]
 layout_mode = 2
 script = ExtResource("4")
+popupOverlay = NodePath("../../../../../PopupOverlay")
 
 [node name="CivilopediaButton" type="TextureButton" parent="CanvasLayer/Control/ToolBar/MarginContainer/HBoxContainer"]
 layout_mode = 2

--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -108,7 +108,7 @@ grow_horizontal = 0
 grow_vertical = 0
 script = ExtResource("7")
 
-[node name="UnitButtons" type="VBoxContainer" parent="CanvasLayer/Control"]
+[node name="UnitButtons" type="VBoxContainer" parent="CanvasLayer/Control" node_paths=PackedStringArray("primaryControls", "specializedControls", "advancedControls")]
 layout_mode = 1
 anchors_preset = 12
 anchor_top = 1.0
@@ -119,6 +119,9 @@ grow_horizontal = 2
 grow_vertical = 0
 size_flags_vertical = 0
 script = ExtResource("12")
+primaryControls = NodePath("PrimaryUnitControls")
+specializedControls = NodePath("SpecializedUnitControls")
+advancedControls = NodePath("AdvancedUnitControls")
 
 [node name="AdvancedUnitControls" type="HBoxContainer" parent="CanvasLayer/Control/UnitButtons"]
 layout_mode = 2

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -39,6 +39,7 @@ public partial class Game : Node2D {
 	// that. This is useful so that the unit autoselector can be prevented from interfering with the player selecting fortified units.
 	public bool KeepCSUWhenFortified = false;
 
+	[Export]
 	Control Toolbar;
 	private bool IsMovingCamera;
 	private Vector2 OldPosition;
@@ -46,7 +47,12 @@ public partial class Game : Node2D {
 	Stopwatch loadTimer = new Stopwatch();
 	GlobalSingleton Global;
 
+	[Export]
 	private PopupOverlay popupOverlay;
+	[Export]
+	private VSlider slider;
+	[Export]
+	private AnimationPlayer animationPlayer;
 
 	bool errorOnLoad = false;
 
@@ -59,7 +65,6 @@ public partial class Game : Node2D {
 	// that gives an error if we fail to load for some reason.
 	public override void _Ready() {
 		Global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
-		popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
 
 		try {
 			var animSoundPlayer = new AudioStreamPlayer();
@@ -92,8 +97,6 @@ public partial class Game : Node2D {
 						mapView.centerCameraOnTile(startingSettler.location);
 				}
 			}
-
-			Toolbar = GetNode<Control>("CanvasLayer/Control/ToolBar/MarginContainer/HBoxContainer");
 
 			//TODO: What was this supposed to do?  It throws errors and occasinally causes crashes now, because _OnViewportSizeChanged doesn't exist
 			// GetTree().Root.Connect("size_changed",new Callable(this,"_OnViewportSizeChanged"));
@@ -303,7 +306,6 @@ public partial class Game : Node2D {
 	}
 
 	public void AdjustZoomSlider(int numSteps, Vector2 zoomCenter) {
-		VSlider slider = GetNode<VSlider>("CanvasLayer/Control/SlideOutBar/VBoxContainer/Zoom");
 		double newScale = slider.Value + slider.Step * (double)numSteps;
 		if (newScale < slider.MinValue)
 			newScale = slider.MinValue;
@@ -383,10 +385,10 @@ public partial class Game : Node2D {
 						if (shiftDown && tile.cityAtTile?.owner == controller)
 							new RightClickChooseProductionMenu(this, tile.cityAtTile).Open(eventMouseButton.Position);
 						else if ((!shiftDown) && tile.unitsOnTile.Count > 0)
-						    // There are units on this title, so open that menu.
+							// There are units on this title, so open that menu.
 							new RightClickTileMenu(this, tile).Open(eventMouseButton.Position);
 						else if ((!shiftDown) && tile.cityAtTile?.owner == controller)
-						    // There are no units, but this is the player's city.
+							// There are no units, but this is the player's city.
 							new RightClickCityMenu(this, tile).Open(eventMouseButton.Position);
 
 						string yield = tile.YieldString(controller);
@@ -434,7 +436,6 @@ public partial class Game : Node2D {
 			}
 		} else if (@event is InputEventMagnifyGesture magnifyGesture) {
 			// UI slider has the min/max zoom settings for now
-			VSlider slider = GetNode<VSlider>("CanvasLayer/Control/SlideOutBar/VBoxContainer/Zoom");
 			double newScale = mapView.cameraZoom * magnifyGesture.Factor;
 			if (newScale < slider.MinValue)
 				newScale = slider.MinValue;
@@ -504,11 +505,9 @@ public partial class Game : Node2D {
 		if (Input.IsActionJustPressed(C7Action.ToggleZoom)) {
 			if (mapView.cameraZoom != 1) {
 				mapView.setCameraZoomFromMiddle(1.0f);
-				VSlider slider = GetNode<VSlider>("CanvasLayer/Control/SlideOutBar/VBoxContainer/Zoom");
 				slider.Value = 1.0f;
 			} else {
 				mapView.setCameraZoomFromMiddle(0.5f);
-				VSlider slider = GetNode<VSlider>("CanvasLayer/Control/SlideOutBar/VBoxContainer/Zoom");
 				slider.Value = 0.5f;
 			}
 		}
@@ -584,9 +583,9 @@ public partial class Game : Node2D {
 
 	private void _on_SlideToggle_toggled(bool buttonPressed) {
 		if (buttonPressed) {
-			GetNode<AnimationPlayer>("CanvasLayer/Control/SlideOutBar/AnimationPlayer").PlayBackwards("SlideOutAnimation");
+			animationPlayer.PlayBackwards("SlideOutAnimation");
 		} else {
-			GetNode<AnimationPlayer>("CanvasLayer/Control/SlideOutBar/AnimationPlayer").Play("SlideOutAnimation");
+			animationPlayer.Play("SlideOutAnimation");
 		}
 	}
 

--- a/C7/MainMenu.cs
+++ b/C7/MainMenu.cs
@@ -13,7 +13,9 @@ public partial class MainMenu : Node2D
 	ImageTexture HoverButton;
 	TextureRect MainMenuBackground;
 	Util.Civ3FileDialog LoadDialog;
+	[Export]
 	Button SetCiv3Home;
+	[Export]
 	FileDialog SetCiv3HomeDialog;
 	Util.Civ3FileDialog LoadScenarioDialog;
 	GlobalSingleton Global;
@@ -39,10 +41,6 @@ public partial class MainMenu : Node2D
 		LoadScenarioDialog.RelPath = @"Conquests/Scenarios";
 		LoadScenarioDialog.Connect("file_selected",new Callable(this,nameof(_on_FileDialog_file_selected)));
 		GetNode<CanvasLayer>("CanvasLayer").AddChild(LoadDialog);
-		SetCiv3Home = GetNode<Button>("CanvasLayer/SetCiv3Home");
-		SetCiv3HomeDialog = GetNode<FileDialog>("CanvasLayer/SetCiv3HomeDialog");
-		// For some reason this option isn't available in the scene UI
-		SetCiv3HomeDialog.FileMode = FileDialog.FileModeEnum.OpenDir;
 		GetNode<CanvasLayer>("CanvasLayer").AddChild(LoadScenarioDialog);
 		DisplayTitleScreen();
 	}

--- a/C7/MainMenu.tscn
+++ b/C7/MainMenu.tscn
@@ -4,10 +4,12 @@
 [ext_resource type="Script" path="res://MainMenuMusicPlayer.cs" id="3"]
 [ext_resource type="Theme" uid="uid://b0jisy3avwkxf" path="res://MainMenuTheme.tres" id="4"]
 
-[node name="MainMenu" type="Node2D"]
+[node name="MainMenu" type="Node2D" node_paths=PackedStringArray("SetCiv3Home", "SetCiv3HomeDialog")]
 z_index = 1
 z_as_relative = false
 script = ExtResource("1")
+SetCiv3Home = NodePath("CanvasLayer/SetCiv3Home")
+SetCiv3HomeDialog = NodePath("CanvasLayer/SetCiv3HomeDialog")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 layer = -1
@@ -76,6 +78,9 @@ text = "Select Civ3 Home Folder"
 
 [node name="SetCiv3HomeDialog" type="FileDialog" parent="CanvasLayer"]
 mode = 3
+title = "Open a Directory"
+ok_button_text = "Select Current Folder"
+file_mode = 2
 access = 2
 
 [connection signal="pressed" from="CanvasLayer/SetCiv3Home" to="." method="_on_SetCiv3Home_pressed"]

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -1,6 +1,7 @@
 using Godot;
 using Serilog;
 
+[GlobalClass]
 public partial class PopupOverlay : HBoxContainer
 {
 
@@ -13,9 +14,8 @@ public partial class PopupOverlay : HBoxContainer
 
 	Control currentChild = null;
 
-	public static readonly string NodePath = "/root/C7Game/CanvasLayer/PopupOverlay";
-
-	private static readonly string ControlNodePath = "/root/C7Game/CanvasLayer/Control";
+	[Export]
+	private Control control;
 
 	public enum PopupCategory {
 		Advisor,
@@ -31,7 +31,6 @@ public partial class PopupOverlay : HBoxContainer
 		currentChild = null;
 		Hide();
 
-		Control control = getControlNode();
 		// 2. enable mouse interactions with other UI elements
 		setMouseFilter(control, MouseFilterEnum.Pass);
 
@@ -46,10 +45,6 @@ public partial class PopupOverlay : HBoxContainer
 		AudioStreamPlayer player = GetNode<AudioStreamPlayer>("PopupSound");
 		player.Stream = wav;
 		player.Play();
-	}
-
-	private Control getControlNode() {
-		return GetNode<Control>(ControlNodePath);
 	}
 
 	private void setMouseFilter(Node n, MouseFilterEnum filter) {
@@ -91,8 +86,6 @@ public partial class PopupOverlay : HBoxContainer
 
 		// 1. prevent mouse interaction with non-UI elements (ie. the map)
 		MouseFilter = MouseFilterEnum.Stop;
-
-		Control control = getControlNode();
 
 		// 2. prevent clicking other UI elements
 		control.ProcessMode = ProcessModeEnum.Disabled;

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -14,8 +14,14 @@ public partial class UnitButtons : VBoxContainer {
 	private ILogger log = LogManager.ForContext<UnitButtons>();
 
 	private Dictionary<string, UnitControlButton> buttonMap = new Dictionary<string, UnitControlButton>();
+
+	[Export]
 	HBoxContainer primaryControls;
+
+	[Export]
 	HBoxContainer specializedControls;
+
+	[Export]
 	HBoxContainer advancedControls;
 
 	// Called when the node enters the scene tree for the first time.
@@ -23,9 +29,6 @@ public partial class UnitButtons : VBoxContainer {
 		// You can hide buttons like this.  This will come in handy later!
 		// Remember to re-calc the margin after hiding/unhiding buttons, as that may affect the width.
 		// this.GetNode<FortifyButton>("PrimaryUnitControls/FortifyButton").Hide();
-
-		primaryControls = GetNode<HBoxContainer>("PrimaryUnitControls");
-		specializedControls = GetNode<HBoxContainer>("SpecializedUnitControls");
 
 		AddNewButton(primaryControls, new UnitControlButton(C7Action.UnitHold, 0, 0, onButtonPressed));
 		AddNewButton(primaryControls, new UnitControlButton(C7Action.UnitWait, 1, 0, onButtonPressed));

--- a/C7/UIElements/UpperLeftNav/MenuButton.cs
+++ b/C7/UIElements/UpperLeftNav/MenuButton.cs
@@ -4,6 +4,9 @@ using ConvertCiv3Media;
 public partial class MenuButton : TextureButton
 {
 
+	[Export]
+	private PopupOverlay popupOverlay;
+
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()
 	{
@@ -16,7 +19,6 @@ public partial class MenuButton : TextureButton
 
 	public override void _Pressed()
 	{
-		PopupOverlay popupOverlay = GetNode<PopupOverlay>(PopupOverlay.NodePath);
 		popupOverlay.ShowPopup(new GameMenu(), PopupOverlay.PopupCategory.Info);
 	}
 


### PR DESCRIPTION
This pull request addresses the issue with node path management described in #211. 

Instead of separating node paths into constants, as suggested in the issue, this PR takes a different approach. It uses Godot export properties [1] to separate node paths from the source code and move them into the scene editor. This allows nodes to be easily selected within the currently edited scene. This also ensures that the node paths will be automatically updated when relevant nodes are moved, deleted or renamed in the editor.

As a demo of this approach, I've started with refactoring the UnitButtons class. I'm ready to refactor other classes as well.

[1] https://docs.godotengine.org/en/4.2/tutorials/scripting/c_sharp/c_sharp_exports.html