### PR TITLE
Display tile yields when zooming to a city

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -127,6 +127,10 @@ public partial class Game : Node2D {
 					if (startingSettler != null)
 						mapView.centerCameraOnTile(startingSettler.location);
 				}
+
+				// Allow the city screen to control whether tile assignments
+				// are visible.
+				cityScreen.tileAssignmentLayer = mapView.tileAssignmentLayer;
 			}
 
 			//TODO: What was this supposed to do?  It throws errors and occasinally causes crashes now, because _OnViewportSizeChanged doesn't exist
@@ -576,7 +580,7 @@ public partial class Game : Node2D {
 		}
 
 		if (currentAction == C7Action.Escape && cityScreen.Visible) {
-			cityScreen.Hide();
+			cityScreen.HideScreen();
 			return;
 		}
 

--- a/C7/Map/GotoLayer.cs
+++ b/C7/Map/GotoLayer.cs
@@ -8,8 +8,6 @@ using Godot;
 // The layer responsible for drawing the cursor when the player is selecting a
 // move via the "goto" command.
 public partial class GotoLayer : LooseLayer {
-	public const int cursorZIndex = UnitLayer.cursorZIndex - 1;
-
 	public GotoLayer() {
 		// Load the font we'll use for the goto move counter.
 		//

--- a/C7/Map/TileAssignmentLayer.cs
+++ b/C7/Map/TileAssignmentLayer.cs
@@ -1,0 +1,51 @@
+using System;
+using C7GameData;
+using Godot;
+
+namespace C7.Map {
+	public partial class TileAssignmentLayer : LooseLayer {
+		ImageTexture foodTexture = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 195, 1, 21, 30);
+		ImageTexture shieldTexture = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 133, 1, 16, 30);
+		ImageTexture goldTexture = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 67, 1, 21, 30);
+
+		// When non-null, the city whose tile assignments should be shown.
+
+		public City city = null;
+
+		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
+			if (city == null) {
+				return;
+			}
+
+			// TODO: we probably want to indicate whether a tile is part of the
+			// city's big fat cross (assuming a border expand) but ignoring
+			// unworked tiles should work for now.
+			if (tile.personWorkingTile?.city != city && tile.cityAtTile != city) {
+				return;
+			}
+
+			int food = tile.foodYield(city.owner);
+			int shields = tile.productionYield(city.owner);
+			int gold = tile.commerceYield(city.owner);
+
+			int totalWidth = (food * foodTexture.GetWidth()) +
+						(shields * shieldTexture.GetWidth()) +
+						(gold * goldTexture.GetWidth());
+			int currentXOffset = -totalWidth / 2;
+
+			for (int i = 0; i < food; ++i) {
+				looseView.DrawTexture(foodTexture, tileCenter + new Vector2(currentXOffset, -15));
+				currentXOffset += foodTexture.GetWidth();
+			}
+			for (int i = 0; i < shields; ++i) {
+				looseView.DrawTexture(shieldTexture, tileCenter + new Vector2(currentXOffset, -15));
+				currentXOffset += shieldTexture.GetWidth();
+			}
+			for (int i = 0; i < gold; ++i) {
+				looseView.DrawTexture(goldTexture, tileCenter + new Vector2(currentXOffset, -15));
+				currentXOffset += goldTexture.GetWidth();
+			}
+		}
+
+	}
+}

