### PR TITLE
Implement the basic skeleton of the science advisor

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -250,6 +250,9 @@ public partial class Game : Node2D {
 				if (Input.IsKeyPressed(Godot.Key.F1)) {
 					EmitSignal(SignalName.ShowSpecificAdvisor, "F1");
 				}
+				if (Input.IsKeyPressed(Godot.Key.F6)) {
+					EmitSignal(SignalName.ShowSpecificAdvisor, "F6");
+				}
 			}
 		}
 	}

--- a/C7/UIElements/Advisors/Advisors.cs
+++ b/C7/UIElements/Advisors/Advisors.cs
@@ -1,6 +1,7 @@
 using Godot;
 using System;
 using Serilog;
+using System.Collections.Generic;
 
 /**
  * Handles managing the advisor screens.
@@ -10,6 +11,13 @@ using Serilog;
 public partial class Advisors : CenterContainer {
 	private ILogger log = LogManager.ForContext<Advisors>();
 
+	private DomesticAdvisor domesticAdvisor;
+	private ScienceAdvisor scienceAdvisor;
+
+	// A list of all the non-null advisors, so we can hide them whenever we
+	// draw a different advisor.
+	private List<TextureRect> advisors = new();
+
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
 		//Center the advisor container.  Following directions at https://docs.godotengine.org/en/stable/tutorials/gui/size_and_anchors.html?highlight=anchor
@@ -18,19 +26,10 @@ public partial class Advisors : CenterContainer {
 		this.Hide();
 	}
 
-	//  // Called every frame. 'delta' is the elapsed time since the previous frame.
-	//  public override void _Process(float delta)
-	//  {
-	//
-	//  }
-
 	private void ShowLatestAdvisor() {
 		log.Debug("Received request to show latest advisor");
 
-		if (this.GetChildCount() == 0) {
-			DomesticAdvisor advisor = new DomesticAdvisor();
-			AddChild(advisor);
-		}
+		OnShowSpecificAdvisor("F1");
 		this.Show();
 	}
 
@@ -39,10 +38,28 @@ public partial class Advisors : CenterContainer {
 	}
 
 	private void OnShowSpecificAdvisor(string advisorType) {
+		// Hide any existing advisors so we can draw the requested one.
+		foreach (TextureRect tr in advisors) {
+			tr.Hide();
+		}
+
 		if (advisorType.Equals("F1")) {
-			if (this.GetChildCount() == 0) {
-				DomesticAdvisor advisor = new DomesticAdvisor();
-				AddChild(advisor);
+			if (domesticAdvisor == null) {
+				domesticAdvisor = new DomesticAdvisor();
+				advisors.Add(domesticAdvisor);
+				AddChild(domesticAdvisor);
+			} else {
+				domesticAdvisor.Show();
+			}
+			this.Show();
+		}
+		if (advisorType.Equals("F6")) {
+			if (scienceAdvisor == null) {
+				scienceAdvisor = new ScienceAdvisor();
+				advisors.Add(scienceAdvisor);
+				AddChild(scienceAdvisor);
+			} else {
+				scienceAdvisor.Show();
 			}
 			this.Show();
 		}

--- a/C7/UIElements/Advisors/ScienceAdvisor.cs
+++ b/C7/UIElements/Advisors/ScienceAdvisor.cs
@@ -1,0 +1,80 @@
+using C7Engine;
+using C7GameData;
+using Godot;
+using System;
+using System.Collections.Generic;
+
+public partial class ScienceAdvisor : TextureRect {
+	// Called when the node enters the scene tree for the first time.
+	public override void _Ready() {
+		this.CreateUI();
+	}
+
+	private void CreateUI() {
+		// TODO: support other eras. Amusingly the dependency arrows are drawn
+		// on this texture, so to render prereqs we need to update this per era.
+		ImageTexture DomesticBackground = Util.LoadTextureFromPCX("Art/Advisors/science_ancient.pcx");
+		this.Texture = DomesticBackground;
+
+		// TODO: Age-based background.  Only use Ancient for now.
+		// TODO: Consider moving this to an advisor utility, since we're copying
+		// these x,y coordinates in multiple places.
+		ImageTexture AdvisorHappy = Util.LoadTextureFromPCX("Art/SmallHeads/popupSCIENCE.pcx", 1, 40, 149, 110);
+		ImageTexture AdvisorAngry = Util.LoadTextureFromPCX("Art/SmallHeads/popupSCIENCE.pcx", 151, 40, 149, 110);
+		ImageTexture AdvisorSad = Util.LoadTextureFromPCX("Art/SmallHeads/popupSCIENCE.pcx", 301, 40, 149, 110);
+		ImageTexture AdvisorSurprised = Util.LoadTextureFromPCX("Art/SmallHeads/popupSCIENCE.pcx", 451, 40, 149, 110);
+
+		TextureRect AdvisorHead = new();
+		//TODO: Randomize or set logically
+		AdvisorHead.Texture = AdvisorSurprised;
+		AdvisorHead.SetPosition(new Vector2(851, 0));
+		AddChild(AdvisorHead);
+
+		ImageTexture DialogBoxTexture = Util.LoadTextureFromPCX("Art/Advisors/dialogbox.pcx");
+		TextureButton DialogBox = new TextureButton();
+		DialogBox.TextureNormal = DialogBoxTexture;
+		DialogBox.SetPosition(new Vector2(806, 110));
+		AddChild(DialogBox);
+
+		//TODO: Multi-line capabilities
+		Label DialogBoxAdvise = new Label();
+		DialogBoxAdvise.Text = "You are running C7!";
+		DialogBoxAdvise.SetPosition(new Vector2(815, 119));
+		AddChild(DialogBoxAdvise);
+
+		ImageTexture GoBackTexture = Util.LoadTextureFromPCX("Art/exitBox-backgroundStates.pcx", 0, 0, 72, 48);
+		TextureButton GoBackButton = new TextureButton();
+		GoBackButton.TextureNormal = GoBackTexture;
+		GoBackButton.SetPosition(new Vector2(952, 720));
+		AddChild(GoBackButton);
+		GoBackButton.Pressed += ReturnToMenu;
+
+		// TODO: Figure out how to pick which of the different sized tech boxes
+		// we should use for a given tech.
+		//
+		// NOTE: this pcx has 4 columns (discovered, planned, possible,
+		// not yet researchable), and 16 rows, 4 per era, with different sizes.
+		ImageTexture techBox = Util.LoadTextureFromPCX("Art/Advisors/techboxes.pcx", 1, 1, 180, 80);
+		using (UIGameDataAccess gameDataAccess = new()) {
+			List<Tech> techs = gameDataAccess.gameData.techs;
+
+			foreach (Tech tech in techs) {
+				// TODO: handle other eras.
+				if (tech.Era != "Ancient Times") {
+					continue;
+				}
+
+				// TODO: draw the icon, name, etc. Consider sticking that in
+				// its own class.
+				TextureButton techButton = new();
+				techButton.TextureNormal = techBox;
+				techButton.SetPosition(new Vector2(tech.X, tech.Y));
+				AddChild(techButton);
+			}
+		}
+	}
+
+	private void ReturnToMenu() {
+		GetParent<Advisors>().Hide();
+	}
+}


### PR DESCRIPTION
This pr:
 - adds the F6 keyboard shortcut to pull up the advisor
 - draws the science advisor background
 - draws the ancient era tech boxes in the correct positions (though not yet the correct sizes)
 - handles switching back and forth between the domestic and science advisors

I've left TODOs for the next steps

![Screenshot 2025-01-21 8 13 16 PM](https://github.com/user-attachments/assets/e3e837cb-7549-4ebb-b66c-9e6ec0d7f324)


#392