### PR TITLE
Keep track of the currently researched tech and let the user change it

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -208,6 +208,11 @@ public partial class Game : Node2D {
 						setSelectedUnit(CurrentlySelectedUnit);
 					}
 					break;
+				case MsgUpdateUiAfterTechSelection mUUATS:
+					// F6 is the science advisor.
+					// TODO: Move the F* key strings to a set of constants/enum.
+					EmitSignal(SignalName.ShowSpecificAdvisor, "F6");
+					break;
 			}
 		}
 	}

--- a/C7/UIElements/Advisors/Advisors.cs
+++ b/C7/UIElements/Advisors/Advisors.cs
@@ -54,13 +54,16 @@ public partial class Advisors : CenterContainer {
 			this.Show();
 		}
 		if (advisorType.Equals("F6")) {
-			if (scienceAdvisor == null) {
-				scienceAdvisor = new ScienceAdvisor();
-				advisors.Add(scienceAdvisor);
-				AddChild(scienceAdvisor);
-			} else {
-				scienceAdvisor.Show();
+			// TODO: What's the best way to refresh the tech tree UI without
+			// adding too many children?
+			if (scienceAdvisor != null) {
+				RemoveChild(scienceAdvisor);
+				scienceAdvisor = null;
 			}
+
+			scienceAdvisor = new ScienceAdvisor();
+			advisors.Add(scienceAdvisor);
+			AddChild(scienceAdvisor);
 			this.Show();
 		}
 	}

