### PR TITLE
Fix Error on Windows when CIV3_HOME was not set.

### DIFF
--- a/QueryCiv3/Civ3Location.cs
+++ b/QueryCiv3/Civ3Location.cs
@@ -31,6 +31,7 @@ namespace QueryCiv3 {
 		}
 
 		private static string GetExpandedPath(string path) {
+			// if (path == null) return null;
 			bool isUnixLike = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 			if (isUnixLike && path[0] == '~') path = GetHome() + path.Substring(1);
 			if (isUnixLike) path = ConvertUnixVarsToWindowsVars(path);
@@ -41,8 +42,8 @@ namespace QueryCiv3 {
 
 		public static string GetCiv3Path() {
 			// Use CIV3_HOME env var if present
-			string path = GetExpandedPath(Environment.GetEnvironmentVariable("CIV3_HOME"));
-			if (path != null) { return path; }
+			string path = Environment.GetEnvironmentVariable("CIV3_HOME");
+			if (path != null) { return GetExpandedPath(path); }
 
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
 				// Look up in Windows registry if present

--- a/QueryCiv3/Civ3Location.cs
+++ b/QueryCiv3/Civ3Location.cs
@@ -31,7 +31,6 @@ namespace QueryCiv3 {
 		}
 
 		private static string GetExpandedPath(string path) {
-			// if (path == null) return null;
 			bool isUnixLike = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 			if (isUnixLike && path[0] == '~') path = GetHome() + path.Substring(1);
 			if (isUnixLike) path = ConvertUnixVarsToWindowsVars(path);


### PR DESCRIPTION
I move the check for null one step up in the chain and now it works, but should also work for Linux. 

The original problem was that Environment.ExpandEnvironmentVariables(path); throws a nullpointerexception when fed a null value.