### PR TITLE
 Provide tile assignments for cities in scenarios

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -6,6 +6,7 @@ using C7GameData;
 using Serilog;
 using C7Engine.Pathing;
 using System.Collections.Generic;
+using C7Engine.AI;
 
 public partial class Game : Node2D {
 	[Signal] public delegate void TurnStartedEventHandler();
@@ -105,6 +106,17 @@ public partial class Game : Node2D {
 				Util.setModPath(scenarioSearchPath);
 				log.Debug("RelativeModPath ", scenarioSearchPath);
 				return Util.Civ3MediaPath("Text/PediaIcons.txt");
+			}, (City city, CitizenType ct) => {
+				// Provide tile assignments for scenarios, which don't specify
+				// this in the BIC file.
+				for (int i = 0; i < city.size; ++i) {
+					CityResident newResident = new() {
+						citizenType = ct,
+						nationality = city.owner.civilization,
+						city = city
+					};
+					CityTileAssignmentAI.AssignNewCitizenToTile(newResident);
+				}
 			}); // Spawns engine thread
 			Global.ResetLoadGamePath();
 

--- a/C7Engine/EntryPoints/CreateGame.cs
+++ b/C7Engine/EntryPoints/CreateGame.cs
@@ -12,12 +12,14 @@ namespace C7Engine {
 		 * quickly.  By keeping all the client-callable APIs in the EntryPoints folder,
 		 * hopefully it won't be too much of a goose hunt to refactor it later if we decide to do so.
 		 **/
-		public static Player createGame(string loadFilePath, string defaultBicPath, Func<string, string> getPediaIconsPath) {
+		public static Player createGame(string loadFilePath, string defaultBicPath,
+										Func<string, string> getPediaIconsPath,
+										Action<City, CitizenType> assignScenarioResidents) {
 			EngineStorage.createThread();
 			EngineStorage.gameDataMutex.WaitOne();
 
 			SaveGame save = SaveManager.LoadSave(loadFilePath, defaultBicPath, getPediaIconsPath);
-			GameData gameData = save.ToGameData();
+			GameData gameData = save.ToGameData(assignScenarioResidents);
 
 			EngineStorage.gameData = gameData;
 

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -579,10 +579,6 @@ namespace C7GameData {
 					foodNeededToGrow = 20, // HACK: don't know where to find this
 				};
 
-				// TODO: figure out how residents are assigned in scenarios - is
-				// it just the default assignment? If so maybe we can just use
-				// our tile assignment ai.
-
 				save.Cities.Add(saveCity);
 			}
 		}

--- a/C7GameData/Save/SaveCity.cs
+++ b/C7GameData/Save/SaveCity.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace C7GameData.Save {
@@ -50,7 +51,13 @@ namespace C7GameData.Save {
 			});
 		}
 
-		public City ToCity(GameMap gameMap, List<Player> players, List<UnitPrototype> unitPrototypes, List<Civilization> civilizations, List<Building> buildings, List<CitizenType> citizenTypes) {
+		public City ToCity(GameMap gameMap,
+							List<Player> players,
+							List<UnitPrototype> unitPrototypes,
+							List<Civilization> civilizations,
+							List<Building> buildings,
+							List<CitizenType> citizenTypes,
+							Action<City, CitizenType> assignScenarioResidents) {
 			City city = new City{
 				id = id,
 				location = gameMap.tileAt(location.X, location.Y),
@@ -80,6 +87,15 @@ namespace C7GameData.Save {
 			foreach (CityResident cr in city.residents) {
 				cr.tileWorked.personWorkingTile = cr;
 			}
+
+			// Scenarios don't specify the citizens of each city, only the city
+			// size. So we need to do that assignment now. This requires using
+			// the tile assignment AI, which due to dependency reasons we can't
+			// access directly, so we do this via a lambda.
+			if (city.residents.Count == 0) {
+				assignScenarioResidents(city, citizenTypes.Find(x => x.IsDefaultCitizen));
+			}
+
 			return city;
 		}
 	}

--- a/C7GameData/Save/SaveGame.cs
+++ b/C7GameData/Save/SaveGame.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -87,7 +88,7 @@ namespace C7GameData.Save {
 		// TODO: GameData should store Civilizations, otherwise the round trip from
 		// SaveGame to GameData and back loses Civilization instances that are not
 		// assigned to a player.
-		public GameData ToGameData() {
+		public GameData ToGameData(Action<City, CitizenType> assignScenarioResidents) {
 			// copy data without references
 			GameData data = new GameData{
 				seed = Seed,
@@ -115,7 +116,7 @@ namespace C7GameData.Save {
 			});
 
 			// cities require game map for location and players for city owner
-			data.cities = Cities.ConvertAll(city => city.ToCity(data.map, data.players, UnitPrototypes, Civilizations, Buildings, CitizenTypes));
+			data.cities = Cities.ConvertAll(city => city.ToCity(data.map, data.players, UnitPrototypes, Civilizations, Buildings, CitizenTypes, assignScenarioResidents));
 
 			// Once cities are known, players can reference cities.
 			data.players.ForEach(player => {

--- a/C7GameDataTests/SaveTest.cs
+++ b/C7GameDataTests/SaveTest.cs
@@ -61,7 +61,9 @@ public class SaveTests {
 		SaveGame saveNeverGameData = SaveGame.Load(developerSave);
 
 		saveNeverGameData.Save(outputNeverGameDataPath);
-		GameData gameData = saveNeverGameData.ToGameData();
+		GameData gameData = saveNeverGameData.ToGameData((City c, CitizenType ct) => {
+			// We don't care about scenario tile assignment here.
+		});
 		SaveGame saveWasGameData = SaveGame.FromGameData(gameData);
 		saveWasGameData.Save(outputWasGameDataPath);
 
@@ -110,7 +112,9 @@ public class SaveTests {
 			});
 			Assert.Null(ex);
 			ex = Record.Exception(() => {
-				gd = game.ToGameData();
+				gd = game.ToGameData((City c, CitizenType ct) => {
+					// We don't care about scenario tile assignment here.
+				});
 			});
 			Assert.Null(ex);
 			Assert.NotNull(game);
@@ -162,7 +166,9 @@ public class SaveTests {
 			});
 			Assert.True(ex == null, name + ": " + ex?.ToString());
 			ex = Record.Exception(() => {
-				gd = game.ToGameData();
+				gd = game.ToGameData((City c, CitizenType ct) => {
+					// We don't care about scenario tile assignment here.
+				});
 			});
 			Assert.True(ex == null, name + ":" + ex?.ToString());
 			Assert.NotNull(game);


### PR DESCRIPTION
Unlike with `.SAV` files, scenarios don't specify the tile assignments for each of the citizens in cities. To handle this we backfill them using the tile assignment AI. This is slightly complicated by fact that the `C7Engine` code can't depend directly on the AI logic, so we have to do some dependency injection via an `Action`.

#541
