### PR TITLE
Increase a tile's production by one when mined

### DIFF
--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -58111,6 +58111,7 @@
       "baseCommerceProduction": 0,
       "movementCost": 1,
       "allowCities": true,
+      "miningBonus": 1,
       "defenseBonus": {
         "description": "Desert",
         "amount": 0.1
@@ -58124,6 +58125,7 @@
       "baseCommerceProduction": 0,
       "movementCost": 1,
       "allowCities": true,
+      "miningBonus": 1,
       "defenseBonus": {
         "description": "Plains",
         "amount": 0.1
@@ -58137,6 +58139,7 @@
       "baseCommerceProduction": 0,
       "movementCost": 1,
       "allowCities": true,
+      "miningBonus": 1,
       "defenseBonus": {
         "description": "Grassland",
         "amount": 0.1
@@ -58150,6 +58153,7 @@
       "baseCommerceProduction": 0,
       "movementCost": 1,
       "allowCities": true,
+      "miningBonus": 1,
       "defenseBonus": {
         "description": "Tundra",
         "amount": 0.1
@@ -58163,6 +58167,7 @@
       "baseCommerceProduction": 0,
       "movementCost": 1,
       "allowCities": true,
+      "miningBonus": 1,
       "defenseBonus": {
         "description": "Flood Plain",
         "amount": 0.1
@@ -58176,6 +58181,7 @@
       "baseCommerceProduction": 0,
       "movementCost": 2,
       "allowCities": true,
+      "miningBonus": 1,
       "defenseBonus": {
         "description": "Hills",
         "amount": 0.5
@@ -58189,6 +58195,7 @@
       "baseCommerceProduction": 0,
       "movementCost": 3,
       "allowCities": false,
+      "miningBonus": 1,
       "defenseBonus": {
         "description": "Mountains",
         "amount": 1
@@ -58202,6 +58209,7 @@
       "baseCommerceProduction": 0,
       "movementCost": 2,
       "allowCities": true,
+      "miningBonus": 0,
       "defenseBonus": {
         "description": "Forest",
         "amount": 0.25
@@ -58215,6 +58223,7 @@
       "baseCommerceProduction": 0,
       "movementCost": 3,
       "allowCities": true,
+      "miningBonus": 0,
       "defenseBonus": {
         "description": "Jungle",
         "amount": 0.25
@@ -58228,6 +58237,7 @@
       "baseCommerceProduction": 0,
       "movementCost": 2,
       "allowCities": false,
+      "miningBonus": 0,
       "defenseBonus": {
         "description": "Marsh",
         "amount": 0.2
@@ -58241,6 +58251,7 @@
       "baseCommerceProduction": 0,
       "movementCost": 3,
       "allowCities": false,
+      "miningBonus": 0,
       "defenseBonus": {
         "description": "Volcano",
         "amount": 0.8
@@ -58254,6 +58265,7 @@
       "baseCommerceProduction": 2,
       "movementCost": 1,
       "allowCities": false,
+      "miningBonus": 0,
       "defenseBonus": {
         "description": "Coast",
         "amount": 0.1
@@ -58267,6 +58279,7 @@
       "baseCommerceProduction": 1,
       "movementCost": 1,
       "allowCities": false,
+      "miningBonus": 0,
       "defenseBonus": {
         "description": "Sea",
         "amount": 0.1
@@ -58280,6 +58293,7 @@
       "baseCommerceProduction": 0,
       "movementCost": 1,
       "allowCities": false,
+      "miningBonus": 0,
       "defenseBonus": {
         "description": "Ocean",
         "amount": 0.1

--- a/C7GameData/TerrainType.cs
+++ b/C7GameData/TerrainType.cs
@@ -16,6 +16,7 @@ namespace C7GameData {
 		public int baseCommerceProduction { get; set; }
 		public int movementCost { get; set; }
 		public bool allowCities { get; set; } = true;
+		public int miningBonus { get; set; }
 		public StrengthBonus defenseBonus;
 
 		//some stuff about graphics would probably make sense, too
@@ -57,6 +58,7 @@ namespace C7GameData {
 				description = civ3Terrain.Name,
 				amount = civ3Terrain.DefenseBonus / 100.0
 			};
+			c7Terrain.miningBonus = civ3Terrain.MiningBonus;
 			return c7Terrain;
 		}
 

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -186,6 +186,9 @@ namespace C7GameData {
 			if (Resource != Resource.NONE && player.KnowsAboutResource(Resource)) {
 				yield += this.Resource.ShieldsBonus;
 			}
+			if (this.overlays.mine) {
+				yield += this.overlayTerrainType.miningBonus;
+			}
 			return yield;
 		}
 


### PR DESCRIPTION
When combined with https://github.com/C7-Game/Prototype/pull/499, this allows players to start modifying their territory to improve their land and improve production.

If the scenario rules have specified a different mining bonus, we use that as well.

#493 