### PR TITLE
Run the code formatter over all the C# code

### DIFF
--- a/C7/AnimationTracker.cs
+++ b/C7/AnimationTracker.cs
@@ -10,8 +10,7 @@ public partial class AnimationTracker {
 	private AnimationManager civ3AnimData;
 	public bool endAllImmediately = false; // If true, update() ends all running animations regardless of time remaining.
 
-	public AnimationTracker(AnimationManager civ3AnimData)
-	{
+	public AnimationTracker(AnimationManager civ3AnimData) {
 		this.civ3AnimData = civ3AnimData;
 	}
 
@@ -24,13 +23,11 @@ public partial class AnimationTracker {
 
 	private Dictionary<ID, ActiveAnimation> activeAnims = new Dictionary<ID, ActiveAnimation>();
 
-	public long getCurrentTimeMS()
-	{
+	public long getCurrentTimeMS() {
 		return DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
 	}
 
-	private void startAnimation(ID id, C7Animation anim, AutoResetEvent completionEvent, AnimationEnding ending)
-	{
+	private void startAnimation(ID id, C7Animation anim, AutoResetEvent completionEvent, AnimationEnding ending) {
 		long currentTimeMS = getCurrentTimeMS();
 		long animDurationMS = (long)(1000.0 * anim.getDuration());
 
@@ -41,26 +38,28 @@ public partial class AnimationTracker {
 			if (aa.completionEvent != null)
 				aa.completionEvent.Set();
 		}
-		aa = new ActiveAnimation { startTimeMS = currentTimeMS, endTimeMS = currentTimeMS + animDurationMS, completionEvent = completionEvent,
-			ending = ending, anim = anim };
+		aa = new ActiveAnimation {
+			startTimeMS = currentTimeMS,
+			endTimeMS = currentTimeMS + animDurationMS,
+			completionEvent = completionEvent,
+			ending = ending,
+			anim = anim
+		};
 
 		anim.playSound();
 
 		activeAnims[id] = aa;
 	}
 
-	public void startAnimation(MapUnit unit, MapUnit.AnimatedAction action, AutoResetEvent completionEvent, AnimationEnding ending)
-	{
+	public void startAnimation(MapUnit unit, MapUnit.AnimatedAction action, AutoResetEvent completionEvent, AnimationEnding ending) {
 		startAnimation(unit.id, civ3AnimData.forUnit(unit.unitType, action), completionEvent, ending);
 	}
 
-	public void startAnimation(Tile tile, AnimatedEffect effect, AutoResetEvent completionEvent, AnimationEnding ending)
-	{
+	public void startAnimation(Tile tile, AnimatedEffect effect, AutoResetEvent completionEvent, AnimationEnding ending) {
 		startAnimation(tile.Id, civ3AnimData.forEffect(effect), completionEvent, ending);
 	}
 
-	public void endAnimation(MapUnit unit)
-	{
+	public void endAnimation(MapUnit unit) {
 		ActiveAnimation aa;
 		if (activeAnims.TryGetValue(unit.id, out aa)) {
 			if (aa.completionEvent != null)
@@ -69,13 +68,11 @@ public partial class AnimationTracker {
 		}
 	}
 
-	public bool hasCurrentAction(MapUnit unit)
-	{
+	public bool hasCurrentAction(MapUnit unit) {
 		return activeAnims.ContainsKey(unit.id);
 	}
 
-	public (MapUnit.AnimatedAction, float) getCurrentActionAndProgress(ID id)
-	{
+	public (MapUnit.AnimatedAction, float) getCurrentActionAndProgress(ID id) {
 		ActiveAnimation aa = activeAnims[id];
 
 		var durationMS = (double)(aa.endTimeMS - aa.startTimeMS);
@@ -91,18 +88,15 @@ public partial class AnimationTracker {
 		return (aa.anim.action, (float)progress);
 	}
 
-	public (MapUnit.AnimatedAction, float) getCurrentActionAndProgress(MapUnit unit)
-	{
+	public (MapUnit.AnimatedAction, float) getCurrentActionAndProgress(MapUnit unit) {
 		return getCurrentActionAndProgress(unit.id);
 	}
 
-	public (MapUnit.AnimatedAction, float) getCurrentActionAndProgress(Tile tile)
-	{
+	public (MapUnit.AnimatedAction, float) getCurrentActionAndProgress(Tile tile) {
 		return getCurrentActionAndProgress(tile.Id);
 	}
 
-	public void update()
-	{
+	public void update() {
 		long currentTimeMS = (! endAllImmediately) ? getCurrentTimeMS() : long.MaxValue;
 		var keysToRemove = new List<ID>();
 		foreach (var guidAAPair in activeAnims.Where(guidAAPair => guidAAPair.Value.endTimeMS <= currentTimeMS)) {
@@ -118,8 +112,7 @@ public partial class AnimationTracker {
 			activeAnims.Remove(key);
 	}
 
-	public MapUnit.Appearance getUnitAppearance(MapUnit unit)
-	{
+	public MapUnit.Appearance getUnitAppearance(MapUnit unit) {
 		if (hasCurrentAction(unit)) {
 			var (action, progress) = getCurrentActionAndProgress(unit);
 
@@ -148,8 +141,7 @@ public partial class AnimationTracker {
 		}
 	}
 
-	public C7Animation getTileEffect(Tile tile)
-	{
+	public C7Animation getTileEffect(Tile tile) {
 		return activeAnims.TryGetValue(tile.Id, out ActiveAnimation aa) ? aa.anim : null;
 	}
 }

--- a/C7/Civ3Map/Civ3Map.cs
+++ b/C7/Civ3Map/Civ3Map.cs
@@ -4,8 +4,7 @@ using System.Collections.Generic;
 using ConvertCiv3Media;
 using C7GameData;
 
-public partial class Civ3Map : Node2D
-{
+public partial class Civ3Map : Node2D {
 	public List<Tile> Civ3Tiles;
 	public int[,] Map { get; protected set; }
 	TileMap TM;
@@ -16,8 +15,7 @@ public partial class Civ3Map : Node2D
 	public int MapHeight;
 	// If a mod is in effect, set this, otherwise set to "" or "Conquests"
 	public string ModRelPath = "";
-	public Civ3Map(int mapWidth, int mapHeight, string modRelPath = "")
-	{
+	public Civ3Map(int mapWidth, int mapHeight, string modRelPath = "") {
 		MapWidth = mapWidth;
 		MapHeight = mapHeight;
 		ModRelPath = modRelPath;
@@ -26,11 +24,11 @@ public partial class Civ3Map : Node2D
 		if (TM != null) { RemoveChild(TM); }
 		// Although tiles appear isometric, they are logically laid out as a checkerboard pattern on a square grid
 		TM = new TileMap();
-		TM.TileSet.TileSize = new Vector2I(64,32);
+		TM.TileSet.TileSize = new Vector2I(64, 32);
 		// TM.CenteredTextures = true;
 		TS = TM.TileSet;
 
-		TileIDLookup = new int[9,81];
+		TileIDLookup = new int[9, 81];
 
 		// int id = TS.GetLastUnusedTileId();
 
@@ -41,18 +39,16 @@ public partial class Civ3Map : Node2D
 		// TS.CreateTile(id);
 		// id++;
 
-		Map = new int[MapWidth,MapHeight];
+		Map = new int[MapWidth, MapHeight];
 
 		// Populate map values
-		if(Civ3Tiles != null)
-		{
-			foreach (Tile tile in Civ3Tiles)
-			{
+		if (Civ3Tiles != null) {
+			foreach (Tile tile in Civ3Tiles) {
 				// If tile media file not loaded yet
 				if (TileIDLookup[tile.ExtraInfo.BaseTerrainFileID, 1] == 0) { LoadTileSet(tile.ExtraInfo.BaseTerrainFileID); }
 				// var _ = TileIDLookup[tile.ExtraInfo.BaseTerrainFileID, tile.ExtraInfo.BaseTerrainImageID];
 				Map[tile.xCoordinate, tile.yCoordinate] = 0;
-				Map[tile.xCoordinate, tile.yCoordinate] = TileIDLookup[tile.ExtraInfo.BaseTerrainFileID,tile.ExtraInfo.BaseTerrainImageID];
+				Map[tile.xCoordinate, tile.yCoordinate] = TileIDLookup[tile.ExtraInfo.BaseTerrainFileID, tile.ExtraInfo.BaseTerrainImageID];
 			}
 		}
 		/* This code sets the tiles for display, but that is being done by MapView now
@@ -64,8 +60,7 @@ public partial class Civ3Map : Node2D
 		AddChild(TM);
 		*/
 	}
-	private void LoadTileSet(int fileID)
-	{
+	private void LoadTileSet(int fileID) {
 		Hashtable FileNameLookup = new Hashtable
 		{
 			{ 0, "Art/Terrain/xtgc.pcx" },
@@ -85,7 +80,7 @@ public partial class Civ3Map : Node2D
 			ImageTexture Txtr = PCXToGodot.getImageTextureFromPCX(PcxTxtr);
 
 			for (int y = 0; y < PcxTxtr.Height; y += 64) {
-				for (int x = 0; x < PcxTxtr.Width; x+= 128/*, id++*/) {
+				for (int x = 0; x < PcxTxtr.Width; x += 128/*, id++*/) {
 					// TS.Create
 					// TS.CreateTile(id);
 					// TS.TileSetTexture(id, Txtr);

--- a/C7/Civ3Unit/Civ3Unit.cs
+++ b/C7/Civ3Unit/Civ3Unit.cs
@@ -2,8 +2,7 @@ using Godot;
 using ConvertCiv3Media;
 using System;
 
-public partial class Civ3Unit : Civ3UnitSprite
-{
+public partial class Civ3Unit : Civ3UnitSprite {
 	public MovingSprite AS;
 	public SpriteFrames SF;
 	// constructor to copy existing unit
@@ -53,8 +52,7 @@ public partial class Civ3Unit : Civ3UnitSprite
 		AS.Play(actnName);
 	}
 	public override void Move(Direction direction, float speed = (float)0.6) {
-		switch (direction)
-		{
+		switch (direction) {
 			case Direction.SW:
 				AS.Velocity = new Vector2(-2, 1).Normalized() * speed;
 				break;
@@ -103,7 +101,7 @@ public partial class Civ3Unit : Civ3UnitSprite
 			short* sPtr;
 			bPtr[0] = 66;    //B
 			bPtr[1] = 77;    //M
-			bPtr+=2;
+			bPtr += 2;
 			iPtr = (int*)bPtr;
 			iPtr[0] = bmpSize;  //size of BMP file in bytes
 			iPtr[1] = 0;    //reserved, two shorts
@@ -111,11 +109,11 @@ public partial class Civ3Unit : Civ3UnitSprite
 			iPtr[3] = 40;   //size of Windows 3 BMP header
 			iPtr[4] = width;
 			iPtr[5] = height;
-			bPtr+=24;   //6 * 4
+			bPtr += 24;   //6 * 4
 			sPtr = (short*)bPtr;
 			sPtr[0] = 1;    //num color planes
 			sPtr[1] = 32;   //bit depth.  we want 32-bit with alpha
-			bPtr+=4;
+			bPtr += 4;
 			iPtr = (int*)bPtr;
 			iPtr[0] = 0;    //compression - none.  Godot doesn't support compression
 			iPtr[1] = bmpSize - 54; //size, without headers
@@ -123,18 +121,16 @@ public partial class Civ3Unit : Civ3UnitSprite
 			iPtr[3] = 0;    //vertical resolution.  ignored.
 			iPtr[4] = 0;    //num colors in palette.  not relevant for 32-bit
 			iPtr[5] = 0;    //num important colors in palette.  not relevant.
-			bPtr+=24;   //6 * 4
+			bPtr += 24;   //6 * 4
 			iPtr = (int*)bPtr;
 			//Ready for image data
 
 			int c = 0;
 			//The BMP data is stored bottom-to-top, whereas our data is top-to-bottom
 			//Thus we'll use c to calculate the index for each row
-			for (int y = height - 1; y > -1; y--)
-			{
+			for (int y = height - 1; y > -1; y--) {
 				c = width * y;
-				for (int x = 0; x < width; x++)
-				{
+				for (int x = 0; x < width; x++) {
 					if (shadows && colorIndices[c] > 239) {
 						// using black and transparency
 						iPtr[0] = ((255 - colorIndices[c]) << 4) << 24;

--- a/C7/ComponentManager.cs
+++ b/C7/ComponentManager.cs
@@ -3,46 +3,38 @@ using System.Collections.Generic;
 using Godot;
 
 // modeled after the Unity Toolbox pattern from https://wiki.unity3d.com/index.php/Toolbox
-public sealed class ComponentManager
-{
+public sealed class ComponentManager {
 	// singleton implemenation taken from example at https://csharpindepth.com/Articles/Singleton
 	private static readonly ComponentManager _instance = new ComponentManager();
 
-	static ComponentManager()
-	{
+	static ComponentManager() {
 
 	}
 
-	private ComponentManager()
-	{
+	private ComponentManager() {
 
 	}
 
-	public static ComponentManager Instance
-	{
+	public static ComponentManager Instance {
 		get { return _instance; }
 	}
 
 	// type dictionary taken from Jon Skeet's implementation at https://codeblog.jonskeet.uk/2008/10/08/mapping-from-a-type-to-an-instance-of-that-type/
 	private Dictionary<Type, GameComponent> _components = new Dictionary<Type, GameComponent>();
 
-	public void AddComponent<T>(T component) where T : GameComponent
-	{
+	public void AddComponent<T>(T component) where T : GameComponent {
 		_components.Add(typeof(T), component);
 	}
 
-	public T GetComponent<T>() where T : GameComponent
-	{
+	public T GetComponent<T>() where T : GameComponent {
 		GameComponent component;
-		if (_components.TryGetValue(typeof(T), out component))
-		{
+		if (_components.TryGetValue(typeof(T), out component)) {
 			return (T)component;
 		}
 		return default(T);
 	}
 }
 
-public partial class GameComponent : GodotObject
-{
+public partial class GameComponent : GodotObject {
 
 }

--- a/C7/Credits.cs
+++ b/C7/Credits.cs
@@ -1,29 +1,23 @@
 using Godot;
 using Serilog;
 
-public partial class Credits : Node2D
-{
+public partial class Credits : Node2D {
 	private string creditsText = "Could not load credits file";
 
 	private static ILogger log = Log.ForContext<Credits>();
 
 	// Called when the node enters the scene tree for the first time.
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		log.Information("Now rolling the credits!");
-		try
-		{
+		try {
 			creditsText = System.IO.File.ReadAllText("./Text/credits.txt");
-		}
-		catch(System.Exception ex)
-		{
+		} catch (System.Exception ex) {
 			log.Error(ex, "Failed to read from credits.txt!");
 		}
 		ShowCredits();
 	}
 
-	private void ShowCredits()
-	{
+	private void ShowCredits() {
 		ImageTexture creditsTexture = Util.LoadTextureFromPCX("Art/Credits/credits_background.pcx");
 		ImageTexture goBackTexture = Util.LoadTextureFromPCX("Art/exitBox-backgroundStates.pcx", 0, 0, 72, 48);
 
@@ -64,8 +58,7 @@ public partial class Credits : Node2D
 		AddChild(goBackButton);
 		goBackButton.Pressed += ReturnToMenu;
 	}
-	public void ReturnToMenu()
-	{
+	public void ReturnToMenu() {
 		log.Information("Returning to main menu");
 		GetTree().ChangeSceneToFile("res://MainMenu.tscn");
 	}

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -178,7 +178,7 @@ public partial class Game : Node2D {
 					// are still alive, etc.
 					if (mCD.city.owner.RemainingCities() == 0) {
 						popupOverlay.ShowPopup(new CivilizationDestroyed(mCD.city.owner.civilization), PopupOverlay.PopupCategory.Advisor);
-						for (int i =0; i < mCD.city.owner.units.Count; ++i) {
+						for (int i = 0; i < mCD.city.owner.units.Count; ++i) {
 							MapUnitExtensions.disband(mCD.city.owner.units[i]);
 						}
 					}
@@ -523,7 +523,7 @@ public partial class Game : Node2D {
 
 		if (this.HasCurrentlySelectedUnit()) {
 			TileDirection? dir = C7Action.ToTileDirection(currentAction);
-			
+
 			if (dir.HasValue) {
 				new MsgMoveUnit(CurrentlySelectedUnit.id, dir.Value).send();
 				setSelectedUnit(CurrentlySelectedUnit); //also triggers updating the lower-left info box

--- a/C7/MainMenu.cs
+++ b/C7/MainMenu.cs
@@ -3,8 +3,7 @@ using System;
 using C7Engine;
 using Serilog;
 
-public partial class MainMenu : Node2D
-{
+public partial class MainMenu : Node2D {
 	private ILogger log;
 
 	readonly int BUTTON_LABEL_OFFSET = 0;
@@ -24,8 +23,7 @@ public partial class MainMenu : Node2D
 	readonly int MENU_OFFSET_FROM_LEFT = 180;
 
 	// Called when the node enters the scene tree for the first time.
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		log = LogManager.ForContext<MainMenu>();
 		log.Debug("enter MainMenu._Ready");
 
@@ -45,8 +43,7 @@ public partial class MainMenu : Node2D
 		DisplayTitleScreen();
 	}
 
-	private void DisplayTitleScreen()
-	{
+	private void DisplayTitleScreen() {
 		try {
 			SetMainMenuBackground();
 
@@ -66,23 +63,21 @@ public partial class MainMenu : Node2D
 
 			// Hide select home folder if valid path is present as proven by reaching this point in code
 			SetCiv3Home.Visible = false;
-		} catch(Exception ex) {
+		} catch (Exception ex) {
 			log.Error(ex, "Could not set up the main menu");
 			GetNode<Label>("CanvasLayer/Label").Visible = true;
 			GetNode<ColorRect>("CanvasLayer/ColorRect").Visible = true;
 		}
 	}
 
-	private void SetMainMenuBackground()
-	{
+	private void SetMainMenuBackground() {
 		ImageTexture TitleScreenTexture = Util.LoadTextureFromC7JPG("Art/Title_Screen.jpg");
 		MainMenuBackground = GetNode<TextureRect>("CanvasLayer/MainMenuBackground");
 		MainMenuBackground.StretchMode = TextureRect.StretchModeEnum.Scale;
 		MainMenuBackground.Texture = TitleScreenTexture;
 	}
 
-	private void AddButton(string label, int verticalPosition, Action action)
-	{
+	private void AddButton(string label, int verticalPosition, Action action) {
 		TextureButton newButton = new TextureButton();
 		newButton.TextureNormal = InactiveButton;
 		newButton.TextureHover = HoverButton;
@@ -101,70 +96,59 @@ public partial class MainMenu : Node2D
 		newButtonLabel.Pressed += action;
 	}
 
-	public void StartGame()
-	{
+	public void StartGame() {
 		log.Information("start game button pressed");
 		PlayButtonPressedSound();
 		GetTree().ChangeSceneToFile("res://C7Game.tscn");
 	}
 
-	public void LoadGame()
-	{
+	public void LoadGame() {
 		log.Information("load game button pressed");
 		PlayButtonPressedSound();
 		LoadDialog.Popup();
 	}
 
-	public void LoadScenario()
-	{
+	public void LoadScenario() {
 		log.Information("load scenario button pressed");
 		PlayButtonPressedSound();
 		LoadScenarioDialog.Popup();
 	}
 
-	public void showCredits()
-	{
+	public void showCredits() {
 		log.Information("credits button pressed");
 		GetTree().ChangeSceneToFile("res://Credits.tscn");
 	}
 
-	public void HallOfFame()
-	{
+	public void HallOfFame() {
 		PlayButtonPressedSound();
 	}
 
-	public void Preferences()
-	{
+	public void Preferences() {
 		PlayButtonPressedSound();
 	}
 
-	public void _on_Exit_pressed()
-	{
+	public void _on_Exit_pressed() {
 		GetTree().Quit(); // no need to notify the scene tree
 	}
 
-	private void PlayButtonPressedSound()
-	{
+	private void PlayButtonPressedSound() {
 		AudioStreamWav wav = Util.LoadWAVFromDisk(Util.Civ3MediaPath("Sounds/Button1.wav"));
 		AudioStreamPlayer player = GetNode<AudioStreamPlayer>("CanvasLayer/SoundEffectPlayer");
 		player.Stream = wav;
 		player.Play();
 	}
 
-	private void _on_FileDialog_file_selected(string path)
-	{
+	private void _on_FileDialog_file_selected(string path) {
 		log.Information($"loading {path}");
 		Global.LoadGamePath = path;
 		GetTree().ChangeSceneToFile("res://C7Game.tscn");
 	}
 
-	private void _on_SetCiv3Home_pressed()
-	{
+	private void _on_SetCiv3Home_pressed() {
 		SetCiv3HomeDialog.Popup();
 	}
 
-	private void _on_SetCiv3HomeDialog_dir_selected(string path)
-	{
+	private void _on_SetCiv3HomeDialog_dir_selected(string path) {
 		Util.Civ3Root = path;
 		C7Settings.SetValue("locations", "civ3InstallDir", path);
 		C7Settings.SaveSettings();

--- a/C7/MainMenuMusicPlayer.cs
+++ b/C7/MainMenuMusicPlayer.cs
@@ -3,15 +3,13 @@ using System;
 using C7Engine;
 using Serilog;
 
-public partial class MainMenuMusicPlayer : AudioStreamPlayer
-{
+public partial class MainMenuMusicPlayer : AudioStreamPlayer {
 	private ILogger log;
 
 	private bool musicEnabled = true;
 
 	// Called when the node enters the scene tree for the first time.
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		log = LogManager.ForContext<MainMenuMusicPlayer>();
 		//Figured out how to load the mp3 from this post: https://godotengine.org/qa/30210/how-do-load-resource-works
 
@@ -20,7 +18,7 @@ public partial class MainMenuMusicPlayer : AudioStreamPlayer
 			FileAccess mp3File = FileAccess.Open(mp3Path, FileAccess.ModeFlags.Read);
 
 			AudioStreamMP3 mp3 = new AudioStreamMP3();
-			long fileSize = (long)mp3File.GetLength();	//might blow up if it's > 2 GB, oh well
+			long fileSize = (long)mp3File.GetLength();  //might blow up if it's > 2 GB, oh well
 			mp3.Data = mp3File.GetBuffer(fileSize);
 			mp3.Loop = true;
 			this.Stream = mp3;
@@ -38,8 +36,7 @@ public partial class MainMenuMusicPlayer : AudioStreamPlayer
 				AudioServer.SetBusVolumeDb(busIndex, targetVolumeOffset);
 				Play();
 			}
-		}
-		catch(ApplicationException ex) {
+		} catch (ApplicationException ex) {
 			log.Error(ex, "could not load mp3 for main menu music");
 		}
 	}
@@ -51,8 +48,7 @@ public partial class MainMenuMusicPlayer : AudioStreamPlayer
 	 * Our users are probably more used to a 0% to 100% system.
 	 * So this method converts between them.
 	 */
-	private float GetVolumeOffset(string volume)
-	{
+	private float GetVolumeOffset(string volume) {
 		if (volume == null) {
 			//First run.  Save the setting.
 			C7Settings.SetValue("audio", "musicVolume", "100");
@@ -62,11 +58,9 @@ public partial class MainMenuMusicPlayer : AudioStreamPlayer
 		int userVolumeSetting = int.Parse(volume);
 		if (userVolumeSetting == 100) {
 			return 0;
-		}
-		else if (userVolumeSetting == 0) {
+		} else if (userVolumeSetting == 0) {
 			return float.MinValue;
-		}
-		else {
+		} else {
 			//Conversion math based on https://stackoverflow.com/a/37810295/3534605
 			return 20.0f * (float)(Math.Log10(userVolumeSetting / 100.0f));
 		}

--- a/C7/Map/CityLabelScene.cs
+++ b/C7/Map/CityLabelScene.cs
@@ -89,7 +89,7 @@ namespace C7.Map {
 			int productionDescriptionWidth = (int)smallFont.GetStringSize(productionDescription).X;
 			int maxTextWidth = Math.Max(cityNameAndGrowthWidth, productionDescriptionWidth);
 
-			int cityLabelWidth = maxTextWidth + (city.IsCapital()? 70 : 45);	//TODO: Is 65 right?  70?  Will depend on whether it's capital, too
+			int cityLabelWidth = maxTextWidth + (city.IsCapital()? 70 : 45);    //TODO: Is 65 right?  70?  Will depend on whether it's capital, too
 			int textAreaWidth = cityLabelWidth - (city.IsCapital() ? 50 : 25);
 			if (log.IsEnabled(LogEventLevel.Verbose)) {
 				log.Verbose("Width of city name = " + maxTextWidth);
@@ -99,7 +99,7 @@ namespace C7.Map {
 
 			if (cityLabelWidth != lastLabelWidth) {
 				Image labelBackground = CreateLabelBackground(cityLabelWidth, city, textAreaWidth);
-				cityLabel =  ImageTexture.CreateFromImage(labelBackground);
+				cityLabel = ImageTexture.CreateFromImage(labelBackground);
 				lastLabelWidth = cityLabelWidth;
 			}
 
@@ -107,8 +107,7 @@ namespace C7.Map {
 			DrawTextOnLabel(tileCenter, cityNameAndGrowthWidth, productionDescriptionWidth, city, cityNameAndGrowth, productionDescription, cityLabelWidth);
 		}
 
-		private void DrawLabelOnScreen(Vector2I tileCenter, int cityLabelWidth, City city, ImageTexture cityLabel)
-		{
+		private void DrawLabelOnScreen(Vector2I tileCenter, int cityLabelWidth, City city, ImageTexture cityLabel) {
 			labelTextureRect.OffsetLeft = tileCenter.X + (cityLabelWidth / -2);
 			labelTextureRect.OffsetTop = tileCenter.Y + 24;
 			labelTextureRect.Texture = cityLabel;
@@ -150,8 +149,7 @@ namespace C7.Map {
 			popSizeLabel.OffsetTop = tileCenter.Y + 22;
 		}
 
-		private Image CreateLabelBackground(int cityLabelWidth, City city, int textAreaWidth)
-		{
+		private Image CreateLabelBackground(int cityLabelWidth, City city, int textAreaWidth) {
 			//Label/name/producing area
 			Image labelImage = Image.Create(cityLabelWidth, CITY_LABEL_HEIGHT, false, Image.Format.Rgba8);
 			labelImage.Fill(Color.Color8(0, 0, 0, 0));

--- a/C7/Map/CityLayer.cs
+++ b/C7/Map/CityLayer.cs
@@ -7,8 +7,7 @@ namespace C7.Map {
 	public class CityLayer : LooseLayer {
 		private Dictionary<City, CityScene> citySceneLookup = new();
 
-		public CityLayer()
-		{
+		public CityLayer() {
 		}
 
 		public void UpdateAfterCityDestruction(City city) {
@@ -16,8 +15,7 @@ namespace C7.Map {
 			cityScene.Hide();
 		}
 
-		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
-		{
+		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
 			if (tile.cityAtTile is null) {
 				return;
 			}

--- a/C7/Map/ResourceLayer.cs
+++ b/C7/Map/ResourceLayer.cs
@@ -3,23 +3,19 @@ using Godot;
 using Resource = C7GameData.Resource;
 using Serilog;
 
-namespace C7.Map
-{
-	public partial class ResourceLayer : LooseLayer
-	{
+namespace C7.Map {
+	public partial class ResourceLayer : LooseLayer {
 		private ILogger log = LogManager.ForContext<ResourceLayer>();
 
 		private static readonly Vector2 resourceSize = new Vector2(50, 50);
 		private int maxRow;
 		private ImageTexture resourceTexture;
 
-		public ResourceLayer()
-		{
+		public ResourceLayer() {
 			resourceTexture = Util.LoadTextureFromPCX("Art/resources.pcx");
 			maxRow = (resourceTexture.GetHeight() / 50) - 1;
 		}
-		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
-		{
+		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
 			Resource resource = tile.Resource;
 			if (resource != Resource.NONE) {
 				int resourceIcon = tile.Resource.Icon;

--- a/C7/Map/RoadLayer.cs
+++ b/C7/Map/RoadLayer.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 using C7GameData;
 using Godot;
 
-namespace C7.Map
-{
+namespace C7.Map {
 	public partial class RoadLayer : LooseLayer {
 		private readonly ImageTexture roadTexture;
 		private readonly ImageTexture railroadTexture;

--- a/C7/Map/TntLayer.cs
+++ b/C7/Map/TntLayer.cs
@@ -3,15 +3,13 @@ using Godot;
 using Resource = C7GameData.Resource;
 using Serilog;
 
-namespace C7.Map
-{
+namespace C7.Map {
 	/// <summary>
 	/// Displays terrain yield overlays (from the tnt.pcx file).  These are most well known for letting you know where
 	/// there are bonus grasslands.
 	/// Note: I don't know why it's called tnt.
 	/// </summary>
-	public partial class TntLayer : LooseLayer
-	{
+	public partial class TntLayer : LooseLayer {
 		private ILogger log = LogManager.ForContext<TntLayer>();
 
 		private static readonly Vector2 tntSize = new Vector2(128, 64);
@@ -28,12 +26,10 @@ namespace C7.Map
 		private readonly int FLOOD_PLAIN_ROW = 5;
 #pragma warning restore CS0414
 
-		public TntLayer()
-		{
+		public TntLayer() {
 			tntTexture = Util.LoadTextureFromPCX("Art/Terrain/tnt.pcx");
 		}
-		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
-		{
+		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
 			if (tile.overlayTerrainType.Key == "grassland" && tile.isBonusShield) {
 				Rect2 tntRectangle = new Rect2(0, BONUS_GRASSLAND_TNT_OFF_ROW * tntSize.Y, tntSize);
 				Rect2 screenTarget = new Rect2(tileCenter - 0.5f * tntSize, tntSize);

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -24,8 +24,8 @@ public abstract class LooseLayer {
 	//     MapView already transforms the looseView node to account for those things.
 	public abstract void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter);
 
-	public virtual void onBeginDraw(LooseView looseView, GameData gameData) {}
-	public virtual void onEndDraw(LooseView looseView, GameData gameData) {}
+	public virtual void onBeginDraw(LooseView looseView, GameData gameData) { }
+	public virtual void onEndDraw(LooseView looseView, GameData gameData) { }
 
 	// The layer will be skipped during map drawing if visible is false
 	public bool visible = true;
@@ -41,19 +41,16 @@ public partial class TerrainLayer : LooseLayer {
 	// TileToDraw stores the arguments passed to drawObject so the draws can be sorted by texture before being submitted. This significantly
 	// reduces the number of draw calls Godot must generate (1483 to 312 when fully zoomed out on our test map) and modestly improves framerate
 	// (by about 14% on my system).
-	private class TileToDraw : IComparable<TileToDraw>
-	{
+	private class TileToDraw : IComparable<TileToDraw> {
 		public Tile tile;
 		public Vector2 tileCenter;
 
-		public TileToDraw(Tile tile, Vector2 tileCenter)
-		{
+		public TileToDraw(Tile tile, Vector2 tileCenter) {
 			this.tile = tile;
 			this.tileCenter = tileCenter;
 		}
 
-		public int CompareTo(TileToDraw other)
-		{
+		public int CompareTo(TileToDraw other) {
 			// "other" might be null, in which case we should return a positive value. CompareTo(null) will do this.
 			try {
 				return this.tile.ExtraInfo.BaseTerrainFileID.CompareTo(other?.tile.ExtraInfo.BaseTerrainFileID);
@@ -66,13 +63,11 @@ public partial class TerrainLayer : LooseLayer {
 
 	private List<TileToDraw> tilesToDraw = new List<TileToDraw>();
 
-	public TerrainLayer()
-	{
+	public TerrainLayer() {
 		tripleSheets = loadTerrainTripleSheets();
 	}
 
-	public List<ImageTexture> loadTerrainTripleSheets()
-	{
+	public List<ImageTexture> loadTerrainTripleSheets() {
 		List<string> fileNames = new List<string> {
 			"Art/Terrain/xtgc.pcx",
 			"Art/Terrain/xpgc.pcx",
@@ -87,8 +82,7 @@ public partial class TerrainLayer : LooseLayer {
 		return fileNames.ConvertAll(name => Util.LoadTextureFromPCX(name));
 	}
 
-	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
-	{
+	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
 		tilesToDraw.Add(new TileToDraw(tile, tileCenter));
 		tilesToDraw.Add(new TileToDraw(tile.neighbors[TileDirection.SOUTH], tileCenter + new Vector2(0, 64)));
 		tilesToDraw.Add(new TileToDraw(tile.neighbors[TileDirection.SOUTHWEST], tileCenter + new Vector2(-64, 32)));
@@ -114,7 +108,7 @@ public partial class TerrainLayer : LooseLayer {
 
 public partial class HillsLayer : LooseLayer {
 	public static readonly Vector2 mountainSize = new Vector2(128, 88);
-	public static readonly Vector2 volcanoSize = new Vector2(128, 88);	//same as mountain
+	public static readonly Vector2 volcanoSize = new Vector2(128, 88);  //same as mountain
 	public static readonly Vector2 hillsSize = new Vector2(128, 72);
 	private ImageTexture mountainTexture;
 	private ImageTexture snowMountainTexture;
@@ -140,8 +134,7 @@ public partial class HillsLayer : LooseLayer {
 		jungleVolcanoTexture = Util.LoadTextureFromPCX("Art/Terrain/Volcanos jungles.pcx");
 	}
 
-	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
-	{
+	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
 		if (tile.overlayTerrainType.isHilly()) {
 			int pcxIndex = getMountainIndex(tile);
 			int row = pcxIndex/4;
@@ -152,49 +145,40 @@ public partial class HillsLayer : LooseLayer {
 				ImageTexture mountainGraphics;
 				if (tile.isSnowCapped) {
 					mountainGraphics = snowMountainTexture;
-				}
-				else {
+				} else {
 					TerrainType dominantVegetation = getDominantVegetationNearHillyTile(tile);
 					if (dominantVegetation.Key == "forest") {
 						mountainGraphics = forestMountainTexture;
-					}
-					else if (dominantVegetation.Key == "jungle") {
+					} else if (dominantVegetation.Key == "jungle") {
 						mountainGraphics = jungleMountainTexture;
-					}
-					else {
+					} else {
 						mountainGraphics = mountainTexture;
 					}
 				}
 				looseView.DrawTextureRectRegion(mountainGraphics, screenTarget, mountainRectangle);
-			}
-			else if (tile.overlayTerrainType.Key == "hills") {
+			} else if (tile.overlayTerrainType.Key == "hills") {
 				Rect2 hillsRectangle = new Rect2(column * hillsSize.X, row * hillsSize.Y, hillsSize);
 				Rect2 screenTarget = new Rect2(tileCenter - (float)0.5 * hillsSize + new Vector2(0, -4), hillsSize);
 				ImageTexture hillGraphics;
 				TerrainType dominantVegetation = getDominantVegetationNearHillyTile(tile);
 				if (dominantVegetation.Key == "forest") {
 					hillGraphics = forestHillsTexture;
-				}
-				else if (dominantVegetation.Key == "jungle") {
+				} else if (dominantVegetation.Key == "jungle") {
 					hillGraphics = jungleHillsTexture;
-				}
-				else {
+				} else {
 					hillGraphics = hillsTexture;
 				}
 				looseView.DrawTextureRectRegion(hillGraphics, screenTarget, hillsRectangle);
-			}
-			else if (tile.overlayTerrainType.Key == "volcano") {
+			} else if (tile.overlayTerrainType.Key == "volcano") {
 				Rect2 volcanoRectangle = new Rect2(column * volcanoSize.X, row * volcanoSize.Y, volcanoSize);
 				Rect2 screenTarget = new Rect2(tileCenter - (float)0.5 * volcanoSize + new Vector2(0, -12), volcanoSize);
 				ImageTexture volcanoGraphics;
 				TerrainType dominantVegetation = getDominantVegetationNearHillyTile(tile);
 				if (dominantVegetation.Key == "forest") {
 					volcanoGraphics = forestVolcanoTexture;
-				}
-				else if (dominantVegetation.Key == "jungle") {
+				} else if (dominantVegetation.Key == "jungle") {
 					volcanoGraphics = jungleVolcanoTexture;
-				}
-				else {
+				} else {
 					volcanoGraphics = volcanosTexture;
 				}
 				looseView.DrawTextureRectRegion(volcanoGraphics, screenTarget, volcanoRectangle);
@@ -202,8 +186,7 @@ public partial class HillsLayer : LooseLayer {
 		}
 	}
 
-	private TerrainType getDominantVegetationNearHillyTile(Tile center)
-	{
+	private TerrainType getDominantVegetationNearHillyTile(Tile center) {
 		TerrainType northeastType = center.neighbors[TileDirection.NORTHEAST].overlayTerrainType;
 		TerrainType northwestType = center.neighbors[TileDirection.NORTHWEST].overlayTerrainType;
 		TerrainType southeastType = center.neighbors[TileDirection.SOUTHEAST].overlayTerrainType;
@@ -221,22 +204,20 @@ public partial class HillsLayer : LooseLayer {
 		foreach (TerrainType type in neighborTerrains) {
 			if (type.isHilly()) {
 				hills++;
-			}
-			else if (type.Key == "forest") {
+			} else if (type.Key == "forest") {
 				forests++;
 				forest = type;
-			}
-			else if (type.Key == "jungle") {
+			} else if (type.Key == "jungle") {
 				jungles++;
 				jungle = type;
 			}
 		}
 
-		if (hills + forests + jungles < 4) {	//some surrounding tiles are neither forested nor hilly
+		if (hills + forests + jungles < 4) {    //some surrounding tiles are neither forested nor hilly
 			return TerrainType.NONE;
 		}
 		if (forests == 0 && jungles == 0) {
-			return TerrainType.NONE;	//all hills
+			return TerrainType.NONE;    //all hills
 		}
 		if (forests > jungles) {
 			return forest;
@@ -258,13 +239,13 @@ public partial class HillsLayer : LooseLayer {
 			index++;
 		}
 		if (tile.neighbors[TileDirection.NORTHEAST].overlayTerrainType.isHilly()) {
-			index+=2;
+			index += 2;
 		}
 		if (tile.neighbors[TileDirection.SOUTHWEST].overlayTerrainType.isHilly()) {
-			index+=4;
+			index += 4;
 		}
 		if (tile.neighbors[TileDirection.SOUTHEAST].overlayTerrainType.isHilly()) {
-			index+=8;
+			index += 8;
 		}
 		return index;
 	}
@@ -286,17 +267,17 @@ public partial class ForestLayer : LooseLayer {
 	private ImageTexture pineTundraTexture;
 
 	public ForestLayer() {
-		largeJungleTexture       = Util.LoadTextureFromPCX("Art/Terrain/grassland forests.pcx", 0,   0, 512, 176);
-		smallJungleTexture       = Util.LoadTextureFromPCX("Art/Terrain/grassland forests.pcx", 0, 176, 768, 176);
-		largeForestTexture       = Util.LoadTextureFromPCX("Art/Terrain/grassland forests.pcx", 0, 352, 512, 176);
-		largePlainsForestTexture = Util.LoadTextureFromPCX("Art/Terrain/plains forests.pcx",    0, 352, 512, 176);
-		largeTundraForestTexture = Util.LoadTextureFromPCX("Art/Terrain/tundra forests.pcx",    0, 352, 512, 176);
-		smallForestTexture       = Util.LoadTextureFromPCX("Art/Terrain/grassland forests.pcx", 0, 528, 640, 176);
-		smallPlainsForestTexture = Util.LoadTextureFromPCX("Art/Terrain/plains forests.pcx",    0, 528, 640, 176);
-		smallTundraForestTexture = Util.LoadTextureFromPCX("Art/Terrain/tundra forests.pcx",    0, 528, 640, 176);
-		pineForestTexture        = Util.LoadTextureFromPCX("Art/Terrain/grassland forests.pcx", 0, 704, 768, 176);
-		pinePlainsTexture        = Util.LoadTextureFromPCX("Art/Terrain/plains forests.pcx"   , 0, 704, 768, 176);
-		pineTundraTexture        = Util.LoadTextureFromPCX("Art/Terrain/tundra forests.pcx"   , 0, 704, 768, 176);
+		largeJungleTexture = Util.LoadTextureFromPCX("Art/Terrain/grassland forests.pcx", 0, 0, 512, 176);
+		smallJungleTexture = Util.LoadTextureFromPCX("Art/Terrain/grassland forests.pcx", 0, 176, 768, 176);
+		largeForestTexture = Util.LoadTextureFromPCX("Art/Terrain/grassland forests.pcx", 0, 352, 512, 176);
+		largePlainsForestTexture = Util.LoadTextureFromPCX("Art/Terrain/plains forests.pcx", 0, 352, 512, 176);
+		largeTundraForestTexture = Util.LoadTextureFromPCX("Art/Terrain/tundra forests.pcx", 0, 352, 512, 176);
+		smallForestTexture = Util.LoadTextureFromPCX("Art/Terrain/grassland forests.pcx", 0, 528, 640, 176);
+		smallPlainsForestTexture = Util.LoadTextureFromPCX("Art/Terrain/plains forests.pcx", 0, 528, 640, 176);
+		smallTundraForestTexture = Util.LoadTextureFromPCX("Art/Terrain/tundra forests.pcx", 0, 528, 640, 176);
+		pineForestTexture = Util.LoadTextureFromPCX("Art/Terrain/grassland forests.pcx", 0, 704, 768, 176);
+		pinePlainsTexture = Util.LoadTextureFromPCX("Art/Terrain/plains forests.pcx", 0, 704, 768, 176);
+		pineTundraTexture = Util.LoadTextureFromPCX("Art/Terrain/tundra forests.pcx", 0, 704, 768, 176);
 	}
 
 	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
@@ -310,8 +291,7 @@ public partial class ForestLayer : LooseLayer {
 			if (tile.getEdgeNeighbors().Any(t => t.IsWater())) {
 				randomJungleColumn = tile.xCoordinate % 6;
 				jungleTexture = smallJungleTexture;
-			}
-			else {
+			} else {
 				randomJungleColumn = tile.xCoordinate % 4;
 				jungleTexture = largeJungleTexture;
 			}
@@ -328,37 +308,29 @@ public partial class ForestLayer : LooseLayer {
 				forestColumn = tile.xCoordinate % 6;
 				if (tile.baseTerrainType.Key == "grassland") {
 					forestTexture = pineForestTexture;
-				}
-				else if (tile.baseTerrainType.Key == "plains") {
+				} else if (tile.baseTerrainType.Key == "plains") {
 					forestTexture = pinePlainsTexture;
-				}
-				else { //Tundra
+				} else { //Tundra
 					forestTexture = pineTundraTexture;
 				}
-			}
-			else {
+			} else {
 				forestRow = tile.yCoordinate % 2;
 				if (tile.getEdgeNeighbors().Any(t => t.IsWater())) {
 					forestColumn = tile.xCoordinate % 5;
 					if (tile.baseTerrainType.Key == "grassland") {
 						forestTexture = smallForestTexture;
-					}
-					else if (tile.baseTerrainType.Key == "plains") {
+					} else if (tile.baseTerrainType.Key == "plains") {
 						forestTexture = smallPlainsForestTexture;
-					}
-					else {	//tundra
+					} else {    //tundra
 						forestTexture = smallTundraForestTexture;
 					}
-				}
-				else {
+				} else {
 					forestColumn = tile.xCoordinate % 4;
 					if (tile.baseTerrainType.Key == "grassland") {
 						forestTexture = largeForestTexture;
-					}
-					else if (tile.baseTerrainType.Key == "plains") {
+					} else if (tile.baseTerrainType.Key == "plains") {
 						forestTexture = largePlainsForestTexture;
-					}
-					else {	//tundra
+					} else {    //tundra
 						forestTexture = largeTundraForestTexture;
 					}
 				}
@@ -379,7 +351,7 @@ public partial class MarshLayer : LooseLayer {
 	private ImageTexture smallMarshTexture;
 
 	public MarshLayer() {
-		largeMarshTexture = Util.LoadTextureFromPCX("Art/Terrain/marsh.pcx", 0,   0, 512, 176);
+		largeMarshTexture = Util.LoadTextureFromPCX("Art/Terrain/marsh.pcx", 0, 0, 512, 176);
 		smallMarshTexture = Util.LoadTextureFromPCX("Art/Terrain/marsh.pcx", 0, 176, 640, 176);
 	}
 
@@ -391,8 +363,7 @@ public partial class MarshLayer : LooseLayer {
 			if (tile.getEdgeNeighbors().Any(t => t.IsWater())) {
 				randomMarshColumn = tile.xCoordinate % 5;
 				marshTexture = smallMarshTexture;
-			}
-			else {
+			} else {
 				randomMarshColumn = tile.xCoordinate % 4;
 				marshTexture = largeMarshTexture;
 			}
@@ -403,8 +374,7 @@ public partial class MarshLayer : LooseLayer {
 	}
 }
 
-public partial class RiverLayer : LooseLayer
-{
+public partial class RiverLayer : LooseLayer {
 	public static readonly Vector2 riverSize = new Vector2(128, 64);
 	public static readonly Vector2 riverCenterOffset = new Vector2(riverSize.X / 2, 0);
 	private ImageTexture riverTexture;
@@ -413,8 +383,7 @@ public partial class RiverLayer : LooseLayer
 		riverTexture = Util.LoadTextureFromPCX("Art/Terrain/mtnRivers.pcx");
 	}
 
-	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
-	{
+	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
 		//The "point" is the easternmost point of the tile for which we are drawing rivers.
 		//Which river graphics to used is calculated by evaluating the tiles that neighbor
 		//that point.
@@ -429,13 +398,13 @@ public partial class RiverLayer : LooseLayer
 			riverGraphicsIndex++;
 		}
 		if (eastOfPoint.riverNorthwest) {
-			riverGraphicsIndex+=2;
+			riverGraphicsIndex += 2;
 		}
 		if (westOfPoint.riverSoutheast) {
-			riverGraphicsIndex+=4;
+			riverGraphicsIndex += 4;
 		}
 		if (southOfPoint.riverNortheast) {
-			riverGraphicsIndex+=8;
+			riverGraphicsIndex += 8;
 		}
 		if (riverGraphicsIndex == 0) {
 			return;
@@ -453,16 +422,15 @@ public partial class GridLayer : LooseLayer {
 	public Color color = Color.Color8(50, 50, 50, 150);
 	public float lineWidth = (float)1.0;
 
-	public GridLayer() {}
+	public GridLayer() { }
 
-	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
-	{
+	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
 		Vector2 cS = MapView.cellSize;
 		Vector2 left  = tileCenter + new Vector2(-cS.X, 0    );
 		Vector2 top   = tileCenter + new Vector2( 0   , -cS.Y);
 		Vector2 right = tileCenter + new Vector2( cS.X, 0    );
-		looseView.DrawLine(left, top  , color, lineWidth);
-		looseView.DrawLine(top , right, color, lineWidth);
+		looseView.DrawLine(left, top, color, lineWidth);
+		looseView.DrawLine(top, right, color, lineWidth);
 	}
 }
 
@@ -470,19 +438,17 @@ public partial class BuildingLayer : LooseLayer {
 	private ImageTexture buildingsTex;
 	private Vector2 buildingSpriteSize;
 
-	public BuildingLayer()
-	{
+	public BuildingLayer() {
 		var buildingsPCX = new Pcx(Util.Civ3MediaPath("Art/Terrain/TerrainBuildings.PCX"));
 		buildingsTex = PCXToGodot.getImageTextureFromPCX(buildingsPCX);
 		//In Conquests, this graphic is 4x4, and the search path will now find the Conquests one first
 		buildingSpriteSize = new Vector2((float)buildingsTex.GetWidth() / 4, (float)buildingsTex.GetHeight() / 4);
 	}
 
-	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
-	{
+	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
 		if (tile.hasBarbarianCamp) {
 			var texRect = new Rect2(buildingSpriteSize * new Vector2 (2, 0), buildingSpriteSize); //(2, 0) is the offset in the TerrainBuildings.PCX file (top row, third in)
-			// TODO: Modify this calculation so it doesn't assume buildingSpriteSize is the same as the size of the terrain tiles
+																								  // TODO: Modify this calculation so it doesn't assume buildingSpriteSize is the same as the size of the terrain tiles
 			var screenRect = new Rect2(tileCenter - (float)0.5 * buildingSpriteSize, buildingSpriteSize);
 			looseView.DrawTextureRectRegion(buildingsTex, screenRect, texRect);
 		}
@@ -493,19 +459,16 @@ public partial class LooseView : Node2D {
 	public MapView mapView;
 	public List<LooseLayer> layers = new List<LooseLayer>();
 
-	public LooseView(MapView mapView)
-	{
+	public LooseView(MapView mapView) {
 		this.mapView = mapView;
 	}
 
-	private struct VisibleTile
-	{
+	private struct VisibleTile {
 		public Tile tile;
 		public Vector2 tileCenter;
 	}
 
-	public override void _Draw()
-	{
+	public override void _Draw() {
 		base._Draw();
 
 		using (var gameDataAccess = new UIGameDataAccess()) {
@@ -567,10 +530,10 @@ public partial class MapView : Node2D {
 
 	public Game game;
 
-	public int mapWidth  { get; private set; }
+	public int mapWidth { get; private set; }
 	public int mapHeight { get; private set; }
 	public bool wrapHorizontally { get; private set; }
-	public bool wrapVertically   { get; private set; }
+	public bool wrapVertically { get; private set; }
 
 	private Vector2 internalCameraLocation = new Vector2(0, 0);
 	public Vector2 cameraLocation {
@@ -597,9 +560,8 @@ public partial class MapView : Node2D {
 		public int upperLeftX, upperLeftY;
 		public int lowerRightX, lowerRightY;
 
-		public int getRowStartX(int y)
-		{
-			return upperLeftX + (y - upperLeftY)%2;
+		public int getRowStartX(int y) {
+			return upperLeftX + (y - upperLeftY) % 2;
 		}
 	}
 
@@ -608,8 +570,7 @@ public partial class MapView : Node2D {
 
 	public ImageTexture civColorWhitePalette = null;
 
-	public MapView(Game game, int mapWidth, int mapHeight, bool wrapHorizontally, bool wrapVertically)
-	{
+	public MapView(Game game, int mapWidth, int mapHeight, bool wrapHorizontally, bool wrapVertically) {
 		this.game = game;
 		this.mapWidth = mapWidth;
 		this.mapHeight = mapHeight;
@@ -639,53 +600,50 @@ public partial class MapView : Node2D {
 		AddChild(looseView);
 	}
 
-	public override void _Process(double delta)
-	{
+	public override void _Process(double delta) {
 		// Redraw everything. This is necessary so that animations play. Maybe we could only update the unit layer but long term I think it's
 		// better to redraw everything every frame like a typical modern video game.
 		looseView.QueueRedraw();
 	}
 
 	// Returns the size in pixels of the area in which the map will be drawn. This is the viewport size or, if that's null, the window size.
-	public Vector2 getVisibleAreaSize()
-	{
+	public Vector2 getVisibleAreaSize() {
 		return GetViewport() != null ? GetViewportRect().Size : DisplayServer.WindowGetSize();
 	}
 
-	public VisibleRegion getVisibleRegion()
-	{
+	public VisibleRegion getVisibleRegion() {
 		(int x0, int y0) = tileCoordsOnScreenAt(new Vector2(0, 0));
 		Vector2 mapViewSize = new Vector2(2, 4) + getVisibleAreaSize() / scaledCellSize;
-		return new VisibleRegion { upperLeftX = x0 - 2, upperLeftY = y0 - 2,
-			lowerRightX = x0 + (int)mapViewSize.X, lowerRightY = y0 + (int)mapViewSize.Y };
+		return new VisibleRegion {
+			upperLeftX = x0 - 2,
+			upperLeftY = y0 - 2,
+			lowerRightX = x0 + (int)mapViewSize.X,
+			lowerRightY = y0 + (int)mapViewSize.Y
+		};
 	}
 
 	// "center" is the screen location around which the zoom is centered, e.g., if center is (0, 0) the tile in the top left corner will be the
 	// same after the zoom level is changed, and if center is screenSize/2, the tile in the center of the window won't change.
-	public void setCameraZoom(float newScale, Vector2 center)
-	{
+	public void setCameraZoom(float newScale, Vector2 center) {
 		Vector2 v2NewZoom = new Vector2(newScale, newScale);
 		Vector2 v2OldZoom = new Vector2(cameraZoom, cameraZoom);
 		if (v2NewZoom != v2OldZoom) {
 			internalCameraZoom = newScale;
 			looseView.Scale = v2NewZoom;
-			setCameraLocation ((v2NewZoom / v2OldZoom) * (cameraLocation + center) - center);
+			setCameraLocation((v2NewZoom / v2OldZoom) * (cameraLocation + center) - center);
 		}
 	}
 
 	// Zooms in or out centered on the middle of the screen
-	public void setCameraZoomFromMiddle(float newScale)
-	{
+	public void setCameraZoomFromMiddle(float newScale) {
 		setCameraZoom(newScale, getVisibleAreaSize() / 2);
 	}
 
-	public void moveCamera(Vector2 offset)
-	{
+	public void moveCamera(Vector2 offset) {
 		setCameraLocation(cameraLocation + offset);
 	}
 
-	public void setCameraLocation(Vector2 location)
-	{
+	public void setCameraLocation(Vector2 location) {
 		// Prevent the camera from moving beyond an unwrapped edge of the map. One complication here is that the viewport might actually be
 		// larger than the map (if we're zoomed far out) so in that case we must apply the constraint the other way around, i.e. constrain the
 		// map to the viewport rather than the viewport to the map.
@@ -731,8 +689,7 @@ public partial class MapView : Node2D {
 		looseView.Position = -location;
 	}
 
-	public Vector2 screenLocationOfTileCoords(int x, int y, bool center = true)
-	{
+	public Vector2 screenLocationOfTileCoords(int x, int y, bool center = true) {
 		// Add one to x & y to get the tile center b/c in Civ 3 the tile at (x, y) is a diamond centered on (x+1, y+1).
 		Vector2 centeringOffset = center ? new Vector2(1, 1) : new Vector2(0, 0);
 
@@ -742,15 +699,13 @@ public partial class MapView : Node2D {
 
 	// Returns the location of tile (x, y) on the screen, if "center" is true returns the location of the tile center and otherwise returns the
 	// upper left. Works even if (x, y) is off screen or out of bounds.
-	public Vector2 screenLocationOfTile(Tile tile, bool center = true)
-	{
+	public Vector2 screenLocationOfTile(Tile tile, bool center = true) {
 		return screenLocationOfTileCoords(tile.xCoordinate, tile.yCoordinate, center);
 	}
 
 	// Returns the virtual tile coordinates on screen at the given location. "Virtual" meaning the coordinates are unwrapped and there isn't
 	// necessarily a tile there at all.
-	public (int, int) tileCoordsOnScreenAt(Vector2 screenLocation)
-	{
+	public (int, int) tileCoordsOnScreenAt(Vector2 screenLocation) {
 		Vector2 mapLoc = (screenLocation + cameraLocation) / scaledCellSize;
 		Vector2 intMapLoc = mapLoc.Floor();
 		Vector2 fracMapLoc = mapLoc - intMapLoc;
@@ -770,14 +725,12 @@ public partial class MapView : Node2D {
 		return (x, y);
 	}
 
-	public Tile tileOnScreenAt(GameMap map, Vector2 screenLocation)
-	{
+	public Tile tileOnScreenAt(GameMap map, Vector2 screenLocation) {
 		(int x, int y) = tileCoordsOnScreenAt(screenLocation);
 		return map.tileAt(x, y);
 	}
 
-	public void centerCameraOnTile(Tile t)
-	{
+	public void centerCameraOnTile(Tile t) {
 		var tileCenter = new Vector2(t.xCoordinate + 1, t.yCoordinate + 1) * scaledCellSize;
 		setCameraLocation(tileCenter - (float)0.5 * getVisibleAreaSize());
 	}

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -448,7 +448,8 @@ public partial class BuildingLayer : LooseLayer {
 	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
 		if (tile.hasBarbarianCamp) {
 			var texRect = new Rect2(buildingSpriteSize * new Vector2 (2, 0), buildingSpriteSize); //(2, 0) is the offset in the TerrainBuildings.PCX file (top row, third in)
-																								  // TODO: Modify this calculation so it doesn't assume buildingSpriteSize is the same as the size of the terrain tiles
+
+			// TODO: Modify this calculation so it doesn't assume buildingSpriteSize is the same as the size of the terrain tiles
 			var screenRect = new Rect2(tileCenter - (float)0.5 * buildingSpriteSize, buildingSpriteSize);
 			looseView.DrawTextureRectRegion(buildingsTex, screenRect, texRect);
 		}

--- a/C7/PCXToGodot.cs
+++ b/C7/PCXToGodot.cs
@@ -2,8 +2,7 @@ using Godot;
 using System;
 using ConvertCiv3Media;
 
-public partial class PCXToGodot : GodotObject
-{
+public partial class PCXToGodot : GodotObject {
 	private readonly static byte CIV3_TRANSPARENCY_START = 254;
 
 	public static ImageTexture getImageTextureFromPCX(Pcx pcx) {
@@ -125,7 +124,7 @@ public partial class PCXToGodot : GodotObject
 		return (getImageFromBufferData(width, height, baseLayer), getImageFromBufferData(width, height, tintLayer));
 	}
 
-        // Utility for loading a civilization color from an ntp file
+	// Utility for loading a civilization color from an ntp file
 	public static Color GetColorFromPCX(Pcx pcx) {
 		int paletteLookupIdx = pcx.ColorIndexAt(0, 0);
 

--- a/C7/UIElements/Advisors/Advisors.cs
+++ b/C7/UIElements/Advisors/Advisors.cs
@@ -7,27 +7,24 @@ using Serilog;
  * Showing them, hiding them... maybe some other things eventually.
  * This is part of the effort to de-centralize from Game.cs and be more event driven.
  */
-public partial class Advisors : CenterContainer
-{
+public partial class Advisors : CenterContainer {
 	private ILogger log = LogManager.ForContext<Advisors>();
 
 	// Called when the node enters the scene tree for the first time.
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		//Center the advisor container.  Following directions at https://docs.godotengine.org/en/stable/tutorials/gui/size_and_anchors.html?highlight=anchor
 		//Also taking advantage of it being 1024x768, as the directions didn't really work.  This is not 100% ideal (would be great for a general-purpose solution to work),
 		//but does work with the current graphics independent of resolution.
 		this.Hide();
 	}
 
-//  // Called every frame. 'delta' is the elapsed time since the previous frame.
-//  public override void _Process(float delta)
-//  {
-//
-//  }
+	//  // Called every frame. 'delta' is the elapsed time since the previous frame.
+	//  public override void _Process(float delta)
+	//  {
+	//
+	//  }
 
-	private void ShowLatestAdvisor()
-	{
+	private void ShowLatestAdvisor() {
 		log.Debug("Received request to show latest advisor");
 
 		if (this.GetChildCount() == 0) {
@@ -37,13 +34,11 @@ public partial class Advisors : CenterContainer
 		this.Show();
 	}
 
-	private void _on_Advisor_hide()
-	{
+	private void _on_Advisor_hide() {
 		this.Hide();
 	}
 
-	private void OnShowSpecificAdvisor(string advisorType)
-	{
+	private void OnShowSpecificAdvisor(string advisorType) {
 		if (advisorType.Equals("F1")) {
 			if (this.GetChildCount() == 0) {
 				DomesticAdvisor advisor = new DomesticAdvisor();
@@ -53,21 +48,17 @@ public partial class Advisors : CenterContainer
 		}
 	}
 
-	public override void _UnhandledInput(InputEvent @event)
-	{
+	public override void _UnhandledInput(InputEvent @event) {
 		if (this.Visible) {
-			if (@event is InputEventKey eventKey)
-			{
+			if (@event is InputEventKey eventKey) {
 				//As I've added more shortcuts, I've realized checking all of them here could be irksome.
 				//For now, I'm thinking it would make more sense to process or allow through the ones that should go through,
 				//as most of the global ones should *not* go through here.
-				if (eventKey.Pressed)
-				{
+				if (eventKey.Pressed) {
 					if (eventKey.Keycode == Godot.Key.Escape) {
 						this.Hide();
 						GetViewport().SetInputAsHandled();
-					}
-					else {
+					} else {
 						log.Debug("Advisor received a key press; stopping propagation.");
 						GetViewport().SetInputAsHandled();
 					}

--- a/C7/UIElements/Advisors/DomesticAdvisor.cs
+++ b/C7/UIElements/Advisors/DomesticAdvisor.cs
@@ -1,15 +1,13 @@
 using Godot;
 using System;
 
-public partial class DomesticAdvisor : TextureRect
-{
+public partial class DomesticAdvisor : TextureRect {
 	// Declare member variables here. Examples:
 	// private int a = 2;
 	// private string b = "text";
 
 	// Called when the node enters the scene tree for the first time.
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		this.CreateUI();
 	}
 
@@ -49,8 +47,7 @@ public partial class DomesticAdvisor : TextureRect
 		GoBackButton.Pressed += ReturnToMenu;
 	}
 
-	private void ReturnToMenu()
-	{
+	private void ReturnToMenu() {
 		GetParent<Advisors>().Hide();
 	}
 }

--- a/C7/UIElements/GameStatus/GameStatus.cs
+++ b/C7/UIElements/GameStatus/GameStatus.cs
@@ -3,8 +3,7 @@ using System;
 using C7GameData;
 using Serilog;
 
-public partial class GameStatus : MarginContainer
-{
+public partial class GameStatus : MarginContainer {
 
 	private ILogger log = LogManager.ForContext<GameStatus>();
 
@@ -14,33 +13,28 @@ public partial class GameStatus : MarginContainer
 	[Signal] public delegate void BlinkyEndTurnButtonPressedEventHandler();
 
 	// Called when the node enters the scene tree for the first time.
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		OffsetLeft = -(294 + 5);
 		OffsetTop = -(137 + 1);
 		AddChild(LowerRightInfoBox);
 	}
 
-	public void OnNewUnitSelected(ParameterWrapper<MapUnit> wrappedMapUnit)
-	{
+	public void OnNewUnitSelected(ParameterWrapper<MapUnit> wrappedMapUnit) {
 		MapUnit newUnit = wrappedMapUnit.Value;
 		log.Information("Selected unit: " + newUnit + " at " + newUnit.location);
 		LowerRightInfoBox.UpdateUnitInfo(newUnit, newUnit.location.overlayTerrainType);
 	}
 
-	private void OnTurnEnded()
-	{
+	private void OnTurnEnded() {
 		LowerRightInfoBox.StopToggling();
 	}
 
-	private void OnTurnStarted(int turnNumber)
-	{
+	private void OnTurnStarted(int turnNumber) {
 		//Oh hai, we do need this handler here!
 		LowerRightInfoBox.SetTurn(turnNumber);
 	}
 
-	private void OnNoMoreAutoselectableUnits()
-	{
+	private void OnNoMoreAutoselectableUnits() {
 		LowerRightInfoBox.SetEndOfTurnStatus();
 	}
 }

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -3,8 +3,7 @@ using ConvertCiv3Media;
 using C7GameData;
 using Serilog;
 
-public partial class LowerRightInfoBox : TextureRect
-{
+public partial class LowerRightInfoBox : TextureRect {
 	private ILogger log = LogManager.ForContext<LowerRightInfoBox>();
 
 	TextureButton nextTurnButton = new TextureButton();
@@ -18,11 +17,10 @@ public partial class LowerRightInfoBox : TextureRect
 	Label yearAndGold = new Label();
 
 	Timer blinkingTimer = new Timer();
-	bool timerStarted = false;	//This "isStopped" returns false if it's never been started.  So we need this to know if we've ever started it.
+	bool timerStarted = false;  //This "isStopped" returns false if it's never been started.  So we need this to know if we've ever started it.
 
 	// Called when the node enters the scene tree for the first time.
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		this.CreateUI();
 	}
 
@@ -81,7 +79,7 @@ public partial class LowerRightInfoBox : TextureRect
 		civAndGovt.AnchorLeft = 0.5f;
 		civAndGovt.AnchorRight = 0.5f;
 		boxRightRectangle.AddChild(civAndGovt);
-		civAndGovt.OffsetLeft = -1 * (civAndGovt.Size.X/2.0f);
+		civAndGovt.OffsetLeft = -1 * (civAndGovt.Size.X / 2.0f);
 
 		yearAndGold.Text = "Turn 0  10 Gold (+0 per turn)";
 		yearAndGold.HorizontalAlignment = HorizontalAlignment.Center;
@@ -89,7 +87,7 @@ public partial class LowerRightInfoBox : TextureRect
 		yearAndGold.AnchorLeft = 0.5f;
 		yearAndGold.AnchorRight = 0.5f;
 		boxRightRectangle.AddChild(yearAndGold);
-		yearAndGold.OffsetLeft = -1 * (yearAndGold.Size.X/2.0f);
+		yearAndGold.OffsetLeft = -1 * (yearAndGold.Size.X / 2.0f);
 
 		//Setup up, but do not start, the timer.
 		blinkingTimer.OneShot = false;
@@ -113,13 +111,11 @@ public partial class LowerRightInfoBox : TextureRect
 		}
 	}
 
-	private void toggleEndTurnButton()
-	{
+	private void toggleEndTurnButton() {
 		if (nextTurnButton.TextureNormal == nextTurnOnTexture) {
 			nextTurnButton.TextureNormal = nextTurnBlinkTexture;
 			lblUnitSelected.Visible = true;
-		}
-		else {
+		} else {
 			nextTurnButton.TextureNormal = nextTurnOnTexture;
 			lblUnitSelected.Visible = false;
 		}
@@ -138,16 +134,14 @@ public partial class LowerRightInfoBox : TextureRect
 		GetParent().EmitSignal(GameStatus.SignalName.BlinkyEndTurnButtonPressed);
 	}
 
-	public void UpdateUnitInfo(MapUnit NewUnit, TerrainType terrain)
-	{
+	public void UpdateUnitInfo(MapUnit NewUnit, TerrainType terrain) {
 		terrainType.Text = terrain.DisplayName;
 		terrainType.Visible = true;
 		lblUnitSelected.Text = NewUnit.unitType.name;
 		lblUnitSelected.Visible = true;
 		string movementPointsRemaining = NewUnit.movementPoints.canMove ? "" + $"{(NewUnit.movementPoints.getMixedNumber())}" : "0";
 		string bombardText = "";
-		if (NewUnit.unitType.bombard > 0)
-		{
+		if (NewUnit.unitType.bombard > 0) {
 			bombardText = $"({NewUnit.unitType.bombard})";
 		}
 		attackDefenseMovement.Text = $"{NewUnit.unitType.attack}{bombardText}.{NewUnit.unitType.defense} {movementPointsRemaining}/{NewUnit.unitType.movement}";
@@ -156,8 +150,7 @@ public partial class LowerRightInfoBox : TextureRect
 
 	///This is going to evolve a lot over time.  Probably this info box will need to keep some local state.
 	///But for now it'll show the changing turn number, providing some interactivity
-	public void SetTurn(int turnNumber)
-	{
+	public void SetTurn(int turnNumber) {
 		yearAndGold.Text = $"Turn {turnNumber}  10 Gold (+0 per turn)";
 	}
 }

--- a/C7/UIElements/Popups/BuildCityDialog.cs
+++ b/C7/UIElements/Popups/BuildCityDialog.cs
@@ -1,16 +1,14 @@
 using Godot;
 using Serilog;
 
-public partial class BuildCityDialog : Popup
-{
+public partial class BuildCityDialog : Popup {
 
 	LineEdit cityName = new LineEdit();
 	private string defaultName = "";
 
 	private ILogger log = LogManager.ForContext<BuildCityDialog>();
 
-	public BuildCityDialog(string defaultName)
-	{
+	public BuildCityDialog(string defaultName) {
 		cityName.Theme = ThemeFactory.DefaultTheme;
 		cityName.CaretBlink = true;
 		this.defaultName = defaultName;
@@ -18,8 +16,7 @@ public partial class BuildCityDialog : Popup
 		margins = new Margins(right: -10); // 10px margin from the right
 	}
 
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		base._Ready();
 
 		//Dimensions are 530x260 (roughly).
@@ -89,13 +86,11 @@ public partial class BuildCityDialog : Popup
 	/**
 	 * Need a second method b/c the LineEdit sends a param and the ConfirmButton doesn't.
 	 **/
-	public void OnConfirmButtonPressed()
-	{
+	public void OnConfirmButtonPressed() {
 		this.OnCityNameEntered(cityName.Text);
 	}
 
-	public void OnCityNameEntered(string name)
-	{
+	public void OnCityNameEntered(string name) {
 		GetViewport().SetInputAsHandled();
 		log.Debug("The user hit enter with a city name of " + name);
 		GetParent().EmitSignal(PopupOverlay.SignalName.BuildCity, name);

--- a/C7/UIElements/Popups/CivilizationDestroyed.cs
+++ b/C7/UIElements/Popups/CivilizationDestroyed.cs
@@ -4,19 +4,16 @@ using System.Diagnostics;
 using C7GameData;
 using Serilog;
 
-public partial class CivilizationDestroyed : Popup
-{
+public partial class CivilizationDestroyed : Popup {
 	string civNoun = "";
 
-	public CivilizationDestroyed(Civilization civ)
-	{
+	public CivilizationDestroyed(Civilization civ) {
 		alignment = BoxContainer.AlignmentMode.End;
 		margins = new Margins(right: 10);
 		civNoun = civ.noun;
 	}
 
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		base._Ready();
 
 		//Dimensions are 530x260 (roughly).
@@ -43,8 +40,7 @@ public partial class CivilizationDestroyed : Popup
 		AddButton("Very well.", 215, ContinueAction);
 	}
 
-	private void ContinueAction()
-	{
+	private void ContinueAction() {
 		GetParent().EmitSignal("HidePopup");
 	}
 }

--- a/C7/UIElements/Popups/DisbandConfirmation.cs
+++ b/C7/UIElements/Popups/DisbandConfirmation.cs
@@ -4,8 +4,7 @@ using System.Diagnostics;
 using C7GameData;
 using Serilog;
 
-public partial class DisbandConfirmation : Popup
-{
+public partial class DisbandConfirmation : Popup {
 	private ILogger log = LogManager.ForContext<DisbandConfirmation>();
 
 	string unitType = "";
@@ -14,22 +13,19 @@ public partial class DisbandConfirmation : Popup
 
 	//So Godot doesn't print error " Cannot construct temporary MonoObject because the class does not define a parameterless constructor"
 	//Not sure how important that is *shrug*
-	public DisbandConfirmation() {}
+	public DisbandConfirmation() { }
 
-	public DisbandConfirmation(MapUnit unit)
-	{
+	public DisbandConfirmation(MapUnit unit) {
 		alignment = BoxContainer.AlignmentMode.End;
 		margins = new Margins(right: 10);
 		unitType = unit.unitType.name;
 	}
 
-	public override void _EnterTree()
-	{
+	public override void _EnterTree() {
 		loadTimer.Start();
 	}
 
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		base._Ready();
 
 		// Dimensions in-game are 530x320
@@ -73,15 +69,13 @@ public partial class DisbandConfirmation : Popup
 		log.Verbose("Disband popup load time: " + Convert.ToInt32(stopwatchElapsed.TotalMilliseconds) + " ms");
 	}
 
-	private void disband()
-	{
+	private void disband() {
 		//tell the game to disband it.  right now we're doing that first, which is WRONG!
 		GetParent().EmitSignal(PopupOverlay.SignalName.UnitDisbanded);
 		GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
 	}
 
-	private void cancel()
-	{
+	private void cancel() {
 		GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
 	}
 }

--- a/C7/UIElements/Popups/ErrorMessage.cs
+++ b/C7/UIElements/Popups/ErrorMessage.cs
@@ -1,7 +1,6 @@
 using Godot;
 
-public partial class ErrorMessage : Popup
-{
+public partial class ErrorMessage : Popup {
 	private string message = "";
 
 	public ErrorMessage(string message) {
@@ -10,8 +9,7 @@ public partial class ErrorMessage : Popup
 		margins = new Margins(top: 100);
 	}
 
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		base._Ready();
 
 		AddTexture(615, 325);
@@ -31,8 +29,7 @@ public partial class ErrorMessage : Popup
 		AddButton("Return to Menu", 290, quit);
 	}
 
-	private void quit()
-	{
+	private void quit() {
 		GetTree().ChangeSceneToFile("res://MainMenu.tscn");
 	}
 }

--- a/C7/UIElements/Popups/EscapeQuitPopup.cs
+++ b/C7/UIElements/Popups/EscapeQuitPopup.cs
@@ -1,16 +1,13 @@
 using Godot;
 
-public partial class EscapeQuitPopup : Popup
-{
+public partial class EscapeQuitPopup : Popup {
 
-	public EscapeQuitPopup()
-	{
+	public EscapeQuitPopup() {
 		alignment = BoxContainer.AlignmentMode.Center;
 		margins = new Margins(top: 100);
 	}
 
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		base._Ready();
 
 		// Dimensions in-game are 270x295, centered at the top
@@ -37,13 +34,11 @@ public partial class EscapeQuitPopup : Popup
 		AddButton("Yes, immediately!", 116, quit);
 	}
 
-	private void quit()
-	{
+	private void quit() {
 		GetParent().EmitSignal(PopupOverlay.SignalName.Quit);
 	}
 
-	private void cancel()
-	{
+	private void cancel() {
 		GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
 	}
 }

--- a/C7/UIElements/Popups/GameMenu.cs
+++ b/C7/UIElements/Popups/GameMenu.cs
@@ -1,16 +1,14 @@
 using System;
 using Godot;
 
-public partial class GameMenu : Popup
-{
+public partial class GameMenu : Popup {
 
 	public GameMenu() {
 		alignment = BoxContainer.AlignmentMode.Center;
 		margins = new Margins(top: 100);
 	}
 
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		base._Ready();
 
 		AddTexture(370, 300);
@@ -43,18 +41,15 @@ public partial class GameMenu : Popup
 		throw new NotImplementedException();
 	}
 
-	private void quit()
-	{
+	private void quit() {
 		GetParent().EmitSignal(PopupOverlay.SignalName.Quit);
 	}
 
-	private void retire()
-	{
+	private void retire() {
 		GetParent().EmitSignal(PopupOverlay.SignalName.Retire);
 	}
 
-	private void map()
-	{
+	private void map() {
 		GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
 	}
 

--- a/C7/UIElements/Popups/Popup.cs
+++ b/C7/UIElements/Popups/Popup.cs
@@ -5,10 +5,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Serilog;
 
-public partial class Margins
-{
-	public Margins(float top = 0, float bottom = 0, float left = 0, float right = 0)
-	{
+public partial class Margins {
+	public Margins(float top = 0, float bottom = 0, float left = 0, float right = 0) {
 		this.top = top;
 		this.bottom = bottom;
 		this.left = left;
@@ -29,8 +27,7 @@ public partial class Margins
  * pixels lower than it would otherwise. This is used when a popup includes an advisor, since the vOffset adds a
  * transparent region above the top of the popup background in which the advisor texture can be drawn.
  */
-public partial class Popup : TextureRect
-{
+public partial class Popup : TextureRect {
 	private ILogger log = LogManager.ForContext<Popup>();
 
 	public BoxContainer.AlignmentMode alignment;
@@ -38,14 +35,13 @@ public partial class Popup : TextureRect
 
 	const int HTILE_SIZE = 61;
 	const int VTILE_SIZE = 44;
-	private readonly static int BUTTON_LABEL_OFFSET = 0;	//Necessary in Godot 3, appears unnecessary in 4
+	private readonly static int BUTTON_LABEL_OFFSET = 0;    //Necessary in Godot 3, appears unnecessary in 4
 
 	private static ImageTexture InactiveButton = Util.LoadTextureFromPCX("Art/buttonsFINAL.pcx", 1, 1, 20, 20, false);
 	private static ImageTexture HoverButton = Util.LoadTextureFromPCX("Art/buttonsFINAL.pcx", 22, 1, 20, 20, false);
 	private static Dictionary<(int, int), ImageTexture> backgroundCache = new Dictionary<(int, int), ImageTexture>();
 
-	protected void AddButton(string label, int verticalPosition, Action action)
-	{
+	protected void AddButton(string label, int verticalPosition, Action action) {
 		const int HORIZONTAL_POSITION = 30;
 		TextureButton newButton = new TextureButton();
 		newButton.TextureNormal = InactiveButton;
@@ -65,8 +61,7 @@ public partial class Popup : TextureRect
 		newButtonLabel.Pressed += action;
 	}
 
-	protected void AddHeader(string text, int vOffset)
-	{
+	protected void AddHeader(string text, int vOffset) {
 		HBoxContainer header = new HBoxContainer();
 		header.Alignment = BoxContainer.AlignmentMode.Center;
 		Label advisorType = new Label();
@@ -92,14 +87,12 @@ public partial class Popup : TextureRect
 		AddChild(header);
 	}
 
-	private void DrawRow(Image image, int vOffset, int width, Image left, Image center, Image right)
-	{
+	private void DrawRow(Image image, int vOffset, int width, Image left, Image center, Image right) {
 
 		image.BlitRect(left, new Rect2I(new Vector2I(0, 0), new Vector2I(left.GetWidth(), left.GetHeight())), new Vector2I(0, vOffset));
 
 		int leftOffset = HTILE_SIZE;
-		for (; leftOffset < width - HTILE_SIZE; leftOffset += HTILE_SIZE)
-		{
+		for (; leftOffset < width - HTILE_SIZE; leftOffset += HTILE_SIZE) {
 			image.BlitRect(center, new Rect2I(new Vector2I(0, 0), new Vector2I(center.GetWidth(), center.GetHeight())), new Vector2I(leftOffset, vOffset));
 		}
 
@@ -107,26 +100,22 @@ public partial class Popup : TextureRect
 		image.BlitRect(right, new Rect2I(new Vector2I(0, 0), new Vector2I(right.GetWidth(), right.GetHeight())), new Vector2I(leftOffset, vOffset));
 	}
 
-	protected void AddTexture(int width, int height)
-	{
+	protected void AddTexture(int width, int height) {
 		Image image = Image.Create(width, height, false, Image.Format.Rgba8);
 		image.Fill(Color.Color8(0, 0, 0, 0));
 		this.Texture = ImageTexture.CreateFromImage(image);
 	}
 
-	protected void AddBackground(int width, int height, int vOffset = 0)
-	{
+	protected void AddBackground(int width, int height, int vOffset = 0) {
 		TextureRect background = CreateBackground(width, height);
 		background.SetPosition(new Vector2(0, vOffset));
 		AddChild(background);
 	}
 
-	private TextureRect CreateBackground(int width, int height)
-	{
+	private TextureRect CreateBackground(int width, int height) {
 		TextureRect rect = new TextureRect();
 
-		if (backgroundCache.ContainsKey((width, height)))
-		{
+		if (backgroundCache.ContainsKey((width, height))) {
 			rect.Texture = backgroundCache[(width, height)];
 			return rect;
 		}
@@ -161,8 +150,7 @@ public partial class Popup : TextureRect
 		int vOffset = 0;
 		DrawRow(image, vOffset, width, topLeftPopup, topCenterPopup, topRightPopup);
 		vOffset += VTILE_SIZE;
-		for (; vOffset < height - VTILE_SIZE; vOffset += VTILE_SIZE)
-		{
+		for (; vOffset < height - VTILE_SIZE; vOffset += VTILE_SIZE) {
 			DrawRow(image, vOffset, width, middleLeftPopup, middleCenterPopup, middleRightPopup);
 		}
 		vOffset = height - VTILE_SIZE;

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -2,8 +2,7 @@ using Godot;
 using Serilog;
 
 [GlobalClass]
-public partial class PopupOverlay : HBoxContainer
-{
+public partial class PopupOverlay : HBoxContainer {
 
 	private ILogger log = LogManager.ForContext<PopupOverlay>();
 
@@ -21,11 +20,10 @@ public partial class PopupOverlay : HBoxContainer
 	public enum PopupCategory {
 		Advisor,
 		Console,
-		Info	//Sounds similar to the above, but lower-pitched in the second half
+		Info    //Sounds similar to the above, but lower-pitched in the second half
 	}
 
-	public void OnHidePopup()
-	{
+	public void OnHidePopup() {
 		// 1. enable mouse interaction with non-UI nodes
 		MouseFilter = MouseFilterEnum.Pass;
 		RemoveChild(currentChild);
@@ -41,8 +39,7 @@ public partial class PopupOverlay : HBoxContainer
 
 	public bool ShowingPopup => currentChild is not null;
 
-	public void PlaySound(AudioStreamWav wav)
-	{
+	public void PlaySound(AudioStreamWav wav) {
 		AudioStreamPlayer player = GetNode<AudioStreamPlayer>("PopupSound");
 		player.Stream = wav;
 		player.Play();
@@ -57,8 +54,7 @@ public partial class PopupOverlay : HBoxContainer
 		}
 	}
 
-	public void ShowPopup(Popup child, PopupCategory category)
-	{
+	public void ShowPopup(Popup child, PopupCategory category) {
 		if (child is null) {
 			// not necessary if we don't pass null?
 			log.Error("Received request to show null popup");
@@ -105,8 +101,7 @@ public partial class PopupOverlay : HBoxContainer
 	 * If we find that the majority of popups should close on Escape, we may want to make that the default,
 	 * but so far, 2 out of 3 popups do not close on escape.
 	 **/
-	public override void _UnhandledInput(InputEvent @event)
-	{
+	public override void _UnhandledInput(InputEvent @event) {
 		if (Visible && @event is InputEventKey eventKey && eventKey.Pressed) {
 			// As I've added more shortcuts, I've realized checking all of them here could be irksome.
 			// For now, I'm thinking it would make more sense to process or allow through the ones that should go through,

--- a/C7/UIElements/UnitButtons/RenameButton.cs
+++ b/C7/UIElements/UnitButtons/RenameButton.cs
@@ -1,11 +1,9 @@
 using Godot;
 using ConvertCiv3Media;
 
-public partial class RenameButton : TextureButton
-{
+public partial class RenameButton : TextureButton {
 	// Called when the node enters the scene tree for the first time.
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		//TODO: The "Conquests" shouldn't be necessary, but is currently.
 		Pcx buttonPcx = new Pcx(Util.Civ3MediaPath("Conquests/Art/interface/NormButtons.PCX"));
 		Pcx buttonPcxAlpha = new Pcx(Util.Civ3MediaPath("Conquests/Art/interface/ButtonAlpha.pcx"));

--- a/C7/UIElements/UpperLeftNav/AdvisorButton.cs
+++ b/C7/UIElements/UpperLeftNav/AdvisorButton.cs
@@ -1,11 +1,9 @@
 using Godot;
 using ConvertCiv3Media;
 
-public partial class AdvisorButton : TextureButton
-{
+public partial class AdvisorButton : TextureButton {
 	// Called when the node enters the scene tree for the first time.
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		Pcx buttonPcx = new Pcx(Util.Civ3MediaPath("Art/interface/menuButtons.pcx"));
 		Pcx buttonPcxAlpha = new Pcx(Util.Civ3MediaPath("Art/interface/menuButtonsAlpha.pcx"));
 		ImageTexture texture = PCXToGodot.getImageFromPCXWithAlphaBlend(buttonPcx, buttonPcxAlpha, 73, 1, 35, 29);

--- a/C7/UIElements/UpperLeftNav/CivilopediaButton.cs
+++ b/C7/UIElements/UpperLeftNav/CivilopediaButton.cs
@@ -1,12 +1,10 @@
 using Godot;
 using ConvertCiv3Media;
 
-public partial class CivilopediaButton : TextureButton
-{
+public partial class CivilopediaButton : TextureButton {
 
 	// Called when the node enters the scene tree for the first time.
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		Pcx buttonPcx = new Pcx(Util.Civ3MediaPath("Art/interface/menuButtons.pcx"));
 		Pcx buttonPcxAlpha = new Pcx(Util.Civ3MediaPath("Art/interface/menuButtonsAlpha.pcx"));
 		ImageTexture menuTexture = PCXToGodot.getImageFromPCXWithAlphaBlend(buttonPcx, buttonPcxAlpha, 36, 1, 35, 29);

--- a/C7/UIElements/UpperLeftNav/MenuButton.cs
+++ b/C7/UIElements/UpperLeftNav/MenuButton.cs
@@ -1,15 +1,13 @@
 using Godot;
 using ConvertCiv3Media;
 
-public partial class MenuButton : TextureButton
-{
+public partial class MenuButton : TextureButton {
 
 	[Export]
 	private PopupOverlay popupOverlay;
 
 	// Called when the node enters the scene tree for the first time.
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		Pcx buttonPcx = Util.LoadPCX("Art/interface/menuButtons.pcx");
 		Pcx buttonPcxAlpha = Util.LoadPCX("Art/interface/menuButtonsAlpha.pcx");
 		//TODO: Caching for these textures
@@ -17,8 +15,7 @@ public partial class MenuButton : TextureButton
 		this.TextureNormal = menuTexture;
 	}
 
-	public override void _Pressed()
-	{
+	public override void _Pressed() {
 		popupOverlay.ShowPopup(new GameMenu(), PopupOverlay.PopupCategory.Info);
 	}
 

--- a/C7/tests/TestUnit.cs
+++ b/C7/tests/TestUnit.cs
@@ -2,12 +2,10 @@ using Godot;
 using System;
 using ConvertCiv3Media;
 
-public partial class TestUnit : Node2D
-{
+public partial class TestUnit : Node2D {
 
 	// Called when the node enters the scene tree for the first time.
-	public override void _Ready()
-	{
+	public override void _Ready() {
 		//AudioStreamPlayer player = GetNode<AudioStreamPlayer>("CanvasLayer/SoundEffectPlayer");
 
 		AnimatedSprite2D sprite = new AnimatedSprite2D();
@@ -22,7 +20,7 @@ public partial class TestUnit : Node2D
 
 		ShaderMaterial material = new ShaderMaterial();
 		material.Shader = GD.Load<Shader>("res://UnitTint.gdshader");
-		material.SetShaderParameter("tintColor", new Vector3(1f,1f,1f));
+		material.SetShaderParameter("tintColor", new Vector3(1f, 1f, 1f));
 		spriteTint.Material = material;
 
 		AddChild(sprite);
@@ -47,7 +45,6 @@ public partial class TestUnit : Node2D
 	}
 
 	// Called every frame. 'delta' is the elapsed time since the previous frame.
-	public override void _Process(double delta)
-	{
+	public override void _Process(double delta) {
 	}
 }

--- a/C7Engine/AI/BarbarianAI.cs
+++ b/C7Engine/AI/BarbarianAI.cs
@@ -45,8 +45,7 @@ namespace C7Engine {
 				}
 			}
 		}
-		private static bool UnitIsFreeToMove(MapUnit unit)
-		{
+		private static bool UnitIsFreeToMove(MapUnit unit) {
 			if (!unit.location.hasBarbarianCamp) {
 				return true;
 			}

--- a/C7Engine/AI/CityProductionAI.cs
+++ b/C7Engine/AI/CityProductionAI.cs
@@ -4,8 +4,7 @@ using System.Linq;
 using C7Engine.AI.StrategicAI;
 using Serilog;
 
-namespace C7Engine
-{
+namespace C7Engine {
 	using C7GameData;
 
 	/**
@@ -14,8 +13,7 @@ namespace C7Engine
 	 * eventually.  For now, I just want to separate it out from the main
 	 * interaction events and make it clear that it's an AI component.
 	 */
-	public class CityProductionAI
-	{
+	public class CityProductionAI {
 
 		private static ILogger log = Log.ForContext<CityProductionAI>();
 
@@ -83,7 +81,7 @@ namespace C7Engine
 				if (unit.movement > 1) {
 					//Multiple by 0.5 for each movement point
 					//N.B. Eventually this should be influenced by the military strategy
-					baseScore = baseScore + baseScore/2 * (unit.movement - 1);
+					baseScore = baseScore + baseScore / 2 * (unit.movement - 1);
 				}
 				baseScore = baseScore - unit.shieldCost;
 				baseScore = baseScore - 10 * unit.populationCost;
@@ -123,7 +121,7 @@ namespace C7Engine
 				}
 				idx++;
 			}
-			return items[0];	//TODO: Fallback
+			return items[0];    //TODO: Fallback
 		}
 
 		public static float AdjustScoreByPopCost(City city, UnitPrototype unitPrototype, float baseScore) {

--- a/C7Engine/AI/CityTileAssignmentAI.cs
+++ b/C7Engine/AI/CityTileAssignmentAI.cs
@@ -2,12 +2,10 @@ using System;
 using C7GameData;
 using Serilog;
 
-namespace C7Engine.AI
-{
-	public class CityTileAssignmentAI
-	{
+namespace C7Engine.AI {
+	public class CityTileAssignmentAI {
 		public static int DesiredFoodSurplusPerTurn = 2;
-		private static readonly int FOOD_PER_CITIZEN = 2;	//eventually will be configured by rules
+		private static readonly int FOOD_PER_CITIZEN = 2;   //eventually will be configured by rules
 
 
 		private static int foodPriorityRate = 40;
@@ -16,8 +14,7 @@ namespace C7Engine.AI
 
 		private static ILogger log = Log.ForContext<CityTileAssignmentAI>();
 
-		public static void AssignNewCitizenToTile(City city, CityResident newResident)
-		{
+		public static void AssignNewCitizenToTile(City city, CityResident newResident) {
 			int foodYield = city.CurrentFoodYield();
 
 			int desiredFoodRate = city.size * FOOD_PER_CITIZEN + DesiredFoodSurplusPerTurn;
@@ -47,8 +44,7 @@ namespace C7Engine.AI
 			city.residents.Add(newResident);
 		}
 
-		public static double CalculateTileYieldScore(Tile t, int targetFoodAmount, Player player)
-		{
+		public static double CalculateTileYieldScore(Tile t, int targetFoodAmount, Player player) {
 			int score = t.foodYield(player) * foodPriorityRate + t.productionYield(player) * productionPriorityRate + t.commerceYield(player) * commercePriorityRate;
 			int penalty = (targetFoodAmount - t.foodYield(player));
 			if (penalty <= 0) {

--- a/C7Engine/AI/IAI.cs
+++ b/C7Engine/AI/IAI.cs
@@ -1,7 +1,7 @@
-namespace C7Engine {    
-    using C7GameData;
+namespace C7Engine {
+	using C7GameData;
 
-    interface IAI {
-        void PlayTurn(Player player, GameData gameData);
-    }
+	interface IAI {
+		void PlayTurn(Player player, GameData gameData);
+	}
 }

--- a/C7Engine/AI/Pathing/BFSLandAlgorithm.cs
+++ b/C7Engine/AI/Pathing/BFSLandAlgorithm.cs
@@ -2,8 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using C7GameData;
 
-namespace C7Engine.Pathing
-{
+namespace C7Engine.Pathing {
 	/**
 	 * Uses the Breadth-First Search Algorithm to find a path between two tiles.
 	 * Advantages: Simple.  Allows avoidance of obstacles such as water.
@@ -13,11 +12,9 @@ namespace C7Engine.Pathing
 	 * Modifications: Use the predecessors structure to allow us to backtrack and
 	 * find the path used for the shortest route, not just the distance.
 	 */
-	public class BFSLandAlgorithm : PathingAlgorithm
-	{
+	public class BFSLandAlgorithm : PathingAlgorithm {
 		//N.B. This should really be static, but we can't put a static method on interfaces, so it isn't.
-		public override TilePath PathFrom(Tile start, Tile destination)
-		{
+		public override TilePath PathFrom(Tile start, Tile destination) {
 			if (start == destination) {
 				return TilePath.EmptyPath(destination);
 			}
@@ -30,7 +27,7 @@ namespace C7Engine.Pathing
 			Queue<Tile> tilesToVisit = new Queue<Tile>();
 			distances[start] = 0;
 
-			foreach(Tile tile in start.GetLandNeighbors()) {
+			foreach (Tile tile in start.GetLandNeighbors()) {
 				distances[tile] = 1;
 				predecessors[tile] = start;
 				tilesToVisit.Enqueue(tile);

--- a/C7Engine/AI/Pathing/BinaryMinHeap.cs
+++ b/C7Engine/AI/Pathing/BinaryMinHeap.cs
@@ -5,7 +5,7 @@ namespace C7Engine.Pathing {
 	/**
 	 * https://en.wikipedia.org/wiki/Binary_heap
 	 */
-	public class BinaryMinHeap<TValue> where TValue: IComparable<TValue> {
+	public class BinaryMinHeap<TValue> where TValue : IComparable<TValue> {
 		private readonly List<TValue> data = new List<TValue>();
 
 		public int count { get => data.Count; }

--- a/C7Engine/AI/Pathing/DijkstrasAlgorithm.cs
+++ b/C7Engine/AI/Pathing/DijkstrasAlgorithm.cs
@@ -4,7 +4,7 @@ using C7GameData;
 
 namespace C7Engine.Pathing {
 
-	public class DijkstrasAlgorithm: PathingAlgorithm {
+	public class DijkstrasAlgorithm : PathingAlgorithm {
 		private readonly EdgeWalker<Tile> edgeWalker;
 
 		public DijkstrasAlgorithm(EdgeWalker<Tile> edgeWalker) {
@@ -21,8 +21,7 @@ namespace C7Engine.Pathing {
 		 * when stopWhenReachDestination == false it calculates distances to each available point
 		 */
 		public static Dictionary<TNode, Edge<TNode>> run<TNode>(TNode start, TNode destination,
-			EdgeWalker<TNode> edgeWalker, bool stopWhenReachDestination = true)
-		{
+			EdgeWalker<TNode> edgeWalker, bool stopWhenReachDestination = true) {
 			Dictionary<TNode, Edge<TNode>> visitedNodes = new Dictionary<TNode, Edge<TNode>>();
 			BinaryMinHeap<Edge<TNode>> edgesQueue = new BinaryMinHeap<Edge<TNode>>();
 

--- a/C7Engine/AI/Pathing/DijkstrasLandAlgorithm.cs
+++ b/C7Engine/AI/Pathing/DijkstrasLandAlgorithm.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using C7GameData;
 
-namespace C7Engine.Pathing
-{
+namespace C7Engine.Pathing {
 	/**
 	 * Uses Dijkstra's Algorithm to find a path between two tiles.
 	 * Advantages: Finds the shortest path accounting for tile movement cost

--- a/C7Engine/AI/Pathing/Edge.cs
+++ b/C7Engine/AI/Pathing/Edge.cs
@@ -1,8 +1,7 @@
 using System;
 
-namespace C7Engine.Pathing
-{
-	public class Edge<TNode>: IComparable<Edge<TNode>> {
+namespace C7Engine.Pathing {
+	public class Edge<TNode> : IComparable<Edge<TNode>> {
 		public readonly TNode prev;
 		public readonly TNode current;
 		public float distanceToCurrent { get; private set; }

--- a/C7Engine/AI/Pathing/PathingAlgorithm.cs
+++ b/C7Engine/AI/Pathing/PathingAlgorithm.cs
@@ -2,8 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using C7GameData;
 
-namespace C7Engine.Pathing
-{
+namespace C7Engine.Pathing {
 	public abstract class PathingAlgorithm {
 		public abstract TilePath PathFrom(Tile start, Tile destination);
 

--- a/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
+++ b/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
@@ -1,17 +1,14 @@
-namespace C7Engine.Pathing
-{
+namespace C7Engine.Pathing {
 	/**
 	 * Returns a pathing algorithm to use.
 	 * Eventually, this will depend on some map considerations.
 	 * For now, just return the first one.
 	 */
-	public class PathingAlgorithmChooser
-	{
+	public class PathingAlgorithmChooser {
 		private static PathingAlgorithm landAlgorithm = new DijkstrasAlgorithm(new WalkerOnLand());
 		private static PathingAlgorithm waterAlgorithm = new DijkstrasAlgorithm(new WalkerOnWater());
 
-		public static PathingAlgorithm GetAlgorithm(bool isLandUnit)
-		{
+		public static PathingAlgorithm GetAlgorithm(bool isLandUnit) {
 			return isLandUnit ? landAlgorithm : waterAlgorithm;
 		}
 	}

--- a/C7Engine/AI/StrategicAI/ExpansionPriority.cs
+++ b/C7Engine/AI/StrategicAI/ExpansionPriority.cs
@@ -7,10 +7,10 @@ using Serilog;
 namespace C7GameData.AIData {
 	public class ExpansionPriority : StrategicPriority {
 		private readonly int TEMP_GAME_LENGTH = 540;
-		private readonly int EARLY_GAME_CUTOFF = 25;	//what percentage of the game is early game, which should give expansion a boost?
+		private readonly int EARLY_GAME_CUTOFF = 25;    //what percentage of the game is early game, which should give expansion a boost?
 
-		private static readonly int SETTLER_FLAT_APPEAL = 30;			//the base "flat" appeal of settler-type units
-		private static readonly float SETTLER_WEIGHTED_APPEAL = 4.0f;	//the multiplier effect on settler-type units
+		private static readonly int SETTLER_FLAT_APPEAL = 30;           //the base "flat" appeal of settler-type units
+		private static readonly float SETTLER_WEIGHTED_APPEAL = 4.0f;   //the multiplier effect on settler-type units
 
 		private ILogger log = Log.ForContext<ExpansionPriority>();
 
@@ -60,8 +60,7 @@ namespace C7GameData.AIData {
 			return "ExpansionPriority";
 		}
 
-		private int ApplyEarlyGameMultiplier(int score)
-		{
+		private int ApplyEarlyGameMultiplier(int score) {
 			//If it's early game, multiply this score.
 			//TODO: We haven't implemented the part for "how many turns does the game have?" yet.  So this is hard-coded.
 			int gameTurn = EngineStorage.gameData.turn;

--- a/C7Engine/AI/StrategicAI/UtilityCalculations.cs
+++ b/C7Engine/AI/StrategicAI/UtilityCalculations.cs
@@ -10,11 +10,10 @@ namespace C7Engine.AI.StrategicAI {
 	/// </summary>
 	public class UtilityCalculations {
 
-		private static readonly int POSSIBLE_CITY_LOCATION_SCORE = 2;	//how much weight to give to each possible city location
-		private static readonly int TILE_SCORE_DIVIDER = 10;	//how much to divide each location's tile score by
+		private static readonly int POSSIBLE_CITY_LOCATION_SCORE = 2;   //how much weight to give to each possible city location
+		private static readonly int TILE_SCORE_DIVIDER = 10;    //how much to divide each location's tile score by
 
-		public static int CalculateAvailableLandScore(Player player)
-		{
+		public static int CalculateAvailableLandScore(Player player) {
 			//Figure out if there's land to settle, and how much
 			Dictionary<Tile, int> possibleLocations = SettlerLocationAI.GetScoredSettlerCandidates(player.cities[0].location, player);
 			int score = possibleLocations.Count * POSSIBLE_CITY_LOCATION_SCORE;

--- a/C7Engine/AI/StrategicAI/WarPriority.cs
+++ b/C7Engine/AI/StrategicAI/WarPriority.cs
@@ -12,7 +12,7 @@ namespace C7GameData.AIData {
 	/// </summary>
 	public class WarPriority : StrategicPriority {
 
-		private readonly int TEMP_WAR_PRIORITY_WEIGHT = 50;	//temporary weight of this priority, if it isn't zero
+		private readonly int TEMP_WAR_PRIORITY_WEIGHT = 50; //temporary weight of this priority, if it isn't zero
 
 		public WarPriority() {
 			key = "WarPriority";
@@ -31,20 +31,19 @@ namespace C7GameData.AIData {
 				int landScore = UtilityCalculations.CalculateAvailableLandScore(player);
 				//N.B. Eventually this won't be an all-or-nothing proposition; if land is getting tight but not quite zero,
 				//the AI may decide it's time for the next phrase of the game, especially if it's aggressive.
-				if (landScore == 0) {	//nowhere else to expand
-					//Figure out who to fight.  This should obviously be more sophisticated and should favor reachable opponents.
-					//However, we don't yet store info on who's been discovered, so for now we'll choose someone randomly
+				if (landScore == 0) {   //nowhere else to expand
+										//Figure out who to fight.  This should obviously be more sophisticated and should favor reachable opponents.
+										//However, we don't yet store info on who's been discovered, so for now we'll choose someone randomly
 					int opponentCount = EngineStorage.gameData.players.Count - 1;
-					foreach (Player nation in EngineStorage.gameData.players)
-					{
+					foreach (Player nation in EngineStorage.gameData.players) {
 						if (nation != player) {
-						int rnd = GameData.rng.Next(opponentCount);
+							int rnd = GameData.rng.Next(opponentCount);
 							if (rnd == 0) {
 								//Let's fight this nation!
 								properties["opponent"] = nation.id.ToString();
 								calculatedWeight = TEMP_WAR_PRIORITY_WEIGHT;
 							} else {
-								opponentCount--;	//guarantees we'll eventually get an opponent selected
+								opponentCount--;    //guarantees we'll eventually get an opponent selected
 							}
 						}
 					}

--- a/C7Engine/AI/StrategicAI/WarPriority.cs
+++ b/C7Engine/AI/StrategicAI/WarPriority.cs
@@ -31,9 +31,11 @@ namespace C7GameData.AIData {
 				int landScore = UtilityCalculations.CalculateAvailableLandScore(player);
 				//N.B. Eventually this won't be an all-or-nothing proposition; if land is getting tight but not quite zero,
 				//the AI may decide it's time for the next phrase of the game, especially if it's aggressive.
-				if (landScore == 0) {   //nowhere else to expand
-										//Figure out who to fight.  This should obviously be more sophisticated and should favor reachable opponents.
-										//However, we don't yet store info on who's been discovered, so for now we'll choose someone randomly
+
+				//nowhere else to expand
+				if (landScore == 0) {
+					//Figure out who to fight.  This should obviously be more sophisticated and should favor reachable opponents.
+					//However, we don't yet store info on who's been discovered, so for now we'll choose someone randomly
 					int opponentCount = EngineStorage.gameData.players.Count - 1;
 					foreach (Player nation in EngineStorage.gameData.players) {
 						if (nation != player) {

--- a/C7Engine/AI/StrategicPriorityArbitrator.cs
+++ b/C7Engine/AI/StrategicPriorityArbitrator.cs
@@ -126,7 +126,7 @@ namespace C7Engine.AI {
 				}
 				idx++;
 			}
-			return new WarPriority();	//TODO: Fallback
+			return new WarPriority();   //TODO: Fallback
 		}
 	}
 }

--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -7,18 +7,15 @@ using C7GameData.AIData;
 using C7Engine.Pathing;
 using Serilog;
 
-namespace C7Engine
-{
+namespace C7Engine {
 	public class ExplorerAI : UnitAI {
 		private static ILogger log = Log.ForContext<ExplorerAI>();
 
-		public bool PlayTurn(Player player, MapUnit unit)
-		{
+		public bool PlayTurn(Player player, MapUnit unit) {
 			ExplorerAIData explorerData = (ExplorerAIData)unit.currentAIData;
 			if (MovingToNewExplorationArea(explorerData)) {
 				return MoveToNextTileOnPath(explorerData, unit);
-			}
-			else {
+			} else {
 				bool foundNeighboringTileToExplore = ExploreNeighboringTile(player, unit, explorerData);
 				if (foundNeighboringTileToExplore) {
 					return true;
@@ -74,8 +71,7 @@ namespace C7Engine
 			watch.Start();
 			List<Tile> validExplorerTiles = new List<Tile>();
 			foreach (Tile t in player.tileKnowledge.AllKnownTiles()
-					.Where(t => unit.CanEnterTile(t, false) && t.cityAtTile == null && numUnknownNeighboringTiles(player, t) > 0))
-			{
+					.Where(t => unit.CanEnterTile(t, false) && t.cityAtTile == null && numUnknownNeighboringTiles(player, t) > 0)) {
 				validExplorerTiles.Add(t);
 			}
 
@@ -136,8 +132,7 @@ namespace C7Engine
 			return true;
 		}
 
-		public static KeyValuePair<Tile, float> FindTopScoringTileForExploration(Player player, IEnumerable<Tile> possibleNewLocations, ExplorerAIData.ExplorationType type)
-		{
+		public static KeyValuePair<Tile, float> FindTopScoringTileForExploration(Player player, IEnumerable<Tile> possibleNewLocations, ExplorerAIData.ExplorationType type) {
 			//Technically, this should be the *estimated* new tiles revealed.  If a mountain blocks visibility,
 			//we won't know that till we move there.
 			Dictionary<Tile, float> explorationScore = new Dictionary<Tile, float>();
@@ -145,8 +140,7 @@ namespace C7Engine
 				int baseScore = numUnknownNeighboringTiles(player, t);
 				if (baseScore == 0) {
 					explorationScore[t] = 0;
-				}
-				else if (type == ExplorerAIData.ExplorationType.NEAR_CITIES) {
+				} else if (type == ExplorerAIData.ExplorationType.NEAR_CITIES) {
 					if (baseScore == 0) {
 						explorationScore[t] = 0;
 					}
@@ -175,14 +169,11 @@ namespace C7Engine
 			}
 			//Calculate whether it, and its neighbors are in known tiles.
 			int discoverableTiles = 0;
-			if (!player.tileKnowledge.isTileKnown(t))
-			{
+			if (!player.tileKnowledge.isTileKnown(t)) {
 				discoverableTiles++;
 			}
-			foreach (Tile n in t.neighbors.Values)
-			{
-				if (!player.tileKnowledge.isTileKnown(n))
-				{
+			foreach (Tile n in t.neighbors.Values) {
+				if (!player.tileKnowledge.isTileKnown(n)) {
 					discoverableTiles++;
 				}
 			}

--- a/C7Engine/AI/UnitAI/SettlerAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerAI.cs
@@ -31,8 +31,7 @@ start:
 						//TODO: This should use a message, and the message handler should cause the disbanding to happen.
 						CityInteractions.BuildCity(unit.location.xCoordinate, unit.location.yCoordinate, player.id, unit.owner.GetNextCityName());
 						unit.disband();
-					}
-					else {
+					} else {
 						//If the settler has no destination, then disband rather than crash later.
 						if (settlerAi.destination == Tile.NONE) {
 							log.Information("Disbanding settler " + unit.id + " with no valid destination");
@@ -42,8 +41,7 @@ start:
 						try {
 							Tile nextTile = settlerAi.pathToDestination.Next();
 							unit.move(unit.location.directionTo(nextTile));
-						}
-						catch (Exception ex) {
+						} catch (Exception ex) {
 							//This occurs when on the previous turn, a settler tries to move to the next location on its path, but cannot, due to another
 							//civilization's unit (or a barbarian unit) being on that tile.
 							//TODO: #213 - If the path cannot be completed, we should create a different path instead.
@@ -57,8 +55,7 @@ start:
 						//TODO: Actually join the city.  Haven't added that action.
 						//For now, just get rid of the unit.  Sorry, bro.
 						unit.disband();
-					}
-					else {
+					} else {
 						//TODO: Eventually, go to the city we're supposed to join
 						//For now, just disband
 						unit.disband();

--- a/C7Engine/AI/UnitAI/SettlerLocationAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerLocationAI.cs
@@ -6,8 +6,7 @@ using System.Linq;
 using C7GameData.AIData;
 using Serilog;
 
-namespace C7Engine
-{
+namespace C7Engine {
 	public class SettlerLocationAI {
 		private static ILogger log = Log.ForContext<SettlerLocationAI>();
 
@@ -21,14 +20,13 @@ namespace C7Engine
 		public static Tile findSettlerLocation(Tile start, Player player) {
 			Dictionary<Tile, int> scores = GetScoredSettlerCandidates(start, player);
 			if (scores.Count == 0 || scores.Values.Max() <= 0) {
-				return Tile.NONE;	//nowhere to settle
+				return Tile.NONE;   //nowhere to settle
 			}
 
 			IOrderedEnumerable<KeyValuePair<Tile, int> > orderedScores = scores.OrderByDescending(t => t.Value);
 			log.Debug("Top city location candidates from " + start + ":");
 			Tile returnValue = null;
-			foreach (KeyValuePair<Tile, int> kvp in orderedScores.Take(5))
-			{
+			foreach (KeyValuePair<Tile, int> kvp in orderedScores.Take(5)) {
 				if (returnValue == null) {
 					returnValue = kvp.Key;
 				}
@@ -46,8 +44,7 @@ namespace C7Engine
 			return scores;
 		}
 
-		private static Dictionary<Tile, int> AssignTileScores(Tile startTile, Player player, IEnumerable<Tile> candidates, List<MapUnit> playerSettlers)
-		{
+		private static Dictionary<Tile, int> AssignTileScores(Tile startTile, Player player, IEnumerable<Tile> candidates, List<MapUnit> playerSettlers) {
 			Dictionary<Tile, int> scores = new Dictionary<Tile, int>();
 			candidates = candidates.Where(t => !SettlerAlreadyMovingTowardsTile(t, playerSettlers) && t.IsAllowCities());
 			foreach (Tile t in candidates) {
@@ -83,15 +80,13 @@ namespace C7Engine
 			}
 			return scores;
 		}
-		private static int GetTileYieldScore(Tile t, Player owner)
-		{
+		private static int GetTileYieldScore(Tile t, Player owner) {
 			int score = t.foodYield(owner) * 5;
 			score += t.productionYield(owner) * 3;
 			score += t.commerceYield(owner) * 2;
 			if (t.Resource.Category == ResourceCategory.STRATEGIC) {
 				score += STRATEGIC_RESOURCE_BONUS;
-			}
-			else if (t.Resource.Category == ResourceCategory.LUXURY) {
+			} else if (t.Resource.Category == ResourceCategory.LUXURY) {
 				score += LUXURY_RESOURCE_BONUS;
 			}
 			return score;
@@ -129,8 +124,7 @@ namespace C7Engine
 		/// <param name="playerSettlers">The settlers owned by the AI considering building a city.</param>
 		/// <returns></returns>
 		public static bool SettlerAlreadyMovingTowardsTile(Tile tile, List<MapUnit> playerSettlers) {
-			foreach (MapUnit otherSettler in playerSettlers)
-			{
+			foreach (MapUnit otherSettler in playerSettlers) {
 				if (otherSettler.currentAIData is SettlerAIData otherSettlerAI) {
 					if (otherSettlerAI.destination == tile) {
 						return true;

--- a/C7Engine/AI/UnitAI/UnitAI.cs
+++ b/C7Engine/AI/UnitAI/UnitAI.cs
@@ -1,14 +1,12 @@
 using C7GameData;
 using C7GameData.AIData;
 
-namespace C7Engine
-{
+namespace C7Engine {
 	//Not-fully-fleshed out player unit AI.
 	//Right now it's kind of random to just add some appearance
 	//of stuff being done.  I.e. it kinda sucks.  But that's okay.
 	//It has to start somewhere, right?
-	public interface UnitAI
-	{
+	public interface UnitAI {
 		bool PlayTurn(Player player, MapUnit unit);
 	}
 }

--- a/C7Engine/C7Settings.cs
+++ b/C7Engine/C7Settings.cs
@@ -1,8 +1,7 @@
 using System.IO;
 using IniParser.Exceptions;
 
-namespace C7Engine
-{
+namespace C7Engine {
 	using IniParser;
 	using IniParser.Model;
 
@@ -13,8 +12,7 @@ namespace C7Engine
 		public static void LoadSettings() {
 			try {
 				settings = new FileIniDataParser().ReadFile(SETTINGS_FILE_NAME);
-			}
-			catch(ParsingException) {
+			} catch (ParsingException) {
 				//First run.  The file doesn't exist.  That's okay.  We'll use sensible defaults.
 				settings = new IniData();
 				SaveSettings();
@@ -25,8 +23,7 @@ namespace C7Engine
 			new FileIniDataParser().WriteFile(SETTINGS_FILE_NAME, settings);
 		}
 
-		public static void SetValue(string section, string key, string value)
-		{
+		public static void SetValue(string section, string key, string value) {
 			settings[section][key] = value;
 		}
 

--- a/C7Engine/CityExtensions.cs
+++ b/C7Engine/CityExtensions.cs
@@ -1,15 +1,13 @@
-namespace C7Engine
-{
+namespace C7Engine {
 
-using System.Linq;
-using System.Collections.Generic;
-using C7GameData;
+	using System.Linq;
+	using System.Collections.Generic;
+	using C7GameData;
 
-public static class CityExtensions {
-	public static IEnumerable<IProducible> ListProductionOptions(this City city)
-	{
-		return EngineStorage.gameData.unitPrototypes.Values.Where(u => city.CanBuildUnit(u));
+	public static class CityExtensions {
+		public static IEnumerable<IProducible> ListProductionOptions(this City city) {
+			return EngineStorage.gameData.unitPrototypes.Values.Where(u => city.CanBuildUnit(u));
+		}
 	}
-}
 
 }

--- a/C7Engine/EngineStorage.cs
+++ b/C7Engine/EngineStorage.cs
@@ -1,5 +1,4 @@
-namespace C7Engine
-{
+namespace C7Engine {
 	using System;
 	using System.Threading;
 	using System.Collections.Concurrent;
@@ -14,24 +13,22 @@ namespace C7Engine
 	 * all be handled within C7GameData.  We just need a pointer to the main, top level
 	 * so we don't forget the state of the game after we create it.
 	 **/
-	public static class EngineStorage
-	{
+	public static class EngineStorage {
 		public static Mutex gameDataMutex = new Mutex();
-		internal static GameData gameData {get; set;}
+		internal static GameData gameData { get; set; }
 		public static ID uiControllerID;
 		internal static bool animationsEnabled = true;
 
 		private static Thread engineThread = null;
 		internal static AutoResetEvent uiEvent = new AutoResetEvent(false); // Used to block engineThread while waiting for the UI, f.e. while
-										   // an animation plays.
+																			// an animation plays.
 
 		internal static ConcurrentQueue<MessageToEngine> pendingMessages = new ConcurrentQueue<MessageToEngine>();
 		internal static AutoResetEvent actionAddedToQueue = new AutoResetEvent(false);
 
 		public static ConcurrentQueue<MessageToUI> messagesToUI = new ConcurrentQueue<MessageToUI>();
 
-		private static void processActions()
-		{
+		private static void processActions() {
 			bool stopProcessing = false;
 			while (!stopProcessing) {
 				actionAddedToQueue.WaitOne();
@@ -48,8 +45,7 @@ namespace C7Engine
 			}
 		}
 
-		internal static void createThread()
-		{
+		internal static void createThread() {
 			// TODO: What if engineThread is not null, i.e. if the thread has already been created? Should we join() it? Does it matter?
 			engineThread = new Thread(processActions);
 			engineThread.Start();
@@ -57,13 +53,11 @@ namespace C7Engine
 	}
 
 	public class UIGameDataAccess : IDisposable {
-		public UIGameDataAccess()
-		{
+		public UIGameDataAccess() {
 			EngineStorage.gameDataMutex.WaitOne();
 		}
 
-		public void Dispose()
-		{
+		public void Dispose() {
 			EngineStorage.gameDataMutex.ReleaseMutex();
 		}
 

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -1,14 +1,11 @@
 using System.Linq;
 using C7Engine.AI;
 
-namespace C7Engine
-{
+namespace C7Engine {
 	using C7GameData;
 
-	public class CityInteractions
-	{
-		public static void BuildCity(int x, int y, ID playerID, string name)
-		{
+	public class CityInteractions {
+		public static void BuildCity(int x, int y, ID playerID, string name) {
 			GameData gameData = EngineStorage.gameData;
 			Player owner = gameData.GetPlayer(playerID);
 			Tile tileWithNewCity = gameData.map.tileAt(x, y);

--- a/C7Engine/EntryPoints/CreateGame.cs
+++ b/C7Engine/EntryPoints/CreateGame.cs
@@ -3,19 +3,16 @@ using System.Linq;
 using C7GameData;
 using C7GameData.Save;
 
-namespace C7Engine
-{
+namespace C7Engine {
 
-	public class CreateGame
-	{
+	public class CreateGame {
 		/**
 		 * For now, I'm making the methods that the C7 client can call be static.
 		 * We may want a different solution in the end, but this lets us start prototyping
 		 * quickly.  By keeping all the client-callable APIs in the EntryPoints folder,
 		 * hopefully it won't be too much of a goose hunt to refactor it later if we decide to do so.
 		 **/
-		public static Player createGame(string loadFilePath, string defaultBicPath)
-		{
+		public static Player createGame(string loadFilePath, string defaultBicPath) {
 			EngineStorage.createThread();
 			EngineStorage.gameDataMutex.WaitOne();
 

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -1,15 +1,13 @@
 using Serilog;
 
-namespace C7Engine
-{
+namespace C7Engine {
 	using System;
 	using C7GameData;
 
 	public abstract class MessageToEngine {
 		public abstract void process();
 
-		public void send()
-		{
+		public void send() {
 			EngineStorage.pendingMessages.Enqueue(this);
 			EngineStorage.actionAddedToQueue.Set();
 		}
@@ -18,25 +16,21 @@ namespace C7Engine
 	public class MsgShutdownEngine : MessageToEngine {
 		private ILogger log = Log.ForContext<MsgShutdownEngine>();
 
-		public override void process()
-		{
+		public override void process() {
 			log.Information("Engine received shutdown message.");
 		}
 	}
 
-	public class MsgSetFortification : MessageToEngine
-	{
+	public class MsgSetFortification : MessageToEngine {
 		private ID unitID;
 		private bool fortifyElseWake;
 
-		public MsgSetFortification(ID unitID, bool fortifyElseWake)
-		{
+		public MsgSetFortification(ID unitID, bool fortifyElseWake) {
 			this.unitID = unitID;
 			this.fortifyElseWake = fortifyElseWake;
 		}
 
-		public override void process()
-		{
+		public override void process() {
 			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
 
 			// Simply do nothing if we weren't given a valid GUID. TODO: Maybe this is an error we need to handle? In an MP game, we should reject
@@ -50,55 +44,46 @@ namespace C7Engine
 		}
 	}
 
-	public class MsgMoveUnit : MessageToEngine
-	{
+	public class MsgMoveUnit : MessageToEngine {
 		private ID unitID;
 		private TileDirection dir;
 
-		public MsgMoveUnit(ID unitID, TileDirection dir)
-		{
+		public MsgMoveUnit(ID unitID, TileDirection dir) {
 			this.unitID = unitID;
 			this.dir = dir;
 		}
 
-		public override void process()
-		{
+		public override void process() {
 			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
 			unit?.move(dir);
 		}
 	}
 
-	public class MsgSetUnitPath : MessageToEngine
-	{
+	public class MsgSetUnitPath : MessageToEngine {
 		private ID unitID;
 		private int destX;
 		private int destY;
 
-		public MsgSetUnitPath(ID unitID, Tile tile)
-		{
+		public MsgSetUnitPath(ID unitID, Tile tile) {
 			this.unitID = unitID;
 			this.destX = tile.xCoordinate;
 			this.destY = tile.yCoordinate;
 		}
 
-		public override void process()
-		{
+		public override void process() {
 			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
 			unit?.setUnitPath(EngineStorage.gameData.map.tileAt(destX, destY));
 		}
 	}
 
-	public class MsgSkipUnitTurn : MessageToEngine
-	{
+	public class MsgSkipUnitTurn : MessageToEngine {
 		private ID unitID;
 
-		public MsgSkipUnitTurn(ID unitID)
-		{
+		public MsgSkipUnitTurn(ID unitID) {
 			this.unitID = unitID;
 		}
 
-		public override void process()
-		{
+		public override void process() {
 			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
 			unit?.skipTurn();
 		}
@@ -107,13 +92,11 @@ namespace C7Engine
 	public class MsgDisbandUnit : MessageToEngine {
 		private ID unitID;
 
-		public MsgDisbandUnit(ID unitID)
-		{
+		public MsgDisbandUnit(ID unitID) {
 			this.unitID = unitID;
 		}
 
-		public override void process()
-		{
+		public override void process() {
 			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
 			unit?.disband();
 		}
@@ -123,14 +106,12 @@ namespace C7Engine
 		private ID unitID;
 		private string cityName;
 
-		public MsgBuildCity(ID unitID, string cityName)
-		{
+		public MsgBuildCity(ID unitID, string cityName) {
 			this.unitID = unitID;
 			this.cityName = cityName;
 		}
 
-		public override void process()
-		{
+		public override void process() {
 			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
 			unit?.buildCity(cityName);
 		}
@@ -153,14 +134,12 @@ namespace C7Engine
 		private ID cityID;
 		private string producibleName;
 
-		public MsgChooseProduction(ID cityID, string producibleName)
-		{
+		public MsgChooseProduction(ID cityID, string producibleName) {
 			this.cityID = cityID;
 			this.producibleName = producibleName;
 		}
 
-		public override void process()
-		{
+		public override void process() {
 			City city = EngineStorage.gameData.cities.Find(c => c.id == cityID);
 			if (city != null) {
 				foreach (IProducible producible in city.ListProductionOptions()) {
@@ -177,8 +156,7 @@ namespace C7Engine
 
 		private ILogger log = Log.ForContext<MsgEndTurn>();
 
-		public override void process()
-		{
+		public override void process() {
 			Player controller = EngineStorage.gameData.GetPlayer(EngineStorage.uiControllerID);
 
 			foreach (MapUnit unit in controller.units) {
@@ -196,13 +174,11 @@ namespace C7Engine
 	public class MsgSetAnimationsEnabled : MessageToEngine {
 		private bool enabled;
 
-		public MsgSetAnimationsEnabled(bool enabled)
-		{
+		public MsgSetAnimationsEnabled(bool enabled) {
 			this.enabled = enabled;
 		}
 
-		public override void process()
-		{
+		public override void process() {
 			EngineStorage.animationsEnabled = enabled;
 		}
 	}

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -1,11 +1,9 @@
-namespace C7Engine
-{
+namespace C7Engine {
 	using System.Threading;
 	using C7GameData;
 
 	public class MessageToUI {
-		public void send()
-		{
+		public void send() {
 			EngineStorage.messagesToUI.Enqueue(this);
 		}
 	}
@@ -16,8 +14,7 @@ namespace C7Engine
 		public AutoResetEvent completionEvent;
 		public AnimationEnding ending;
 
-		public MsgStartUnitAnimation(MapUnit unit, MapUnit.AnimatedAction action, AutoResetEvent completionEvent, AnimationEnding ending)
-		{
+		public MsgStartUnitAnimation(MapUnit unit, MapUnit.AnimatedAction action, AutoResetEvent completionEvent, AnimationEnding ending) {
 			this.unitID = unit.id;
 			this.action = action;
 			this.completionEvent = completionEvent;
@@ -31,8 +28,7 @@ namespace C7Engine
 		public AutoResetEvent completionEvent;
 		public AnimationEnding ending;
 
-		public MsgStartEffectAnimation(Tile tile, AnimatedEffect effect, AutoResetEvent completionEvent, AnimationEnding ending)
-		{
+		public MsgStartEffectAnimation(Tile tile, AnimatedEffect effect, AutoResetEvent completionEvent, AnimationEnding ending) {
 			this.tileIndex = EngineStorage.gameData.map.tileCoordsToIndex(tile.xCoordinate, tile.yCoordinate);
 			this.effect = effect;
 			this.completionEvent = completionEvent;
@@ -40,14 +36,13 @@ namespace C7Engine
 		}
 	}
 
-	public class MsgStartTurn : MessageToUI {}
+	public class MsgStartTurn : MessageToUI { }
 
 
 	public class MsgCityDestroyed : MessageToUI {
 		public City city;
 
-		public MsgCityDestroyed(City city)
-		{
+		public MsgCityDestroyed(City city) {
 			this.city = city;
 		}
 	}

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -2,15 +2,13 @@ using System.Diagnostics;
 using C7Engine.AI;
 using Serilog;
 
-namespace C7Engine
-{
+namespace C7Engine {
 	using C7GameData;
 	using System;
 	public class TurnHandling {
 		private static ILogger log = Log.ForContext<TurnHandling>();
 
-		internal static void OnBeginTurn()
-		{
+		internal static void OnBeginTurn() {
 			GameData gameData = EngineStorage.gameData;
 			log.Information("\n*** Beginning turn " + gameData.turn + " ***");
 
@@ -55,23 +53,20 @@ namespace C7Engine
 		/// <param name="gameData"></param>
 		/// <param name="firstTurn"></param>
 		/// <returns>true when it is time for the human to take control again</returns>
-		private static bool PlayPlayerTurns(GameData gameData, bool firstTurn)
-		{
+		private static bool PlayPlayerTurns(GameData gameData, bool firstTurn) {
 			foreach (Player player in gameData.players) {
 				if ((!player.hasPlayedThisTurn) &&
-				    !(firstTurn && player.SitsOutFirstTurn())) {
+					!(firstTurn && player.SitsOutFirstTurn())) {
 					if (player.isBarbarians) {
 						//Call the barbarian AI
 						//TODO: The AIs should be stored somewhere on the game state as some of them will store state (plans,
 						//strategy, etc.) For now, we only have a random AI, so that will be in a future commit
 						new BarbarianAI().PlayTurn(player, gameData);
 						player.hasPlayedThisTurn = true;
-					}
-					else if (!player.isHuman) {
+					} else if (!player.isHuman) {
 						PlayerAI.PlayTurn(player, GameData.rng);
 						player.hasPlayedThisTurn = true;
-					}
-					else if (player.id != EngineStorage.uiControllerID) {
+					} else if (player.id != EngineStorage.uiControllerID) {
 						player.hasPlayedThisTurn = true;
 					}
 					//Human player check.  Let the human see what's going on even if they are in observer mode.
@@ -83,8 +78,7 @@ namespace C7Engine
 			}
 			return false;
 		}
-		private static void SpawnBarbarians(GameData gameData)
-		{
+		private static void SpawnBarbarians(GameData gameData) {
 			//Generate new barbarian units.
 			Player barbPlayer = gameData.players.Find(player => player.isBarbarians);
 			foreach (Tile tile in gameData.map.barbarianCamps) {
@@ -105,8 +99,7 @@ namespace C7Engine
 					gameData.mapUnits.Add(newUnit);
 					barbPlayer.units.Add(newUnit);
 					log.Debug("New barbarian added at " + tile);
-				}
-				else if (tile.NeighborsWater() && result < 6) {
+				} else if (tile.NeighborsWater() && result < 6) {
 					MapUnit newUnit = new MapUnit(gameData.ids.CreateID(gameData.barbarianInfo.barbarianSeaUnit.name));
 					newUnit.location = tile;
 					newUnit.owner = gameData.players[0]; //todo: make this reliably point to the barbs
@@ -123,8 +116,7 @@ namespace C7Engine
 				}
 			}
 		}
-		private static void HandleCityResults(GameData gameData)
-		{
+		private static void HandleCityResults(GameData gameData) {
 
 			log.Information("\n*** City production for turn " + gameData.turn + " ***");
 
@@ -136,13 +128,11 @@ namespace C7Engine
 					CityResident newResident = new CityResident();
 					newResident.nationality = city.owner.civilization;
 					CityTileAssignmentAI.AssignNewCitizenToTile(city, newResident);
-				}
-				else if (newSize < initialSize) {
+				} else if (newSize < initialSize) {
 					int diff = initialSize - newSize;
 					if (newSize <= 0) {
 						log.Error($"Attempting to remove the last resident from {city}");
-					}
-					else {
+					} else {
 						city.RemoveCitizens(diff);
 					}
 				}
@@ -172,8 +162,7 @@ namespace C7Engine
 		}
 
 		///Eventually we'll have a game year or month or whatever, but for now this provides feedback on our progression
-		public static int GetTurnNumber()
-		{
+		public static int GetTurnNumber() {
 			return EngineStorage.gameData.turn;
 		}
 	}

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -1,19 +1,16 @@
 using System.Linq;
 using Serilog;
 
-namespace C7Engine
-{
+namespace C7Engine {
 	using C7GameData;
 	using System.Collections.Generic;
 
-	public class UnitInteractions
-	{
+	public class UnitInteractions {
 
 		private static Queue<MapUnit> waitQueue = new Queue<MapUnit>();
 		private static ILogger log = Log.ForContext<UnitInteractions>();
 
-		public static MapUnit getNextSelectedUnit(GameData gameData)
-		{
+		public static MapUnit getNextSelectedUnit(GameData gameData) {
 			foreach (Player player in gameData.players.Where(p => p.isHuman)) {
 				//TODO: Should pass in a player GUID instead of checking for human
 				//This current limits us to one human player, although it's better
@@ -39,8 +36,7 @@ namespace C7Engine
 		 * We probably *should* be returning just a list of the actions.  However, we're passing the result around via Godot signals, so
 		 * I'm going to save that for a separate commit.
 		 **/
-		public static MapUnit UnitWithAvailableActions(MapUnit unit)
-		{
+		public static MapUnit UnitWithAvailableActions(MapUnit unit) {
 			unit.availableActions.Clear();
 
 			if (unit == MapUnit.NONE) {
@@ -70,17 +66,13 @@ namespace C7Engine
 			return unit;
 		}
 
-		public static void ClearWaitQueue()
-		{
+		public static void ClearWaitQueue() {
 			waitQueue.Clear();
 		}
 
-		public static void waitUnit(GameData gameData, ID id)
-		{
-			foreach (MapUnit unit in gameData.mapUnits)
-			{
-				if (unit.id == id)
-				{
+		public static void waitUnit(GameData gameData, ID id) {
+			foreach (MapUnit unit in gameData.mapUnits) {
+				if (unit.id == id) {
 					log.Verbose("Found matching unit with id " + id + " of type " + unit.GetType().Name + "; adding it to the wait queue");
 					waitQueue.Enqueue(unit);
 				}

--- a/C7Engine/SaveManager.cs
+++ b/C7Engine/SaveManager.cs
@@ -1,5 +1,4 @@
-﻿namespace C7Engine
-{
+﻿namespace C7Engine {
 	using System.IO;
 	using C7GameData;
 	using C7GameData.Save;
@@ -13,10 +12,8 @@
 
 	// The engine performs all save file creating, reading, and updating
 	// via the SaveManager
-	public static class SaveManager
-	{
-		private static SaveFileFormat getFileFormat(string path)
-		{
+	public static class SaveManager {
+		private static SaveFileFormat getFileFormat(string path) {
 			return Path.GetExtension(path).ToUpper() switch {
 				".SAV" => SaveFileFormat.Sav,
 				".BIQ" => SaveFileFormat.Biq,
@@ -27,8 +24,7 @@
 		}
 
 		// Load and initialize a save
-		public static SaveGame LoadSave(string path, string bicPath)
-		{
+		public static SaveGame LoadSave(string path, string bicPath) {
 			SaveGame save = getFileFormat(path) switch {
 				SaveFileFormat.Sav => ImportCiv3.ImportSav(path, bicPath),
 				SaveFileFormat.Biq => ImportCiv3.ImportBiq(path, bicPath),

--- a/C7Engine/TileExtensions.cs
+++ b/C7Engine/TileExtensions.cs
@@ -1,13 +1,11 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace C7Engine
-{
+namespace C7Engine {
 	using C7GameData;
 
 	public static class TileExtensions {
-		public static MapUnit FindTopDefender(this Tile tile, MapUnit opponent)
-		{
+		public static MapUnit FindTopDefender(this Tile tile, MapUnit opponent) {
 			if (tile.unitsOnTile.Count > 0) {
 				IEnumerable<MapUnit> potentialDefenders = tile.unitsOnTile.Where(u => u.CanDefendAgainst(opponent));
 				if (potentialDefenders.Count() == 0) {
@@ -42,8 +40,7 @@ namespace C7Engine
 			}
 		}
 
-		public static void Animate(this Tile tile, AnimatedEffect effect, bool wait)
-		{
+		public static void Animate(this Tile tile, AnimatedEffect effect, bool wait) {
 			if (EngineStorage.animationsEnabled) {
 				new MsgStartEffectAnimation(tile, effect, wait ? EngineStorage.uiEvent : null, AnimationEnding.Stop).send();
 				if (wait) {


### PR DESCRIPTION
I'd like to be able to have "format on save" turned on without it generating obnoxiously large diffs.

Doing this all at once makes it clearer this is safe.

To do this I configured VSCode [according to the wiki instructions](https://github.com/C7-Game/Prototype/wiki/Developing-and-Setting-Up-IDEs#code-formatting) and then used the [workspace formatter extension](https://marketplace.visualstudio.com/items?itemName=franneck94.workspace-formatter) to run the formatter on the relevant directories.

#406 