### PR TITLE
Use the correct texture for known/in progress/possible techs

### DIFF
--- a/C7/UIElements/Advisors/ScienceAdvisor.cs
+++ b/C7/UIElements/Advisors/ScienceAdvisor.cs
@@ -51,6 +51,7 @@ public partial class ScienceAdvisor : TextureRect {
 
 		using (UIGameDataAccess gameDataAccess = new()) {
 			List<Tech> techs = gameDataAccess.gameData.techs;
+			List<ID> knownTechs = gameDataAccess.gameData.GetHumanPlayers()[0].knownTechs;
 
 			foreach (Tech tech in techs) {
 				// TODO: handle other eras.
@@ -58,7 +59,22 @@ public partial class ScienceAdvisor : TextureRect {
 					continue;
 				}
 
-				TechBox techButton = new(tech);
+				// TODO: track the currently researched tech for kInProgress.
+				TechBox.TechState techState = TechBox.TechState.kBlocked;
+				if (knownTechs.Contains(tech.id)) {
+					techState = TechBox.TechState.kKnown;
+				} else {
+					bool prereqsKnown = true;
+					foreach (Tech prereq in tech.Prerequisites) {
+						if (!knownTechs.Contains(prereq.id)) {
+							prereqsKnown = false;
+							break;
+						}
+					}
+					techState = prereqsKnown ? TechBox.TechState.kPossible : TechBox.TechState.kBlocked;
+				}
+
+				TechBox techButton = new(tech, techState);
 				techButton.SetPosition(new Vector2(tech.X, tech.Y));
 				AddChild(techButton);
 			}

--- a/C7/UIElements/Advisors/TechBox.cs
+++ b/C7/UIElements/Advisors/TechBox.cs
@@ -1,22 +1,52 @@
 
+using System;
 using C7GameData;
 using Godot;
 
 public partial class TechBox : TextureButton {
 	private Tech tech;
+	private TechState techState;
 
-	public TechBox(Tech tech) {
+	public enum TechState {
+		// This tech is known to the player.
+		kKnown,
+		// The player is actively researching this tech.
+		kInProgress,
+		// The player could research this tech.
+		kPossible,
+		// The player needs to research the prerequisites before this tech can
+		// be researched.
+		kBlocked,
+	}
+
+	public TechBox(Tech tech, TechState techState) {
 		this.tech = tech;
+		this.techState = techState;
 	}
 
 	public override void _Ready() {
 		// TODO: Figure out how to pick which of the different sized tech boxes
 		// we should use for a given tech.
 		//
-		// NOTE: this pcx has 4 columns (discovered, planned, possible,
-		// not yet researchable), and 16 rows, 4 per era, with different sizes.
-		ImageTexture techBox = Util.LoadTextureFromPCX("Art/Advisors/techboxes.pcx", 1, 1, 180, 80);
-		TextureNormal = techBox;
+		// NOTE: this pcx has 16 rows, 4 per era, with different sizes.
+		//
+		// NOTE: the x coordinates of each column were found via guess+check.
+		ImageTexture knownTechBox = Util.LoadTextureFromPCX("Art/Advisors/techboxes.pcx",
+			1, 1, 180, 80);
+		ImageTexture inProgressTechBox = Util.LoadTextureFromPCX("Art/Advisors/techboxes.pcx",
+			192, 1, 180, 80);
+		ImageTexture possibleTechBox = Util.LoadTextureFromPCX("Art/Advisors/techboxes.pcx",
+			381, 1, 180, 80);
+		ImageTexture blockedTechBox = Util.LoadTextureFromPCX("Art/Advisors/techboxes.pcx",
+			568, 1, 180, 80);
+
+		TextureNormal = techState switch {
+			TechState.kKnown => knownTechBox,
+			TechState.kInProgress => inProgressTechBox,
+			TechState.kPossible => possibleTechBox,
+			TechState.kBlocked => blockedTechBox,
+			_ => throw new ArgumentOutOfRangeException("Invalid tech state")
+		};
 
 		ImageTexture iconTexture = Util.LoadTextureFromPCX(tech.SmallIconPath);
 		TextureRect icon = new() {


### PR DESCRIPTION
We can now see what techs we know as Carthage starting out, what techs are available to research, and what techs are blocked.

![Screenshot 2025-01-22 9 54 35 PM](https://github.com/user-attachments/assets/7c13d9cb-7d2b-452a-a65d-ed3c50350a40)


#392