### PR TITLE
Refactor handling of Godot signals

### DIFF
--- a/C7/Credits.cs
+++ b/C7/Credits.cs
@@ -62,7 +62,7 @@ public partial class Credits : Node2D
 		goBackButton.TextureNormal = goBackTexture;
 		goBackButton.SetPosition(new Vector2(952, 720));
 		AddChild(goBackButton);
-		goBackButton.Connect("pressed",new Callable(this,"ReturnToMenu"));
+		goBackButton.Pressed += ReturnToMenu;
 	}
 	public void ReturnToMenu()
 	{

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -212,7 +212,7 @@ public partial class Game : Node2D {
 				//without a manual cast to int.
 				//https://github.com/godotengine/godot/issues/16388
 				if (Input.IsKeyPressed(Godot.Key.F1)) {
-					EmitSignal("ShowSpecificAdvisor", "F1");
+					EmitSignal(SignalName.ShowSpecificAdvisor, "F1");
 				}
 			}
 		}
@@ -273,9 +273,9 @@ public partial class Game : Node2D {
 		// Also emit the signal for a new unit being selected, so other areas such as Game Status and Unit Buttons can update
 		if (CurrentlySelectedUnit != MapUnit.NONE) {
 			ParameterWrapper<MapUnit> wrappedUnit = new ParameterWrapper<MapUnit>(CurrentlySelectedUnit);
-			EmitSignal("NewAutoselectedUnit", wrappedUnit);
+			EmitSignal(SignalName.NewAutoselectedUnit, wrappedUnit);
 		} else {
-			EmitSignal("NoMoreAutoselectableUnits");
+			EmitSignal(SignalName.NoMoreAutoselectableUnits);
 		}
 	}
 
