### PR TITLE
Improve handling of variables and relative paths when reading paths from env vars

### DIFF
--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -1,57 +1,20 @@
 using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using C7Engine;
-using Godot;
 using ConvertCiv3Media;
-using C7GameData;
+using Godot;
 using QueryCiv3;
 
 public partial class Util {
 	static public string Civ3Root = Civ3Location.GetCiv3Path();
 
-	static private string SteamCommonDir() {
-		string home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.Personal);
-		if (home == null) { return null; }
-		return System.IO.Path.Combine(home, "Library/Application Support/Steam/steamapps/common");
-	}
-
-	static private bool FolderIsCiv3(System.IO.DirectoryInfo di) {
-		return di.EnumerateFiles().Any(f => f.Name == "civ3id.mb");
-	}
-
 	static public string GetCiv3Path() {
-		// Use CIV3_HOME env var if present
-		string path = System.Environment.GetEnvironmentVariable("CIV3_HOME");
-		if (path != null) { return path; }
-
-		// Use settings value if present
-		path = C7Settings.GetSettingValue("locations", "civ3InstallDir");
+		string path = C7Settings.GetSettingValue("locations", "civ3InstallDir");
 		if (path != null) return path;
 
-		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-			// Look up in Windows registry if present
-			path = Civ3PathFromRegistry();
-			if (path != null) { return path; }
-		} else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
-			// Check for a civ3 folder in steamapps/common
-			System.IO.DirectoryInfo root = new System.IO.DirectoryInfo(Util.SteamCommonDir());
-			foreach (System.IO.DirectoryInfo di in root.GetDirectories()) {
-				if (Util.FolderIsCiv3(di)) {
-					return di.FullName;
-				}
-			}
-		}
-
-		return "/civ3/path/not/found";
-	}
-
-	static public string Civ3PathFromRegistry() {
-		// Assuming 64-bit platform, get vanilla Civ3 install folder from registry
-		// Return null if value not present or if key not found
-		object path = Microsoft.Win32.Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Infogrames Interactive\Civilization III", "install_path", null);
-		return path == null ? null : (string)path;
+		return Civ3Location.GetCiv3Path();
 	}
 
 	// Checks if a file exists ignoring case on the latter parts of its path. If the file is found, returns its full path re-capitalized as

--- a/QueryCiv3/Civ3Location.cs
+++ b/QueryCiv3/Civ3Location.cs
@@ -1,5 +1,8 @@
+using System;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 
 namespace QueryCiv3 {
 	public class Civ3Location {
@@ -7,20 +10,38 @@ namespace QueryCiv3 {
 
 		private static string SteamCommonDir() {
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-				string programFilesX86 = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFilesX86);
-				return System.IO.Path.Join(programFilesX86, "Steam\\steamapps\\common");
+				string programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+				return Path.Join(programFilesX86, "Steam\\steamapps\\common");
 			}
-			string home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.Personal);
-			return home == null ? null : System.IO.Path.Combine(home, "Library/Application Support/Steam/steamapps/common");
+			string home = GetHome();
+			return home == null ? null : Path.Combine(home, "Library/Application Support/Steam/steamapps/common");
 		}
 
-		private static bool FolderIsCiv3(System.IO.DirectoryInfo di) {
+		private static string GetHome() => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+		private static bool FolderIsCiv3(DirectoryInfo di) {
 			return di.EnumerateFiles().Any(f => f.Name == "civ3id.mb");
+		}
+
+		private static string ConvertUnixVarsToWindowsVars(string input) {
+			if (string.IsNullOrEmpty(input)) return input;
+
+			// Replace all instances of $VARIABLE with %VARIABLE%
+			return Regex.Replace(input, @"\$(\w+)", match => $"%{match.Groups[1].Value}%");
+		}
+
+		private static string GetExpandedPath(string path) {
+			bool isUnixLike = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+			if (isUnixLike && path[0] == '~') path = GetHome() + path.Substring(1);
+			if (isUnixLike) path = ConvertUnixVarsToWindowsVars(path);
+			path = Environment.ExpandEnvironmentVariables(path);
+			path = Path.GetFullPath(path);
+			return path;
 		}
 
 		public static string GetCiv3Path() {
 			// Use CIV3_HOME env var if present
-			string path = System.Environment.GetEnvironmentVariable("CIV3_HOME");
+			string path = GetExpandedPath(Environment.GetEnvironmentVariable("CIV3_HOME"));
 			if (path != null) { return path; }
 
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
@@ -30,16 +51,18 @@ namespace QueryCiv3 {
 					return path;
 				}
 			}
+
 			// Check for a civ3 folder in steamapps/common
 			string steam = SteamCommonDir();
 			if (!string.IsNullOrEmpty(steam)) {
-				System.IO.DirectoryInfo root = new(steam);
-				foreach (System.IO.DirectoryInfo di in root.GetDirectories()) {
+				DirectoryInfo root = new(steam);
+				foreach (DirectoryInfo di in root.GetDirectories()) {
 					if (FolderIsCiv3(di)) {
 						return di.FullName;
 					}
 				}
 			}
+
 			return "/civ3/path/not/found";
 		}
 	}


### PR DESCRIPTION
Should resolve https://github.com/C7-Game/Prototype/issues/460 . 

Some notes on the approach taken: 

Dotnet has [Environment.ExpandEnvironmentVariables](https://learn.microsoft.com/en-us/dotnet/api/system.environment.expandenvironmentvariables?view=net-9.0) which seems like it'd be suitable for expanding any nested environment variables, but [by design](https://github.com/dotnet/runtime/issues/25792) that method only supports Windows-style `%VARIABLES%`. I could not find any ready-made .NET functions or util libraries that fully addressed the concerns flagged in issue 460, so I added some ad-hoc checks and updates to the `GetCiv3Path` method in `Civ3Location.cs`.

In `Util.cs`, I noticed that its `GetCiv3Path` method seems to be unused at the moment, with the `Civ3Root` property forwarding out to `Civ3Location.GetCiv3Path`. I thought it made sense to consolidate the similar `GetCiv3Path` methods in `Util.cs` and `Civ3Location.cs` to a single method, so I updated `Util.GetCiv3Path` to point to `Civ3Location.GetCiv3Path` (but first checking C7Settings for a saved civ3 location, since that seemed like a significant difference between the two methods). I'd be happy to either fully remove `Util.GetCiv3Path` or restore its original method body and then also add my changes to that method if either of those would be preferred. 

I updated the `GetHome` function from using `Environment.SpecialFolder.Personal` to using `Environment.SpecialFolder.UserProfile` , this is because .NET 8 (which I see is on the roadmap) has a breaking change to `SpecialFolder.Personal` changing behavior for Linux systems from returning `$HOME` to returning "`XDG_DOCUMENTS_DIR` if available; otherwise `$HOME/Documents`". `Environment.SpecialFolder.UserProfile` returns $HOME under both .NET 7 and .NET 8.

Tested relative directory handling and environment variable replacement on a local Windows game build with these changes, both worked successfully. I tested the logic for relative directory handling, Unix-style environment variable replacement, and `~` home path replacement in a Console app in WSL and that also worked as expected. Haven't tested the full game build with these changes on Linux or OSX because I don't currently have setups for those operating systems, but if that's needed before merge I can setup a Linux VM and try to validate there as well.