### PR TITLE
Draw civilization borders

### DIFF
--- a/C7/Map/BorderLayer.cs
+++ b/C7/Map/BorderLayer.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using C7GameData;
+using Godot;
+using ConvertCiv3Media;
+
+namespace C7.Map {
+	public class BorderLayer : LooseLayer {
+		private readonly string texturePath = "Art/Terrain/Territory.pcx";
+		private readonly ImageTexture[] borderGraphics = new ImageTexture[8];
+		private readonly Dictionary<(int, Color), ImageTexture> textureCache = new();
+
+		public BorderLayer() {
+			Pcx texturePcx = Util.LoadPCX(texturePath);
+
+			int textureWidth = 128;
+			int textureHeight = 72;
+
+			for (int j = 0; j < 4; j++) {
+				for (int k = 0; k < 2; k++) {
+					borderGraphics[j * 2 + k] = PCXToGodot.getImageTextureFromPCX(texturePcx, k * textureWidth, j * textureHeight, textureWidth, textureHeight, true);
+				}
+			}
+		}
+
+		// TODO: This method doesn't precisely mirror Civ3 coloring
+		private static Color CalcSecondaryColor(Color mainColor) {
+			return new Color(mainColor.R * 0.8f, mainColor.G * 0.8f, mainColor.B * 0.8f);
+		}
+
+		private ImageTexture GetBorderTexture(int textureIndex, Color borderColor) {
+			if (textureCache.TryGetValue((textureIndex, borderColor), out ImageTexture res)) {
+				return res;
+			}
+
+			ImageTexture texture = borderGraphics[textureIndex];
+
+			Color secondaryColor = CalcSecondaryColor(borderColor);
+
+			Dictionary<Color, Color> colorReplacements = new Dictionary<Color, Color>
+			{
+				{ Color.Color8(236, 255, 0), borderColor },
+				{ Color.Color8(255, 0, 0), secondaryColor}
+			};
+
+			Image image = Util.TransformColors(texture.GetImage(), colorReplacements);
+
+			var newTexture = ImageTexture.CreateFromImage(image);
+			textureCache[(textureIndex, borderColor)] = newTexture;
+
+			return newTexture;
+		}
+
+		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
+			if (tile.owner is null) {
+				return;
+			}
+
+			var directionToTextureIdx = new Dictionary<TileDirection, int>
+				{
+					{ TileDirection.NORTHWEST, 0 },
+					{ TileDirection.NORTHEAST, 2 },
+					{ TileDirection.SOUTHWEST, 4 },
+					{ TileDirection.SOUTHEAST, 6 }
+				};
+
+			Color borderColor = Util.LoadColor(tile.owner.colorIndex);
+
+			foreach (var entry in directionToTextureIdx) {
+				if (tile.neighbors[entry.Key].owner != tile.owner) {
+					ImageTexture texture = GetBorderTexture(entry.Value, borderColor);
+					Vector2 offset = texture.GetSize() * 0.5f;
+
+					looseView.DrawTexture(texture, tileCenter - offset);
+				}
+			}
+		}
+	}
+}

