### PR TITLE
Code cleanup to address godot4 PR comments

### DIFF
--- a/C7/PCXToGodot.cs
+++ b/C7/PCXToGodot.cs
@@ -4,6 +4,17 @@ using ConvertCiv3Media;
 using System.Collections.Generic;
 
 public partial class PCXToGodot : GodotObject {
+	private const byte SHADOW_START_INDEX = 224;
+	private const byte CIVCOLOR_START_INDEX = 239;
+	private const byte TRANSPARENCY_START_INDEX = 254;
+	private const byte SHADOW_INDEX_RANGE = CIVCOLOR_START_INDEX - SHADOW_START_INDEX;
+	private const ushort MAX_PALETTE_SIZE = 256;
+
+	private const byte GREEN_BITSHIFT = 8;
+	private const byte BLUE_BITSHIFT = 16;
+	private const byte ALPHA_BITSHIFT = 24;
+	private const byte MAX_COLOR = 255;
+
 	public readonly record struct CropRegion(int LeftStart, int TopStart, int CroppedWidth, int CroppedHeight);
 
 	public struct ColorOptions {
@@ -66,17 +77,15 @@ public partial class PCXToGodot : GodotObject {
 
 	public static ImageTexture getPureAlphaFromPCX(Pcx alphaPcx) {
 		int[] bufferData = new int[alphaPcx.Width * alphaPcx.Height];
-		int[] alphaData = new int[256];
-		for (int i = 0; i < 256; i++) {
+		int[] alphaData = new int[MAX_PALETTE_SIZE];
+		for (int i = 0; i < MAX_PALETTE_SIZE; i++) {
 			alphaData[i] = alphaPcx.Palette[i, 0];
 		}
 		int dataIndex = 0;
 		for (int y = 0; y < alphaPcx.Height; y++) {
 			for (int x = 0; x < alphaPcx.Width; x++, dataIndex++) {
 				int index = alphaPcx.ColorIndexAt(x, y);
-
 				bufferData[dataIndex] = (255 - alphaData[index]) << 24;
-
 			}
 		}
 
@@ -136,13 +145,13 @@ public partial class PCXToGodot : GodotObject {
 		for (int i = 0; i < width * height; i++) {
 			int index = colorIndices[i];
 			bool tinted = index < 16 || (index < 64 && index % 2 == 0);
-			bool shadow = index >= 224 && index <= 239;
+			bool shadow = index >= SHADOW_START_INDEX && index <= CIVCOLOR_START_INDEX;
 			if (tinted) {
 				tintLayer[i] = whiteColorData[index];
 				baseLayer[i] = 0; // transparent
 			} else if (shadow) {
 				// shadow belongs to the base texture
-				baseLayer[i] = ((int)new Color(1.0f, 1.0f, 1.0f, (float)index - 224f / 239f - 224f).ToArgb32());
+				baseLayer[i] = ((int)new Color(1.0f, 1.0f, 1.0f, (float)(index - SHADOW_START_INDEX) / SHADOW_INDEX_RANGE).ToArgb32());
 				tintLayer[i] = 0; // transparent
 			} else {
 				baseLayer[i] = colorData[index];
@@ -153,6 +162,7 @@ public partial class PCXToGodot : GodotObject {
 	}
 
 	// Utility for loading a civilization color from an ntp file
+	// Note that this retrieves the color of the (only) pixel, not a particular palette index.
 	public static Color GetColorFromPCX(Pcx pcx) {
 		int paletteLookupIdx = pcx.ColorIndexAt(0, 0);
 
@@ -176,21 +186,21 @@ public partial class PCXToGodot : GodotObject {
 
 	private static int[] loadPalette(byte[,] palette, ColorOptions colorOptions) {
 		int Red, Green, Blue;
-		int[] ColorData = new int[256];
+		int[] ColorData = new int[MAX_PALETTE_SIZE];
 
-		for (int i = 0; i < 256; i++) {
+		for (int i = 0; i < MAX_PALETTE_SIZE; i++) {
 			Red = palette[i, 0];
-			Green = palette[i, 1] << 8;
-			Blue = palette[i, 2] << 16;
+			Green = palette[i, 1] << GREEN_BITSHIFT;
+			Blue = palette[i, 2] << BLUE_BITSHIFT;
 
-			int Alpha = colorOptions.transparentColorIndexes.Contains(i) ? 0 : 255 << 24;
+			int Alpha = colorOptions.transparentColorIndexes.Contains(i) ? 0 : MAX_COLOR << ALPHA_BITSHIFT;
 
 			ColorData[i] = Red + Green + Blue + Alpha;
 		}
 
 		if (colorOptions.shadows) {
 			for (int i = 240; i < 256; i++) {
-				ColorData[i] = ((255 - i) * 16) << 24;
+				ColorData[i] = ((MAX_COLOR - i) * 16) << ALPHA_BITSHIFT;
 			}
 		}
 
@@ -198,9 +208,9 @@ public partial class PCXToGodot : GodotObject {
 	}
 
 	private static int[] loadAlphaPalette(byte[,] palette, int[] ColorData) {
-		int[] AlphaData = new int[256];
+		int[] AlphaData = new int[MAX_PALETTE_SIZE];
 
-		for (int i = 0; i < 256; i++) {
+		for (int i = 0; i < MAX_PALETTE_SIZE; i++) {
 			// Assumption based on menuButtonsAlpha.pcx: The palette in the alpha PCX always has the same red, green, and blue values (i.e. is grayscale).
 			// Examining it with breakpoints in my Java code, it appears it starts at 255, 255, 255, and goes down one at a time.  But this code
 			// doesn't assume that, it only assumes the grayscale aspect.  In theory, this should work for any transparency, 0 to 255.

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -456,20 +456,6 @@ namespace C7GameData {
 				default: throw new ArgumentOutOfRangeException("Invalid TileDirection");
 			}
 		}
-
-		// public static string shortName(this TileDirection dir) {
-		// 	switch (dir) {
-		// 	case TileDirection.NORTH:     return "N";
-		// 	case TileDirection.NORTHEAST: return "NE";
-		// 	case TileDirection.EAST:      return "E";
-		// 	case TileDirection.SOUTHEAST: return "SE";
-		// 	case TileDirection.SOUTH:     return "S";
-		// 	case TileDirection.SOUTHWEST: return "SW";
-		// 	case TileDirection.WEST:      return "W";
-		// 	case TileDirection.NORTHWEST: return "NW";
-		// 	default: throw new ArgumentOutOfRangeException("Invalid TileDirection");
-		// 	}
-		// }
 	}
 
 	public class TileOverlays {

--- a/C7GameDataTests/GameMapTest.cs
+++ b/C7GameDataTests/GameMapTest.cs
@@ -1,12 +1,12 @@
 using C7GameData;
 using Xunit;
 
+namespace C7GameDataTests;
+
 public class GameMapTest {
 	[Fact]
-	public void CityWith2ProductionPerTurn_ShouldReturn1TurnIf9_of_10ProductionDone() {
-		System.Random rng = new System.Random(12345);
+	public void DefaultGameMap_ShouldGenerateGameMap80TilesTall() {
 		GameMap gm = GameMap.Generate(new GameData());
-
 		Assert.Equal(80, gm.numTilesTall);
 	}
 }


### PR DESCRIPTION
Resolved some of the open comment threads by pruning dead or commented out code and renaming things. Civ3Map.LoadTileSet did not seem to serve any purpose anymore, as it did not return or modify anything outside of the method. I did not address the question of what purpose MovingSprite serves in Civ3Unit or what its values mean.