### PR TITLE
Ensure that destroyed cities no longer show up in the UI  (no longer preferred)

### DIFF
--- a/C7/Map/CityLayer.cs
+++ b/C7/Map/CityLayer.cs
@@ -7,8 +7,12 @@ namespace C7.Map {
 	public class CityLayer : LooseLayer {
 
 		private ILogger log = LogManager.ForContext<CityLayer>();
+
+		private ImageTexture cityTexture;
+		private Dictionary<string, ImageTexture> cityLabels = new Dictionary<string, ImageTexture>();
+
+		private List<City> citiesWithScenes = new List<City>();
 		private Dictionary<City, CityScene> citySceneLookup = new Dictionary<City, CityScene>();
-		private Dictionary<Tile, City> tileCityLookup = new();
 
 		public CityLayer()
 		{
@@ -17,18 +21,6 @@ namespace C7.Map {
 		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
 		{
 			if (tile.cityAtTile is null) {
-				tileCityLookup.TryGetValue(tile, out City maybeCity);
-
-				// The tile doesn't have a city and we have no record of a city. We're done.
-				if (maybeCity == null) {
-					return;
-				}
-
-				// The tile doesn't have a city but we have record of a city. It must have
-				// just been destroyed. Remove our tracking of it.
-				citySceneLookup.Remove(maybeCity, out CityScene cityScene);
-				tileCityLookup.Remove(tile);
-				cityScene.Hide();
 				return;
 			}
 
@@ -37,7 +29,6 @@ namespace C7.Map {
 				CityScene cityScene = new CityScene(city, tile, new Vector2I((int)tileCenter.X, (int)tileCenter.Y));
 				looseView.AddChild(cityScene);
 				citySceneLookup[city] = cityScene;
-				tileCityLookup[tile] = city;
 			} else {
 				CityScene scene = citySceneLookup[city];
 				scene._Draw();

--- a/C7/Map/CityLayer.cs
+++ b/C7/Map/CityLayer.cs
@@ -7,12 +7,8 @@ namespace C7.Map {
 	public class CityLayer : LooseLayer {
 
 		private ILogger log = LogManager.ForContext<CityLayer>();
-
-		private ImageTexture cityTexture;
-		private Dictionary<string, ImageTexture> cityLabels = new Dictionary<string, ImageTexture>();
-
-		private List<City> citiesWithScenes = new List<City>();
 		private Dictionary<City, CityScene> citySceneLookup = new Dictionary<City, CityScene>();
+		private Dictionary<Tile, City> tileCityLookup = new();
 
 		public CityLayer()
 		{
@@ -21,6 +17,18 @@ namespace C7.Map {
 		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
 		{
 			if (tile.cityAtTile is null) {
+				tileCityLookup.TryGetValue(tile, out City maybeCity);
+
+				// The tile doesn't have a city and we have no record of a city. We're done.
+				if (maybeCity == null) {
+					return;
+				}
+
+				// The tile doesn't have a city but we have record of a city. It must have
+				// just been destroyed. Remove our tracking of it.
+				citySceneLookup.Remove(maybeCity, out CityScene cityScene);
+				tileCityLookup.Remove(tile);
+				cityScene.Hide();
 				return;
 			}
 
@@ -29,6 +37,7 @@ namespace C7.Map {
 				CityScene cityScene = new CityScene(city, tile, new Vector2I((int)tileCenter.X, (int)tileCenter.Y));
 				looseView.AddChild(cityScene);
 				citySceneLookup[city] = cityScene;
+				tileCityLookup[tile] = city;
 			} else {
 				CityScene scene = citySceneLookup[city];
 				scene._Draw();

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -32,6 +32,7 @@ namespace C7Engine
 			tile.cityAtTile.owner.cities.Remove(tile.cityAtTile);
 			EngineStorage.gameData.cities.Remove(tile.cityAtTile);
 			tile.cityAtTile = null;
+			tile.overlays.road = false;
 		}
 	}
 }

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -32,7 +32,6 @@ namespace C7Engine
 			tile.cityAtTile.owner.cities.Remove(tile.cityAtTile);
 			EngineStorage.gameData.cities.Remove(tile.cityAtTile);
 			tile.cityAtTile = null;
-			tile.overlays.road = false;
 		}
 	}
 }


### PR DESCRIPTION
Now if a city is captured it is removed from the UI and the implicit
city road is removed.

Let me know if this is the preferred approach. I could also see a valid implementation where we exposed the `cityLayer` in `MapView.cs`, added a new `MessageToUI`, and had `Game.cs` do the modifications to the city layer. I'm not sure what's the stylistic choice; the latter is a bit more complex, but might work better for capturing cities in the future.

To make this easier to test I modified `c7-static-map-save.json` locally
to add this:

```
    {
      "id": "Warrior-1",
      "prototype": "Warrior",
      "owner": "player-2",
      "previousLocation": {
        "x": -1,
        "y": -1
      },
      "currentLocation": {
        "x": 57,
        "y": 43
      },
      "hitPointsRemaining": 5,
      "movePointsRemaining": 1,
      "facingDirection": "north",
      "experience": "Elite"
    },
```

and modified this (to change the x/y position so an AI spawns next to
us, so our added warrior can destroy the city)

```
    {
      "id": "Settler-2",
      "prototype": "Settler",
      "owner": "player-3",
      "previousLocation": {
        "x": -1,
        "y": -1
      },
      "currentLocation": {
        "x": 59,
        "y": 43
      },
      "hitPointsRemaining": 3,
      "movePointsRemaining": 1,
      "facingDirection": "north",
      "experience": "Regular"
    },
```
