### PR TITLE
Fix border not disappearing after capturing a city

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -197,6 +197,8 @@ public partial class Game : Node2D {
 							MapUnitExtensions.disband(mCD.city.owner.units[i]);
 						}
 					}
+
+					gameData.UpdateTileOwnersOnCityDestruction(mCD.city);
 					break;
 				case MsgUpdateUiAfterMove mUUAM:
 					// The unit finished moving and still has moves left, so we need to

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -197,8 +197,6 @@ public partial class Game : Node2D {
 							MapUnitExtensions.disband(mCD.city.owner.units[i]);
 						}
 					}
-
-					gameData.UpdateTileOwnersOnCityDestruction(mCD.city);
 					break;
 				case MsgUpdateUiAfterMove mUUAM:
 					// The unit finished moving and still has moves left, so we need to

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -34,6 +34,7 @@ namespace C7Engine {
 			tile.cityAtTile.RemoveAllCitizens();
 			tile.cityAtTile.owner.cities.Remove(tile.cityAtTile);
 			EngineStorage.gameData.cities.Remove(tile.cityAtTile);
+			EngineStorage.gameData.UpdateTileOwnersOnCityDestruction(tile.cityAtTile);
 			new MsgCityDestroyed(tile.cityAtTile).send();
 			tile.cityAtTile = null;
 			tile.overlays.road = false;

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -77,12 +77,26 @@ namespace C7GameData {
 		// Currently, it marks a tile as owned only if it is a city tile or adjacent to a city.
 		public void UpdateTileOwners() {
 			foreach (City city in cities) {
+				if (city.size == 0) {
+					continue; // skip destroyed cities
+				}
+
 				city.location.owner = city.owner;
 
 				foreach (Tile tile in city.location.neighbors.Values) {
 					tile.owner = city.owner;
 				}
 			}
+		}
+
+		public void UpdateTileOwnersOnCityDestruction(City city) {
+			city.location.owner = null;
+
+			foreach (Tile tile in city.location.neighbors.Values) {
+				tile.owner = null;
+			}
+
+			UpdateTileOwners();
 		}
 
 		/**


### PR DESCRIPTION
A minor fix that adds border recalculation on city capturing. The logic for recalculating borders can definitely be made cleaner (mainly to avoid recalculating all borders after a capture), but I see no sense in doing so until we have proper culture/territory calculations.