### PR TITLE
GameMap.cs: Move the tile neighbor calculations to Tile.cs

### DIFF
--- a/C7GameData/GameMap.cs
+++ b/C7GameData/GameMap.cs
@@ -129,40 +129,9 @@ namespace C7GameData
 		 * or the NONE tile if there is no neighbor in said direction.
 		 **/
 		public Tile tileNeighbor(Tile center, TileDirection direction) {
-			int x = center.xCoordinate;
-			int y = center.yCoordinate;
-			switch (direction) {
-				case TileDirection.NORTH:
-					y-=2;
-					break;
-				case TileDirection.NORTHEAST:
-					y--;
-					x++;
-					break;
-				case TileDirection.EAST:
-					x+=2;
-					break;
-				case TileDirection.SOUTHEAST:
-					y++;
-					x++;
-					break;
-				case TileDirection.SOUTH:
-					y+=2;
-					break;
-				case TileDirection.SOUTHWEST:
-					y++;
-					x--;
-					break;
-				case TileDirection.WEST:
-					x-=2;
-					break;
-				case TileDirection.NORTHWEST:
-					x--;
-					y--;
-					break;
-			}
+			Tuple<int, int> neighbor = Tile.NeighborCoordinate(center.xCoordinate, center.yCoordinate, direction);
 			//TODO: World wrap should also be accounted for.
-			return tileAt(x, y);
+			return tileAt(neighbor.Item1, neighbor.Item2);
 		}
 
 		public delegate int[,] TerrainNoiseMapGenerator(int rng, int width, int height);

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -216,6 +216,41 @@ namespace C7GameData
 		public string YieldString(Player player) {
 			return $"{foodYield(player)}/{productionYield(player)}/{commerceYield(player)})";
 		}
+
+		// Returns the x and y coordinates of the neighbor in the specified direction.
+		public static Tuple<int, int> NeighborCoordinate(int x, int y, TileDirection direction) {
+			switch (direction) {
+				case TileDirection.NORTH:
+					y-=2;
+					break;
+				case TileDirection.NORTHEAST:
+					y--;
+					x++;
+					break;
+				case TileDirection.EAST:
+					x+=2;
+					break;
+				case TileDirection.SOUTHEAST:
+					y++;
+					x++;
+					break;
+				case TileDirection.SOUTH:
+					y+=2;
+					break;
+				case TileDirection.SOUTHWEST:
+					y++;
+					x--;
+					break;
+				case TileDirection.WEST:
+					x-=2;
+					break;
+				case TileDirection.NORTHWEST:
+					x--;
+					y--;
+					break;
+			}
+			return Tuple.Create(x, y);
+		}
 	}
 
 	public enum TileDirection {


### PR DESCRIPTION
This puts this utility in a lower dependency module, which will allow me to reuse it in a future PR that needs to calculate neighbors when determining what tiles are visible for scenario loading.

I've intentionally made this a static method so it can be used when we don't have a tile on hand.

Note: in C++ I would normally just make this a `neighbor_coordinate.cc` file with a single method, with the idea that it could have the minimal dependency footprint, but I don't see that kind of pattern with this project, so I just tossed it in the lowest dependency thing that seemed relevant. Let me know if I should do something else.