### PR TITLE
ImportCiv3.cs: Add support for loading cities in scenarios

### DIFF
--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -166,6 +166,7 @@ namespace C7GameData {
 			ImportSharedBiqData();
 			ImportBicLeaders();
 			ImportBicUnits();
+			ImportBicCities();
 
 			Dictionary<int, Resource> resourcesByIndex = ImportCiv3Resources();
 			SetMapDimensions(biq, save);
@@ -432,6 +433,31 @@ namespace C7GameData {
 					size = city.Popd.CitizenCount,
 					shieldsStored = city.ShieldsCollected,
 					foodStored = city.TotalFood,
+					foodNeededToGrow = 20, // HACK: don't know where to find this
+					// residents = city.Ppod // TODO: load tiles worked from PPOD
+				};
+				save.Cities.Add(saveCity);
+			}
+		}
+
+		private void ImportBicCities() {
+			BiqData theBiq = biq.Unit is null ? defaultBiq : biq;
+
+			foreach (CITY city in theBiq.City) {
+				if (city.Owner < 0 || city.Owner >= save.Players.Count) {
+					continue;
+				}
+				SavePlayer player = save.Players[city.Owner];
+				SaveCity saveCity = new SaveCity{
+					id = ids.CreateID("city"),
+					owner = player.id,
+					location = new TileLocation(city.X, city.Y),
+					// TODO: try and get this from the unit prototype
+					producible = "Worker",
+					name = city.Name,
+					size = city.Size,
+					shieldsStored = 0,
+					foodStored = 0,
 					foodNeededToGrow = 20, // HACK: don't know where to find this
 					// residents = city.Ppod // TODO: load tiles worked from PPOD
 				};


### PR DESCRIPTION
This still has some limitations, in that it will only work if there is a "Worker" unit. The `producible` field really should be loading from the list of unit prototyes, but that can be done later.

Some example screenshots:

![Screenshot 2025-01-05 1 32 22 PM](https://github.com/user-attachments/assets/05258581-a8c4-4301-80ce-5ce869f984b9)
![Screenshot 2025-01-05 1 31 06 PM](https://github.com/user-attachments/assets/ae1b388e-5df2-40c1-9c2a-ac090d438ce3)

The labels on the cities seems slightly amiss, and the unit health bars are somewhat obscured by the cities, but I don't think that's an issue with this PR.