### PR TITLE
Refactor how simple messages to the engine are passed

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -581,7 +581,7 @@ public partial class Game : Node2D {
 
 		// actions with unit buttons
 		if (currentAction == C7Action.UnitHold) {
-			new MsgSkipUnitTurn(CurrentlySelectedUnit.id).send();
+			new ActionToEngineMsg(() => CurrentlySelectedUnit?.skipTurn()).send();
 		}
 
 		if (currentAction == C7Action.UnitWait) {
@@ -629,11 +629,11 @@ public partial class Game : Node2D {
 		}
 
 		if (currentAction == C7Action.UnitBuildRoad && CurrentlySelectedUnit.canBuildRoad()) {
-			new MsgBuildRoad(CurrentlySelectedUnit.id).send();
+			new ActionToEngineMsg(() => CurrentlySelectedUnit?.buildRoad()).send();
 		}
 
 		if (currentAction == C7Action.UnitBuildMine && CurrentlySelectedUnit.canBuildMine()) {
-			new MsgBuildMine(CurrentlySelectedUnit.id).send();
+			new ActionToEngineMsg(() => CurrentlySelectedUnit?.buildMine()).send();
 		}
 
 	}
@@ -660,7 +660,7 @@ public partial class Game : Node2D {
 
 	// Called by the disband popup
 	private void OnUnitDisbanded() {
-		new MsgDisbandUnit(CurrentlySelectedUnit.id).send();
+		new ActionToEngineMsg(() => CurrentlySelectedUnit?.disband()).send();
 	}
 
 	/**
@@ -672,6 +672,6 @@ public partial class Game : Node2D {
 	}
 
 	private void OnBuildCity(string name) {
-		new MsgBuildCity(CurrentlySelectedUnit.id, name).send();
+		new ActionToEngineMsg(() => CurrentlySelectedUnit?.buildCity(name)).send();
 	}
 }

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -88,70 +88,19 @@ namespace C7Engine {
 		}
 	}
 
-	public class MsgSkipUnitTurn : MessageToEngine {
-		private ID unitID;
-
-		public MsgSkipUnitTurn(ID unitID) {
-			this.unitID = unitID;
+	// A generic class that allows the UI to have the game engine run some
+	// action, assumed to be on a unit.
+	//
+	// Actions that require more than a 1 or 2 line lambda should probably use
+	// a custom subclass.
+	public class ActionToEngineMsg : MessageToEngine {
+		private Action action;
+		public ActionToEngineMsg(Action action) {
+			this.action = action;
 		}
 
 		public override void process() {
-			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
-			unit?.skipTurn();
-		}
-	}
-
-	public class MsgDisbandUnit : MessageToEngine {
-		private ID unitID;
-
-		public MsgDisbandUnit(ID unitID) {
-			this.unitID = unitID;
-		}
-
-		public override void process() {
-			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
-			unit?.disband();
-		}
-	}
-
-	public class MsgBuildCity : MessageToEngine {
-		private ID unitID;
-		private string cityName;
-
-		public MsgBuildCity(ID unitID, string cityName) {
-			this.unitID = unitID;
-			this.cityName = cityName;
-		}
-
-		public override void process() {
-			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
-			unit?.buildCity(cityName);
-		}
-	}
-
-	public class MsgBuildRoad : MessageToEngine {
-		private ID unitID;
-
-		public MsgBuildRoad(ID unitID) {
-			this.unitID = unitID;
-		}
-
-		public override void process() {
-			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
-			unit?.buildRoad();
-		}
-	}
-
-	public class MsgBuildMine : MessageToEngine {
-		private ID unitID;
-
-		public MsgBuildMine(ID unitID) {
-			this.unitID = unitID;
-		}
-
-		public override void process() {
-			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
-			unit?.buildMine();
+			action();
 		}
 	}
 


### PR DESCRIPTION
We shouldn't need N subclasses for N different types of messages when C# provides simple support for lambdas.

#506