### PR TITLE
Fix unresponsive unit buttons

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -265,6 +265,7 @@ script = ExtResource("3")
 [connection signal="Retire" from="CanvasLayer/PopupOverlay" to="." method="_on_QuitButton_pressed"]
 [connection signal="UnitDisbanded" from="CanvasLayer/PopupOverlay" to="." method="OnUnitDisbanded"]
 [connection signal="BlinkyEndTurnButtonPressed" from="CanvasLayer/Control/GameStatus" to="." method="OnPlayerEndTurn"]
+[connection signal="ActionRequested" from="CanvasLayer/Control/UnitButtons" to="." method="ProcessAction"]
 [connection signal="pressed" from="CanvasLayer/Control/ToolBar/MarginContainer/HBoxContainer/AdvisorButton" to="CanvasLayer/Advisor" method="ShowLatestAdvisor"]
 [connection signal="pressed" from="CanvasLayer/Control/ToolBar/MarginContainer/HBoxContainer/UiBarEndTurnButton" to="." method="_onEndTurnButtonPressed"]
 [connection signal="toggled" from="CanvasLayer/Control/SlideOutBar/SlideToggle" to="." method="_on_SlideToggle_toggled"]

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -509,10 +509,10 @@ public partial class Game : Node2D {
 		}
 
 		if (this.HasCurrentlySelectedUnit()) {
-			(bool moveUnit, TileDirection dir) = C7Action.ToTileDirection(currentAction);
+			TileDirection? dir = C7Action.ToTileDirection(currentAction);
 			
-			if (moveUnit) {
-				new MsgMoveUnit(CurrentlySelectedUnit.id, dir).send();
+			if (dir.HasValue) {
+				new MsgMoveUnit(CurrentlySelectedUnit.id, dir.Value).send();
 				setSelectedUnit(CurrentlySelectedUnit); //also triggers updating the lower-left info box
 			}
 		}

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -1,13 +1,11 @@
 using Godot;
 using System;
-using System.Collections;
 using System.Diagnostics;
 using C7Engine;
 using C7GameData;
 using Serilog;
 using C7Engine.Pathing;
 using System.Collections.Generic;
-using C7.Map;
 
 public partial class Game : Node2D {
 	[Signal] public delegate void TurnStartedEventHandler();
@@ -186,7 +184,7 @@ public partial class Game : Node2D {
 	}
 
 	public override void _Process(double delta) {
-		processActions();
+		ProcessActions();
 
 		// TODO: Is it necessary to keep the game data mutex locked for this entire method?
 		using (var gameDataAccess = new UIGameDataAccess()) {
@@ -484,8 +482,18 @@ public partial class Game : Node2D {
 	}
 
 	// Handle Godot keybind actions
-	private void processActions() {
-		if (Input.IsActionJustPressed(C7Action.Escape) && popupOverlay.ShowingPopup) {
+	private void ProcessActions() {
+		Godot.Collections.Array<StringName> actions = InputMap.GetActions();
+
+		foreach (StringName action in actions) {
+			if (Input.IsActionJustPressed(action)) {
+				ProcessAction(action.ToString());
+			}
+		}
+	}
+
+	private void ProcessAction(string currentAction) {
+		if (currentAction == C7Action.Escape && popupOverlay.ShowingPopup) {
 			popupOverlay.OnHidePopup();
 			return;
 		}
@@ -495,7 +503,7 @@ public partial class Game : Node2D {
 			return;
 		}
 
-		if (Input.IsActionJustPressed(C7Action.EndTurn) && !this.HasCurrentlySelectedUnit()) {
+		if (currentAction == C7Action.EndTurn && !this.HasCurrentlySelectedUnit()) {
 			log.Verbose("end_turn key pressed");
 			this.OnPlayerEndTurn();
 		}
@@ -504,21 +512,21 @@ public partial class Game : Node2D {
 			// TODO: replace bool with an invalid TileDirection enum
 			TileDirection dir = TileDirection.NORTH;
 			bool moveUnit = true;
-			if (Input.IsActionJustPressed(C7Action.MoveUnitSouthwest)) {
+			if (currentAction == C7Action.MoveUnitSouthwest) {
 				dir = TileDirection.SOUTHWEST;
-			} else if (Input.IsActionJustPressed(C7Action.MoveUnitSouth)) {
+			} else if (currentAction == C7Action.MoveUnitSouth) {
 				dir = TileDirection.SOUTH;
-			} else if (Input.IsActionJustPressed(C7Action.MoveUnitSoutheast)) {
+			} else if (currentAction == C7Action.MoveUnitSoutheast) {
 				dir = TileDirection.SOUTHEAST;
-			} else if (Input.IsActionJustPressed(C7Action.MoveUnitWest)) {
+			} else if (currentAction == C7Action.MoveUnitWest) {
 				dir = TileDirection.WEST;
-			} else if (Input.IsActionJustPressed(C7Action.MoveUnitEast)) {
+			} else if (currentAction == C7Action.MoveUnitEast) {
 				dir = TileDirection.EAST;
-			} else if (Input.IsActionJustPressed(C7Action.MoveUnitNorthwest)) {
+			} else if (currentAction == C7Action.MoveUnitNorthwest) {
 				dir = TileDirection.NORTHWEST;
-			} else if (Input.IsActionJustPressed(C7Action.MoveUnitNorth)) {
+			} else if (currentAction == C7Action.MoveUnitNorth) {
 				dir = TileDirection.NORTH;
-			} else if (Input.IsActionJustPressed(C7Action.MoveUnitNortheast)) {
+			} else if (currentAction == C7Action.MoveUnitNortheast) {
 				dir = TileDirection.NORTHEAST;
 			} else {
 				moveUnit = false;
@@ -529,16 +537,16 @@ public partial class Game : Node2D {
 			}
 		}
 
-		if (Input.IsActionJustPressed(C7Action.ToggleGrid)) {
+		if (currentAction == C7Action.ToggleGrid) {
 			this.mapView.gridLayer.visible = !this.mapView.gridLayer.visible;
 		}
 
-		if (Input.IsActionJustPressed(C7Action.Escape) && this.gotoInfo == null) {
+		if (currentAction == C7Action.Escape && this.gotoInfo == null) {
 			log.Debug("Got request for escape/quit");
 			popupOverlay.ShowPopup(new EscapeQuitPopup(), PopupOverlay.PopupCategory.Info);
 		}
 
-		if (Input.IsActionJustPressed(C7Action.ToggleZoom)) {
+		if (currentAction == C7Action.ToggleZoom) {
 			if (mapView.cameraZoom != 1) {
 				mapView.setCameraZoomFromMiddle(1.0f);
 				slider.Value = 1.0f;
@@ -548,52 +556,52 @@ public partial class Game : Node2D {
 			}
 		}
 
-		if (Input.IsActionJustPressed(C7Action.ToggleAnimations)) {
+		if (currentAction == C7Action.ToggleAnimations) {
 			SetAnimationsEnabled(false);
 		} else if (Input.IsActionJustReleased(C7Action.ToggleAnimations)) {
 			SetAnimationsEnabled(true);
 		}
 
 		// actions with unit buttons
-		if (Input.IsActionJustPressed(C7Action.UnitHold)) {
+		if (currentAction == C7Action.UnitHold) {
 			new MsgSkipUnitTurn(CurrentlySelectedUnit.id).send();
 		}
 
-		if (Input.IsActionJustPressed(C7Action.UnitWait)) {
+		if (currentAction == C7Action.UnitWait) {
 			using (var gameDataAccess = new UIGameDataAccess()) {
 				UnitInteractions.waitUnit(gameDataAccess.gameData, CurrentlySelectedUnit.id);
 				GetNextAutoselectedUnit(gameDataAccess.gameData);
 			}
 		}
 
-		if (Input.IsActionJustPressed(C7Action.UnitFortify)) {
+		if (currentAction == C7Action.UnitFortify) {
 			new MsgSetFortification(CurrentlySelectedUnit.id, true).send();
 		}
 
-		if (Input.IsActionJustPressed(C7Action.UnitDisband)) {
+		if (currentAction == C7Action.UnitDisband) {
 			popupOverlay.ShowPopup(new DisbandConfirmation(CurrentlySelectedUnit), PopupOverlay.PopupCategory.Advisor);
 		}
 
 		// unit_goto's behavior is more complicated than other actions - it
 		// toggles the go to state, but must be detoggled in _*Input methods if
 		// it is not the input being pressed.
-		if (Input.IsActionJustPressed(C7Action.UnitGoto)) {
+		if (currentAction == C7Action.UnitGoto) {
 			setGotoMode(true);
 		}
 
-		if (Input.IsActionJustPressed(C7Action.UnitExplore)) {
+		if (currentAction == C7Action.UnitExplore) {
 			// unimplemented
 		}
 
-		if (Input.IsActionJustPressed(C7Action.UnitSentry)) {
+		if (currentAction == C7Action.UnitSentry) {
 			// unimplemented
 		}
 
-		if (Input.IsActionJustPressed(C7Action.UnitSentryEnemyOnly)) {
+		if (currentAction == C7Action.UnitSentryEnemyOnly) {
 			// unimplemented
 		}
 
-		if (Input.IsActionJustPressed(C7Action.UnitBuildCity) && CurrentlySelectedUnit.canBuildCity()) {
+		if (currentAction == C7Action.UnitBuildCity && CurrentlySelectedUnit.canBuildCity()) {
 			using (var gameDataAccess = new UIGameDataAccess()) {
 				MapUnit currentUnit = gameDataAccess.gameData.GetUnit(CurrentlySelectedUnit.id);
 				log.Debug(currentUnit.Describe());
@@ -603,7 +611,7 @@ public partial class Game : Node2D {
 			}
 		}
 
-		if (Input.IsActionJustPressed(C7Action.UnitBuildRoad) && CurrentlySelectedUnit.canBuildRoad()) {
+		if (currentAction == C7Action.UnitBuildRoad && CurrentlySelectedUnit.canBuildRoad()) {
 			new MsgBuildRoad(CurrentlySelectedUnit.id).send();
 		}
 

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -509,28 +509,8 @@ public partial class Game : Node2D {
 		}
 
 		if (this.HasCurrentlySelectedUnit()) {
-			// TODO: replace bool with an invalid TileDirection enum
-			TileDirection dir = TileDirection.NORTH;
-			bool moveUnit = true;
-			if (currentAction == C7Action.MoveUnitSouthwest) {
-				dir = TileDirection.SOUTHWEST;
-			} else if (currentAction == C7Action.MoveUnitSouth) {
-				dir = TileDirection.SOUTH;
-			} else if (currentAction == C7Action.MoveUnitSoutheast) {
-				dir = TileDirection.SOUTHEAST;
-			} else if (currentAction == C7Action.MoveUnitWest) {
-				dir = TileDirection.WEST;
-			} else if (currentAction == C7Action.MoveUnitEast) {
-				dir = TileDirection.EAST;
-			} else if (currentAction == C7Action.MoveUnitNorthwest) {
-				dir = TileDirection.NORTHWEST;
-			} else if (currentAction == C7Action.MoveUnitNorth) {
-				dir = TileDirection.NORTH;
-			} else if (currentAction == C7Action.MoveUnitNortheast) {
-				dir = TileDirection.NORTHEAST;
-			} else {
-				moveUnit = false;
-			}
+			(bool moveUnit, TileDirection dir) = C7Action.ToTileDirection(currentAction);
+			
 			if (moveUnit) {
 				new MsgMoveUnit(CurrentlySelectedUnit.id, dir).send();
 				setSelectedUnit(CurrentlySelectedUnit); //also triggers updating the lower-left info box

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -10,6 +10,7 @@ using Serilog;
 */
 
 public partial class UnitButtons : VBoxContainer {
+	[Signal] public delegate void ActionRequestedEventHandler(string action);
 
 	private ILogger log = LogManager.ForContext<UnitButtons>();
 
@@ -77,7 +78,7 @@ public partial class UnitButtons : VBoxContainer {
 	}
 
 	private void onButtonPressed(string action) {
-		Input.ActionPress(action);
+		EmitSignal(SignalName.ActionRequested, action);
 	}
 
 	private void OnNoMoreAutoselectableUnits() {

--- a/C7GameData/Actions.cs
+++ b/C7GameData/Actions.cs
@@ -1,28 +1,46 @@
 namespace C7GameData {
 	public static class C7Action {
-		public static readonly string EndTurn = "end_turn";
-		public static readonly string Escape = "escape";
-		public static readonly string MoveUnitSouthwest = "move_unit_southwest";
-		public static readonly string MoveUnitSouth = "move_unit_south";
-		public static readonly string MoveUnitSoutheast = "move_unit_southeast";
-		public static readonly string MoveUnitWest = "move_unit_west";
-		public static readonly string MoveUnitEast = "move_unit_east";
-		public static readonly string MoveUnitNorthwest = "move_unit_northwest";
-		public static readonly string MoveUnitNorth = "move_unit_north";
-		public static readonly string MoveUnitNortheast = "move_unit_northeast";
-		public static readonly string ToggleAnimations = "toggle_animations";
-		public static readonly string ToggleGrid = "toggle_grid";
-		public static readonly string ToggleZoom = "toggle_zoom";
-		public static readonly string UnitBombard = "unit_bombard";
-		public static readonly string UnitBuildCity = "unit_build_city";
-		public static readonly string UnitBuildRoad = "unit_build_road";
-		public static readonly string UnitDisband = "unit_disband";
-		public static readonly string UnitExplore = "unit_explore";
-		public static readonly string UnitFortify = "unit_fortify";
-		public static readonly string UnitGoto = "unit_goto";
-		public static readonly string UnitHold = "unit_hold";
-		public static readonly string UnitSentry = "unit_sentry";
-		public static readonly string UnitSentryEnemyOnly = "unit_sentry_enemy_only";
-		public static readonly string UnitWait = "unit_wait";
+		public const string EndTurn = "end_turn";
+		public const string Escape = "escape";
+		public const string MoveUnitSouthwest = "move_unit_southwest";
+		public const string MoveUnitSouth = "move_unit_south";
+		public const string MoveUnitSoutheast = "move_unit_southeast";
+		public const string MoveUnitWest = "move_unit_west";
+		public const string MoveUnitEast = "move_unit_east";
+		public const string MoveUnitNorthwest = "move_unit_northwest";
+		public const string MoveUnitNorth = "move_unit_north";
+		public const string MoveUnitNortheast = "move_unit_northeast";
+		public const string ToggleAnimations = "toggle_animations";
+		public const string ToggleGrid = "toggle_grid";
+		public const string ToggleZoom = "toggle_zoom";
+		public const string UnitBombard = "unit_bombard";
+		public const string UnitBuildCity = "unit_build_city";
+		public const string UnitBuildRoad = "unit_build_road";
+		public const string UnitDisband = "unit_disband";
+		public const string UnitExplore = "unit_explore";
+		public const string UnitFortify = "unit_fortify";
+		public const string UnitGoto = "unit_goto";
+		public const string UnitHold = "unit_hold";
+		public const string UnitSentry = "unit_sentry";
+		public const string UnitSentryEnemyOnly = "unit_sentry_enemy_only";
+		public const string UnitWait = "unit_wait";
+
+		// This method transforms an action string into a TileDirection.
+		// The boolean value in the returned tuple indicates whether the conversion was successful.
+		public static (bool, TileDirection) ToTileDirection(string action) {
+			// TODO: replace bool with an invalid TileDirection enum
+			// More in this issue: https://github.com/C7-Game/Prototype/issues/397
+			return action switch {
+				MoveUnitSouthwest => (true, TileDirection.SOUTHWEST),
+				MoveUnitSouth => (true, TileDirection.SOUTH),
+				MoveUnitSoutheast => (true, TileDirection.SOUTHEAST),
+				MoveUnitWest => (true, TileDirection.WEST),
+				MoveUnitEast => (true, TileDirection.EAST),
+				MoveUnitNorthwest => (true, TileDirection.NORTHWEST),
+				MoveUnitNorth => (true, TileDirection.NORTH),
+				MoveUnitNortheast => (true, TileDirection.NORTHEAST),
+				_ => (false, TileDirection.NORTH),
+			};
+		}
 	}
 }

--- a/C7GameData/Actions.cs
+++ b/C7GameData/Actions.cs
@@ -26,20 +26,18 @@ namespace C7GameData {
 		public const string UnitWait = "unit_wait";
 
 		// This method transforms an action string into a TileDirection.
-		// The boolean value in the returned tuple indicates whether the conversion was successful.
-		public static (bool, TileDirection) ToTileDirection(string action) {
-			// TODO: replace bool with an invalid TileDirection enum
-			// More in this issue: https://github.com/C7-Game/Prototype/issues/397
+		// A null value will be returned if the conversion is unsuccessful.
+		public static TileDirection? ToTileDirection(string action) {
 			return action switch {
-				MoveUnitSouthwest => (true, TileDirection.SOUTHWEST),
-				MoveUnitSouth => (true, TileDirection.SOUTH),
-				MoveUnitSoutheast => (true, TileDirection.SOUTHEAST),
-				MoveUnitWest => (true, TileDirection.WEST),
-				MoveUnitEast => (true, TileDirection.EAST),
-				MoveUnitNorthwest => (true, TileDirection.NORTHWEST),
-				MoveUnitNorth => (true, TileDirection.NORTH),
-				MoveUnitNortheast => (true, TileDirection.NORTHEAST),
-				_ => (false, TileDirection.NORTH),
+				MoveUnitSouthwest => TileDirection.SOUTHWEST,
+				MoveUnitSouth => TileDirection.SOUTH,
+				MoveUnitSoutheast => TileDirection.SOUTHEAST,
+				MoveUnitWest => TileDirection.WEST,
+				MoveUnitEast => TileDirection.EAST,
+				MoveUnitNorthwest => TileDirection.NORTHWEST,
+				MoveUnitNorth => TileDirection.NORTH,
+				MoveUnitNortheast => TileDirection.NORTHEAST,
+				_ => null,
 			};
 		}
 	}


### PR DESCRIPTION
Prior to this commit, some of the unit buttons (e.g., Build City, Build Road) could become unresponsive. This issue was related to how the game handled button presses. When a button was pressed, the game emulated the press of an action hotkey, which should have been handled by the Game class. However, in some cases, the input simulation didn't work properly, and the game didn't react to the button presses.

To solve this issue, I decoupled the handling of button presses from the handling of hotkey input. Now, instead of imitating input, a unit button sends a signal to the Game class. In the Game class, the logic for handling action requests has been moved into a new method, which is now used for both handling signals from unit buttons and processing hotkey input.