--- a/C7/UIElements/Advisors/ScienceAdvisor.cs
+++ b/C7/UIElements/Advisors/ScienceAdvisor.cs
@@ -5,9 +5,15 @@ using System;
 using System.Collections.Generic;
 
 public partial class ScienceAdvisor : TextureRect {
+	private ImageTexture AncientBackground;
+	private ImageTexture MiddleBackground;
+	private ImageTexture IndustrialBackground;
+	private ImageTexture ModernBackground;
+
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
 		this.CreateUI();
+		this.DrawTechTree();
 	}
 
 	private void CreateUI() {
@@ -16,10 +22,10 @@ public partial class ScienceAdvisor : TextureRect {
 		//
 		// science_industrial_new is used as the industrial tech tree is
 		// different from vanilla civ3.
-		ImageTexture AncientBackground = Util.LoadTextureFromPCX("Art/Advisors/science_ancient.pcx");
-		ImageTexture MiddleBackground = Util.LoadTextureFromPCX("Art/Advisors/science_middle.pcx");
-		ImageTexture IndustrialBackground = Util.LoadTextureFromPCX("Art/Advisors/science_industrial_new.pcx");
-		ImageTexture ModernBackground = Util.LoadTextureFromPCX("Art/Advisors/science_modern.pcx");
+		AncientBackground = Util.LoadTextureFromPCX("Art/Advisors/science_ancient.pcx");
+		MiddleBackground = Util.LoadTextureFromPCX("Art/Advisors/science_middle.pcx");
+		IndustrialBackground = Util.LoadTextureFromPCX("Art/Advisors/science_industrial_new.pcx");
+		ModernBackground = Util.LoadTextureFromPCX("Art/Advisors/science_modern.pcx");
 
 		// TODO: Age-based background.  Only use Ancient for now.
 		// TODO: Consider moving this to an advisor utility, since we're copying
@@ -53,11 +59,13 @@ public partial class ScienceAdvisor : TextureRect {
 		GoBackButton.SetPosition(new Vector2(952, 720));
 		AddChild(GoBackButton);
 		GoBackButton.Pressed += ReturnToMenu;
+	}
 
+	void DrawTechTree() {
 		using (UIGameDataAccess gameDataAccess = new()) {
 			List<Tech> techs = gameDataAccess.gameData.techs;
 			Player player = gameDataAccess.gameData.GetHumanPlayers()[0];
-			List<ID> knownTechs = player.knownTechs;
+			HashSet<ID> knownTechs = player.knownTechs;
 
 			// Set the tech background based on the player's era.
 			if (player.eraCivilopediaName == "ERAS_Ancient_Times") {
@@ -75,10 +83,11 @@ public partial class ScienceAdvisor : TextureRect {
 					continue;
 				}
 
-				// TODO: track the currently researched tech for kInProgress.
 				TechBox.TechState techState = TechBox.TechState.kBlocked;
 				if (knownTechs.Contains(tech.id)) {
 					techState = TechBox.TechState.kKnown;
+				} else if (player.currentlyResearchedTech == tech.id) {
+					techState = TechBox.TechState.kInProgress;
 				} else {
 					bool prereqsKnown = true;
 					foreach (Tech prereq in tech.Prerequisites) {
@@ -92,6 +101,9 @@ public partial class ScienceAdvisor : TextureRect {
 
 				TechBox techButton = new(tech, techState);
 				techButton.SetPosition(new Vector2(tech.X, tech.Y));
+				techButton.Pressed += () => {
+					new MsgChooseResearch(tech.id).send();
+				};
 				AddChild(techButton);
 			}
 		}

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -126,6 +126,34 @@ namespace C7Engine {
 		}
 	}
 
+	public class MsgChooseResearch : MessageToEngine {
+		private ID techId;
+		public MsgChooseResearch(ID techId) {
+			this.techId = techId;
+		}
+
+		public override void process() {
+			Player player = EngineStorage.gameData.GetHumanPlayers()[0];
+			if (player.currentlyResearchedTech == techId) {
+				return;
+			}
+			Tech requestedTech = EngineStorage.gameData.techs.Find(t => t.id == techId);
+
+			// Ensure this is an eligible tech to research.
+			//
+			// TODO: do a topological sort to allow a queue of techs to study.
+			foreach (Tech prereq in requestedTech.Prerequisites) {
+				if (!player.knownTechs.Contains(prereq.id)) {
+					return;
+				}
+			}
+
+			// Start researching this tech and update the UI.
+			player.currentlyResearchedTech = requestedTech.id;
+			new MsgUpdateUiAfterTechSelection().send();
+		}
+	}
+
 	public class MsgEndTurn : MessageToEngine {
 
 		private ILogger log = Log.ForContext<MsgEndTurn>();

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -40,6 +40,8 @@ namespace C7Engine {
 
 	public class MsgUpdateUiAfterMove : MessageToUI { }
 
+	public class MsgUpdateUiAfterTechSelection : MessageToUI { }
+
 	public class MsgCityDestroyed : MessageToUI {
 		public City city;
 

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -400,9 +400,10 @@ namespace C7GameData {
 										  /*cityNameIndex=*/leader.FoundedCities,
 										  /*era=*/theBiq.Eras[leader.Era].CivilopediaEntry);
 
-
-				// TODO: store non-negative values of leader.Researching,
-				// which indexes into save.Techs.
+				// Record what the player is currently researching.
+				if (leader.Researching > -1) {
+					player.currentlyResearchedTech = save.Techs[leader.Researching].id;
+				}
 
 				// Record any techs that this player knows.
 				for (int k = 0; k < savData.KnownTechFlags.Length; ++k) {

--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -24,7 +24,10 @@ namespace C7GameData {
 		public List<StrategicPriority> strategicPriorityData = new List<StrategicPriority>();
 
 		// The list of techs known by this player.
-		public List<ID> knownTechs = new();
+		public HashSet<ID> knownTechs = new();
+
+		// The tech the player is currently researching.
+		public ID currentlyResearchedTech;
 
 		// The civilopedia name of the era this player is in.
 		//

--- a/C7GameData/Save/SavePlayer.cs
+++ b/C7GameData/Save/SavePlayer.cs
@@ -15,7 +15,10 @@ namespace C7GameData.Save {
 		public List<TileLocation> tileKnowledge = new List<TileLocation>();
 
 		// The list of techs known by this player.
-		public List<ID> knownTechs = new();
+		public HashSet<ID> knownTechs = new();
+
+		// The tech the player is currently researching.
+		public ID currentlyResearchedTech;
 
 		// The civilopedia name of the era this player is in.
 		//
@@ -36,6 +39,7 @@ namespace C7GameData.Save {
 				cityNameIndex = cityNameIndex,
 				tileKnowledge = new TileKnowledge(),
 				knownTechs = knownTechs,
+				currentlyResearchedTech = currentlyResearchedTech,
 				eraCivilopediaName = eraCivilopediaName,
 			};
 			foreach (TileLocation tile in tileKnowledge) {
@@ -64,6 +68,7 @@ namespace C7GameData.Save {
 			tileKnowledge = player.tileKnowledge.AllKnownTiles().ConvertAll(tile => new TileLocation(tile));
 			turnsUntilPriorityReevaluation = player.turnsUntilPriorityReevaluation;
 			knownTechs = player.knownTechs;
+			currentlyResearchedTech = player.currentlyResearchedTech;
 			eraCivilopediaName = player.eraCivilopediaName;
 		}
 	}


### PR DESCRIPTION
This PR also loads this information from save files.

#392

A screenshot from the same industrial era save file of mine, showing refining selected.

![Screenshot 2025-01-25 3 21 11 PM](https://github.com/user-attachments/assets/e5d6a563-23ef-449d-b416-bf70bfc71c0a)