--- a/C7/Map/UnitLayer.cs
+++ b/C7/Map/UnitLayer.cs
@@ -12,9 +12,9 @@ public partial class UnitLayer : LooseLayer {
 
 	// The unit animations, effect animations, and cursor are all drawn as children attached to the looseView but aren't created and attached in
 	// any particular order so we must use the ZIndex property to ensure they're properly layered.
-	public const int effectAnimZIndex = 150;
-	public const int unitAnimZIndex = 100;
-	public const int cursorZIndex = 50;
+	public const int effectAnimZIndex = 1;
+	public const int unitAnimZIndex = 0;
+	public const int cursorZIndex = -1;
 
 	public UnitLayer() {
 		var iconPCX = new Pcx(Util.Civ3MediaPath("Art/Units/units_32.pcx"));

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -551,7 +551,7 @@ public partial class MapView : Node2D {
 		set { setCameraZoomFromMiddle(value); }
 	}
 
-	private LooseView looseView;
+	private List<LooseView> looseViews = new();
 
 	// Specifies a rectangular block of tiles that are currently potentially on screen. Accessible through getVisibleRegion(). Tile coordinates
 	// are "virtual", i.e. "unwrapped", so there isn't necessarily a tile at each location. The region is intended to include the upper left
@@ -568,6 +568,7 @@ public partial class MapView : Node2D {
 
 	public GridLayer gridLayer { get; private set; }
 	public CityLayer cityLayer { get; private set; }
+	public TileAssignmentLayer tileAssignmentLayer { get; private set; }
 
 	public ImageTexture civColorWhitePalette = null;
 
@@ -578,34 +579,68 @@ public partial class MapView : Node2D {
 		this.wrapHorizontally = wrapHorizontally;
 		this.wrapVertically = wrapVertically;
 
-		looseView = new LooseView(this);
-		looseView.layers.Add(new TerrainLayer());
-		looseView.layers.Add(new RiverLayer());
-		looseView.layers.Add(new ForestLayer());
-		looseView.layers.Add(new MarshLayer());
-		looseView.layers.Add(new HillsLayer());
-		looseView.layers.Add(new TntLayer());
-		looseView.layers.Add(new TileOverlayLayer());
-		looseView.layers.Add(new ResourceLayer());
+		// Set up our set of views, and the layers within each view.
+		//
+		// The drawing order within a view matches the order of `layers`, so
+		// here borders will be drawn on top of the terrain.
+		//
+		// However, because cities and units use child nodes, we need separate
+		// LooseView objects to get the ordering correct between textures and
+		// nodes. Without this unit health bars (which are textures) would
+		// be drawn behind cities (which are child nodes).
+		LooseView terrainView = new(this);
+		terrainView.layers.Add(new TerrainLayer());
+		terrainView.layers.Add(new RiverLayer());
+		terrainView.layers.Add(new ForestLayer());
+		terrainView.layers.Add(new MarshLayer());
+		terrainView.layers.Add(new HillsLayer());
+		terrainView.layers.Add(new TntLayer());
+		terrainView.layers.Add(new TileOverlayLayer());
+		terrainView.layers.Add(new ResourceLayer());
 		this.gridLayer = new GridLayer();
-		looseView.layers.Add(this.gridLayer);
-		looseView.layers.Add(new BuildingLayer());
-		looseView.layers.Add(new BorderLayer());
-		looseView.layers.Add(new UnitLayer());
-		looseView.layers.Add(new GotoLayer());
+		terrainView.layers.Add(this.gridLayer);
+		terrainView.layers.Add(new BuildingLayer());
+		terrainView.layers.Add(new BorderLayer());
+
+		LooseView cityView = new(this);
 		this.cityLayer = new();
-		looseView.layers.Add(this.cityLayer);
-		looseView.layers.Add(new FogOfWarLayer());
+		cityView.layers.Add(this.cityLayer);
+
+		LooseView unitView = new(this);
+		unitView.layers.Add(new UnitLayer());
+		unitView.layers.Add(new GotoLayer());
+
+		LooseView tileAssignmentView = new(this);
+		this.tileAssignmentLayer = new();
+		tileAssignmentView.layers.Add(this.tileAssignmentLayer);
+
+		LooseView fogOfWarView = new(this);
+		fogOfWarView.layers.Add(new FogOfWarLayer());
 
 		(civColorWhitePalette, _) = Util.loadPalettizedPCX("Art/Units/Palettes/ntp00.pcx");
 
-		AddChild(looseView);
+		AddChild(terrainView);
+		looseViews.Add(terrainView);
+
+		AddChild(cityView);
+		looseViews.Add(cityView);
+
+		AddChild(unitView);
+		looseViews.Add(unitView);
+
+		AddChild(tileAssignmentView);
+		looseViews.Add(tileAssignmentView);
+
+		AddChild(fogOfWarView);
+		looseViews.Add(fogOfWarView);
 	}
 
 	public override void _Process(double delta) {
 		// Redraw everything. This is necessary so that animations play. Maybe we could only update the unit layer but long term I think it's
 		// better to redraw everything every frame like a typical modern video game.
-		looseView.QueueRedraw();
+		foreach (LooseView looseView in looseViews) {
+			looseView.QueueRedraw();
+		}
 	}
 
 	// Returns the size in pixels of the area in which the map will be drawn. This is the viewport size or, if that's null, the window size.
@@ -631,7 +666,9 @@ public partial class MapView : Node2D {
 		Vector2 v2OldZoom = new Vector2(cameraZoom, cameraZoom);
 		if (v2NewZoom != v2OldZoom) {
 			internalCameraZoom = newScale;
-			looseView.Scale = v2NewZoom;
+			foreach (LooseView looseView in looseViews) {
+				looseView.Scale = v2NewZoom;
+			}
 			setCameraLocation((v2NewZoom / v2OldZoom) * (cameraLocation + center) - center);
 		}
 	}
@@ -688,7 +725,9 @@ public partial class MapView : Node2D {
 		}
 
 		internalCameraLocation = location;
-		looseView.Position = -location;
+		foreach (LooseView looseView in looseViews) {
+			looseView.Position = -location;
+		}
 	}
 
 	public Vector2 screenLocationOfTileCoords(int X, int Y, bool center = true) {

--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -3,12 +3,14 @@ using System;
 using Serilog;
 using System.Collections.Generic;
 using C7GameData;
+using C7.Map;
 
 
 // Handles the city screen, where citizens can be assigned and other details of
 // the city can bee seen.
 public partial class CityScreen : CenterContainer {
 	private ILogger log = LogManager.ForContext<CityScreen>();
+	public TileAssignmentLayer tileAssignmentLayer;
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
@@ -23,13 +25,19 @@ public partial class CityScreen : CenterContainer {
 			TexturePressed = Util.LoadTextureFromPCX("Art/city screen/cityMgmtButtons.pcx", 155, 99, 32, 48)
 		};
 		close.SetPosition(new Vector2(950, 20));
-		close.Pressed += () => { this.Hide(); };
+		close.Pressed += () => { HideScreen(); };
 		background.AddChild(close);
 
 		this.Hide();
 	}
 
+	public void HideScreen() {
+		this.Hide();
+		tileAssignmentLayer.city = null;
+	}
+
 	private void OnShowCityScreen(ParameterWrapper<City> city) {
 		this.Show();
+		tileAssignmentLayer.city = city.Value;
 	}
 }

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -172,6 +172,7 @@ namespace C7GameData {
 			return (Math.Abs(other.XCoordinate - this.XCoordinate) + Math.Abs(other.YCoordinate - this.YCoordinate)) / 2;
 		}
 
+		// TODO: This is innacurate for city centers.
 		public int foodYield(Player player) {
 			int yield = overlayTerrainType.baseFoodProduction;
 			if (this.Resource != Resource.NONE && player.KnowsAboutResource(Resource)) {
@@ -183,6 +184,7 @@ namespace C7GameData {
 			return yield;
 		}
 
+		// TODO: This is innacurate for city centers.
 		public int productionYield(Player player) {
 			int yield = overlayTerrainType.baseShieldProduction;
 			if (overlayTerrainType.Key == "grassland" && this.isBonusShield) {
@@ -197,6 +199,7 @@ namespace C7GameData {
 			return yield;
 		}
 
+		// TODO: This is innacurate for city centers.
 		public int commerceYield(Player player) {
 			int yield = overlayTerrainType.baseCommerceProduction;
 			if (this.Resource != Resource.NONE && player.KnowsAboutResource(Resource)) {


### PR DESCRIPTION
This allows us to see what tiles are being worked, and also makes it clearer that we are currently giving the wrong yield for city centers.

In order for this to render properly I had to fix some issues with how the map view layers worked. Previously all the layers we part of the same `Node2D`, and most things were draw as textures. However, cities and units are child nodes, and child nodes are drawn on top of textures. This usually isn't a problem, but it meant that drawing the city center tile yield was hidden by the city itself. This also is the reason health bars were partially hidden by the city - the health bar is a texture, the city is a node.

To fix this I grouped the layers into separate nodes, so that within each node the layer ordering was simple, and then the node ordering took effect after that. As a result health bars now render properly, and we can see the city center yield.

This also shows that the city center yield is wrong! Next steps will include fixing that tile yield, and implementing support for changing tile assignments.

Some screenshots:

Right after creating the city:

![image](https://github.com/user-attachments/assets/c00ebf75-2a04-4678-8d39-516952846349)

After mining+roading a tile:

![image](https://github.com/user-attachments/assets/816533fd-a522-48e8-8e11-219dca7b06b8)

After irrigating+roading a tile:

![image](https://github.com/user-attachments/assets/32f139a8-ad9c-4870-85f3-db7bf561ebeb)

#541