### PR TITLE
Add the worker "mine" action and fix UI updates after moves

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -183,6 +183,16 @@ public partial class Game : Node2D {
 						}
 					}
 					break;
+				case MsgUpdateUiAfterMove mUUAM:
+					// The unit finished moving and still has moves left, so we need to
+					// mark it as the selected unit again.
+					//
+					// Among other things, this will refresh the UI and ensure that the
+					// unit action buttons are correct.
+					if (CurrentlySelectedUnit != MapUnit.NONE) {
+						setSelectedUnit(CurrentlySelectedUnit);
+					}
+					break;
 			}
 		}
 	}
@@ -526,7 +536,6 @@ public partial class Game : Node2D {
 
 			if (dir.HasValue) {
 				new MsgMoveUnit(CurrentlySelectedUnit.id, dir.Value).send();
-				setSelectedUnit(CurrentlySelectedUnit); //also triggers updating the lower-left info box
 			}
 		}
 
@@ -606,6 +615,10 @@ public partial class Game : Node2D {
 
 		if (currentAction == C7Action.UnitBuildRoad && CurrentlySelectedUnit.canBuildRoad()) {
 			new MsgBuildRoad(CurrentlySelectedUnit.id).send();
+		}
+
+		if (currentAction == C7Action.UnitBuildMine && CurrentlySelectedUnit.canBuildMine()) {
+			new MsgBuildMine(CurrentlySelectedUnit.id).send();
 		}
 
 	}

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -58936,6 +58936,7 @@
       ],
       "actions": [
         "unit_build_road",
+        "unit_build_mine",
         "unit_hold",
         "unit_wait",
         "unit_fortify",

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -61,7 +61,7 @@ public partial class UnitButtons : VBoxContainer {
 
 		AddNewButton(specializedControls, new UnitControlButton("fortress", 0, 3, onButtonPressed));
 		AddNewButton(specializedControls, new UnitControlButton("barricade", 4, 4, onButtonPressed));
-		AddNewButton(specializedControls, new UnitControlButton("mine", 1, 3, onButtonPressed));
+		AddNewButton(specializedControls, new UnitControlButton(C7Action.UnitBuildMine, 1, 3, onButtonPressed));
 		AddNewButton(specializedControls, new UnitControlButton("irrigate", 2, 3, onButtonPressed));
 		AddNewButton(specializedControls, new UnitControlButton("chopForest", 3, 3, onButtonPressed));
 		AddNewButton(specializedControls, new UnitControlButton("chopJungle", 4, 3, onButtonPressed));

--- a/C7/project.godot
+++ b/C7/project.godot
@@ -183,6 +183,11 @@ unit_build_road={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":114,"echo":false,"script":null)
 ]
 }
+unit_build_mine={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":77,"key_label":0,"unicode":109,"echo":false,"script":null)
+]
+}
 
 [mono]
 

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -19,7 +19,11 @@ namespace C7Engine {
 			gameData.cities.Add(newCity);
 			owner.cities.Add(newCity);
 			tileWithNewCity.cityAtTile = newCity;
+
+			// Cities are treated as though they have a road, but if
+			// a city is build on a mine, the mine should be removed.
 			tileWithNewCity.overlays.road = true;
+			tileWithNewCity.overlays.mine = false;
 		}
 
 		public static void DestroyCity(int x, int y) {

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -56,6 +56,12 @@ namespace C7Engine {
 		public override void process() {
 			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
 			unit?.move(dir);
+
+			// The unit moved to a new tile - if it still has movement points,
+			// update the UI to reflect this new position and movement points.
+			if (unit?.movementPoints.canMove == true) {
+				new MsgUpdateUiAfterMove().send();
+			}
 		}
 	}
 
@@ -73,6 +79,12 @@ namespace C7Engine {
 		public override void process() {
 			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
 			unit?.setUnitPath(EngineStorage.gameData.map.tileAt(destX, destY));
+
+			// The unit moved to a new tile - if it still has movement points,
+			// update the UI to reflect this new position and movement points.
+			if (unit?.movementPoints.canMove == true) {
+				new MsgUpdateUiAfterMove().send();
+			}
 		}
 	}
 
@@ -127,6 +139,19 @@ namespace C7Engine {
 		public override void process() {
 			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
 			unit?.buildRoad();
+		}
+	}
+
+	public class MsgBuildMine : MessageToEngine {
+		private ID unitID;
+
+		public MsgBuildMine(ID unitID) {
+			this.unitID = unitID;
+		}
+
+		public override void process() {
+			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
+			unit?.buildMine();
 		}
 	}
 

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -38,6 +38,7 @@ namespace C7Engine {
 
 	public class MsgStartTurn : MessageToUI { }
 
+	public class MsgUpdateUiAfterMove : MessageToUI { }
 
 	public class MsgCityDestroyed : MessageToUI {
 		public City city;

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -54,6 +54,10 @@ namespace C7Engine {
 				result.Add(C7Action.UnitBuildRoad);
 			}
 
+			if (unit.canBuildMine()) {
+				result.Add(C7Action.UnitBuildMine);
+			}
+
 			// Eventually we will have advanced actions too, whose availability will rely on their base actions' availability.
 			// unit.availableActions.Add("rename");
 

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -452,5 +452,27 @@ namespace C7Engine {
 			unit.movementPoints.onConsumeAll();
 		}
 
+		public static bool canBuildMine(this MapUnit unit) {
+			// Mines can only be built on land, if there is no mine already there,
+			// and if there isn't a city.
+			//
+			// Volcanos also cannot be mined.
+			return unit.unitType.actions.Contains(C7Action.UnitBuildMine) &&
+				unit.location.IsLand() &&
+				!unit.location.IsVolcano() &&
+				!unit.location.overlays.mine &&
+				unit.location.cityAtTile == null;
+		}
+
+		public static void buildMine(this MapUnit unit) {
+			if (!unit.canBuildMine()) {
+				log.Warning($"can't build mine by {unit}");
+				return;
+			}
+
+			// TODO add animation and long process of building
+			unit.location.overlays.mine = true;
+			unit.movementPoints.onConsumeAll();
+		}
 	}
 }

--- a/C7GameData/Actions.cs
+++ b/C7GameData/Actions.cs
@@ -1,4 +1,5 @@
 namespace C7GameData {
+	// The strings for each action correspond to values in project.godot for keyboard shortcuts
 	public static class C7Action {
 		public const string EndTurn = "end_turn";
 		public const string Escape = "escape";
@@ -16,6 +17,7 @@ namespace C7GameData {
 		public const string UnitBombard = "unit_bombard";
 		public const string UnitBuildCity = "unit_build_city";
 		public const string UnitBuildRoad = "unit_build_road";
+		public const string UnitBuildMine = "unit_build_mine";
 		public const string UnitDisband = "unit_disband";
 		public const string UnitExplore = "unit_explore";
 		public const string UnitFortify = "unit_fortify";

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -464,6 +464,9 @@ namespace C7GameData {
 				if (prto.BuildRoad) {
 					prototype.actions.Add(C7Action.UnitBuildRoad);
 				}
+				if (prto.BuildMine) {
+					prototype.actions.Add(C7Action.UnitBuildMine);
+				}
 				if (prto.Bombard) {
 					prototype.actions.Add(C7Action.UnitBombard);
 				}

--- a/C7GameData/TerrainType.cs
+++ b/C7GameData/TerrainType.cs
@@ -27,6 +27,10 @@ namespace C7GameData {
 			return false;
 		}
 
+		public bool isVolcano() {
+			return Key.Equals("volcano");
+		}
+
 		//TODO: Once we have IDs, this should *not* rely on the display name.
 		//That will be after issue 58, which will be after PR 70.
 		public bool isWater() {

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -136,6 +136,10 @@ namespace C7GameData {
 			return overlayTerrainType.allowCities;
 		}
 
+		public bool IsVolcano() {
+			return overlayTerrainType.isVolcano();
+		}
+
 		public TileDirection directionTo(Tile other) {
 			// TODO: Consider edge wrapping, the direction should point along the shortest path as the crow flies.
 


### PR DESCRIPTION
This PR has two parts, and I honestly would normally split them into two
(or even 3) PRs but git doesn't make this very easy (I miss my `hg csplit`)
and the GitHub UI doesn't seem to have good support for diffbases
(the diff from PR 498 shows up in this diff, despite this change being
on a separate branch; I know that it is part of the diff from Development,
but it would be nice to be able to easily review only the changes introduced
in this PR). Anyways, enough complaining.

The first part of this PR is straightforward: just mirroring all the existing logic
for building roads, but with method names for mines instead. Things like
the logic for whether we can build a mine, the keyboard shortcut, the
message to the engine, etc. This required adding logic for whether a
tile has a volcano, since that's a special tile for mines.

The second part was a bit trickier: ensuring that the UI was correctly
updated after moving a unit, when that unit still had movement points
available. This was partially implemented for keyboard-based moves in
`Game.cs`, but I suspect this was fundamentally racy - it raced the
message to the engine being received and updating the unit's position
against setting the selected unit. I tried duplicating this for the goto
logic and found it racy, so I suspect the same was true for the keyboard
moves, but I didn't exhaustively test this.

The solution here is to add a new message back to the UI from the
engine. Once the engine has finished doing all of its work on updating
the position of the unit we can safely reset the selected unit without
fear of races. This ensures that if a unit walks from a roaded tile
with a mine on it to a roaded tile that doesn't have a mine, the mine button
appears (for workers). It also fixes updating the move counter in the
lower right hand info panel.

---

Screenshots!

Before a mine is built:

![Screenshot 2025-01-12 2 50 03 PM](https://github.com/user-attachments/assets/dd60532e-27d5-4fce-8035-0fde0d457482)

After a mine is built:

![Screenshot 2025-01-12 2 50 08 PM](https://github.com/user-attachments/assets/048b4f46-5531-4cf7-a353-0ea208b13c6b)

#493 