### PR TITLE
Import the tile assignments of citizens from save files

### DIFF
--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -514,8 +514,19 @@ namespace C7GameData {
 					shieldsStored = city.ShieldsCollected,
 					foodStored = city.TotalFood,
 					foodNeededToGrow = 20, // HACK: don't know where to find this
-					// residents = city.Ppod // TODO: load tiles worked from PPOD
 				};
+
+				foreach (QueryCiv3.Sav.CTZN ctzn in savData.CityCtzn[i]) {
+					if (ctzn.TileWorked == 0) {
+						// TODO: handle resistors and specialists
+						continue;
+					}
+					SaveCityResident scr = new();
+					scr.city = saveCity.id;
+					scr.tileWorked = GetTileFromSpiral(saveCity.location, ctzn.TileWorked);
+					scr.nationality = save.Civilizations[ctzn.Nationality].name;
+					saveCity.residents.Add(scr);
+				}
 				save.Cities.Add(saveCity);
 			}
 		}
@@ -540,8 +551,12 @@ namespace C7GameData {
 					shieldsStored = 0,
 					foodStored = 0,
 					foodNeededToGrow = 20, // HACK: don't know where to find this
-					// residents = city.Ppod // TODO: load tiles worked from PPOD
 				};
+
+				// TODO: figure out how residents are assigned in scenarios - is
+				// it just the default assignment? If so maybe we can just use
+				// our tile assignment ai.
+
 				save.Cities.Add(saveCity);
 			}
 		}
@@ -777,6 +792,61 @@ namespace C7GameData {
 				save.Map.tilesTall = biq.Wmap[0].Height;
 				save.Map.tilesWide = biq.Wmap[0].Width;
 			}
+		}
+
+		// The position of citizens is encoded in a single byte as positions in
+		// a spiral around the city, starting with the NE tile and going
+		// clockwise. After the inner spiral, it continues with the top of the
+		// NE outer spiral. Here's a crude ASCII diagram of this.
+		//
+		//                      <   8  >
+		//                  <   7  ><   1  >
+		//              <   6  >< City ><   2  >
+		//                  <   5  ><   3  >
+		//                      <   4  >
+		//
+		//                  <  20  ><  9  >
+		//              <  19  >        <  10  >
+		//          <  18  >                <  11 >
+		//                      < City >
+		//          <  17  >                <  12  >
+		//              <  16  >        <  13  >
+		//                  <  15  ><  14  >
+		private static TileLocation GetTileFromSpiral(TileLocation start, int spiral) {
+			return spiral switch {
+				// Inner circle.
+				1 => Tile.NeighborCoordinate(start, TileDirection.NORTHEAST),
+				2 => Tile.NeighborCoordinate(start, TileDirection.EAST),
+				3 => Tile.NeighborCoordinate(start, TileDirection.SOUTHEAST),
+				4 => Tile.NeighborCoordinate(start, TileDirection.SOUTH),
+				5 => Tile.NeighborCoordinate(start, TileDirection.SOUTHWEST),
+				6 => Tile.NeighborCoordinate(start, TileDirection.WEST),
+				7 => Tile.NeighborCoordinate(start, TileDirection.NORTHWEST),
+				8 => Tile.NeighborCoordinate(start, TileDirection.NORTH),
+
+				// Outer circle, to the NE
+				9 => Tile.NeighborCoordinate(Tile.NeighborCoordinate(start, TileDirection.NORTHEAST), TileDirection.NORTH),
+				10 => Tile.NeighborCoordinate(Tile.NeighborCoordinate(start, TileDirection.NORTHEAST), TileDirection.NORTHEAST),
+				11 => Tile.NeighborCoordinate(Tile.NeighborCoordinate(start, TileDirection.NORTHEAST), TileDirection.EAST),
+
+				// Outer circle, to the SE
+				12 => Tile.NeighborCoordinate(Tile.NeighborCoordinate(start, TileDirection.SOUTHEAST), TileDirection.EAST),
+				13 => Tile.NeighborCoordinate(Tile.NeighborCoordinate(start, TileDirection.SOUTHEAST), TileDirection.SOUTHEAST),
+				14 => Tile.NeighborCoordinate(Tile.NeighborCoordinate(start, TileDirection.SOUTHEAST), TileDirection.SOUTH),
+
+				// Outer circle, to the SW
+				15 => Tile.NeighborCoordinate(Tile.NeighborCoordinate(start, TileDirection.SOUTHWEST), TileDirection.SOUTH),
+				16 => Tile.NeighborCoordinate(Tile.NeighborCoordinate(start, TileDirection.SOUTHWEST), TileDirection.SOUTHWEST),
+				17 => Tile.NeighborCoordinate(Tile.NeighborCoordinate(start, TileDirection.SOUTHWEST), TileDirection.WEST),
+
+				// Outer circle, to the NW
+				18 => Tile.NeighborCoordinate(Tile.NeighborCoordinate(start, TileDirection.NORTHWEST), TileDirection.WEST),
+				19 => Tile.NeighborCoordinate(Tile.NeighborCoordinate(start, TileDirection.NORTHWEST), TileDirection.NORTHWEST),
+				20 => Tile.NeighborCoordinate(Tile.NeighborCoordinate(start, TileDirection.NORTHWEST), TileDirection.NORTH),
+
+				_ => throw new ArgumentOutOfRangeException("Invalid spiral value" + spiral),
+			};
+
 		}
 	}
 }

--- a/C7GameData/Save/SaveCity.cs
+++ b/C7GameData/Save/SaveCity.cs
@@ -63,6 +63,11 @@ namespace C7GameData.Save {
 					city = city,
 				};
 			});
+
+			// Fill in the back pointers.
+			foreach (CityResident cr in city.residents) {
+				cr.tileWorked.personWorkingTile = cr;
+			}
 			return city;
 		}
 	}

--- a/QueryCiv3/SavSections/Ctzn.cs
+++ b/QueryCiv3/SavSections/Ctzn.cs
@@ -7,6 +7,8 @@ namespace QueryCiv3.Sav {
 		private fixed byte HeaderText[4];
 		public int Length;
 		private fixed byte UnknownBuffer[1];
+
+		// See ImportCiv3::GetTileFromSpiral for details on this field.
 		public byte TileWorked;
 
 		private fixed byte Text[262];


### PR DESCRIPTION
This doesn't yet handle resistors or specialists, and doesn't handle scenarios.

The "spiral" logic was tested by creating a bunch of sav files with one city and one population, and then positioning that citizen in each of the spots. I then printed the tile worked variable in the `SaveTest` for each of them to confirm the ordering.

#541


Example screenshot from a random save:

![image](https://github.com/user-attachments/assets/237540fb-6fd0-4ce0-bb97-5e2aae94dff2)