### PR TITLE
Run unit tests automatically on new PRs and commits to Development

### DIFF
--- a/.github/workflows/export-c7.yml
+++ b/.github/workflows/export-c7.yml
@@ -48,6 +48,9 @@ jobs:
         cd ${EXPORT_NAME}
         dotnet build
         godot -v --headless --export${BUILD_SUFFIX} "Windows Desktop" ../build/${FOLDER_NAME}/${EXPORT_NAME}.exe
+    - name: Run tests
+      run: |
+        dotnet test C7
     - name: Copy Static Files
       run: |
         if cp -r ${EXPORT_NAME}/Text build/${FOLDER_NAME}/Text && cp -r ${EXPORT_NAME}/Art build/${FOLDER_NAME}/Art
@@ -78,6 +81,9 @@ jobs:
         cd ${EXPORT_NAME}
         dotnet build
         godot -v --headless --export${BUILD_SUFFIX} "Linux/X11" ../build/${FOLDER_NAME}/${EXPORT_NAME}.x86_64
+    - name: Run tests
+      run: |
+        dotnet test C7
     - name: Copy Static Files
       run: |
         if cp -r ${EXPORT_NAME}/Text build/${FOLDER_NAME}/Text && cp -r ${EXPORT_NAME}/Art build/${FOLDER_NAME}/Art
@@ -111,6 +117,9 @@ jobs:
         cd ${EXPORT_NAME}
         dotnet build
         godot -v --headless --export${BUILD_SUFFIX} "macOS" ../build/${FOLDER_NAME}.zip
+    - name: Run tests
+      run: |
+        dotnet test C7
     - name: Copy Static Files
       run: |
         cd ${EXPORT_NAME}

--- a/C7GameDataTests/SaveTest.cs
+++ b/C7GameDataTests/SaveTest.cs
@@ -106,6 +106,14 @@ public class SaveTests {
 
 	[Fact]
 	public void LoadAllConquests() {
+		// When running the tests via github actions, civ3 isn't installed so we can't
+		// check the conquests directories.
+		//
+		// See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
+		// for a full list of env vars.
+		string is_on_github = System.Environment.GetEnvironmentVariable("CI");
+		if (is_on_github != null) { return; }
+
 		string conquests = Path.Join(Civ3Location.GetCiv3Path(), "Conquests/Conquests");
 		DirectoryInfo directoryInfo = new DirectoryInfo(conquests);
 		IEnumerable<FileInfo> saveFiles = directoryInfo.EnumerateFiles().Where(fi => {


### PR DESCRIPTION
This required one slight change to a unit test that was assuming Civ 3 was installed on the machine running the test; the rest of the tests work fine.

Here's the latest run: https://github.com/C7-Game/Prototype/actions/runs/12739968114