### PR TITLE
Set up CI runs for PRs and pushes to the Development branch

### DIFF
--- a/.github/workflows/composite/buildSetup/action.yml
+++ b/.github/workflows/composite/buildSetup/action.yml
@@ -7,7 +7,7 @@ runs:
   - name: Optionally set BUILD_SUFFIX
     shell: bash
     run: |
-      if [[ ${{ github.event.inputs.debug-build }} == 'true' ]]; then
+      if [[ ${{ github.event.inputs.debug-build || 'true' }} == 'true' ]]; then
         echo "BUILD_SUFFIX=-debug" >> $GITHUB_ENV
       else
         echo "BUILD_SUFFIX=-release" >> $GITHUB_ENV
@@ -35,7 +35,7 @@ runs:
   - name: Set FOLDER_NAME
     shell: bash
     run: |
-      echo "FOLDER_NAME=${EXPORT_NAME}${{ github.event.inputs.folder-suffix }}${GH_USERNAME}${BUILD_TIME}" >> $GITHUB_ENV
+      echo "FOLDER_NAME=${EXPORT_NAME}${{ github.event.inputs.folder-suffix || 'automated_build' }}${GH_USERNAME}${BUILD_TIME}" >> $GITHUB_ENV
   - name: Setup
     shell: bash
     run: |

--- a/.github/workflows/export-c7.yml
+++ b/.github/workflows/export-c7.yml
@@ -17,6 +17,15 @@ on:
         type: boolean
         description: Append ISO8601 date/time to folder name
         default: true
+  pull_request:
+    branches:
+    - 'Development'
+    # Add any long-lived branches that need CI here.
+  push:
+    branches:
+    - 'Development'
+    # Add any long-lived branches that need CI here.
+
 
 env:
   GODOT_VERSION: 4.2.2


### PR DESCRIPTION
Trying to do some basic checks of historical builds for https://github.com/C7-Game/Prototype/issues/485 was complicated by the fact that there weren't exported builds for each PR. The lack of CI also has resulted in build issues in the past after merges, like [this one](https://github.com/C7-Game/Prototype/commit/c90daf5a36efda75377d0b21591e7724a7dc82b2), which this sort of CI would catch.

For now I've limited this to the Development branch, but it's easy to add any other long-lived branches to the list(s). When this branch was on the list, I confirmed it worked with action runs [like this one](https://github.com/C7-Game/Prototype/actions/runs/12621238049).