### PR TITLE
Support a barebones "city screen" view

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -10,6 +10,7 @@
 [ext_resource type="Script" path="res://UIElements/Popups/PopupOverlay.cs" id="9"]
 [ext_resource type="Theme" uid="uid://c1jpmssnhvodi" path="res://C7Theme.tres" id="10"]
 [ext_resource type="Script" path="res://UIElements/UnitButtons/UnitButtons.cs" id="12"]
+[ext_resource type="Script" path="res://UIElements/CityScreen/CityScreen.cs" id="13"]
 
 [sub_resource type="Animation" id="2"]
 length = 0.001
@@ -58,12 +59,14 @@ _data = {
 "SlideOutAnimation": SubResource("1")
 }
 
-[node name="C7Game" type="Node2D" node_paths=PackedStringArray("Toolbar", "popupOverlay", "slider", "animationPlayer")]
+[node name="C7Game" type="Node2D" node_paths=PackedStringArray("Toolbar", "popupOverlay", "slider", "animationPlayer", "cityScreen", "advisor")]
 script = ExtResource("1")
 Toolbar = NodePath("CanvasLayer/Control/ToolBar/MarginContainer/HBoxContainer")
 popupOverlay = NodePath("CanvasLayer/PopupOverlay")
 slider = NodePath("CanvasLayer/Control/SlideOutBar/VBoxContainer/Zoom")
 animationPlayer = NodePath("CanvasLayer/Control/SlideOutBar/AnimationPlayer")
+cityScreen = NodePath("CanvasLayer/CityScreen")
+advisor = NodePath("CanvasLayer/Advisor")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 
@@ -252,11 +255,21 @@ grow_vertical = 2
 theme = ExtResource("10")
 script = ExtResource("3")
 
