### PR TITLE
Display mines in loaded save files and scenarios

### DIFF
--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -13,7 +13,8 @@ using Serilog.Events;
 // that was intended to draw regularly tiled objects like terrain sprites but using LooseLayers for everything was found to be a prefereable
 // approach.) LooseLayer is effectively the standard map layer. The MapView contains a list of loose layers, inside a LooseView object. Right now to
 // add a new layer you must modify the MapView constructor to add it to the list, but (TODO) eventually that will be made moddable.
-public abstract class LooseLayer {
+public abstract class LooseLayer
+{
 	// drawObject draws the things this layer is supposed to draw that are associated with the given tile. Its parameters are:
 	//   looseView: The Node2D to actually draw to, e.g., use looseView.DrawCircle(...) to draw a circle. This object also contains a reference to
 	//     the MapView in case you need it.
@@ -31,7 +32,8 @@ public abstract class LooseLayer {
 	public bool visible = true;
 }
 
-public partial class TerrainLayer : LooseLayer {
+public partial class TerrainLayer : LooseLayer
+{
 
 	public static readonly Vector2 terrainSpriteSize = new Vector2(128, 64);
 
@@ -41,20 +43,26 @@ public partial class TerrainLayer : LooseLayer {
 	// TileToDraw stores the arguments passed to drawObject so the draws can be sorted by texture before being submitted. This significantly
 	// reduces the number of draw calls Godot must generate (1483 to 312 when fully zoomed out on our test map) and modestly improves framerate
 	// (by about 14% on my system).
-	private class TileToDraw : IComparable<TileToDraw> {
+	private class TileToDraw : IComparable<TileToDraw>
+	{
 		public Tile tile;
 		public Vector2 tileCenter;
 
-		public TileToDraw(Tile tile, Vector2 tileCenter) {
+		public TileToDraw(Tile tile, Vector2 tileCenter)
+		{
 			this.tile = tile;
 			this.tileCenter = tileCenter;
 		}
 
-		public int CompareTo(TileToDraw other) {
+		public int CompareTo(TileToDraw other)
+		{
 			// "other" might be null, in which case we should return a positive value. CompareTo(null) will do this.
-			try {
+			try
+			{
 				return this.tile.ExtraInfo.BaseTerrainFileID.CompareTo(other?.tile.ExtraInfo.BaseTerrainFileID);
-			} catch (Exception) {
+			}
+			catch (Exception)
+			{
 				//It also could be Tile.NONE.  In which case, also return a positive value.
 				return 1;
 			}
@@ -63,11 +71,13 @@ public partial class TerrainLayer : LooseLayer {
 
 	private List<TileToDraw> tilesToDraw = new List<TileToDraw>();
 
-	public TerrainLayer() {
+	public TerrainLayer()
+	{
 		tripleSheets = loadTerrainTripleSheets();
 	}
 
-	public List<ImageTexture> loadTerrainTripleSheets() {
+	public List<ImageTexture> loadTerrainTripleSheets()
+	{
 		List<string> fileNames = new List<string> {
 			"Art/Terrain/xtgc.pcx",
 			"Art/Terrain/xpgc.pcx",
@@ -82,17 +92,21 @@ public partial class TerrainLayer : LooseLayer {
 		return fileNames.ConvertAll(name => Util.LoadTextureFromPCX(name));
 	}
 
-	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
+	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
+	{
 		tilesToDraw.Add(new TileToDraw(tile, tileCenter));
 		tilesToDraw.Add(new TileToDraw(tile.neighbors[TileDirection.SOUTH], tileCenter + new Vector2(0, 64)));
 		tilesToDraw.Add(new TileToDraw(tile.neighbors[TileDirection.SOUTHWEST], tileCenter + new Vector2(-64, 32)));
 		tilesToDraw.Add(new TileToDraw(tile.neighbors[TileDirection.SOUTHEAST], tileCenter + new Vector2(64, 32)));
 	}
 
-	public override void onEndDraw(LooseView looseView, GameData gameData) {
+	public override void onEndDraw(LooseView looseView, GameData gameData)
+	{
 		tilesToDraw.Sort();
-		foreach (TileToDraw tTD in tilesToDraw) {
-			if (tTD.tile != Tile.NONE) {
+		foreach (TileToDraw tTD in tilesToDraw)
+		{
+			if (tTD.tile != Tile.NONE)
+			{
 				int xSheet = tTD.tile.ExtraInfo.BaseTerrainImageID % 9, ySheet = tTD.tile.ExtraInfo.BaseTerrainImageID / 9;
 				Rect2 texRect = new Rect2(new Vector2(xSheet, ySheet) * terrainSpriteSize, terrainSpriteSize);
 				Vector2 terrainOffset = new Vector2(0, -1 * MapView.cellSize.Y);
@@ -106,7 +120,8 @@ public partial class TerrainLayer : LooseLayer {
 	}
 }
 
-public partial class HillsLayer : LooseLayer {
+public partial class HillsLayer : LooseLayer
+{
 	public static readonly Vector2 mountainSize = new Vector2(128, 88);
 	public static readonly Vector2 volcanoSize = new Vector2(128, 88);  //same as mountain
 	public static readonly Vector2 hillsSize = new Vector2(128, 72);
@@ -121,7 +136,8 @@ public partial class HillsLayer : LooseLayer {
 	private ImageTexture forestVolcanoTexture;
 	private ImageTexture jungleVolcanoTexture;
 
-	public HillsLayer() {
+	public HillsLayer()
+	{
 		mountainTexture = Util.LoadTextureFromPCX("Art/Terrain/Mountains.pcx");
 		snowMountainTexture = Util.LoadTextureFromPCX("Art/Terrain/Mountains-snow.pcx");
 		forestMountainTexture = Util.LoadTextureFromPCX("Art/Terrain/mountain forests.pcx");
@@ -134,51 +150,76 @@ public partial class HillsLayer : LooseLayer {
 		jungleVolcanoTexture = Util.LoadTextureFromPCX("Art/Terrain/Volcanos jungles.pcx");
 	}
 
-	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
-		if (tile.overlayTerrainType.isHilly()) {
+	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
+	{
+		if (tile.overlayTerrainType.isHilly())
+		{
 			int pcxIndex = getMountainIndex(tile);
-			int row = pcxIndex/4;
+			int row = pcxIndex / 4;
 			int column = pcxIndex % 4;
-			if (tile.overlayTerrainType.Key == "mountains") {
+			if (tile.overlayTerrainType.Key == "mountains")
+			{
 				Rect2 mountainRectangle = new Rect2(column * mountainSize.X, row * mountainSize.Y, mountainSize);
 				Rect2 screenTarget = new Rect2(tileCenter - (float)0.5 * mountainSize + new Vector2(0, -12), mountainSize);
 				ImageTexture mountainGraphics;
-				if (tile.isSnowCapped) {
+				if (tile.isSnowCapped)
+				{
 					mountainGraphics = snowMountainTexture;
-				} else {
+				}
+				else
+				{
 					TerrainType dominantVegetation = getDominantVegetationNearHillyTile(tile);
-					if (dominantVegetation.Key == "forest") {
+					if (dominantVegetation.Key == "forest")
+					{
 						mountainGraphics = forestMountainTexture;
-					} else if (dominantVegetation.Key == "jungle") {
+					}
+					else if (dominantVegetation.Key == "jungle")
+					{
 						mountainGraphics = jungleMountainTexture;
-					} else {
+					}
+					else
+					{
 						mountainGraphics = mountainTexture;
 					}
 				}
 				looseView.DrawTextureRectRegion(mountainGraphics, screenTarget, mountainRectangle);
-			} else if (tile.overlayTerrainType.Key == "hills") {
+			}
+			else if (tile.overlayTerrainType.Key == "hills")
+			{
 				Rect2 hillsRectangle = new Rect2(column * hillsSize.X, row * hillsSize.Y, hillsSize);
 				Rect2 screenTarget = new Rect2(tileCenter - (float)0.5 * hillsSize + new Vector2(0, -4), hillsSize);
 				ImageTexture hillGraphics;
 				TerrainType dominantVegetation = getDominantVegetationNearHillyTile(tile);
-				if (dominantVegetation.Key == "forest") {
+				if (dominantVegetation.Key == "forest")
+				{
 					hillGraphics = forestHillsTexture;
-				} else if (dominantVegetation.Key == "jungle") {
+				}
+				else if (dominantVegetation.Key == "jungle")
+				{
 					hillGraphics = jungleHillsTexture;
-				} else {
+				}
+				else
+				{
 					hillGraphics = hillsTexture;
 				}
 				looseView.DrawTextureRectRegion(hillGraphics, screenTarget, hillsRectangle);
-			} else if (tile.overlayTerrainType.Key == "volcano") {
+			}
+			else if (tile.overlayTerrainType.Key == "volcano")
+			{
 				Rect2 volcanoRectangle = new Rect2(column * volcanoSize.X, row * volcanoSize.Y, volcanoSize);
 				Rect2 screenTarget = new Rect2(tileCenter - (float)0.5 * volcanoSize + new Vector2(0, -12), volcanoSize);
 				ImageTexture volcanoGraphics;
 				TerrainType dominantVegetation = getDominantVegetationNearHillyTile(tile);
-				if (dominantVegetation.Key == "forest") {
+				if (dominantVegetation.Key == "forest")
+				{
 					volcanoGraphics = forestVolcanoTexture;
-				} else if (dominantVegetation.Key == "jungle") {
+				}
+				else if (dominantVegetation.Key == "jungle")
+				{
 					volcanoGraphics = jungleVolcanoTexture;
-				} else {
+				}
+				else
+				{
 					volcanoGraphics = volcanosTexture;
 				}
 				looseView.DrawTextureRectRegion(volcanoGraphics, screenTarget, volcanoRectangle);
@@ -186,7 +227,8 @@ public partial class HillsLayer : LooseLayer {
 		}
 	}
 
-	private TerrainType getDominantVegetationNearHillyTile(Tile center) {
+	private TerrainType getDominantVegetationNearHillyTile(Tile center)
+	{
 		TerrainType northeastType = center.neighbors[TileDirection.NORTHEAST].overlayTerrainType;
 		TerrainType northwestType = center.neighbors[TileDirection.NORTHWEST].overlayTerrainType;
 		TerrainType southeastType = center.neighbors[TileDirection.SOUTHEAST].overlayTerrainType;
@@ -201,57 +243,74 @@ public partial class HillsLayer : LooseLayer {
 		//to grab them directly at this point in time.
 		TerrainType forest = null;
 		TerrainType jungle = null;
-		foreach (TerrainType type in neighborTerrains) {
-			if (type.isHilly()) {
+		foreach (TerrainType type in neighborTerrains)
+		{
+			if (type.isHilly())
+			{
 				hills++;
-			} else if (type.Key == "forest") {
+			}
+			else if (type.Key == "forest")
+			{
 				forests++;
 				forest = type;
-			} else if (type.Key == "jungle") {
+			}
+			else if (type.Key == "jungle")
+			{
 				jungles++;
 				jungle = type;
 			}
 		}
 
-		if (hills + forests + jungles < 4) {    //some surrounding tiles are neither forested nor hilly
+		if (hills + forests + jungles < 4)
+		{    //some surrounding tiles are neither forested nor hilly
 			return TerrainType.NONE;
 		}
-		if (forests == 0 && jungles == 0) {
+		if (forests == 0 && jungles == 0)
+		{
 			return TerrainType.NONE;    //all hills
 		}
-		if (forests > jungles) {
+		if (forests > jungles)
+		{
 			return forest;
 		}
-		if (jungles > forests) {
+		if (jungles > forests)
+		{
 			return jungle;
 		}
 
 		//If we get here, it's a tie between forest and jungle.  Deterministically choose one so it doesn't change on every render
-		if (center.xCoordinate % 2 == 0) {
+		if (center.xCoordinate % 2 == 0)
+		{
 			return forest;
 		}
 		return jungle;
 	}
 
-	private int getMountainIndex(Tile tile) {
+	private int getMountainIndex(Tile tile)
+	{
 		int index = 0;
-		if (tile.neighbors[TileDirection.NORTHWEST].overlayTerrainType.isHilly()) {
+		if (tile.neighbors[TileDirection.NORTHWEST].overlayTerrainType.isHilly())
+		{
 			index++;
 		}
-		if (tile.neighbors[TileDirection.NORTHEAST].overlayTerrainType.isHilly()) {
+		if (tile.neighbors[TileDirection.NORTHEAST].overlayTerrainType.isHilly())
+		{
 			index += 2;
 		}
-		if (tile.neighbors[TileDirection.SOUTHWEST].overlayTerrainType.isHilly()) {
+		if (tile.neighbors[TileDirection.SOUTHWEST].overlayTerrainType.isHilly())
+		{
 			index += 4;
 		}
-		if (tile.neighbors[TileDirection.SOUTHEAST].overlayTerrainType.isHilly()) {
+		if (tile.neighbors[TileDirection.SOUTHEAST].overlayTerrainType.isHilly())
+		{
 			index += 8;
 		}
 		return index;
 	}
 }
 
-public partial class ForestLayer : LooseLayer {
+public partial class ForestLayer : LooseLayer
+{
 	public static readonly Vector2 forestJungleSize = new Vector2(128, 88);
 
 	private ImageTexture largeJungleTexture;
@@ -266,7 +325,8 @@ public partial class ForestLayer : LooseLayer {
 	private ImageTexture pinePlainsTexture;
 	private ImageTexture pineTundraTexture;
 
-	public ForestLayer() {
+	public ForestLayer()
+	{
 		largeJungleTexture = Util.LoadTextureFromPCX("Art/Terrain/grassland forests.pcx", 0, 0, 512, 176);
 		smallJungleTexture = Util.LoadTextureFromPCX("Art/Terrain/grassland forests.pcx", 0, 176, 768, 176);
 		largeForestTexture = Util.LoadTextureFromPCX("Art/Terrain/grassland forests.pcx", 0, 352, 512, 176);
@@ -280,18 +340,23 @@ public partial class ForestLayer : LooseLayer {
 		pineTundraTexture = Util.LoadTextureFromPCX("Art/Terrain/tundra forests.pcx", 0, 704, 768, 176);
 	}
 
-	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
-		if (tile.overlayTerrainType.Key == "jungle") {
+	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
+	{
+		if (tile.overlayTerrainType.Key == "jungle")
+		{
 			//Randomly, but predictably, choose a large jungle graphic
 			//More research is needed on when to use large vs small jungles.  Probably, small is used when neighboring fewer jungles.
 			//For the first pass, we're just always using large jungles.
 			int randomJungleRow = tile.yCoordinate % 2;
 			int randomJungleColumn;
 			ImageTexture jungleTexture;
-			if (tile.getEdgeNeighbors().Any(t => t.IsWater())) {
+			if (tile.getEdgeNeighbors().Any(t => t.IsWater()))
+			{
 				randomJungleColumn = tile.xCoordinate % 6;
 				jungleTexture = smallJungleTexture;
-			} else {
+			}
+			else
+			{
 				randomJungleColumn = tile.xCoordinate % 4;
 				jungleTexture = largeJungleTexture;
 			}
@@ -299,38 +364,60 @@ public partial class ForestLayer : LooseLayer {
 			Rect2 screenTarget = new Rect2(tileCenter - (float)0.5 * forestJungleSize + new Vector2(0, -12), forestJungleSize);
 			looseView.DrawTextureRectRegion(jungleTexture, screenTarget, jungleRectangle);
 		}
-		if (tile.overlayTerrainType.Key == "forest") {
+		if (tile.overlayTerrainType.Key == "forest")
+		{
 			int forestRow = 0;
 			int forestColumn = 0;
 			ImageTexture forestTexture;
-			if (tile.isPineForest) {
+			if (tile.isPineForest)
+			{
 				forestRow = tile.yCoordinate % 2;
 				forestColumn = tile.xCoordinate % 6;
-				if (tile.baseTerrainType.Key == "grassland") {
+				if (tile.baseTerrainType.Key == "grassland")
+				{
 					forestTexture = pineForestTexture;
-				} else if (tile.baseTerrainType.Key == "plains") {
+				}
+				else if (tile.baseTerrainType.Key == "plains")
+				{
 					forestTexture = pinePlainsTexture;
-				} else { //Tundra
+				}
+				else
+				{ //Tundra
 					forestTexture = pineTundraTexture;
 				}
-			} else {
+			}
+			else
+			{
 				forestRow = tile.yCoordinate % 2;
-				if (tile.getEdgeNeighbors().Any(t => t.IsWater())) {
+				if (tile.getEdgeNeighbors().Any(t => t.IsWater()))
+				{
 					forestColumn = tile.xCoordinate % 5;
-					if (tile.baseTerrainType.Key == "grassland") {
+					if (tile.baseTerrainType.Key == "grassland")
+					{
 						forestTexture = smallForestTexture;
-					} else if (tile.baseTerrainType.Key == "plains") {
+					}
+					else if (tile.baseTerrainType.Key == "plains")
+					{
 						forestTexture = smallPlainsForestTexture;
-					} else {    //tundra
+					}
+					else
+					{    //tundra
 						forestTexture = smallTundraForestTexture;
 					}
-				} else {
+				}
+				else
+				{
 					forestColumn = tile.xCoordinate % 4;
-					if (tile.baseTerrainType.Key == "grassland") {
+					if (tile.baseTerrainType.Key == "grassland")
+					{
 						forestTexture = largeForestTexture;
-					} else if (tile.baseTerrainType.Key == "plains") {
+					}
+					else if (tile.baseTerrainType.Key == "plains")
+					{
 						forestTexture = largePlainsForestTexture;
-					} else {    //tundra
+					}
+					else
+					{    //tundra
 						forestTexture = largeTundraForestTexture;
 					}
 				}
@@ -341,7 +428,8 @@ public partial class ForestLayer : LooseLayer {
 		}
 	}
 }
-public partial class MarshLayer : LooseLayer {
+public partial class MarshLayer : LooseLayer
+{
 	public static readonly Vector2 marshSize = new Vector2(128, 88);
 	//Because the marsh graphics are 88 pixels tall instead of the 64 of a tile, we also need an addition 12 pixel offset to the top
 	//88 - 64 = 24; 24/2 = 12.  This keeps the marsh centered with half the extra 24 pixels above the tile and half below.
@@ -350,20 +438,26 @@ public partial class MarshLayer : LooseLayer {
 	private ImageTexture largeMarshTexture;
 	private ImageTexture smallMarshTexture;
 
-	public MarshLayer() {
+	public MarshLayer()
+	{
 		largeMarshTexture = Util.LoadTextureFromPCX("Art/Terrain/marsh.pcx", 0, 0, 512, 176);
 		smallMarshTexture = Util.LoadTextureFromPCX("Art/Terrain/marsh.pcx", 0, 176, 640, 176);
 	}
 
-	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
-		if (tile.overlayTerrainType.Key == "marsh") {
+	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
+	{
+		if (tile.overlayTerrainType.Key == "marsh")
+		{
 			int randomJungleRow = tile.yCoordinate % 2;
 			int randomMarshColumn;
 			ImageTexture marshTexture;
-			if (tile.getEdgeNeighbors().Any(t => t.IsWater())) {
+			if (tile.getEdgeNeighbors().Any(t => t.IsWater()))
+			{
 				randomMarshColumn = tile.xCoordinate % 5;
 				marshTexture = smallMarshTexture;
-			} else {
+			}
+			else
+			{
 				randomMarshColumn = tile.xCoordinate % 4;
 				marshTexture = largeMarshTexture;
 			}
@@ -374,16 +468,19 @@ public partial class MarshLayer : LooseLayer {
 	}
 }
 
-public partial class RiverLayer : LooseLayer {
+public partial class RiverLayer : LooseLayer
+{
 	public static readonly Vector2 riverSize = new Vector2(128, 64);
 	public static readonly Vector2 riverCenterOffset = new Vector2(riverSize.X / 2, 0);
 	private ImageTexture riverTexture;
 
-	public RiverLayer() {
+	public RiverLayer()
+	{
 		riverTexture = Util.LoadTextureFromPCX("Art/Terrain/mtnRivers.pcx");
 	}
 
-	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
+	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
+	{
 		//The "point" is the easternmost point of the tile for which we are drawing rivers.
 		//Which river graphics to used is calculated by evaluating the tiles that neighbor
 		//that point.
@@ -394,19 +491,24 @@ public partial class RiverLayer : LooseLayer {
 
 		int riverGraphicsIndex = 0;
 
-		if (northOfPoint.riverSouthwest) {
+		if (northOfPoint.riverSouthwest)
+		{
 			riverGraphicsIndex++;
 		}
-		if (eastOfPoint.riverNorthwest) {
+		if (eastOfPoint.riverNorthwest)
+		{
 			riverGraphicsIndex += 2;
 		}
-		if (westOfPoint.riverSoutheast) {
+		if (westOfPoint.riverSoutheast)
+		{
 			riverGraphicsIndex += 4;
 		}
-		if (southOfPoint.riverNortheast) {
+		if (southOfPoint.riverNortheast)
+		{
 			riverGraphicsIndex += 8;
 		}
-		if (riverGraphicsIndex == 0) {
+		if (riverGraphicsIndex == 0)
+		{
 			return;
 		}
 		int riverRow = riverGraphicsIndex / 4;
@@ -418,36 +520,42 @@ public partial class RiverLayer : LooseLayer {
 	}
 }
 
-public partial class GridLayer : LooseLayer {
+public partial class GridLayer : LooseLayer
+{
 	public Color color = Color.Color8(50, 50, 50, 150);
 	public float lineWidth = (float)1.0;
 
 	public GridLayer() { }
 
-	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
+	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
+	{
 		Vector2 cS = MapView.cellSize;
-		Vector2 left  = tileCenter + new Vector2(-cS.X, 0    );
-		Vector2 top   = tileCenter + new Vector2( 0   , -cS.Y);
-		Vector2 right = tileCenter + new Vector2( cS.X, 0    );
+		Vector2 left = tileCenter + new Vector2(-cS.X, 0);
+		Vector2 top = tileCenter + new Vector2(0, -cS.Y);
+		Vector2 right = tileCenter + new Vector2(cS.X, 0);
 		looseView.DrawLine(left, top, color, lineWidth);
 		looseView.DrawLine(top, right, color, lineWidth);
 	}
 }
 
-public partial class BuildingLayer : LooseLayer {
+public partial class BuildingLayer : LooseLayer
+{
 	private ImageTexture buildingsTex;
 	private Vector2 buildingSpriteSize;
 
-	public BuildingLayer() {
+	public BuildingLayer()
+	{
 		var buildingsPCX = new Pcx(Util.Civ3MediaPath("Art/Terrain/TerrainBuildings.PCX"));
 		buildingsTex = PCXToGodot.getImageTextureFromPCX(buildingsPCX);
 		//In Conquests, this graphic is 4x4, and the search path will now find the Conquests one first
 		buildingSpriteSize = new Vector2((float)buildingsTex.GetWidth() / 4, (float)buildingsTex.GetHeight() / 4);
 	}
 
-	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
-		if (tile.hasBarbarianCamp) {
-			var texRect = new Rect2(buildingSpriteSize * new Vector2 (2, 0), buildingSpriteSize); //(2, 0) is the offset in the TerrainBuildings.PCX file (top row, third in)
+	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter)
+	{
+		if (tile.hasBarbarianCamp)
+		{
+			var texRect = new Rect2(buildingSpriteSize * new Vector2(2, 0), buildingSpriteSize); //(2, 0) is the offset in the TerrainBuildings.PCX file (top row, third in)
 
 			// TODO: Modify this calculation so it doesn't assume buildingSpriteSize is the same as the size of the terrain tiles
 			var screenRect = new Rect2(tileCenter - (float)0.5 * buildingSpriteSize, buildingSpriteSize);
@@ -456,55 +564,70 @@ public partial class BuildingLayer : LooseLayer {
 	}
 }
 
-public partial class LooseView : Node2D {
+public partial class LooseView : Node2D
+{
 	public MapView mapView;
 	public List<LooseLayer> layers = new List<LooseLayer>();
 
-	public LooseView(MapView mapView) {
+	public LooseView(MapView mapView)
+	{
 		this.mapView = mapView;
 	}
 
-	private struct VisibleTile {
+	private struct VisibleTile
+	{
 		public Tile tile;
 		public Vector2 tileCenter;
 	}
 
-	public override void _Draw() {
+	public override void _Draw()
+	{
 		base._Draw();
 
-		using (var gameDataAccess = new UIGameDataAccess()) {
+		using (var gameDataAccess = new UIGameDataAccess())
+		{
 			GameData gD = gameDataAccess.gameData;
 
 			// Iterating over visible tiles is unfortunately pretty expensive. Assemble a list of Tile references and centers first so we don't
 			// have to reiterate for each layer. Doing this improves framerate significantly.
 			MapView.VisibleRegion visRegion = mapView.getVisibleRegion();
 			List<VisibleTile> visibleTiles = new List<VisibleTile>();
-			for (int y = visRegion.upperLeftY; y < visRegion.lowerRightY; y++) {
-				if (gD.map.isRowAt(y)) {
-					for (int x = visRegion.getRowStartX(y); x < visRegion.lowerRightX; x += 2) {
+			for (int y = visRegion.upperLeftY; y < visRegion.lowerRightY; y++)
+			{
+				if (gD.map.isRowAt(y))
+				{
+					for (int x = visRegion.getRowStartX(y); x < visRegion.lowerRightX; x += 2)
+					{
 						Tile tile = gD.map.tileAt(x, y);
-						if (IsTileKnown(tile, gameDataAccess)) {
+						if (IsTileKnown(tile, gameDataAccess))
+						{
 							visibleTiles.Add(new VisibleTile { tile = tile, tileCenter = MapView.cellSize * new Vector2(x + 1, y + 1) });
 						}
 					}
 				}
 			}
 
-			foreach (LooseLayer layer in layers.FindAll(L => L.visible && !(L is FogOfWarLayer))) {
+			foreach (LooseLayer layer in layers.FindAll(L => L.visible && !(L is FogOfWarLayer)))
+			{
 				layer.onBeginDraw(this, gD);
-				foreach (VisibleTile vT in visibleTiles) {
+				foreach (VisibleTile vT in visibleTiles)
+				{
 					layer.drawObject(this, gD, vT.tile, vT.tileCenter);
 				}
 				layer.onEndDraw(this, gD);
 			}
 
-			if (!gD.observerMode) {
-				foreach (LooseLayer layer in layers.FindAll(layer => layer is FogOfWarLayer)) {
+			if (!gD.observerMode)
+			{
+				foreach (LooseLayer layer in layers.FindAll(layer => layer is FogOfWarLayer))
+				{
 					for (int y = visRegion.upperLeftY; y < visRegion.lowerRightY; y++)
 						if (gD.map.isRowAt(y))
-							for (int x = visRegion.getRowStartX(y); x < visRegion.lowerRightX; x += 2) {
+							for (int x = visRegion.getRowStartX(y); x < visRegion.lowerRightX; x += 2)
+							{
 								Tile tile = gD.map.tileAt(x, y);
-								if (tile != Tile.NONE) {
+								if (tile != Tile.NONE)
+								{
 									VisibleTile invisibleTile = new VisibleTile { tile = tile, tileCenter = MapView.cellSize * new Vector2(x + 1, y + 1) };
 									layer.drawObject(this, gD, tile, invisibleTile.tileCenter);
 								}
@@ -513,19 +636,23 @@ public partial class LooseView : Node2D {
 			}
 		}
 	}
-	private static bool IsTileKnown(Tile tile, UIGameDataAccess gameDataAccess) {
-		if (gameDataAccess.gameData.observerMode) {
+	private static bool IsTileKnown(Tile tile, UIGameDataAccess gameDataAccess)
+	{
+		if (gameDataAccess.gameData.observerMode)
+		{
 			return true;
 		}
 		return tile != Tile.NONE && gameDataAccess.gameData.GetHumanPlayers()[0].tileKnowledge.isTileKnown(tile);
 	}
 }
 
-public partial class MapView : Node2D {
+public partial class MapView : Node2D
+{
 	// cellSize is half the size of the tile sprites, or the amount of space each tile takes up when they are packed on the grid (note tiles are
 	// staggered and half overlap).
 	public static readonly Vector2 cellSize = new Vector2(64, 32);
-	public Vector2 scaledCellSize {
+	public Vector2 scaledCellSize
+	{
 		get { return cellSize * new Vector2(cameraZoom, cameraZoom); }
 	}
 
@@ -537,16 +664,20 @@ public partial class MapView : Node2D {
 	public bool wrapVertically { get; private set; }
 
 	private Vector2 internalCameraLocation = new Vector2(0, 0);
-	public Vector2 cameraLocation {
-		get {
+	public Vector2 cameraLocation
+	{
+		get
+		{
 			return internalCameraLocation;
 		}
-		set {
+		set
+		{
 			setCameraLocation(value);
 		}
 	}
 	public float internalCameraZoom = 1;
-	public float cameraZoom {
+	public float cameraZoom
+	{
 		get { return internalCameraZoom; }
 		set { setCameraZoomFromMiddle(value); }
 	}
@@ -557,11 +688,13 @@ public partial class MapView : Node2D {
 	// are "virtual", i.e. "unwrapped", so there isn't necessarily a tile at each location. The region is intended to include the upper left
 	// coordinates but not the lower right ones. When iterating over all tiles in the region you must account for the fact that map rows are
 	// staggered, see LooseView._Draw for an example.
-	public struct VisibleRegion {
+	public struct VisibleRegion
+	{
 		public int upperLeftX, upperLeftY;
 		public int lowerRightX, lowerRightY;
 
-		public int getRowStartX(int y) {
+		public int getRowStartX(int y)
+		{
 			return upperLeftX + (y - upperLeftY) % 2;
 		}
 	}
@@ -571,7 +704,8 @@ public partial class MapView : Node2D {
 
 	public ImageTexture civColorWhitePalette = null;
 
-	public MapView(Game game, int mapWidth, int mapHeight, bool wrapHorizontally, bool wrapVertically) {
+	public MapView(Game game, int mapWidth, int mapHeight, bool wrapHorizontally, bool wrapVertically)
+	{
 		this.game = game;
 		this.mapWidth = mapWidth;
 		this.mapHeight = mapHeight;
@@ -585,7 +719,7 @@ public partial class MapView : Node2D {
 		looseView.layers.Add(new MarshLayer());
 		looseView.layers.Add(new HillsLayer());
 		looseView.layers.Add(new TntLayer());
-		looseView.layers.Add(new RoadLayer());
+		looseView.layers.Add(new TileOverlayLayer());
 		looseView.layers.Add(new ResourceLayer());
 		this.gridLayer = new GridLayer();
 		looseView.layers.Add(this.gridLayer);
@@ -601,21 +735,25 @@ public partial class MapView : Node2D {
 		AddChild(looseView);
 	}
 
-	public override void _Process(double delta) {
+	public override void _Process(double delta)
+	{
 		// Redraw everything. This is necessary so that animations play. Maybe we could only update the unit layer but long term I think it's
 		// better to redraw everything every frame like a typical modern video game.
 		looseView.QueueRedraw();
 	}
 
 	// Returns the size in pixels of the area in which the map will be drawn. This is the viewport size or, if that's null, the window size.
-	public Vector2 getVisibleAreaSize() {
+	public Vector2 getVisibleAreaSize()
+	{
 		return GetViewport() != null ? GetViewportRect().Size : DisplayServer.WindowGetSize();
 	}
 
-	public VisibleRegion getVisibleRegion() {
+	public VisibleRegion getVisibleRegion()
+	{
 		(int x0, int y0) = tileCoordsOnScreenAt(new Vector2(0, 0));
 		Vector2 mapViewSize = new Vector2(2, 4) + getVisibleAreaSize() / scaledCellSize;
-		return new VisibleRegion {
+		return new VisibleRegion
+		{
 			upperLeftX = x0 - 2,
 			upperLeftY = y0 - 2,
 			lowerRightX = x0 + (int)mapViewSize.X,
@@ -625,10 +763,12 @@ public partial class MapView : Node2D {
 
 	// "center" is the screen location around which the zoom is centered, e.g., if center is (0, 0) the tile in the top left corner will be the
 	// same after the zoom level is changed, and if center is screenSize/2, the tile in the center of the window won't change.
-	public void setCameraZoom(float newScale, Vector2 center) {
+	public void setCameraZoom(float newScale, Vector2 center)
+	{
 		Vector2 v2NewZoom = new Vector2(newScale, newScale);
 		Vector2 v2OldZoom = new Vector2(cameraZoom, cameraZoom);
-		if (v2NewZoom != v2OldZoom) {
+		if (v2NewZoom != v2OldZoom)
+		{
 			internalCameraZoom = newScale;
 			looseView.Scale = v2NewZoom;
 			setCameraLocation((v2NewZoom / v2OldZoom) * (cameraLocation + center) - center);
@@ -636,27 +776,34 @@ public partial class MapView : Node2D {
 	}
 
 	// Zooms in or out centered on the middle of the screen
-	public void setCameraZoomFromMiddle(float newScale) {
+	public void setCameraZoomFromMiddle(float newScale)
+	{
 		setCameraZoom(newScale, getVisibleAreaSize() / 2);
 	}
 
-	public void moveCamera(Vector2 offset) {
+	public void moveCamera(Vector2 offset)
+	{
 		setCameraLocation(cameraLocation + offset);
 	}
 
-	public void setCameraLocation(Vector2 location) {
+	public void setCameraLocation(Vector2 location)
+	{
 		// Prevent the camera from moving beyond an unwrapped edge of the map. One complication here is that the viewport might actually be
 		// larger than the map (if we're zoomed far out) so in that case we must apply the constraint the other way around, i.e. constrain the
 		// map to the viewport rather than the viewport to the map.
 		Vector2 visAreaSize = getVisibleAreaSize();
 		Vector2 mapPixelSize = new Vector2(cameraZoom, cameraZoom) * (new Vector2(cellSize.X * (mapWidth + 1), cellSize.Y * (mapHeight + 1)));
-		if (!wrapHorizontally) {
+		if (!wrapHorizontally)
+		{
 			float leftLim, rightLim;
 			{
-				if (mapPixelSize.X >= visAreaSize.X) {
+				if (mapPixelSize.X >= visAreaSize.X)
+				{
 					leftLim = 0;
 					rightLim = mapPixelSize.X - visAreaSize.X;
-				} else {
+				}
+				else
+				{
 					leftLim = mapPixelSize.X - visAreaSize.X;
 					rightLim = 0;
 				}
@@ -666,16 +813,20 @@ public partial class MapView : Node2D {
 			else if (location.X > rightLim)
 				location.X = rightLim;
 		}
-		if (!wrapVertically) {
+		if (!wrapVertically)
+		{
 			// These margins allow the player to move the camera that far off those map edges so that the UI controls don't cover up the
 			// map. TODO: These values should be read from the sizes of the UI elements instead of hardcoded.
 			float topMargin = 70, bottomMargin = 140;
 			float topLim, bottomLim;
 			{
-				if (mapPixelSize.Y >= visAreaSize.Y) {
+				if (mapPixelSize.Y >= visAreaSize.Y)
+				{
 					topLim = -topMargin;
 					bottomLim = mapPixelSize.Y - visAreaSize.Y + bottomMargin;
-				} else {
+				}
+				else
+				{
 					topLim = mapPixelSize.Y - visAreaSize.Y;
 					bottomLim = 0;
 				}
@@ -690,7 +841,8 @@ public partial class MapView : Node2D {
 		looseView.Position = -location;
 	}
 
-	public Vector2 screenLocationOfTileCoords(int x, int y, bool center = true) {
+	public Vector2 screenLocationOfTileCoords(int x, int y, bool center = true)
+	{
 		// Add one to x & y to get the tile center b/c in Civ 3 the tile at (x, y) is a diamond centered on (x+1, y+1).
 		Vector2 centeringOffset = center ? new Vector2(1, 1) : new Vector2(0, 0);
 
@@ -700,25 +852,31 @@ public partial class MapView : Node2D {
 
 	// Returns the location of tile (x, y) on the screen, if "center" is true returns the location of the tile center and otherwise returns the
 	// upper left. Works even if (x, y) is off screen or out of bounds.
-	public Vector2 screenLocationOfTile(Tile tile, bool center = true) {
+	public Vector2 screenLocationOfTile(Tile tile, bool center = true)
+	{
 		return screenLocationOfTileCoords(tile.xCoordinate, tile.yCoordinate, center);
 	}
 
 	// Returns the virtual tile coordinates on screen at the given location. "Virtual" meaning the coordinates are unwrapped and there isn't
 	// necessarily a tile there at all.
-	public (int, int) tileCoordsOnScreenAt(Vector2 screenLocation) {
+	public (int, int) tileCoordsOnScreenAt(Vector2 screenLocation)
+	{
 		Vector2 mapLoc = (screenLocation + cameraLocation) / scaledCellSize;
 		Vector2 intMapLoc = mapLoc.Floor();
 		Vector2 fracMapLoc = mapLoc - intMapLoc;
 		int x = (int)intMapLoc.X, y = (int)intMapLoc.Y;
-		bool evenColumn = x%2 == 0, evenRow = y%2 == 0;
-		if (evenColumn ^ evenRow) {
+		bool evenColumn = x % 2 == 0, evenRow = y % 2 == 0;
+		if (evenColumn ^ evenRow)
+		{
 			if (fracMapLoc.Y > fracMapLoc.X)
 				x -= 1;
 			else
 				y -= 1;
-		} else {
-			if (fracMapLoc.Y < 1 - fracMapLoc.X) {
+		}
+		else
+		{
+			if (fracMapLoc.Y < 1 - fracMapLoc.X)
+			{
 				x -= 1;
 				y -= 1;
 			}
@@ -726,12 +884,14 @@ public partial class MapView : Node2D {
 		return (x, y);
 	}
 
-	public Tile tileOnScreenAt(GameMap map, Vector2 screenLocation) {
+	public Tile tileOnScreenAt(GameMap map, Vector2 screenLocation)
+	{
 		(int x, int y) = tileCoordsOnScreenAt(screenLocation);
 		return map.tileAt(x, y);
 	}
 
-	public void centerCameraOnTile(Tile t) {
+	public void centerCameraOnTile(Tile t)
+	{
 		var tileCenter = new Vector2(t.xCoordinate + 1, t.yCoordinate + 1) * scaledCellSize;
 		setCameraLocation(tileCenter - (float)0.5 * getVisibleAreaSize());
 	}

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -129,6 +129,9 @@ namespace C7GameData {
 				if (civ3Tile.Railroad) {
 					tile.overlays.Add("railroad");
 				}
+				if (civ3Tile.Mine) {
+					tile.overlays.Add("mine");
+				}
 				Resource tileResource = resourcesByIndex[civ3Tile.ResourceID];
 				if (tileResource != Resource.NONE) {
 					tile.resource = tileResource.Key;
@@ -223,6 +226,9 @@ namespace C7GameData {
 				}
 				if (civ3Tile.Railroad) {
 					tile.overlays.Add("railroad");
+				}
+				if (civ3Tile.Mine) {
+					tile.overlays.Add("mine");
 				}
 				Resource tileResource = resourcesByIndex[civ3Tile.Resource];
 				if (tileResource != Resource.NONE) {

--- a/C7GameData/Save/SaveTile.cs
+++ b/C7GameData/Save/SaveTile.cs
@@ -72,6 +72,7 @@ namespace C7GameData.Save {
 				overlays = new TileOverlays{
 					road = overlays.Contains("road"),
 					railroad = overlays.Contains("railroad"),
+					mine = overlays.Contains("mine"),
 				},
 			};
 

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -298,7 +298,8 @@ namespace C7GameData {
 
 	public class TileOverlays {
 		public bool road = false;
-		public bool railroad = false;
 		// assume that railroad contains road too
+		public bool railroad = false;
+		public bool mine = false;
 	}
 }

--- a/QueryCiv3/SavSections/Tile.cs
+++ b/QueryCiv3/SavSections/Tile.cs
@@ -38,6 +38,7 @@ namespace QueryCiv3.Sav {
 		private fixed byte Flags2[12];
 		public bool Road { get => Util.GetFlag(Flags2[0], 0); }
 		public bool Railroad { get => Util.GetFlag(Flags2[0], 1); }
+		public bool Mine { get => Util.GetFlag(Flags2[0], 2); }
 
 		public int BaseTerrain { get => Flags2[5] & 0x0f; }
 		public int OverlayTerrain { get => (Flags2[5] & 0xf0) >> 4; }


### PR DESCRIPTION
This doesn't yet add the worker action to create new mines (I wanted to have a single PR that just show how to add a tile overlay, and a second one just to show the worker action).

Rather than add a new file in `Map/` for mine overlays, I renamed `RoadLayer` to `TileOverlayLayer`, so that all the various tile overlay graphics logic can be in one place. This also makes it easy to ensure that the mines are drawn after the roads/railroads.

Screenshots (WWII scenario and one of my own civ3 saves):

![Screenshot 2025-01-08 10 26 58 PM](https://github.com/user-attachments/assets/0eb0feda-8aa2-4796-bf49-f8a7f1567a8d)

![Screenshot 2025-01-08 10 26 28 PM](https://github.com/user-attachments/assets/2e1fb134-6df7-4ba7-99bf-3e3dcfed9025)


#493 