### PR TITLE
Tile.cs: Use TileLocation instead of a tuple in NeighborCoordinate

### DIFF
--- a/C7GameData/GameMap.cs
+++ b/C7GameData/GameMap.cs
@@ -1,6 +1,8 @@
 namespace C7GameData {
 	using System;
 	using System.Collections.Generic;
+	using C7GameData.Save;
+
 	/**
 	 * The game map, at the top level.
 	 */
@@ -117,9 +119,9 @@ namespace C7GameData {
 		 * or the NONE tile if there is no neighbor in said direction.
 		 **/
 		public Tile tileNeighbor(Tile center, TileDirection direction) {
-			Tuple<int, int> neighbor = Tile.NeighborCoordinate(center.XCoordinate, center.YCoordinate, direction);
+			TileLocation neighbor = Tile.NeighborCoordinate(new TileLocation(center), direction);
 			//TODO: World wrap should also be accounted for.
-			return tileAt(neighbor.Item1, neighbor.Item2);
+			return tileAt(neighbor.X, neighbor.Y);
 		}
 
 		public delegate int[,] TerrainNoiseMapGenerator(int rng, int width, int height);

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -271,16 +271,14 @@ namespace C7GameData {
 				SavePlayer player = playerLookup[unit.owner];
 				player.tileKnowledge.Add(unit.currentLocation);
 				foreach (TileDirection direction in Enum.GetValues(typeof(TileDirection))) {
-					Tuple<int, int> neighbor = Tile.NeighborCoordinate(unit.currentLocation.X, unit.currentLocation.Y, direction);
-					player.tileKnowledge.Add(new TileLocation(neighbor.Item1, neighbor.Item2));
+					player.tileKnowledge.Add(Tile.NeighborCoordinate(unit.currentLocation, direction));
 				}
 			}
 			foreach (SaveCity city in save.Cities) {
 				SavePlayer player = playerLookup[city.owner];
 				player.tileKnowledge.Add(city.location);
 				foreach (TileDirection direction in Enum.GetValues(typeof(TileDirection))) {
-					Tuple<int, int> neighbor = Tile.NeighborCoordinate(city.location.X, city.location.Y, direction);
-					player.tileKnowledge.Add(new TileLocation(neighbor.Item1, neighbor.Item2));
+					player.tileKnowledge.Add(Tile.NeighborCoordinate(city.location, direction));
 				}
 			}
 

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -3,6 +3,7 @@ namespace C7GameData {
 	using System.Text.Json.Serialization;
 	using System.Collections.Generic;
 	using System.Linq;
+	using C7GameData.Save;
 
 	public class Tile {
 		public ID Id { get; internal set; }
@@ -221,38 +222,38 @@ namespace C7GameData {
 		}
 
 		// Returns the X and Y coordinates of the neighbor in the specified direction.
-		public static Tuple<int, int> NeighborCoordinate(int X, int Y, TileDirection direction) {
+		public static TileLocation NeighborCoordinate(TileLocation location, TileDirection direction) {
 			switch (direction) {
 				case TileDirection.NORTH:
-					Y -= 2;
+					location.Y -= 2;
 					break;
 				case TileDirection.NORTHEAST:
-					Y--;
-					X++;
+					location.Y--;
+					location.X++;
 					break;
 				case TileDirection.EAST:
-					X += 2;
+					location.X += 2;
 					break;
 				case TileDirection.SOUTHEAST:
-					Y++;
-					X++;
+					location.Y++;
+					location.X++;
 					break;
 				case TileDirection.SOUTH:
-					Y += 2;
+					location.Y += 2;
 					break;
 				case TileDirection.SOUTHWEST:
-					Y++;
-					X--;
+					location.Y++;
+					location.X--;
 					break;
 				case TileDirection.WEST:
-					X -= 2;
+					location.X -= 2;
 					break;
 				case TileDirection.NORTHWEST:
-					X--;
-					Y--;
+					location.X--;
+					location.Y--;
 					break;
 			}
-			return Tuple.Create(X, Y);
+			return location;
 		}
 	}
 


### PR DESCRIPTION
This simplifies some expressions and will allow chaining calls to NeighborCoordinate in a following PR.

#541
