### PR TITLE
 Fix ID collisions on save and scenario loading

### DIFF
--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 using Serilog;
 
 namespace C7GameData {
@@ -10,7 +9,7 @@ namespace C7GameData {
 		public int seed = -1;   //change here to set a hard-coded seed
 		public int turn { get; set; }
 		public static Random rng; // TODO: Is GameData really the place for this?
-		public IDFactory ids { get; private set; } = new IDFactory();
+		public ID.Factory ids = new();
 		public GameMap map { get; set; }
 		public List<Player> players = new List<Player>();
 		public List<TerrainType> terrainTypes = new List<TerrainType>();

--- a/C7GameData/ID.cs
+++ b/C7GameData/ID.cs
@@ -1,9 +1,16 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using C7GameData.Save;
 
 namespace C7GameData {
+	public interface IHasID {
+		ID id { get; }
+	}
+
 	public class ID {
 		// at runtime, any ID parsed from a string as "<key>-none" will be
 		// compared to other IDs by -0xC7C7
@@ -27,7 +34,7 @@ namespace C7GameData {
 		}
 
 		public static ID FromString(string str) {
-			string[] split  = str.Split('-', 2);
+			string[] split = str.Split('-', 2);
 			string key = split[0];
 			int n = split[1] == "none" ? magicNoneIdNumber : int.Parse(split[1]);
 			if (n < 0) {
@@ -60,33 +67,45 @@ namespace C7GameData {
 		public static bool operator !=(ID lhs, ID rhs) {
 			return !(lhs == rhs);
 		}
+
+		public class Factory {
+			private Dictionary<string, int> keyCounter;
+
+			public Factory() {
+				keyCounter = new Dictionary<string, int>();
+			}
+
+			// When creating an ID Factory for a loaded save game, 
+			// this constructor finds the largest n-value for each ID key.
+			// ie. loading a save with units ["warrior-1", "warrior-3", "worker-2"]
+			//     should result in an id factory with
+			// keyCounter = {
+			//     "warrior": 4,
+			//     "worker": 3,
+			// }
+			public Factory(SaveGame save) {
+				IEnumerable<IHasID> entities = new List<IEnumerable<IHasID>>() {save.Units, save.Cities}
+												.SelectMany(list=> list); // flattening the list
+
+				keyCounter = entities
+					.GroupBy(entity => entity.id.key)
+					.ToDictionary(
+						group => group.Key,
+						group => group.Select(entity => entity.id.n).Max() + 1
+					);
+			}
+
+			public ID CreateID(string key) {
+				int n = keyCounter.GetValueOrDefault(key, 1);
+				keyCounter[key] = n + 1;
+				return new ID(key, n);
+			}
+		}
 	}
 
 	public class IDJsonConverter : JsonConverter<ID> {
 		public override void Write(Utf8JsonWriter writer, ID id, JsonSerializerOptions options) => writer.WriteStringValue(id.ToString());
 
 		public override ID Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => ID.FromString(reader.GetString());
-	}
-
-	public class IDFactory {
-		private Dictionary<string, int> keyCounter;
-
-		// TODO: when creating an IDFactory for a loaded save game, take care
-		// to find the largest n-value for each ID key.
-		// ie. loading a save with units ["warrior-1", "warrior-3", "worker-2"]
-		//     should result in an id factory with
-		// keyCounter = {
-		//     "warrior": 3,
-		//     "worker": 2,
-		// }
-		public IDFactory() {
-			keyCounter = new Dictionary<string, int>();
-		}
-
-		public ID CreateID(string key) {
-			int n = keyCounter.GetValueOrDefault(key, 1);
-			keyCounter[key] = n + 1;
-			return new ID(key, n);
-		}
 	}
 }

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -29,7 +29,7 @@ namespace C7GameData {
 
 		private ImportCiv3() {
 			save = new SaveGame();
-			ids = new ID.Factory(save);
+			ids = new ID.Factory();
 		}
 
 		/// <summary>

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -23,13 +23,13 @@ namespace C7GameData {
 		private BiqData defaultBiq;
 		private SavData savData;
 		private PediaIcons pediaIcons;
-		private readonly IDFactory ids;
+		private readonly ID.Factory ids;
 
 		private static ILogger log = Log.ForContext<ImportCiv3>();
 
 		private ImportCiv3() {
 			save = new SaveGame();
-			ids = new IDFactory();
+			ids = new ID.Factory(save);
 		}
 
 		/// <summary>
@@ -351,20 +351,20 @@ namespace C7GameData {
 		private void ImportBicLeaders() {
 			BiqData theBiq = biq.Race is null ? defaultBiq : biq;
 
- 			// Make a player for each civ. The barbarians are always civ 0.
- 			for (int i = 0; i < save.Civilizations.Count; ++i) {
- 				save.Players.Add(MakeSavePlayerFromCiv(save.Civilizations[i],
- 										/*isBarbarian=*/i == 0,
- 										/*isHuman=*/false,
-										/*cityNameIndex=*/0,
-										/*era=*/""));
- 			}
+			// Make a player for each civ. The barbarians are always civ 0.
+			for (int i = 0; i < save.Civilizations.Count; ++i) {
+				save.Players.Add(MakeSavePlayerFromCiv(save.Civilizations[i],
+									   /*isBarbarian=*/i == 0,
+									   /*isHuman=*/false,
+									   /*cityNameIndex=*/0,
+									   /*era=*/""));
+			}
 
 			// Now fill in the rest of the data using the leader struct.
 			bool foundHuman = false;
 			int leadIndex = 0;
- 			foreach (LEAD lead in theBiq.Lead) {
- 				SavePlayer player = save.Players[lead.Civ];
+			foreach (LEAD lead in theBiq.Lead) {
+				SavePlayer player = save.Players[lead.Civ];
 
 				// Put the player in the correct starting era.
 				player.eraCivilopediaName = theBiq.Eras[lead.InitialEra].CivilopediaEntry;
@@ -378,7 +378,7 @@ namespace C7GameData {
 
 				// Mark the first human playable civ as the human player.
 				if (lead.HumanPlayer == 1 && !foundHuman) {
- 					player.human = true;
+					player.human = true;
 					foundHuman = true;
 				}
 

--- a/C7GameData/Save/SaveCity.cs
+++ b/C7GameData/Save/SaveCity.cs
@@ -6,8 +6,8 @@ namespace C7GameData.Save {
 		public TileLocation tileWorked;
 	}
 
-	public class SaveCity {
-		public ID id;
+	public class SaveCity : IHasID {
+		public ID id { get; set; }
 		public ID owner;
 		public bool capital;
 		public TileLocation location;

--- a/C7GameData/Save/SaveGame.cs
+++ b/C7GameData/Save/SaveGame.cs
@@ -94,6 +94,7 @@ namespace C7GameData.Save {
 				unitPrototypes = UnitPrototypes.ToDictionary(up => up.name),
 				scenarioSearchPath = ScenarioSearchPath,
 				civilizations = Civilizations,
+				ids = new ID.Factory(this),
 			};
 			// units and cities are empty
 			data.map = Map.ToGameMap(data);

--- a/C7GameData/Save/SaveUnit.cs
+++ b/C7GameData/Save/SaveUnit.cs
@@ -3,8 +3,8 @@ using System.Linq;
 
 namespace C7GameData.Save {
 
-	public class SaveUnit {
-		public ID id;
+	public class SaveUnit : IHasID {
+		public ID id { get; set; }
 		public string prototype;
 		public ID owner;
 		public TileLocation previousLocation = new TileLocation();

--- a/C7GameDataTests/IDFactoryTests.cs
+++ b/C7GameDataTests/IDFactoryTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using Xunit;
+using C7GameData;
+using C7GameData.Save;
+
+public class IDFactoryTests {
+	[Fact]
+	public void CreateID_FirstID_ReturnsCorrectID() {
+		var factory = new ID.Factory();
+
+		var id = factory.CreateID("unit");
+
+		Assert.Equal("unit-1", id.ToString());
+	}
+
+	[Fact]
+	public void CreateID_MultipleIDs_IncrementCorrectly() {
+		var factory = new ID.Factory();
+
+		ID id1 = factory.CreateID("unit");
+		ID id2 = factory.CreateID("unit");
+		ID id3 = factory.CreateID("unit");
+
+		Assert.Equal("unit-1", id1.ToString());
+		Assert.Equal("unit-2", id2.ToString());
+		Assert.Equal("unit-3", id3.ToString());
+	}
+
+	[Fact]
+	public void Factory_InitializesWithSaveGame_CorrectlyCountsExistingIDs() {
+		var warrior1 = new SaveUnit{id=ID.FromString("warrior-1")};
+		var warrior2 = new SaveUnit{id=ID.FromString("warrior-3")};
+		var worker = new SaveUnit{id=ID.FromString("worker-2")};
+		var city = new SaveCity{id=ID.FromString("city-1")};
+
+		var saveGame = new SaveGame {
+			Units = new List<SaveUnit> { warrior1, warrior2, worker },
+			Cities = new List<SaveCity> { city }
+		};
+
+		var factory = new ID.Factory(saveGame);
+
+		ID newUnitID = factory.CreateID("warrior");
+		ID newWorkerID = factory.CreateID("worker");
+		ID newCityID = factory.CreateID("city");
+
+		Assert.Equal("warrior-4", newUnitID.ToString());
+		Assert.Equal("worker-3", newWorkerID.ToString());
+		Assert.Equal("city-2", newCityID.ToString());
+	}
+
+	[Fact]
+	public void Factory_HandlesEmptySaveGame_CreatesNewIDs() {
+		var saveGame = new SaveGame();
+		var factory = new ID.Factory(saveGame);
+
+		ID id = factory.CreateID("unit");
+
+		Assert.Equal("unit-1", id.ToString());
+	}
+}
+


### PR DESCRIPTION
This PR fixes ID collisions when loading existing game files by introducing a new constructor to the ID Factory class. The constructor accepts a SaveGame instance and tracks the highest ID count per ID type.

Currently, this is implemented only for units and cities, as they appear to be the only entity types created during gameplay.  In contrast, civilizations and technologies are assigned IDs only at the start of the game, so tracking them when loading a save file is unnecessary.

The PR includes unit tests for the ID Factory.