### PR TITLE
Add civ destruction

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -171,6 +171,15 @@ public partial class Game : Node2D {
 					break;
 				case MsgCityDestroyed mCD:
 					mapView.cityLayer.UpdateAfterCityDestruction(mCD.city);
+
+					// If this was the last city of the civilization, display a popup
+					// noting that the civ is gone and destroy any remaining units.
+					if (mCD.city.owner.RemainingCities() == 0) {
+						popupOverlay.ShowPopup(new CivilizationDestroyed(mCD.city.owner.civilization), PopupOverlay.PopupCategory.Advisor);
+						for (int i =0; i < mCD.city.owner.units.Count; ++i) {
+							MapUnitExtensions.disband(mCD.city.owner.units[i]);
+						}
+					}
 					break;
 			}
 		}

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -174,6 +174,10 @@ public partial class Game : Node2D {
 
 					// If this was the last city of the civilization, display a popup
 					// noting that the civ is gone and destroy any remaining units.
+					//
+					// TODO: Implement the full set of conditions for destroying a civ;
+					// handling cases like 1 city elimination, regicide, settlers that
+					// are still alive, etc.
 					if (mCD.city.owner.RemainingCities() == 0) {
 						popupOverlay.ShowPopup(new CivilizationDestroyed(mCD.city.owner.civilization), PopupOverlay.PopupCategory.Advisor);
 						for (int i =0; i < mCD.city.owner.units.Count; ++i) {

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -58661,7 +58661,7 @@
       "facingDirection": "north",
       "experience": "Regular"
     },
-    {
+	{
       "id": "Settler-2",
       "prototype": "Settler",
       "owner": "player-3",
@@ -61858,6 +61858,7 @@
   "civilizations": [
     {
       "name": "A Barbarian Chiefdom",
+	  "noun": "Barbarians",
       "colorIndex": 0,
       "leaderGender": "male",
       "cityNames": [
@@ -61941,6 +61942,7 @@
     },
     {
       "name": "Rome",
+	  "noun": "Romans",
       "leader": "Caesar",
       "colorIndex": 1,
       "leaderGender": "male",
@@ -61993,6 +61995,7 @@
     },
     {
       "name": "Egypt",
+	  "noun": "Egyptians",
       "leader": "Cleopatra",
       "colorIndex": 3,
       "leaderGender": "female",
@@ -62030,6 +62033,7 @@
     },
     {
       "name": "Greece",
+	  "noun": "Greeks",
       "leader": "Alexander",
       "colorIndex": 10,
       "leaderGender": "male",
@@ -62067,6 +62071,7 @@
     },
     {
       "name": "Babylon",
+	  "noun": "Babylonians",
       "leader": "Hammurabi",
       "colorIndex": 1,
       "leaderGender": "male",
@@ -62102,6 +62107,7 @@
     },
     {
       "name": "Germany",
+	  "noun": "Germans",
       "leader": "Bismarck",
       "colorIndex": 6,
       "leaderGender": "male",
@@ -62126,6 +62132,7 @@
     },
     {
       "name": "Russia",
+	  "noun": "Russians",
       "leader": "Catherine",
       "colorIndex": 9,
       "leaderGender": "female",
@@ -62173,6 +62180,7 @@
     },
     {
       "name": "China",
+	  "noun": "Chinese",
       "leader": "Mao",
       "colorIndex": 5,
       "leaderGender": "male",
@@ -62199,6 +62207,7 @@
     },
     {
       "name": "America",
+	  "noun": "Americans",
       "leader": "Lincoln",
       "colorIndex": 5,
       "leaderGender": "male",
@@ -62247,6 +62256,7 @@
     },
     {
       "name": "Japan",
+	  "noun": "Japanese",
       "leader": "Tokugawa",
       "colorIndex": 4,
       "leaderGender": "male",
@@ -62281,6 +62291,7 @@
     },
     {
       "name": "France",
+	  "noun": "French",
       "leader": "Joan d\u0027Arc",
       "colorIndex": 7,
       "leaderGender": "female",
@@ -62310,6 +62321,7 @@
     },
     {
       "name": "India",
+	  "noun": "Indians",
       "leader": "Gandhi",
       "colorIndex": 8,
       "leaderGender": "male",
@@ -62335,6 +62347,7 @@
     },
     {
       "name": "Persia",
+	  "noun": "Persians",
       "leader": "Xerxes",
       "colorIndex": 10,
       "leaderGender": "male",
@@ -62372,6 +62385,7 @@
     },
     {
       "name": "Aztecs",
+	  "noun": "Aztecs",
       "leader": "Montezuma",
       "colorIndex": 4,
       "leaderGender": "male",
@@ -62416,6 +62430,7 @@
     },
     {
       "name": "Zululand",
+	  "noun": "Zulu",
       "leader": "Shaka",
       "colorIndex": 3,
       "leaderGender": "male",
@@ -62440,6 +62455,7 @@
     },
     {
       "name": "Iroquois",
+	  "noun": "Iroquois",
       "leader": "Hiawatha",
       "colorIndex": 8,
       "leaderGender": "male",
@@ -62477,6 +62493,7 @@
     },
     {
       "name": "England",
+	  "noun": "English",
       "leader": "Elizabeth",
       "colorIndex": 2,
       "leaderGender": "female",
@@ -62514,6 +62531,7 @@
     },
     {
       "name": "Mongols",
+	  "noun": "Mongols",
       "leader": "Temujin",
       "colorIndex": 3,
       "leaderGender": "male",
@@ -62552,6 +62570,7 @@
     },
     {
       "name": "Spain",
+	  "noun": "Spanish",
       "leader": "Isabella",
       "colorIndex": 5,
       "leaderGender": "female",
@@ -62591,6 +62610,7 @@
     },
     {
       "name": "Scandinavia",
+	  "noun": "Vikings",
       "leader": "Ragnar Lodbrok",
       "colorIndex": 8,
       "leaderGender": "male",
@@ -62632,6 +62652,7 @@
     },
     {
       "name": "Ottomans",
+	  "noun": "Ottomans",
       "leader": "Osman",
       "colorIndex": 2,
       "leaderGender": "male",
@@ -62669,6 +62690,7 @@
     },
     {
       "name": "Celts",
+	  "noun": "Celts",
       "leader": "Brennus",
       "colorIndex": 4,
       "leaderGender": "male",
@@ -62707,6 +62729,7 @@
     },
     {
       "name": "Arabia",
+	  "noun": "Arabs",
       "leader": "Abu Bakr",
       "colorIndex": 7,
       "leaderGender": "male",
@@ -62743,6 +62766,7 @@
     },
     {
       "name": "Carthage",
+	  "noun": "Carthaginians",
       "leader": "Hannibal",
       "colorIndex": 9,
       "leaderGender": "male",
@@ -62781,6 +62805,7 @@
     },
     {
       "name": "Korea",
+	  "noun": "Koreans",
       "leader": "Wang Kon",
       "colorIndex": 6,
       "leaderGender": "male",
@@ -62819,6 +62844,7 @@
     },
     {
       "name": "Sumeria",
+	  "noun": "Sumerians",
       "leader": "Gilgamesh",
       "colorIndex": 5,
       "leaderGender": "male",
@@ -62852,6 +62878,7 @@
     },
     {
       "name": "Hittites",
+	  "noun": "Hittites",
       "leader": "Mursilis",
       "colorIndex": 14,
       "leaderGender": "male",
@@ -62885,6 +62912,7 @@
     },
     {
       "name": "Netherlands",
+	  "noun": "Dutch",
       "leader": "William",
       "colorIndex": 2,
       "leaderGender": "male",
@@ -62918,6 +62946,7 @@
     },
     {
       "name": "Portugal",
+	  "noun": "Portugese",
       "leader": "Henry",
       "colorIndex": 8,
       "leaderGender": "male",
@@ -62962,6 +62991,7 @@
     },
     {
       "name": "Byzantines",
+	  "noun": "Byzantines",
       "leader": "Theodora",
       "colorIndex": 11,
       "leaderGender": "female",
@@ -62995,6 +63025,7 @@
     },
     {
       "name": "Inca",
+	  "noun": "Inca",
       "leader": "Pachacuti",
       "colorIndex": 7,
       "leaderGender": "male",
@@ -63028,6 +63059,7 @@
     },
     {
       "name": "Maya",
+	  "noun": "Maya",
       "leader": "Smoke-Jaguar",
       "colorIndex": 6,
       "leaderGender": "male",

--- a/C7/UIElements/Popups/CivilizationDestroyed.cs
+++ b/C7/UIElements/Popups/CivilizationDestroyed.cs
@@ -1,0 +1,54 @@
+using Godot;
+using System;
+using System.Diagnostics;
+using C7GameData;
+using Serilog;
+
+public partial class CivilizationDestroyed : Popup
+{
+	string civNoun = "";
+
+	//So Godot doesn't print error " Cannot construct temporary MonoObject because the class does not define a parameterless constructor"
+	//Not sure how important that is *shrug*
+	// public CivilizationDestroyed() {}
+
+	public CivilizationDestroyed(Civilization civ)
+	{
+		alignment = BoxContainer.AlignmentMode.End;
+		margins = new Margins(right: 10);
+		civNoun = civ.noun;
+	}
+
+	public override void _Ready()
+	{
+		base._Ready();
+
+		//Dimensions are 530x260 (roughly).
+		//The top 110 px are for the advisor.
+		AddTexture(530, 260);
+
+		ImageTexture AdvisorHappy = Util.LoadTextureFromPCX("Art/SmallHeads/popupMILITARY.pcx", 1, 40, 149, 110, false);
+		TextureRect AdvisorHead = new() {
+			Texture = AdvisorHappy
+		};
+		//Appears at 400, 110 in game, but leftmost 25px are transparent with default graphics
+		AdvisorHead.SetPosition(new Vector2(375, 0));
+		AddChild(AdvisorHead);
+
+		AddBackground(530, 150, 110);
+		AddHeader("Military Advisor", 120);
+
+		Label message = new() {
+			Text = "The " + civNoun + " have been destroyed."
+		};
+		message.SetPosition(new Vector2(25, 170));
+		AddChild(message);
+
+		AddButton("Very well.", 215, "ContinueAction");
+	}
+
+	private void ContinueAction()
+	{
+		GetParent().EmitSignal("HidePopup");
+	}
+}

--- a/C7/UIElements/Popups/CivilizationDestroyed.cs
+++ b/C7/UIElements/Popups/CivilizationDestroyed.cs
@@ -8,10 +8,6 @@ public partial class CivilizationDestroyed : Popup
 {
 	string civNoun = "";
 
-	//So Godot doesn't print error " Cannot construct temporary MonoObject because the class does not define a parameterless constructor"
-	//Not sure how important that is *shrug*
-	// public CivilizationDestroyed() {}
-
 	public CivilizationDestroyed(Civilization civ)
 	{
 		alignment = BoxContainer.AlignmentMode.End;

--- a/C7GameData/Civilization.cs
+++ b/C7GameData/Civilization.cs
@@ -21,7 +21,7 @@ namespace C7GameData
 		}
 		public string name;
 
-		// "Americans" for "America", or "Spanish" for "Spain".
+		// `noun` is "Americans" for "America", or "Spanish" for "Spain", etc.
 		public string noun;
 		public string leader;
 		public int colorIndex;

--- a/C7GameData/Civilization.cs
+++ b/C7GameData/Civilization.cs
@@ -20,6 +20,9 @@ namespace C7GameData
 			this.name = name;
 		}
 		public string name;
+
+		// "Americans" for "America", or "Spanish" for "Spain".
+		public string noun;
 		public string leader;
 		public int colorIndex;
 		public Gender leaderGender;

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -315,6 +315,7 @@ namespace C7GameData {
 			foreach (RACE race in theBiq.Race) {
 				Civilization civ = new Civilization{
 					name = race.Name,
+					noun = race.Noun,
 					leader = race.LeaderName,
 					leaderGender = race.LeaderGender == 0 ? Gender.Male : Gender.Female,
 					colorIndex = race.DefaultColor,

--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -68,6 +68,17 @@ public class Player
 		return true;
 	}
 
+	public int RemainingCities() {
+		int result = 0;
+		foreach (City city in cities) {
+			// Destroyed cities have a size of zero.
+			if (city.size > 0) {
+				++result;
+			}
+		}
+		return result;
+	}
+
 	public override string ToString() {
 		if (civilization != null)
 			return civilization.cityNames.First();


### PR DESCRIPTION
... and display a popup so the user knows they accomplished this.

This gets us a step closer to being able to "win" a game of C7, instead of just being able to produce units and fight.

To make the popup dialog read reasonably well I had to fill in the "noun" field for each civilization.

As with many of these city/settler related PRs, I used the procedure from https://github.com/C7-Game/Prototype/pull/469 to have the AI build a city right next to me on turn 2.

---

Some screenshots are below. In particular, note that the American worker is destroyed at the same time the city is.

![image](https://github.com/user-attachments/assets/4c064d62-ae46-4831-a148-8e57df7b2714)

![image](https://github.com/user-attachments/assets/7af883b5-c31c-4ac7-8b8b-4ef8305334ae)
