### PR TITLE
ImportCiv3: Properly handle the "entire map visible" scenario option

### DIFF
--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -245,8 +245,10 @@ namespace C7GameData {
 				}
 
 				// Some tiles are known ahead of time, like all of europe in age of
-				// discovery. Add those tiles ahead of time.
-				if (civ3Tile.FogOfWar != 0) {
+				// discovery. Other scenarios set the entire map to be visible.
+				//
+				// Add those tiles ahead of time.
+				if (civ3Tile.FogOfWar != 0 || biq.Game[0].MapVisible == 1) {
 					for (int playerIndex = 0; playerIndex < save.Players.Count; playerIndex++) {
 						SavePlayer player = save.Players[playerIndex];
 						player.tileKnowledge.Add(new TileLocation(X, Y));


### PR DESCRIPTION
This is relevant for WWII, which now shows the entire map, as expected.

Zoomed out screenshot: 
![image](https://github.com/user-attachments/assets/167874d4-0597-4b03-aa0a-16bb6d13e057)
