### PR TITLE
Fix the unit tests

### DIFF
--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -58661,7 +58661,7 @@
       "facingDirection": "north",
       "experience": "Regular"
     },
-	{
+    {
       "id": "Settler-2",
       "prototype": "Settler",
       "owner": "player-3",
@@ -61858,7 +61858,7 @@
   "civilizations": [
     {
       "name": "A Barbarian Chiefdom",
-	  "noun": "Barbarians",
+      "noun": "Barbarians",
       "colorIndex": 0,
       "leaderGender": "male",
       "cityNames": [
@@ -61942,7 +61942,7 @@
     },
     {
       "name": "Rome",
-	  "noun": "Romans",
+      "noun": "Romans",
       "leader": "Caesar",
       "colorIndex": 1,
       "leaderGender": "male",
@@ -61995,7 +61995,7 @@
     },
     {
       "name": "Egypt",
-	  "noun": "Egyptians",
+      "noun": "Egyptians",
       "leader": "Cleopatra",
       "colorIndex": 3,
       "leaderGender": "female",
@@ -62033,7 +62033,7 @@
     },
     {
       "name": "Greece",
-	  "noun": "Greeks",
+      "noun": "Greeks",
       "leader": "Alexander",
       "colorIndex": 10,
       "leaderGender": "male",
@@ -62071,7 +62071,7 @@
     },
     {
       "name": "Babylon",
-	  "noun": "Babylonians",
+      "noun": "Babylonians",
       "leader": "Hammurabi",
       "colorIndex": 1,
       "leaderGender": "male",
@@ -62107,7 +62107,7 @@
     },
     {
       "name": "Germany",
-	  "noun": "Germans",
+      "noun": "Germans",
       "leader": "Bismarck",
       "colorIndex": 6,
       "leaderGender": "male",
@@ -62132,7 +62132,7 @@
     },
     {
       "name": "Russia",
-	  "noun": "Russians",
+      "noun": "Russians",
       "leader": "Catherine",
       "colorIndex": 9,
       "leaderGender": "female",
@@ -62180,7 +62180,7 @@
     },
     {
       "name": "China",
-	  "noun": "Chinese",
+      "noun": "Chinese",
       "leader": "Mao",
       "colorIndex": 5,
       "leaderGender": "male",
@@ -62207,7 +62207,7 @@
     },
     {
       "name": "America",
-	  "noun": "Americans",
+      "noun": "Americans",
       "leader": "Lincoln",
       "colorIndex": 5,
       "leaderGender": "male",
@@ -62256,7 +62256,7 @@
     },
     {
       "name": "Japan",
-	  "noun": "Japanese",
+      "noun": "Japanese",
       "leader": "Tokugawa",
       "colorIndex": 4,
       "leaderGender": "male",
@@ -62291,7 +62291,7 @@
     },
     {
       "name": "France",
-	  "noun": "French",
+      "noun": "French",
       "leader": "Joan d\u0027Arc",
       "colorIndex": 7,
       "leaderGender": "female",
@@ -62321,7 +62321,7 @@
     },
     {
       "name": "India",
-	  "noun": "Indians",
+      "noun": "Indians",
       "leader": "Gandhi",
       "colorIndex": 8,
       "leaderGender": "male",
@@ -62347,7 +62347,7 @@
     },
     {
       "name": "Persia",
-	  "noun": "Persians",
+      "noun": "Persians",
       "leader": "Xerxes",
       "colorIndex": 10,
       "leaderGender": "male",
@@ -62385,7 +62385,7 @@
     },
     {
       "name": "Aztecs",
-	  "noun": "Aztecs",
+      "noun": "Aztecs",
       "leader": "Montezuma",
       "colorIndex": 4,
       "leaderGender": "male",
@@ -62430,7 +62430,7 @@
     },
     {
       "name": "Zululand",
-	  "noun": "Zulu",
+      "noun": "Zulu",
       "leader": "Shaka",
       "colorIndex": 3,
       "leaderGender": "male",
@@ -62455,7 +62455,7 @@
     },
     {
       "name": "Iroquois",
-	  "noun": "Iroquois",
+      "noun": "Iroquois",
       "leader": "Hiawatha",
       "colorIndex": 8,
       "leaderGender": "male",
@@ -62493,7 +62493,7 @@
     },
     {
       "name": "England",
-	  "noun": "English",
+      "noun": "English",
       "leader": "Elizabeth",
       "colorIndex": 2,
       "leaderGender": "female",
@@ -62531,7 +62531,7 @@
     },
     {
       "name": "Mongols",
-	  "noun": "Mongols",
+      "noun": "Mongols",
       "leader": "Temujin",
       "colorIndex": 3,
       "leaderGender": "male",
@@ -62570,7 +62570,7 @@
     },
     {
       "name": "Spain",
-	  "noun": "Spanish",
+      "noun": "Spanish",
       "leader": "Isabella",
       "colorIndex": 5,
       "leaderGender": "female",
@@ -62610,7 +62610,7 @@
     },
     {
       "name": "Scandinavia",
-	  "noun": "Vikings",
+      "noun": "Vikings",
       "leader": "Ragnar Lodbrok",
       "colorIndex": 8,
       "leaderGender": "male",
@@ -62652,7 +62652,7 @@
     },
     {
       "name": "Ottomans",
-	  "noun": "Ottomans",
+      "noun": "Ottomans",
       "leader": "Osman",
       "colorIndex": 2,
       "leaderGender": "male",
@@ -62690,7 +62690,7 @@
     },
     {
       "name": "Celts",
-	  "noun": "Celts",
+      "noun": "Celts",
       "leader": "Brennus",
       "colorIndex": 4,
       "leaderGender": "male",
@@ -62729,7 +62729,7 @@
     },
     {
       "name": "Arabia",
-	  "noun": "Arabs",
+      "noun": "Arabs",
       "leader": "Abu Bakr",
       "colorIndex": 7,
       "leaderGender": "male",
@@ -62766,7 +62766,7 @@
     },
     {
       "name": "Carthage",
-	  "noun": "Carthaginians",
+      "noun": "Carthaginians",
       "leader": "Hannibal",
       "colorIndex": 9,
       "leaderGender": "male",
@@ -62805,7 +62805,7 @@
     },
     {
       "name": "Korea",
-	  "noun": "Koreans",
+      "noun": "Koreans",
       "leader": "Wang Kon",
       "colorIndex": 6,
       "leaderGender": "male",
@@ -62844,7 +62844,7 @@
     },
     {
       "name": "Sumeria",
-	  "noun": "Sumerians",
+      "noun": "Sumerians",
       "leader": "Gilgamesh",
       "colorIndex": 5,
       "leaderGender": "male",
@@ -62878,7 +62878,7 @@
     },
     {
       "name": "Hittites",
-	  "noun": "Hittites",
+      "noun": "Hittites",
       "leader": "Mursilis",
       "colorIndex": 14,
       "leaderGender": "male",
@@ -62912,7 +62912,7 @@
     },
     {
       "name": "Netherlands",
-	  "noun": "Dutch",
+      "noun": "Dutch",
       "leader": "William",
       "colorIndex": 2,
       "leaderGender": "male",
@@ -62946,7 +62946,7 @@
     },
     {
       "name": "Portugal",
-	  "noun": "Portugese",
+      "noun": "Portugese",
       "leader": "Henry",
       "colorIndex": 8,
       "leaderGender": "male",
@@ -62991,7 +62991,7 @@
     },
     {
       "name": "Byzantines",
-	  "noun": "Byzantines",
+      "noun": "Byzantines",
       "leader": "Theodora",
       "colorIndex": 11,
       "leaderGender": "female",
@@ -63025,7 +63025,7 @@
     },
     {
       "name": "Inca",
-	  "noun": "Inca",
+      "noun": "Inca",
       "leader": "Pachacuti",
       "colorIndex": 7,
       "leaderGender": "male",
@@ -63059,7 +63059,7 @@
     },
     {
       "name": "Maya",
-	  "noun": "Maya",
+      "noun": "Maya",
       "leader": "Smoke-Jaguar",
       "colorIndex": 6,
       "leaderGender": "male",


### PR DESCRIPTION
There were some minor formatting changes with the canned save causing failures.

I'll work on getting these tests to run on PRs to avoid this in the future.

```
[xUnit.net 00:00:07.19]     SaveTests.SimpleSave [FAIL]
  Failed SaveTests.SimpleSave [3 s]
  Error Message:
   Assert.Equal() Failure
Expected: Byte[] [123, 10, 32, 32, 34, ...]
Actual:   Byte[] [123, 10, 32, 32, 34, ...]
  Stack Trace:
     at SaveTests.SimpleSave() in /home/tomwer3/C7_real/Prototype/C7GameDataTests/SaveTest.cs:line 71
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)

Failed!  - Failed:     1, Passed:     5, Skipped:     0, Total:     6, Duration: 7 s - C7GameDataTests.dll (net8.0)
```