@@ -290,7 +290,7 @@ public partial class Game : Node2D {
 	private void OnPlayerStartTurn() {
 		log.Information("Starting player turn");
 		int turnNumber = TurnHandling.GetTurnNumber();
-		EmitSignal("TurnStarted", turnNumber);
+		EmitSignal(SignalName.TurnStarted, turnNumber);
 		CurrentState = GameState.PlayerTurn;
 
 		using (var gameDataAccess = new UIGameDataAccess()) {
@@ -301,7 +301,7 @@ public partial class Game : Node2D {
 	private void OnPlayerEndTurn() {
 		if (CurrentState == GameState.PlayerTurn) {
 			log.Information("Ending player turn");
-			EmitSignal("TurnEnded");
+			EmitSignal(SignalName.TurnEnded);
 			log.Information("Starting computer turn");
 			CurrentState = GameState.ComputerTurn;
 			new MsgEndTurn().send(); // Triggers actual backend processing

--- a/C7/MainMenu.cs
+++ b/C7/MainMenu.cs
@@ -36,10 +36,10 @@ public partial class MainMenu : Node2D
 		Global.ResetLoadGamePath();
 		LoadDialog = new Util.Civ3FileDialog();
 		LoadDialog.RelPath = @"Conquests/Saves";
-		LoadDialog.Connect("file_selected",new Callable(this,nameof(_on_FileDialog_file_selected)));
+		LoadDialog.FileSelected += _on_FileDialog_file_selected;
 		LoadScenarioDialog = new Util.Civ3FileDialog();
 		LoadScenarioDialog.RelPath = @"Conquests/Scenarios";
-		LoadScenarioDialog.Connect("file_selected",new Callable(this,nameof(_on_FileDialog_file_selected)));
+		LoadScenarioDialog.FileSelected += _on_FileDialog_file_selected;
 		GetNode<CanvasLayer>("CanvasLayer").AddChild(LoadDialog);
 		GetNode<CanvasLayer>("CanvasLayer").AddChild(LoadScenarioDialog);
 		DisplayTitleScreen();
@@ -53,16 +53,16 @@ public partial class MainMenu : Node2D
 			InactiveButton = Util.LoadTextureFromPCX("Art/buttonsFINAL.pcx", 1, 1, 20, 20, false);
 			HoverButton = Util.LoadTextureFromPCX("Art/buttonsFINAL.pcx", 22, 1, 20, 20, false);
 
-			AddButton("New Game", 0, "StartGame");
-			AddButton("Quick Start", 35, "StartGame");
-			AddButton("Tutorial", 70, "StartGame");
-			AddButton("Load Game", 105, "LoadGame");
-			AddButton("Load Scenario", 140, "LoadScenario");
-			AddButton("Hall of Fame", 175, "HallOfFame");
-			AddButton("Preferences", 210, "Preferences");
-			AddButton("Audio Preferences", 245, "Preferences");
-			AddButton("Credits", 280, "showCredits");
-			AddButton("Exit", 315, "_on_Exit_pressed");
+			AddButton("New Game", 0, StartGame);
+			AddButton("Quick Start", 35, StartGame);
+			AddButton("Tutorial", 70, StartGame);
+			AddButton("Load Game", 105, LoadGame);
+			AddButton("Load Scenario", 140, LoadScenario);
+			AddButton("Hall of Fame", 175, HallOfFame);
+			AddButton("Preferences", 210, Preferences);
+			AddButton("Audio Preferences", 245, Preferences);
+			AddButton("Credits", 280, showCredits);
+			AddButton("Exit", 315, _on_Exit_pressed);
 
 			// Hide select home folder if valid path is present as proven by reaching this point in code
 			SetCiv3Home.Visible = false;
@@ -81,14 +81,14 @@ public partial class MainMenu : Node2D
 		MainMenuBackground.Texture = TitleScreenTexture;
 	}
 
-	private void AddButton(string label, int verticalPosition, string actionName)
+	private void AddButton(string label, int verticalPosition, Action action)
 	{
 		TextureButton newButton = new TextureButton();
 		newButton.TextureNormal = InactiveButton;
 		newButton.TextureHover = HoverButton;
 		newButton.SetPosition(new Vector2(MENU_OFFSET_FROM_LEFT, MENU_OFFSET_FROM_TOP + verticalPosition));
 		MainMenuBackground.AddChild(newButton);
-		newButton.Connect("pressed",new Callable(this, actionName));
+		newButton.Pressed += action;
 
 		Theme theme = new Theme();
 		theme.SetFontSize("font_size", "Button", 14);
@@ -98,7 +98,7 @@ public partial class MainMenu : Node2D
 
 		newButtonLabel.SetPosition(new Vector2(MENU_OFFSET_FROM_LEFT + 25, MENU_OFFSET_FROM_TOP + verticalPosition + BUTTON_LABEL_OFFSET));
 		MainMenuBackground.AddChild(newButtonLabel);
-		newButtonLabel.Connect("pressed", new Callable(this, actionName));
+		newButtonLabel.Pressed += action;
 	}
 
 	public void StartGame()

--- a/C7/UIElements/Advisors/DomesticAdvisor.cs
+++ b/C7/UIElements/Advisors/DomesticAdvisor.cs
@@ -46,7 +46,7 @@ public partial class DomesticAdvisor : TextureRect
 		GoBackButton.TextureNormal = GoBackTexture;
 		GoBackButton.SetPosition(new Vector2(952, 720));
 		AddChild(GoBackButton);
-		GoBackButton.Connect("pressed",new Callable(this,"ReturnToMenu"));
+		GoBackButton.Pressed += ReturnToMenu;
 	}
 
 	private void ReturnToMenu()

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -1,5 +1,4 @@
 using Godot;
-using System;
 using ConvertCiv3Media;
 using C7GameData;
 using Serilog;
@@ -46,7 +45,7 @@ public partial class LowerRightInfoBox : TextureRect
 		nextTurnButton.TextureHover = nextTurnOnTexture;
 		nextTurnButton.SetPosition(new Vector2(0, 0));
 		AddChild(nextTurnButton);
-		nextTurnButton.Connect("pressed",new Callable(this,"turnEnded"));
+		nextTurnButton.Pressed += turnEnded;
 
 
 		//Labels and whatnot in this text box
@@ -95,7 +94,7 @@ public partial class LowerRightInfoBox : TextureRect
 		//Setup up, but do not start, the timer.
 		blinkingTimer.OneShot = false;
 		blinkingTimer.WaitTime = 0.6f;
-		blinkingTimer.Connect("timeout",new Callable(this,"toggleEndTurnButton"));
+		blinkingTimer.Timeout += toggleEndTurnButton;
 		AddChild(blinkingTimer);
 	}
 
@@ -136,7 +135,7 @@ public partial class LowerRightInfoBox : TextureRect
 
 	private void turnEnded() {
 		log.Debug("Emitting the blinky button pressed signal");
-		GetParent().EmitSignal("BlinkyEndTurnButtonPressed");
+		GetParent().EmitSignal(GameStatus.SignalName.BlinkyEndTurnButtonPressed);
 	}
 
 	public void UpdateUnitInfo(MapUnit NewUnit, TerrainType terrain)

--- a/C7/UIElements/Popups/BuildCityDialog.cs
+++ b/C7/UIElements/Popups/BuildCityDialog.cs
@@ -60,7 +60,7 @@ public partial class BuildCityDialog : Popup
 		cityName.SelectAll();
 		cityName.GrabFocus();
 
-		cityName.Connect("text_submitted", new Callable(this, "OnCityNameEntered"));
+		cityName.TextSubmitted += OnCityNameEntered;
 
 		//Cancel/confirm buttons.  Note the X button is thinner than the O button.
 		ImageTexture circleTexture= Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 1, 1, 19, 19);
@@ -82,8 +82,8 @@ public partial class BuildCityDialog : Popup
 		cancelButton.SetPosition(new Vector2(500, 213));
 		AddChild(cancelButton);
 
-		confirmButton.Connect("pressed",new Callable(this,"OnConfirmButtonPressed"));
-		cancelButton.Connect("pressed",new Callable(GetParent(),"OnHidePopup"));
+		confirmButton.Pressed += OnConfirmButtonPressed;
+		cancelButton.Pressed += GetParent<PopupOverlay>().OnHidePopup;
 	}
 
 	/**
@@ -98,8 +98,8 @@ public partial class BuildCityDialog : Popup
 	{
 		GetViewport().SetInputAsHandled();
 		log.Debug("The user hit enter with a city name of " + name);
-		GetParent().EmitSignal("BuildCity", name);
-		GetParent().EmitSignal("HidePopup");
+		GetParent().EmitSignal(PopupOverlay.SignalName.BuildCity, name);
+		GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
 	}
 
 }

--- a/C7/UIElements/Popups/DisbandConfirmation.cs
+++ b/C7/UIElements/Popups/DisbandConfirmation.cs
@@ -65,8 +65,8 @@ public partial class DisbandConfirmation : Popup
 		warningMessage.SetPosition(new Vector2(25, 170));
 		AddChild(warningMessage);
 
-		AddButton("Yes, we need to!", 215, "disband");
-		AddButton("No. Maybe you are right, advisor.", 245, "cancel");
+		AddButton("Yes, we need to!", 215, disband);
+		AddButton("No. Maybe you are right, advisor.", 245, cancel);
 
 		loadTimer.Stop();
 		TimeSpan stopwatchElapsed = loadTimer.Elapsed;
@@ -76,12 +76,12 @@ public partial class DisbandConfirmation : Popup
 	private void disband()
 	{
 		//tell the game to disband it.  right now we're doing that first, which is WRONG!
-		GetParent().EmitSignal("UnitDisbanded");
-		GetParent().EmitSignal("HidePopup");
+		GetParent().EmitSignal(PopupOverlay.SignalName.UnitDisbanded);
+		GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
 	}
 
 	private void cancel()
 	{
-		GetParent().EmitSignal("HidePopup");
+		GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
 	}
 }

--- a/C7/UIElements/Popups/ErrorMessage.cs
+++ b/C7/UIElements/Popups/ErrorMessage.cs
@@ -28,7 +28,7 @@ public partial class ErrorMessage : Popup
 		errorDescription.SetPosition(new Vector2(25, 162));
 		AddChild(errorDescription);
 
-		AddButton("Return to Menu", 290, "quit");
+		AddButton("Return to Menu", 290, quit);
 	}
 
 	private void quit()

--- a/C7/UIElements/Popups/EscapeQuitPopup.cs
+++ b/C7/UIElements/Popups/EscapeQuitPopup.cs
@@ -33,17 +33,17 @@ public partial class EscapeQuitPopup : Popup
 		warningMessage.SetPosition(new Vector2(25, 62));
 		AddChild(warningMessage);
 
-		AddButton("No, not really", 88, "cancel");
-		AddButton("Yes, immediately!", 116, "quit");
+		AddButton("No, not really", 88, cancel);
+		AddButton("Yes, immediately!", 116, quit);
 	}
 
 	private void quit()
 	{
-		GetParent().EmitSignal("Quit");
+		GetParent().EmitSignal(PopupOverlay.SignalName.Quit);
 	}
 
 	private void cancel()
 	{
-		GetParent().EmitSignal("HidePopup");
+		GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
 	}
 }

--- a/C7/UIElements/Popups/GameMenu.cs
+++ b/C7/UIElements/Popups/GameMenu.cs
@@ -1,3 +1,4 @@
+using System;
 using Godot;
 
 public partial class GameMenu : Popup
@@ -17,28 +18,44 @@ public partial class GameMenu : Popup
 
 		AddHeader("Main Menu", 10);
 
-		AddButton("Map", 60, "map");
-		AddButton("Load Game (Ctrl-L)", 85, "load");
-		AddButton("New Game (Ctrl-Shift-Q)", 110, "newGame");
-		AddButton("Preferences (Ctrl-P)", 135, "preferences");
-		AddButton("Retire (Ctrl-Q)", 160, "retire");
-		AddButton("Save Game (Ctrl-S)", 185, "save");
-		AddButton("Quit Game (ESC)", 210, "quit");
+		AddButton("Map", 60, map);
+		AddButton("Load Game (Ctrl-L)", 85, load);
+		AddButton("New Game (Ctrl-Shift-Q)", 110, newGame);
+		AddButton("Preferences (Ctrl-P)", 135, preferences);
+		AddButton("Retire (Ctrl-Q)", 160, retire);
+		AddButton("Save Game (Ctrl-S)", 185, save);
+		AddButton("Quit Game (ESC)", 210, quit);
+	}
+
+	private void save() {
+		throw new NotImplementedException();
+	}
+
+	private void preferences() {
+		throw new NotImplementedException();
+	}
+
+	private void newGame() {
+		throw new NotImplementedException();
+	}
+
+	private void load() {
+		throw new NotImplementedException();
 	}
 
 	private void quit()
 	{
-		GetParent().EmitSignal("Quit");
+		GetParent().EmitSignal(PopupOverlay.SignalName.Quit);
 	}
 
 	private void retire()
 	{
-		GetParent().EmitSignal("Retire");
+		GetParent().EmitSignal(PopupOverlay.SignalName.Retire);
 	}
 
 	private void map()
 	{
-		GetParent().EmitSignal("HidePopup");
+		GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
 	}
 
 }

--- a/C7/UIElements/Popups/Popup.cs
+++ b/C7/UIElements/Popups/Popup.cs
@@ -44,7 +44,7 @@ public partial class Popup : TextureRect
 	private static ImageTexture HoverButton = Util.LoadTextureFromPCX("Art/buttonsFINAL.pcx", 22, 1, 20, 20, false);
 	private static Dictionary<(int, int), ImageTexture> backgroundCache = new Dictionary<(int, int), ImageTexture>();
 
-	protected void AddButton(string label, int verticalPosition, string actionName)
+	protected void AddButton(string label, int verticalPosition, Action action)
 	{
 		const int HORIZONTAL_POSITION = 30;
 		TextureButton newButton = new TextureButton();
@@ -52,7 +52,7 @@ public partial class Popup : TextureRect
 		newButton.TextureHover = HoverButton;
 		newButton.SetPosition(new Vector2(HORIZONTAL_POSITION, verticalPosition));
 		AddChild(newButton);
-		newButton.Connect("pressed",new Callable(this,actionName));
+		newButton.Pressed += action;
 
 		Theme theme = new Theme();
 		theme.SetFontSize("font_size", "Button", 14);
@@ -62,7 +62,7 @@ public partial class Popup : TextureRect
 
 		newButtonLabel.SetPosition(new Vector2(HORIZONTAL_POSITION + 25, verticalPosition + BUTTON_LABEL_OFFSET));
 		AddChild(newButtonLabel);
-		newButtonLabel.Connect("pressed",new Callable(this,actionName));
+		newButtonLabel.Pressed += action;
 	}
 
 	protected void AddHeader(string text, int vOffset)

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -70,7 +70,7 @@ public partial class RightClickMenu : VBoxContainer {
 			button.Icon = icon;
 		}
 		button.Alignment = HorizontalAlignment.Left;
-		button.Connect("pressed", Callable.From(action));
+		button.Pressed += action;
 		this.AddChild(button);
 	}
 

--- a/C7/UIElements/UnitButtons/UnitControlButton.cs
+++ b/C7/UIElements/UnitButtons/UnitControlButton.cs
@@ -31,7 +31,7 @@ public partial class UnitControlButton : TextureButton {
 		this.TextureHover = rolloverTexture;
 		this.TexturePressed = pressedTexture;
 
-		this.Connect("pressed", new Callable(this, "onButtonPress"));
+		this.Pressed += onButtonPress;
 	}
 
 	private void onButtonPress() {


### PR DESCRIPTION
This commit addresses two issues with Godot signal handling, both of which relate to the transition between engine versions. In Godot 3, these were common practices for handling signals; however, the Godot 4 signal API offers more type-safe alternatives.

1) Use of raw strings for signal identification

Previously, raw strings were used to identify signals during emission. This has been improved by using the nested SignalName class provided by Godot signal API.

2) Use of the Connect() method for connecting signals

The Connect() method was used to connect methods to signals, a practice discouraged by the Godot documentation. This commit replaces Connect() with event mechanism.

[Relevant Godot documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/c_sharp_signals.html)
