### PR TITLE
Get all scenarios except 7 (Sengoku) loading properly

### DIFF
--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -270,6 +270,14 @@ namespace C7GameData {
 					player.tileKnowledge.Add(new TileLocation(neighbor.Item1, neighbor.Item2));
 				}
 			}
+			foreach (SaveCity city in save.Cities) {
+				SavePlayer player = playerLookup[city.owner];
+				player.tileKnowledge.Add(city.location);
+				foreach (TileDirection direction in Enum.GetValues(typeof(TileDirection))) {
+					Tuple<int, int> neighbor = Tile.NeighborCoordinate(city.location.x, city.location.y, direction);
+					player.tileKnowledge.Add(new TileLocation(neighbor.Item1, neighbor.Item2));
+				}
+			}
 
 			return save;
 		}
@@ -338,13 +346,21 @@ namespace C7GameData {
 		private void ImportBicLeaders() {
 			BiqData theBiq = biq.Race is null ? defaultBiq : biq;
 
-			int i = 0;
-			foreach (int playerIndex in theBiq.GameCiv[0]) {
-				Civilization civ = save.Civilizations[playerIndex];
-				// TODO: the city name index is wrong, we need to count the number of
-				// cities this civilization has.
-				save.Players.Add(MakeSavePlayerFromCiv(civ, /*isBarbarian=*/i == 0, /*isHuman=*/i == 1, /*cityNameIndex=*/0));
-				i++;
+			// Make a player for each civ. The barbarians are always civ 0.
+			for (int i = 0; i < save.Civilizations.Count; ++i) {
+				save.Players.Add(MakeSavePlayerFromCiv(save.Civilizations[i],
+										/*isBarbarian=*/i == 0,
+										/*isHuman=*/false,
+										/*cityNameIndex=*/0));
+			}
+
+			// Now use the leaders to find the first human player.
+			foreach (LEAD lead in theBiq.Lead) {
+				SavePlayer player = save.Players[lead.Civ];
+				if (lead.HumanPlayer == 1) {
+					player.human = true;
+					break;
+				}
 			}
 		}
 
@@ -398,13 +414,18 @@ namespace C7GameData {
 		}
 
 		private void ImportBicUnits() {
+			// TODO: This doesn't account for default starting units.
 			BiqData theBiq = biq.Unit is null ? defaultBiq : biq;
 
 			foreach (UNIT unit in theBiq.Unit) {
-				if (unit.Owner < 0 || unit.Owner >= save.Players.Count) {
+				if (unit.Owner >= save.Players.Count) {
 					continue;
 				}
+
+				// The owner index is into the list of civs, and we have a 1:1
+				// mapping of players and civs.
 				SavePlayer player = save.Players[unit.Owner];
+
 				PRTO prototype = theBiq.Prto[unit.UnitType];
 				ExperienceLevel experience = save.ExperienceLevels[unit.ExperienceLevel];
 				SaveUnit saveUnit = new SaveUnit{
@@ -442,13 +463,13 @@ namespace C7GameData {
 		}
 
 		private void ImportBicCities() {
-			BiqData theBiq = biq.Unit is null ? defaultBiq : biq;
+			BiqData theBiq = biq.City is null ? defaultBiq : biq;
 
 			foreach (CITY city in theBiq.City) {
-				if (city.Owner < 0 || city.Owner >= save.Players.Count) {
-					continue;
-				}
+				// The owner index is into the list of civs, and we have a 1:1
+				// mapping of players and civs.
 				SavePlayer player = save.Players[city.Owner];
+
 				SaveCity saveCity = new SaveCity{
 					id = ids.CreateID("city"),
 					owner = player.id,

--- a/C7GameData/Save/SaveGame.cs
+++ b/C7GameData/Save/SaveGame.cs
@@ -111,6 +111,12 @@ namespace C7GameData.Save {
 
 			// cities require game map for location and players for city owner
 			data.cities = Cities.ConvertAll(city => city.ToCity(data.map, data.players, UnitPrototypes, Civilizations));
+
+			// Once cities are known, players can reference cities.
+			data.players.ForEach(player => {
+				player.cities = data.cities.Where(city => city.owner.id == player.id).ToList(); ;
+			});
+
 			foreach (City city in data.cities) {
 				data.map.tileAt(city.location.xCoordinate, city.location.yCoordinate).cityAtTile = city;
 			}

--- a/C7GameDataTests/SaveTest.cs
+++ b/C7GameDataTests/SaveTest.cs
@@ -10,8 +10,10 @@ using Xunit;
 using C7GameData;
 using C7GameData.Save;
 using QueryCiv3;
+using System.Runtime.InteropServices;
 
 public class SaveTests {
+
 	private static readonly string C7GameDataTestsFolderName = "C7GameDataTests";
 
 	private static string getBasePath(string file) => Path.Combine(testDirectory, file);
@@ -111,7 +113,7 @@ public class SaveTests {
 	}
 
 	[Fact]
-	public void LoadAllConquests() {
+	public void LoadAllConquestScenarios() {
 		// When running the tests via github actions, civ3 isn't installed so we can't
 		// check the conquests directories.
 		//
@@ -120,7 +122,12 @@ public class SaveTests {
 		string is_on_github = System.Environment.GetEnvironmentVariable("CI");
 		if (is_on_github != null) { return; }
 
-		string conquests = Path.Join(Civ3Location.GetCiv3Path(), "Conquests/Conquests");
+		CheckScenariosInCiv3Subfolder("Conquests/Conquests");
+		CheckScenariosInCiv3Subfolder("Conquests/Scenarios");
+	}
+
+	public void CheckScenariosInCiv3Subfolder(string subfolder) {
+		string conquests = Path.Join(Civ3Location.GetCiv3Path(), subfolder);
 		DirectoryInfo directoryInfo = new DirectoryInfo(conquests);
 		IEnumerable<FileInfo> saveFiles = directoryInfo.EnumerateFiles().Where(fi => {
 			// currently only test 1 Mesopotamia.biq -> 9 WWII in the Pacific.biq:
@@ -136,18 +143,86 @@ public class SaveTests {
 			SaveGame game = null;
 			GameData gd = null;
 			Exception ex = Record.Exception(() => {
-				game = ImportCiv3.ImportBiq(saveFileInfo.FullName, defaultBicPath, (relativeModePath) => {
-					string scenarioDir = relativeModePath.Substring(relativeModePath.LastIndexOf("\\")+1);
-					return Path.Combine(Civ3Location.GetCiv3Path(), "Conquests", "Conquests", scenarioDir, "Text", "PediaIcons.txt");
+				game = ImportCiv3.ImportBiq(saveFileInfo.FullName, defaultBicPath, (relativeModPath) => {
+					if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+						relativeModPath = relativeModPath.Replace("\\conquests\\", "/Conquests/");
+					}
+
+					return Path.GetFullPath(Path.Combine(Civ3Location.GetCiv3Path(), subfolder, relativeModPath, "Text", "PediaIcons.txt"));
 				});
 			});
-			Assert.Null(ex);
+			Assert.True(ex == null, name + ": " + ex?.ToString());
 			ex = Record.Exception(() => {
 				gd = game.ToGameData();
 			});
-			Assert.Null(ex);
+			Assert.True(ex == null, name + ":" + ex?.ToString());
 			Assert.NotNull(game);
 			Assert.NotNull(gd);
+
+			// Check that the human player has at least one settler or city in
+			// each scenario, when looking at the SaveGame.
+			foreach (SavePlayer player in game.Players) {
+				int settlerCount = 0;
+				int totalUnitCount = 0;
+				foreach (SaveUnit su in game.Units) {
+					if (su.owner == player.id) {
+						++totalUnitCount;
+						if (su.prototype == "Settler") {
+							++settlerCount;
+						}
+					}
+				}
+
+				int cityCount = 0;
+				foreach (SaveCity sc in game.Cities) {
+					if (sc.owner == player.id) {
+						++cityCount;
+					}
+				}
+
+				// This debugging output is visible when run via
+				// `dotnet test -v n`
+				Console.WriteLine(name + " : " + player.civilization + " has " +
+									settlerCount + " settlers, " +
+									cityCount + " cities, " +
+									totalUnitCount + " units, and is " +
+									(player.human ? "" : "not ") +
+									"the human player");
+
+				// The human player should always have either a city or a settler.
+				if (player.human) {
+					Assert.True(cityCount + settlerCount > 0,
+								name + " : " + player.civilization);
+				}
+			}
+
+			// And check again, looking at the GameData.
+			foreach (Player player in gd.players) {
+				int settlerCount = 0;
+				int totalUnitCount = 0;
+				foreach (MapUnit mu in player.units) {
+					++totalUnitCount;
+					if (mu.unitType.name == "Settler") {
+						++settlerCount;
+					}
+				}
+
+				int cityCount = player.cities.Count;
+
+				Console.WriteLine(name + " : " + player.civilization.name + " has " +
+									settlerCount + " settlers, " +
+									cityCount + " cities, " +
+									totalUnitCount + " units, and is " +
+									(player.isHuman ? "" : "not ") +
+									"the human player");
+
+				// The human player should always have either a city or a settler.
+				if (player.isHuman) {
+					Assert.True(cityCount + settlerCount > 0,
+								name + " : " + player.civilization.name);
+				}
+			}
+
 			game.Save(Path.Combine(testDirectory, "data", "output", $"conquest_{name[0]}.json"));
 		}
 	}


### PR DESCRIPTION
This fixes how we were loading Bic leaders, to ensure that we always have the right lookups when loading cities and units. It also changes how we pick the human player in the scenario.

To test this, I updated the save test to test both flavors of the scenarios (since they are different for some reason), and also improved the testing to confirm that the human player always has either 1+ city or 1+ settler. This helped shake out a bunch of bugs.