### PR TITLE
Make the retire button on the popup menu work

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -253,6 +253,7 @@ script = ExtResource("3")
 [connection signal="BuildCity" from="CanvasLayer/PopupOverlay" to="." method="OnBuildCity"]
 [connection signal="HidePopup" from="CanvasLayer/PopupOverlay" to="CanvasLayer/PopupOverlay" method="OnHidePopup"]
 [connection signal="Quit" from="CanvasLayer/PopupOverlay" to="." method="OnQuitTheGame"]
+[connection signal="Retire" from="CanvasLayer/PopupOverlay" to="." method="_on_QuitButton_pressed"]
 [connection signal="UnitDisbanded" from="CanvasLayer/PopupOverlay" to="." method="OnUnitDisbanded"]
 [connection signal="BlinkyEndTurnButtonPressed" from="CanvasLayer/Control/GameStatus" to="." method="OnPlayerEndTurn"]
 [connection signal="pressed" from="CanvasLayer/Control/ToolBar/MarginContainer/HBoxContainer/AdvisorButton" to="CanvasLayer/Advisor" method="ShowLatestAdvisor"]

--- a/C7/UIElements/Popups/GameMenu.cs
+++ b/C7/UIElements/Popups/GameMenu.cs
@@ -31,6 +31,11 @@ public partial class GameMenu : Popup
 		GetParent().EmitSignal("Quit");
 	}
 
+	private void retire()
+	{
+		GetParent().EmitSignal("Retire");
+	}
+
 	private void map()
 	{
 		GetParent().EmitSignal("HidePopup");

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -8,6 +8,7 @@ public partial class PopupOverlay : HBoxContainer
 
 	[Signal] public delegate void UnitDisbandedEventHandler();
 	[Signal] public delegate void QuitEventHandler();
+	[Signal] public delegate void RetireEventHandler();
 	[Signal] public delegate void BuildCityEventHandler(string name);
 	[Signal] public delegate void HidePopupEventHandler();
 


### PR DESCRIPTION
This now takes you back to the main menu, where you can start a new game, retire, start a new game, etc.

I don't fully understand the godot4 magic at work here, but was able to cobble this together by copying the other button's behavior.