### PR TITLE
Award techs to the player when fully researched

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -221,10 +221,14 @@ public partial class Game : Node2D {
 					// F6 is the science advisor.
 					// TODO: Move the F* key strings to a set of constants/enum.
 					EmitSignal(SignalName.ShowSpecificAdvisor, "F6");
-					Tech tech = gameData.techs.Find(x => x.id == gameData.GetHumanPlayers()[0].currentlyResearchedTech);
+					Player player = gameData.GetHumanPlayers()[0];
+					Tech tech = gameData.techs.Find(x => x.id == player.currentlyResearchedTech);
 
-					// TODO: calculate research speed.
-					EmitSignal(SignalName.UpdateTechProgress, tech.Name, -1);
+					if (tech != null) {
+						EmitSignal(SignalName.UpdateTechProgress, tech.Name, player.EstimateTurnsToResearch(tech));
+					} else {
+						EmitSignal(SignalName.UpdateTechProgress, "Not selected", int.MaxValue);
+					}
 					break;
 				case MsgUpdateUiAfterSliderChange mUUASC:
 					// F1 is the science advisor.
@@ -356,6 +360,13 @@ public partial class Game : Node2D {
 			Player player = gameDataAccess.gameData.GetHumanPlayers()[0];
 
 			EmitSignal(SignalName.TurnStarted, turnNumber, player.gold, /*goldPerTurn=*/0);
+
+			Tech tech = gameDataAccess.gameData.techs.Find(x => x.id == player.currentlyResearchedTech);
+			if (tech != null) {
+				EmitSignal(SignalName.UpdateTechProgress, tech.Name, player.EstimateTurnsToResearch(tech));
+			} else {
+				EmitSignal(SignalName.UpdateTechProgress, "Not selected", int.MaxValue);
+			}
 			CurrentState = GameState.PlayerTurn;
 
 			GetNextAutoselectedUnit(gameDataAccess.gameData);

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -152,7 +152,7 @@ public partial class LowerRightInfoBox : TextureRect {
 	}
 
 	public void UpdateTechProgress(string techName, int turnsRemaining) {
-		if (turnsRemaining > 0) {
+		if (turnsRemaining >= int.MaxValue) {
 			SetTextAndCenterLabel(scienceProgress, $"{techName} (-- turns)");
 		} else {
 			SetTextAndCenterLabel(scienceProgress, $"{techName} ({turnsRemaining} turns)");

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -54,6 +54,16 @@ namespace C7Engine {
 					// incremented if the player is actually spending money on
 					// research, or has a science specialist.
 					player.turnsResearched++;
+
+					// Check to see if the player has finished researching their
+					// tech, and if they have, add it to the list of known techs
+					if (player.currentlyResearchedTech != null) {
+						Tech tech = gameData.techs.Find(x => x.id == player.currentlyResearchedTech);
+						if (player.EstimateTurnsToResearch(tech) <= 0) {
+							player.knownTechs.Add(player.currentlyResearchedTech);
+							player.SetCurrentlyResearchedTech(null);
+						}
+					}
 				}
 				OnBeginTurn();
 			}

--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using C7Engine.AI.StrategicAI;
@@ -116,6 +117,49 @@ namespace C7GameData {
 			if (civilization != null)
 				return civilization.cityNames.First();
 			return "";
+		}
+
+		public int EstimateTurnsToResearch(Tech tech) {
+			// Cost formula from https://forums.civfanatics.com/threads/research-cost-formula-v1-29f.29485/.
+			// Research Cost = [MM * [10*COST * (1 - N/[CL*1.75])]/(CF * 10)] - progress
+			//
+			// MM = map modifier (tiny=160, small=200, standard=240, large=320, huge=400)
+			// COST = tech cost
+			// CF = difficulty factor, range 10 (easy) to 6 (hard)
+			// N = number of known civs that have discovered the tech
+			// CL = civs left in game
+			//
+			// We also have the min/max turns to research of 4 and 50.
+			// TODO: the min/max costs are in the biq, we should load them.
+			// TODO: implement the civ-related parts of the equation
+			// TODO: figure out what map size we are
+			// TODO: See this this whole equation can be configurable
+			int beakersPerTurn = 0;
+			foreach (City city in cities) {
+				beakersPerTurn += (int)Math.Floor(city.CurrentCommerceYield() * city.owner.scienceRate / 10.0);
+			}
+
+			if (beakersPerTurn == 0) {
+				// No research is happening.
+				return int.MaxValue;
+			}
+
+			int mapModifier = 160;  // small, to make testing faster
+			int difficultyFactor = 10; // easy difficulty
+			int researchCost = mapModifier * 10 * tech.Cost / (difficultyFactor * 10);
+			int remainingCost = researchCost - beakers;
+			int turnsRemaining = (int)Math.Ceiling((double)remainingCost / beakersPerTurn);
+
+			// We never spend more than 50 turns per tech.
+			int maxTurnsRemaining = 50 - turnsResearched;
+
+			int result = Math.Min(turnsRemaining, maxTurnsRemaining);
+
+			// Ensure every tech takes at least 4 turns.
+			if (result < 4 && turnsResearched < 4) {
+				return 4;
+			}
+			return result;
 		}
 	}
 


### PR DESCRIPTION
... and show progress in the UI.

This doesn't add a popup for the player to pick the tech, but as long as the player goes to the science advisor they can pick new techs.

Here's some screenshots showing I was able to research pottery and writing, and that I'm currently researching philosophy.

![image](https://github.com/user-attachments/assets/8292bd2a-48f8-491c-9f90-adc2008accfd)

![image](https://github.com/user-attachments/assets/72a3a0fe-35ef-4084-8376-02247798d95d)

#392