### PR TITLE
chore: :memo: upgrade target .NET framework to 8.0

### DIFF
--- a/.github/workflows/composite/buildSetup/action.yml
+++ b/.github/workflows/composite/buildSetup/action.yml
@@ -22,7 +22,7 @@ runs:
     if: github.event.inputs.include-datetime == 'true'
     run: |
       echo "BUILD_TIME=-$(date --iso-8601=minutes | sed -e 's/:/-/g' | sed -e 's/\+.*//')" >> $GITHUB_ENV
-  - name: Set .net7.0 SDK
+  - name: Set .net8.0 SDK
     shell: bash
     run: |
       wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
@@ -31,7 +31,7 @@ runs:
       apt-get update -qq
       apt-get install -y apt-transport-https
       apt-get update -qq
-      apt-get install -y dotnet-sdk-7.0
+      apt-get install -y dotnet-sdk-8.0
   - name: Set FOLDER_NAME
     shell: bash
     run: |

--- a/Blast/Blast.csproj
+++ b/Blast/Blast.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <PackageId>BlastDecompressor</PackageId>
     <Title>Blast Decompressor</Title>

--- a/C7/C7.csproj
+++ b/C7/C7.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.3.0">
+<Project Sdk="Godot.NET.Sdk/4.2.2">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/C7/C7.csproj
+++ b/C7/C7.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Godot.NET.Sdk/4.2.2">
+<Project Sdk="Godot.NET.Sdk/4.3.0">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>

--- a/C7Engine/C7Engine.csproj
+++ b/C7Engine/C7Engine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/C7GameData/C7GameData.csproj
+++ b/C7GameData/C7GameData.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/C7GameDataTests/C7GameDataTests.csproj
+++ b/C7GameDataTests/C7GameDataTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/ConvertCiv3Media/ConvertCiv3Media.csproj
+++ b/ConvertCiv3Media/ConvertCiv3Media.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EngineTests/EngineTests.csproj
+++ b/EngineTests/EngineTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/QueryCiv3/QueryCiv3.csproj
+++ b/QueryCiv3/QueryCiv3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/_Console/BuildDevSave/BuildDevSave.csproj
+++ b/_Console/BuildDevSave/BuildDevSave.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Closes #483 

This change modifies all .csproj to target .NET 8.0.

This change also upgrades to the latest Godot SDK version of 4.3.0.