### PR TITLE
Import the proper borders from save files

### DIFF
--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -93,6 +93,9 @@ namespace C7GameData {
 					baseTerrain = save.TerrainTypes[civ3Tile.BaseTerrain].Key,
 					overlayTerrain = save.TerrainTypes[civ3Tile.OverlayTerrain].Key,
 				};
+				if (civ3Tile.Owner > 0) {
+					tile.owner = save.Players[(int)civ3Tile.Owner].id;
+				}
 				if (civ3Tile.BonusShield) {
 					tile.features.Add("bonusShield");
 				}

--- a/C7GameData/Save/SaveGame.cs
+++ b/C7GameData/Save/SaveGame.cs
@@ -125,6 +125,13 @@ namespace C7GameData.Save {
 			// add references to map tiles after units and cities are defined
 			populateGameDataTileUnitsAndCities(data);
 
+			// Add references to tile owners once players are defined.
+			foreach (SaveTile st in Map.tiles) {
+				if (st.owner != null) {
+					data.map.tileAt(st.X, st.Y).owner = data.players.Find(x => x.id == st.owner);
+				}
+			}
+
 			// Fill in the list of techs and then backfill the prereqs.
 			//
 			// This is an N^2 approach, but doing a topological sort of the

--- a/C7GameData/Save/SaveTile.cs
+++ b/C7GameData/Save/SaveTile.cs
@@ -11,6 +11,9 @@ namespace C7GameData.Save {
 
 		public SaveTile(Tile tile) {
 			id = tile.Id;
+			if (tile.owner != null) {
+				owner = tile.owner.id;
+			}
 			extraInfo = tile.ExtraInfo;
 			X = tile.XCoordinate;
 			Y = tile.YCoordinate;
@@ -84,6 +87,7 @@ namespace C7GameData.Save {
 		public Civ3ExtraInfo extraInfo;
 
 		public ID id;
+		public ID owner;
 		public int X;
 		public int Y;
 		[JsonRequired]


### PR DESCRIPTION
It doesn't seem like scenarios store this information (it's unclear what the `Border` field is in the `TILE` struct, but it doesn't index into players or civs, and it seems like borders are calculated based on culture in the editor).

#288

Here's a random save I loaded:

![image](https://github.com/user-attachments/assets/e92812d9-5e9b-43dc-97fe-aa4a0b8857c0)