--- a/C7/Map/BorderLayer.cs
+++ b/C7/Map/BorderLayer.cs
@@ -4,6 +4,7 @@ using Godot;
 using ConvertCiv3Media;
 
 namespace C7.Map {
+	// The layer responsible for drawing civilization borders.
 	public class BorderLayer : LooseLayer {
 		private readonly string texturePath = "Art/Terrain/Territory.pcx";
 		private readonly ImageTexture[] borderGraphics = new ImageTexture[8];
@@ -15,6 +16,12 @@ namespace C7.Map {
 			int textureWidth = 128;
 			int textureHeight = 72;
 
+			// This loops slices the PCX image into separate border textures. 
+			// The PCX image contains 4 rows and 2 columns:
+			// - Each row corresponds to a border direction.
+			// - The first column contains border textures for regular terrain.
+			// - The second column contains border textures for hills and mountains 
+			//   (rendering logic for textures of the second column is not yet implemented).
 			for (int j = 0; j < 4; j++) {
 				for (int k = 0; k < 2; k++) {
 					borderGraphics[j * 2 + k] = PCXToGodot.getImageTextureFromPCX(texturePcx, k * textureWidth, j * textureHeight, textureWidth, textureHeight, true);
@@ -27,6 +34,11 @@ namespace C7.Map {
 			return new Color(mainColor.R * 0.8f, mainColor.G * 0.8f, mainColor.B * 0.8f);
 		}
 
+		/// This method retrieves a border texture of a specific index and color.
+		/// It works by replacing two base colors in a border texture template with new colors:
+		/// - The color of civilization, passed as an argument to this method.
+		/// - The secondary color, which is derived from the civilization color.
+		/// The resulting texture is cached.
 		private ImageTexture GetBorderTexture(int textureIndex, Color borderColor) {
 			if (textureCache.TryGetValue((textureIndex, borderColor), out ImageTexture res)) {
 				return res;

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -590,12 +590,12 @@ public partial class MapView : Node2D {
 		this.gridLayer = new GridLayer();
 		looseView.layers.Add(this.gridLayer);
 		looseView.layers.Add(new BuildingLayer());
+		looseView.layers.Add(new BorderLayer());
 		looseView.layers.Add(new UnitLayer());
 		looseView.layers.Add(new GotoLayer());
 		this.cityLayer = new();
 		looseView.layers.Add(this.cityLayer);
 		looseView.layers.Add(new FogOfWarLayer());
-		looseView.layers.Add(new BorderLayer());
 
 		(civColorWhitePalette, _) = Util.loadPalettizedPCX("Art/Units/Palettes/ntp00.pcx");
 

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -729,6 +729,7 @@ public partial class MapView : Node2D
 		this.cityLayer = new();
 		looseView.layers.Add(this.cityLayer);
 		looseView.layers.Add(new FogOfWarLayer());
+		looseView.layers.Add(new BorderLayer());
 
 		(civColorWhitePalette, _) = Util.loadPalettizedPCX("Art/Units/Palettes/ntp00.pcx");
 

--- a/C7/PCXToGodot.cs
+++ b/C7/PCXToGodot.cs
@@ -4,7 +4,7 @@ using ConvertCiv3Media;
 using System.Collections.Generic;
 
 public partial class PCXToGodot : GodotObject {
-	// The set of color indexes considered transparent when loading a Civ2 PCX
+	// The set of color indexes considered transparent when loading a Civ3 PCX
 	private static readonly HashSet<int> transparentColorIndexes = new() { 1, 254, 255 };
 
 	public static ImageTexture getImageTextureFromPCX(Pcx pcx) {

--- a/C7/PCXToGodot.cs
+++ b/C7/PCXToGodot.cs
@@ -4,7 +4,8 @@ using ConvertCiv3Media;
 using System.Collections.Generic;
 
 public partial class PCXToGodot : GodotObject {
-	private static readonly HashSet<int> transparents = new() { 1, 254, 255 };
+	// The set of color indexes considered transparent when loading a Civ2 PCX
+	private static readonly HashSet<int> transparentColorIndexes = new() { 1, 254, 255 };
 
 	public static ImageTexture getImageTextureFromPCX(Pcx pcx) {
 		Image ImgTxtr = ByteArrayToImage(pcx.ColorIndices, pcx.Palette, pcx.Width, pcx.Height);
@@ -45,7 +46,7 @@ public partial class PCXToGodot : GodotObject {
 		for (int y = 0; y < alphaPcx.Height; y++) {
 			for (int x = 0; x < alphaPcx.Width; x++, dataIndex++) {
 				int index = alphaPcx.ColorIndexAt(x, y);
-				if (transparents.Contains(index)) {
+				if (transparentColorIndexes.Contains(index)) {
 					bufferData[dataIndex] = 0;
 				} else {
 					bufferData[dataIndex] = alphaData[index] << 24;
@@ -156,7 +157,7 @@ public partial class PCXToGodot : GodotObject {
 			Green = palette[i, 1] << 8;
 			Blue = palette[i, 2] << 16;
 
-			int Alpha = transparents.Contains(i) ? 0 : 255 << 24;
+			int Alpha = transparentColorIndexes.Contains(i) ? 0 : 255 << 24;
 
 			ColorData[i] = Red + Green + Blue + Alpha;
 		}

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -259,6 +259,23 @@ public partial class Util {
 		ColorCache[colorIndex] = color;
 		return color;
 	}
+	
+	// Replaces image colors based on a given dictionary
+	public static Image TransformColors(Image origin, Dictionary<Color, Color> colorReplacements) {
+		Image result = (Image)origin.Duplicate();
+
+		for (int y = 0; y < origin.GetHeight(); ++y) {
+			for (int x = 0; x < origin.GetWidth(); ++x) {
+				Color origin_color = origin.GetPixel(x, y);
+
+				if (colorReplacements.TryGetValue(origin_color, out Color new_color)) {
+					result.SetPixel(x, y, new_color);
+				}
+			}
+		}
+		
+		return result;
+	}
 
 	// Creates a texture from raw palette data. The data must be 256 pixels by 3 channels. Returns a 16x16 unfiltered RGB texture.
 	public static ImageTexture createPaletteTexture(byte[,] raw) {

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -20,7 +20,8 @@ namespace C7Engine {
 			owner.cities.Add(newCity);
 			tileWithNewCity.cityAtTile = newCity;
 			tileWithNewCity.overlays.road = true;
-		}
+                        gameData.UpdateTileOwners();
+        }
 
 		public static void DestroyCity(int x, int y) {
 			Tile tile = EngineStorage.gameData.map.tileAt(x, y);

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -4,7 +4,7 @@ using Serilog;
 
 namespace C7Engine {
 	using C7GameData;
-	using System;
+
 	public class TurnHandling {
 		private static ILogger log = Log.ForContext<TurnHandling>();
 
@@ -41,6 +41,7 @@ namespace C7Engine {
 
 				SpawnBarbarians(gameData);
 				HandleCityResults(gameData);
+				gameData.UpdateTileOwners();
 
 				gameData.turn++;
 				OnBeginTurn();

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -72,6 +72,18 @@ namespace C7GameData {
 				return null;
 		}
 
+		// TODO: This is a placeholder method for calculating tile owners.
+		// Currently, it marks a tile as owned only if it is a city tile or adjacent to a city.
+		public void UpdateTileOwners() {
+			foreach (City city in cities) {
+				city.location.owner = city.owner;
+
+				foreach (Tile tile in city.location.neighbors.Values) {
+					tile.owner = city.owner;
+				}
+			}
+		}
+
 		/**
 		 * This is intended as a place to set up post-load actions on the save, regardless of
 		 * whether it is loaded from a legacy Civ3 file or a C7 native file.

--- a/C7GameData/Save/SaveGame.cs
+++ b/C7GameData/Save/SaveGame.cs
@@ -158,6 +158,8 @@ namespace C7GameData.Save {
 			data.healRateInHostileField = HealRates["hostile_field"];
 			data.healRateInCity = HealRates["city"];
 
+			data.UpdateTileOwners();
+
 			return data;
 		}
 

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -9,7 +9,7 @@ namespace C7GameData {
 		public Civ3ExtraInfo ExtraInfo;
 		public int xCoordinate;
 		public int yCoordinate;
-		public Player owner;
+		public Player owner; // Represents a civilization within which border the tile is located
 		public string baseTerrainTypeKey { get; set; }
 		[JsonIgnore]
 		public TerrainType baseTerrainType = TerrainType.NONE;

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -3,11 +3,13 @@ namespace C7GameData {
 	using System.Text.Json.Serialization;
 	using System.Collections.Generic;
 	using System.Linq;
+
 	public class Tile {
 		public ID Id { get; internal set; }
 		public Civ3ExtraInfo ExtraInfo;
 		public int xCoordinate;
 		public int yCoordinate;
+		public Player owner;
 		public string baseTerrainTypeKey { get; set; }
 		[JsonIgnore]
 		public TerrainType baseTerrainType = TerrainType.NONE;


### PR DESCRIPTION
This PR implements drawing borders on the game map (#288). The border drawing logic is heavily based on the code from Quintilus' editor.

This PR has following limitations:
* Territory calculation based on culture is not implemented. A placeholder method is used instead, which marks territory as city tiles and tiles neighboring cities.
* In Civ3 two colors are used to color a border of each civ. The first color is the color of civilization, the second color is derived from it. I haven't figured out the exact calculations Civ3 uses to derive this color, so a rough approximation is used instead. 
* The original game draws border over hill and mountains in rather nuanced way, which is not replicated in this PR. 
* Also, there is no border rendering on the edge of the fog of war (see screenshot). I'm not sure whether the problem lies with the border or the fog of war layer.
![image](https://github.com/user-attachments/assets/a9153dd2-16e3-45a3-bb04-9d5f56ef9169)