+[node name="CityScreen" type="CenterContainer" parent="CanvasLayer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("10")
+script = ExtResource("13")
+
 [connection signal="NewAutoselectedUnit" from="." to="CanvasLayer/Control/GameStatus" method="OnNewUnitSelected"]
 [connection signal="NewAutoselectedUnit" from="." to="CanvasLayer/Control/UnitButtons" method="OnNewUnitSelected"]
 [connection signal="NoMoreAutoselectableUnits" from="." to="CanvasLayer/Control/GameStatus" method="OnNoMoreAutoselectableUnits"]
 [connection signal="NoMoreAutoselectableUnits" from="." to="CanvasLayer/Control/UnitButtons" method="OnNoMoreAutoselectableUnits"]
 [connection signal="ShowSpecificAdvisor" from="." to="CanvasLayer/Advisor" method="OnShowSpecificAdvisor"]
+[connection signal="ShowCityScreen" from="." to="CanvasLayer/CityScreen" method="OnShowCityScreen"]
 [connection signal="TurnEnded" from="." to="CanvasLayer/Control/GameStatus" method="OnTurnEnded"]
 [connection signal="TurnStarted" from="." to="CanvasLayer/Control/GameStatus" method="OnTurnStarted"]
 [connection signal="UpdateTechProgress" from="." to="CanvasLayer/Control/GameStatus" method="OnUpdateTechProgress"]

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -14,6 +14,7 @@ public partial class Game : Node2D {
 	[Signal] public delegate void NewAutoselectedUnitEventHandler();
 	[Signal] public delegate void NoMoreAutoselectableUnitsEventHandler();
 	[Signal] public delegate void UpdateTechProgressEventHandler();
+	[Signal] public delegate void ShowCityScreenEventHandler();
 
 	private ILogger log = LogManager.ForContext<Game>();
 
@@ -60,6 +61,10 @@ public partial class Game : Node2D {
 
 	[Export]
 	private PopupOverlay popupOverlay;
+	[Export]
+	private CityScreen cityScreen;
+	[Export]
+	private Advisors advisor;
 	[Export]
 	private VSlider slider;
 	[Export]
@@ -182,6 +187,9 @@ public partial class Game : Node2D {
 					break;
 				case MsgStartTurn mST:
 					OnPlayerStartTurn();
+					break;
+				case MsgCityCreated mCC:
+					ShowCityScreenForCity(mCC.city);
 					break;
 				case MsgCityDestroyed mCD:
 					mapView.cityLayer.UpdateAfterCityDestruction(mCD.city);
@@ -551,8 +559,18 @@ public partial class Game : Node2D {
 			return;
 		}
 
+		if (currentAction == C7Action.Escape && cityScreen.Visible) {
+			cityScreen.Hide();
+			return;
+		}
+
+		if (currentAction == C7Action.Escape && advisor.Visible) {
+			advisor.Hide();
+			return;
+		}
+
 		// never poll for actions if UI elements are visible
-		if (popupOverlay.Visible) {
+		if (popupOverlay.Visible || cityScreen.Visible || advisor.Visible) {
 			return;
 		}
 
@@ -691,6 +709,17 @@ public partial class Game : Node2D {
 	}
 
 	private void OnBuildCity(string name) {
-		new ActionToEngineMsg(() => CurrentlySelectedUnit?.buildCity(name)).send();
+		new ActionToEngineMsg(() => {
+			// Create the city and then let the ui know, so we can show the city
+			// screen.
+			City? city = CurrentlySelectedUnit?.buildCity(name);
+			if (city != null) {
+				new MsgCityCreated(city).send();
+			}
+		}).send();
+	}
+
+	public void ShowCityScreenForCity(City city) {
+		EmitSignal(SignalName.ShowCityScreen, new ParameterWrapper<City>(city));
 	}
 }

--- a/C7/UIElements/Advisors/Advisors.cs
+++ b/C7/UIElements/Advisors/Advisors.cs
@@ -67,23 +67,4 @@ public partial class Advisors : CenterContainer {
 			this.Show();
 		}
 	}
-
-	public override void _UnhandledInput(InputEvent @event) {
-		if (this.Visible) {
-			if (@event is InputEventKey eventKey) {
-				//As I've added more shortcuts, I've realized checking all of them here could be irksome.
-				//For now, I'm thinking it would make more sense to process or allow through the ones that should go through,
-				//as most of the global ones should *not* go through here.
-				if (eventKey.Pressed) {
-					if (eventKey.Keycode == Godot.Key.Escape) {
-						this.Hide();
-						GetViewport().SetInputAsHandled();
-					} else {
-						log.Debug("Advisor received a key press; stopping propagation.");
-						GetViewport().SetInputAsHandled();
-					}
-				}
-			}
-		}
-	}
 }

--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -1,0 +1,35 @@
+using Godot;
+using System;
+using Serilog;
+using System.Collections.Generic;
+using C7GameData;
+
+
+// Handles the city screen, where citizens can be assigned and other details of
+// the city can bee seen.
+public partial class CityScreen : CenterContainer {
+	private ILogger log = LogManager.ForContext<CityScreen>();
+
+	// Called when the node enters the scene tree for the first time.
+	public override void _Ready() {
+		TextureRect background = new() {
+			Texture = Util.LoadTextureFromPCX("Art/city screen/background.pcx")
+		};
+		AddChild(background);
+
+		TextureButton close = new() {
+			TextureNormal = Util.LoadTextureFromPCX("Art/city screen/cityMgmtButtons.pcx", 155, 1, 32, 48),
+			TextureHover = Util.LoadTextureFromPCX("Art/city screen/cityMgmtButtons.pcx", 155, 50, 32, 48),
+			TexturePressed = Util.LoadTextureFromPCX("Art/city screen/cityMgmtButtons.pcx", 155, 99, 32, 48)
+		};
+		close.SetPosition(new Vector2(950, 20));
+		close.Pressed += () => { this.Hide(); };
+		background.AddChild(close);
+
+		this.Hide();
+	}
+
+	private void OnShowCityScreen(ParameterWrapper<City> city) {
+		this.Show();
+	}
+}

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Godot;
 using C7GameData;
 using C7Engine;
+using System;
 
 public partial class RightClickMenu : VBoxContainer {
 	protected Game game;
@@ -151,6 +152,10 @@ public partial class RightClickTileMenu : RightClickMenu {
 				this.CloseAndDelete();
 				new RightClickChooseProductionMenu(game, tile.cityAtTile).Open(this.position);
 			});
+			AddItem("Zoom to city", () => {
+				this.CloseAndDelete();
+				game.ShowCityScreenForCity(tile.cityAtTile);
+			});
 		}
 
 		// If we're looking at an enemy tile, then the behavior depends on whether the units
@@ -223,6 +228,10 @@ public partial class RightClickCityMenu : RightClickMenu {
 				// Close the first menu before opening the second menu.
 				this.CloseAndDelete();
 				new RightClickChooseProductionMenu(game, tile.cityAtTile).Open(this.position);
+			});
+			AddItem("Zoom to city", () => {
+				this.CloseAndDelete();
+				game.ShowCityScreenForCity(tile.cityAtTile);
 			});
 		}
 	}

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -5,7 +5,7 @@ namespace C7Engine {
 	using C7GameData;
 
 	public class CityInteractions {
-		public static void BuildCity(int x, int y, ID playerID, string name) {
+		public static City BuildCity(int x, int y, ID playerID, string name) {
 			GameData gameData = EngineStorage.gameData;
 			Player owner = gameData.GetPlayer(playerID);
 			Tile tileWithNewCity = gameData.map.tileAt(x, y);
@@ -24,8 +24,10 @@ namespace C7Engine {
 			// a city is build on a mine, the mine should be removed.
 			tileWithNewCity.overlays.road = true;
 			tileWithNewCity.overlays.mine = false;
+			tileWithNewCity.overlays.irrigation = false;
 
 			gameData.UpdateTileOwners();
+			return newCity;
 		}
 
 		public static void DestroyCity(int x, int y) {

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -50,4 +50,11 @@ namespace C7Engine {
 		}
 	}
 
+	public class MsgCityCreated : MessageToUI {
+		public City city;
+
+		public MsgCityCreated(City city) {
+			this.city = city;
+		}
+	}
 }

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -420,21 +420,23 @@ namespace C7Engine {
 			return unit.location.neighbors.Values.All(tile => !tile.HasCity);
 		}
 
-		public static void buildCity(this MapUnit unit, string cityName) {
+		public static City? buildCity(this MapUnit unit, string cityName) {
 			if (!unit.canBuildCity()) {
 				log.Warning($"can't build city at {unit.location}");
-				return;
+				return null;
 			}
 
 			unit.animate(MapUnit.AnimatedAction.BUILD, true);
 
 			// TODO: Need to check somewhere that this unit is allowed to build a city on its current tile. Either do that here or in every caller
 			// (probably best to just do it here).
-			CityInteractions.BuildCity(unit.location.xCoordinate, unit.location.yCoordinate, unit.owner.id, cityName);
+			City city = CityInteractions.BuildCity(unit.location.xCoordinate, unit.location.yCoordinate, unit.owner.id, cityName);
 
 			// TODO: Should directly delete the unit instead of disbanding it. Disbanding in a city will eventually award shields, which we
 			// obviously don't want to do here.
 			unit.disband();
+
+			return city;
 		}
 
 		public static bool canBuildRoad(this MapUnit unit) {
@@ -485,7 +487,7 @@ namespace C7Engine {
 				unit.location.overlays.mine ||
 				unit.location.overlays.irrigation ||
 				unit.location.cityAtTile != null) {
-					return false;
+				return false;
 			}
 
 			// If a tile borders a river, it has fresh water access.


### PR DESCRIPTION
This is triggered when building a city and when clicking "zoom to city"

For now I've just added the "exit" button, but hope to add tile yields soon.

I also fixed an issue with the advisor and input handling - previously if you exited the advisor via escape the game would ask if you wanted to exit. Now it works properly.

This will hopefully yield additional good starter PRs - there's lots of labels and icons to place on this screen.

![image](https://github.com/user-attachments/assets/4f6c6f33-91b3-4ce4-a365-c635a88abbb7)
