### PR TITLE
Properly import known technologies when loading saves/scenarios 

### DIFF
--- a/C7GameData/Civilization.cs
+++ b/C7GameData/Civilization.cs
@@ -27,6 +27,6 @@ namespace C7GameData {
 		public List<string> cityNames = new List<string>();
 
 		// The IDs of all the techs that this civ starts with.
-		public List<ID> startingTechs = new();
+		public HashSet<ID> startingTechs = new();
 	}
 }

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -5,7 +5,6 @@ using Serilog;
 using QueryCiv3;
 using QueryCiv3.Biq;
 using C7GameData.Save;
-using System.IO;
 
 /*
   This will read a Civ3 sav into C7 native format for immediate use or saving to native JSON save
@@ -370,6 +369,13 @@ namespace C7GameData {
 				// Put the player in the correct starting era.
 				player.eraCivilopediaName = theBiq.Eras[lead.InitialEra].CivilopediaEntry;
 
+				// Add the starting techs for scenarios.
+				if (theBiq.LeadTech != null) {
+					for (int j = 0; j < theBiq.LeadTech[leadIndex].Length; ++j) {
+						player.knownTechs.Add(save.Techs[theBiq.LeadTech[leadIndex][j]].id);
+					}
+				}
+
 				// Mark the first human playable civ as the human player.
 				if (lead.HumanPlayer == 1 && !foundHuman) {
  					player.human = true;
@@ -394,8 +400,16 @@ namespace C7GameData {
 										  /*cityNameIndex=*/leader.FoundedCities,
 										  /*era=*/theBiq.Eras[leader.Era].CivilopediaEntry);
 
+
 				// TODO: store non-negative values of leader.Researching,
 				// which indexes into save.Techs.
+
+				// Record any techs that this player knows.
+				for (int k = 0; k < savData.KnownTechFlags.Length; ++k) {
+					if (savData.KnownTechFlags[k][i]) {
+						player.knownTechs.Add(save.Techs[k].id);
+					}
+				}
 
 				save.Players.Add(player);
 				i++;
@@ -706,6 +720,19 @@ namespace C7GameData {
 				if (race.FreeTech4 > -1) {
 					sc.startingTechs.Add(save.Techs[race.FreeTech4].id);
 				}
+
+				// Remove any invalid starting techs. Some scenarios like
+				// Fall of Rome give starting techs without giving all of the
+				// prereqs, so they should be ignored.
+				sc.startingTechs.RemoveWhere(t => {
+					SaveTech st = save.Techs.Find(x => x.id == t);
+					foreach (ID prereqId in st.Prerequisites) {
+						if (!sc.startingTechs.Contains(prereqId)) {
+							return true;
+						}
+					}
+					return false;
+				});
 			}
 		}
 

--- a/QueryCiv3/Sav.cs
+++ b/QueryCiv3/Sav.cs
@@ -32,6 +32,7 @@ namespace QueryCiv3 {
 		public CLNY[] Clny;
 
 		public int[] CitiesPerContinent;
+		// Bit k of element i means that civ k knows tech i.
 		public IntBitmap[] KnownTechFlags;
 		public int[] GreatWonderCityIDs;
 		public bool[] GreatWondersBuilt;


### PR DESCRIPTION
Now when loading a save game we can open the science advisor to see what technologies we know. Here's an example from an industrial era save file of mine.

![Screenshot 2025-01-25 1 31 01 PM](https://github.com/user-attachments/assets/d19f08b5-1883-4cd5-8152-77c66a8ec00a)

Here's the fall of rome scenario:

![image](https://github.com/user-attachments/assets/ef9253e3-e85f-4789-8e5f-510027568d55)

And the WWII scenario:

![image](https://github.com/user-attachments/assets/ee073598-c323-4cde-be24-c807c5f62007)


#392