### PR TITLE
Fix linux debug builds

### DIFF
--- a/.github/workflows/export-c7.yml
+++ b/.github/workflows/export-c7.yml
@@ -37,6 +37,7 @@ jobs:
       run: |
         mkdir -v -p build/${FOLDER_NAME}
         cd ${EXPORT_NAME}
+        dotnet build
         godot -v --headless --export${BUILD_SUFFIX} "Windows Desktop" ../build/${FOLDER_NAME}/${EXPORT_NAME}.exe
     - name: Copy Static Files
       run: |
@@ -99,6 +100,7 @@ jobs:
       run: |
         mkdir -v -p build/${FOLDER_NAME}
         cd ${EXPORT_NAME}
+        dotnet build
         godot -v --headless --export${BUILD_SUFFIX} "macOS" ../build/${FOLDER_NAME}.zip
     - name: Copy Static Files
       run: |

--- a/.github/workflows/export-c7.yml
+++ b/.github/workflows/export-c7.yml
@@ -66,6 +66,7 @@ jobs:
       run: |
         mkdir -v -p build/${FOLDER_NAME}
         cd ${EXPORT_NAME}
+        dotnet build
         godot -v --headless --export${BUILD_SUFFIX} "Linux/X11" ../build/${FOLDER_NAME}/${EXPORT_NAME}.x86_64
     - name: Copy Static Files
       run: |

--- a/_Console/BuildDevSave/BuildDevSave.csproj
+++ b/_Console/BuildDevSave/BuildDevSave.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Amusingly enough godot doesn't actually build the C# project when exporting the build - we have to do that ourselves.

This required making all the `.csproj` files have the same .net target version and then just adding the `dotnet build` command. This will also probably fix the other platforms, but I can only easily test linux.

This also explains why I didn't encounter the issue when running locally
- my command when running locally is `dotnet build && godot --rendering-driver opengl3 # run game`, so I'm always rebuilding. 

#485 