### PR TITLE
Fix city destruction (via UI message)

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -7,6 +7,7 @@ using C7GameData;
 using Serilog;
 using C7Engine.Pathing;
 using System.Collections.Generic;
+using C7.Map;
 
 public partial class Game : Node2D {
 	[Signal] public delegate void TurnStartedEventHandler();
@@ -164,6 +165,10 @@ public partial class Game : Node2D {
 					break;
 				case MsgStartTurn mST:
 					OnPlayerStartTurn();
+					break;
+				case MsgCityDestroyed mCD:
+					mapView.cityLayer.citySceneLookup.Remove(mCD.city, out CityScene cityScene);
+					cityScene.Hide();
 					break;
 			}
 		}

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -167,8 +167,7 @@ public partial class Game : Node2D {
 					OnPlayerStartTurn();
 					break;
 				case MsgCityDestroyed mCD:
-					mapView.cityLayer.citySceneLookup.Remove(mCD.city, out CityScene cityScene);
-					cityScene.Hide();
+					mapView.cityLayer.UpdateAfterCityDestruction(mCD.city);
 					break;
 			}
 		}

--- a/C7/Map/CityLayer.cs
+++ b/C7/Map/CityLayer.cs
@@ -5,10 +5,15 @@ using Serilog;
 
 namespace C7.Map {
 	public class CityLayer : LooseLayer {
-		public Dictionary<City, CityScene> citySceneLookup { get; set; } = new();
+		private Dictionary<City, CityScene> citySceneLookup = new();
 
 		public CityLayer()
 		{
+		}
+
+		public void UpdateAfterCityDestruction(City city) {
+			citySceneLookup.Remove(city, out CityScene cityScene);
+			cityScene.Hide();
 		}
 
 		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)

--- a/C7/Map/CityLayer.cs
+++ b/C7/Map/CityLayer.cs
@@ -5,14 +5,7 @@ using Serilog;
 
 namespace C7.Map {
 	public class CityLayer : LooseLayer {
-
-		private ILogger log = LogManager.ForContext<CityLayer>();
-
-		private ImageTexture cityTexture;
-		private Dictionary<string, ImageTexture> cityLabels = new Dictionary<string, ImageTexture>();
-
-		private List<City> citiesWithScenes = new List<City>();
-		private Dictionary<City, CityScene> citySceneLookup = new Dictionary<City, CityScene>();
+		public Dictionary<City, CityScene> citySceneLookup { get; set; } = new();
 
 		public CityLayer()
 		{

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -604,6 +604,7 @@ public partial class MapView : Node2D {
 	}
 
 	public GridLayer gridLayer { get; private set; }
+	public CityLayer cityLayer { get; private set; }
 
 	public ImageTexture civColorWhitePalette = null;
 
@@ -629,7 +630,8 @@ public partial class MapView : Node2D {
 		looseView.layers.Add(new BuildingLayer());
 		looseView.layers.Add(new UnitLayer());
 		looseView.layers.Add(new GotoLayer());
-		looseView.layers.Add(new CityLayer());
+		this.cityLayer = new();
+		looseView.layers.Add(this.cityLayer);
 		looseView.layers.Add(new FogOfWarLayer());
 
 		(civColorWhitePalette, _) = Util.loadPalettizedPCX("Art/Units/Palettes/ntp00.pcx");

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -31,7 +31,9 @@ namespace C7Engine
 			tile.cityAtTile.RemoveAllCitizens();
 			tile.cityAtTile.owner.cities.Remove(tile.cityAtTile);
 			EngineStorage.gameData.cities.Remove(tile.cityAtTile);
+			new MsgCityDestroyed(tile.cityAtTile).send();
 			tile.cityAtTile = null;
+			tile.overlays.road = false;
 		}
 	}
 }

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -42,4 +42,14 @@ namespace C7Engine
 
 	public class MsgStartTurn : MessageToUI {}
 
+
+	public class MsgCityDestroyed : MessageToUI {
+		public City city;
+
+		public MsgCityDestroyed(City city)
+		{
+			this.city = city;
+		}
+	}
+
 }


### PR DESCRIPTION
Now if a city is captured it is removed from the UI and the implicit
city road is removed.

To make this easier to test I modified `c7-static-map-save.json` locally
to add this:

```
    {
      "id": "Warrior-1",
      "prototype": "Warrior",
      "owner": "player-2",
      "previousLocation": {
        "x": -1,
        "y": -1
      },
      "currentLocation": {
        "x": 57,
        "y": 43
      },
      "hitPointsRemaining": 5,
      "movePointsRemaining": 1,
      "facingDirection": "north",
      "experience": "Elite"
    },
```

and modified this (to change the x/y position so an AI spawns next to
us, so our added warrior can destroy the city)

```
    {
      "id": "Settler-2",
      "prototype": "Settler",
      "owner": "player-3",
      "previousLocation": {
        "x": -1,
        "y": -1
      },
      "currentLocation": {
        "x": 59,
        "y": 43
      },
      "hitPointsRemaining": 3,
      "movePointsRemaining": 1,
      "facingDirection": "north",
      "experience": "Regular"
    },
```
