### PR TITLE
Fix save game loading

### DIFF
--- a/C7Engine/EntryPoints/CreateGame.cs
+++ b/C7Engine/EntryPoints/CreateGame.cs
@@ -19,7 +19,7 @@ namespace C7Engine
 			EngineStorage.createThread();
 			EngineStorage.gameDataMutex.WaitOne();
 
-			SaveGame save = SaveGame.Load(loadFilePath);
+			SaveGame save = SaveManager.LoadSave(loadFilePath, defaultBicPath);
 			GameData gameData = save.ToGameData();
 
 			EngineStorage.gameData = gameData;


### PR DESCRIPTION
This doesn't yet fix scenario loading; loading a scenario fails due to a lack of a human player (`...does not contain a human player`).

Poking around in the history it looks like this was broken in [this commit](https://github.com/C7-Game/Prototype/commit/caffcdd7eb65043938b27f34e1d04a3907d63733#diff-3fc4d4ac9715b2904cb97af15abca984009235b0f65f2da5cadf61fb6420c9edR22); loading C7 saves would still work, but the conversion logic was accidentally dropped.