### PR TITLE
Allow modifying tile assignments in the city screen 

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -129,8 +129,9 @@ public partial class Game : Node2D {
 				}
 
 				// Allow the city screen to control whether tile assignments
-				// are visible.
+				// are visible and map UI locations back to map locations.
 				cityScreen.tileAssignmentLayer = mapView.tileAssignmentLayer;
+				cityScreen.mapView = mapView;
 			}
 
 			//TODO: What was this supposed to do?  It throws errors and occasinally causes crashes now, because _OnViewportSizeChanged doesn't exist

--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -4,6 +4,8 @@ using Serilog;
 using System.Collections.Generic;
 using C7GameData;
 using C7.Map;
+using C7Engine;
+using C7Engine.AI;
 
 
 // Handles the city screen, where citizens can be assigned and other details of
@@ -11,6 +13,7 @@ using C7.Map;
 public partial class CityScreen : CenterContainer {
 	private ILogger log = LogManager.ForContext<CityScreen>();
 	public TileAssignmentLayer tileAssignmentLayer;
+	public MapView mapView;
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
@@ -29,6 +32,92 @@ public partial class CityScreen : CenterContainer {
 		background.AddChild(close);
 
 		this.Hide();
+	}
+
+	public override void _UnhandledInput(InputEvent @event) {
+		// Only capture mouse events if we're visible.
+		if (!this.Visible) {
+			return;
+		}
+
+		// If we left clicked on a tile, handle reassigning a citizen accordingly.
+		if (@event is InputEventMouseButton eventMouseButton) {
+			if (eventMouseButton.ButtonIndex == MouseButton.Left) {
+				GetViewport().SetInputAsHandled();
+				if (eventMouseButton.IsPressed()) {
+					using (UIGameDataAccess gameDataAccess = new()) {
+						Tile tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
+						if (tile != null) {
+							HandleReassignment(tile);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private void HandleReassignment(Tile tile) {
+		City city = tileAssignmentLayer.city;
+
+		// We can't assign citizens to other cities.
+		if (tile.cityAtTile != null && tile.cityAtTile != city) {
+			return;
+		}
+
+		// We can't assign citizens to tiles worked by other cities.
+		if (tile.personWorkingTile != null && tile.personWorkingTile.city != city) {
+			return;
+		}
+
+		// If we're already working a tile and click on it, turn the citizen
+		// into an entertainer.
+		if (tile.personWorkingTile != null && tile.personWorkingTile.city == city) {
+			// TODO: implement entertainers.
+			return;
+		}
+
+		// We've clicked on an unworked tile, move the "worst" citizen to that
+		// tile.
+		//
+		// TODO: only allow this within the city's borders/BFC.
+		if (tile.cityAtTile == null) {
+			int worstYield = int.MaxValue;
+			CityResident worst = null;
+
+			foreach (CityResident cr in city.residents) {
+				int tileYield = cr.tileWorked.foodYield(city.owner) +
+								cr.tileWorked.productionYield(city.owner) +
+								cr.tileWorked.commerceYield(city.owner);
+				if (tileYield < worstYield) {
+					worstYield = tileYield;
+					worst = cr;
+				}
+			}
+
+			// Move the worst citizen to our new tile, being sure to update
+			// backpointers from the tile.
+			worst.tileWorked.personWorkingTile = null;
+			worst.tileWorked = tile;
+			tile.personWorkingTile = worst;
+			return;
+		}
+
+		// If we've clicked the city center, re-assign all the citizens using
+		// the basic AI.
+		//
+		// TODO: This throws away existing nationalities, fix that.
+		if (tile.cityAtTile == city) {
+			int numResidents = city.residents.Count;
+			city.RemoveAllCitizens();
+
+			for (int i = 0; i < numResidents; ++i) {
+				CityResident newResident = new() {
+					nationality = city.owner.civilization,
+					city = city
+				};
+				CityTileAssignmentAI.AssignNewCitizenToTile(newResident);
+			}
+		}
 	}
 
 	public void HideScreen() {


### PR DESCRIPTION
This currently only allows moving the "worst" citizen as well as resetting tile assignments by clicking on the city center, but it's a good start. Implementing entertainers (which is necessary to support fancier moves) will be a separate PR.

#541

Here's a screenshot showing a citizen reassigned to a suboptimal tile.

![image](https://github.com/user-attachments/assets/fff493b0-5460-41a4-94d8-049f9b8929ff)
