### PR TITLE
Fix the logic for deciding if a mine can be built

### DIFF
--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -453,13 +453,10 @@ namespace C7Engine {
 		}
 
 		public static bool canBuildMine(this MapUnit unit) {
-			// Mines can only be built on land, if there is no mine already there,
-			// and if there isn't a city.
-			//
-			// Volcanos also cannot be mined.
+			// Mines can only be built tiles with a mining bonus, if there is
+			// no mine already there, and if there isn't a city.
 			return unit.unitType.actions.Contains(C7Action.UnitBuildMine) &&
-				unit.location.IsLand() &&
-				!unit.location.IsVolcano() &&
+				unit.location.overlayTerrainType.miningBonus > 0 &&
 				!unit.location.overlays.mine &&
 				unit.location.cityAtTile == null;
 		}


### PR DESCRIPTION
After poking around in the simulation editor (which annoyingly I haven't gotten to work with steam+linux, unlike civ3 itself), it appears that a non-zero value of the mining bonus is what controls whether a tile can be fined. Volcanos, forests, water tiles, marshes, jungles, etc, all don't have a mining bonus and can't be mined.

The previous logic would have allowed mining forests.

#493 