### PR TITLE
Set the default human player to carthage

### DIFF
--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -61374,11 +61374,11 @@
     },
     {
       "id": "player-2",
-      "colorIndex": 1,
+      "colorIndex": 9,
       "barbarian": false,
       "human": true,
       "hasPlayedCurrentTurn": false,
-      "civilization": "Rome",
+      "civilization": "Carthage",
       "cityNameIndex": 0,
       "tileKnowledge": [
         {


### PR DESCRIPTION
The color index of 9 matches the entry for carthage on line 62747

![image](https://github.com/user-attachments/assets/136553b8-745d-463e-b60e-72b2dc431ec0)
