### PR TITLE
Load culture values from saves and scenarios and display them

### DIFF
--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -17,6 +17,8 @@ public partial class CityScreen : CenterContainer {
 	public List<CitizenType> citizenTypes;
 	private TextureRect background;
 	private List<TextureButton> popHeads = new();
+	private Label culturePerTurn;
+	private Label totalCulture;
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
@@ -33,6 +35,12 @@ public partial class CityScreen : CenterContainer {
 		close.SetPosition(new Vector2(950, 20));
 		close.Pressed += () => { HideScreen(); };
 		background.AddChild(close);
+
+		background.AddChild(new Label() {
+			Text = "CULTURE",
+			OffsetLeft = 714,
+			OffsetTop = 4
+		});
 
 		this.Hide();
 	}
@@ -145,6 +153,28 @@ public partial class CityScreen : CenterContainer {
 		this.Show();
 		tileAssignmentLayer.city = city.Value;
 		RenderPopHeads(city.Value);
+		RenderCulture(city.Value);
+	}
+
+	private void RenderCulture(City city) {
+		if (culturePerTurn == null) {
+			culturePerTurn = new Label() {
+				OffsetLeft = 790,
+				OffsetTop = 4
+			};
+			background.AddChild(culturePerTurn);
+		}
+		culturePerTurn.Text = "0/turn";  // TODO: fill this in
+
+		if (totalCulture == null) {
+			totalCulture = new Label() {
+				OffsetLeft = 714,
+				OffsetTop = 55
+			};
+			background.AddChild(totalCulture);
+		}
+		int nextCultureExpansion = (int)Math.Pow(10, city.GetBorderExpansionLevel());
+		totalCulture.Text = $"Total: {city.GetCulture()}/{nextCultureExpansion}";
 	}
 
 	private void RenderPopHeads(City city) {

--- a/C7GameData/City.cs
+++ b/C7GameData/City.cs
@@ -8,6 +8,7 @@ namespace C7GameData {
 		public Tile location { get; internal set; }
 		public string name;
 		public int size = 1;
+		public Dictionary<Player, int> perPlayerCulture = new();
 
 		//Temporary production code because production is fun.
 		public IProducible itemBeingProduced;
@@ -27,6 +28,9 @@ namespace C7GameData {
 			this.location = location;
 			this.owner = owner;
 			this.name = name;
+			if (owner != null) {
+				this.perPlayerCulture.Add(owner, 0);
+			}
 		}
 
 		internal City() { }
@@ -155,6 +159,22 @@ namespace C7GameData {
 
 		public override string ToString() {
 			return $"{name} ({size})";
+		}
+
+		public int GetCulture() {
+			return perPlayerCulture[owner];
+		}
+
+		public int GetBorderExpansionLevel() {
+			// Give ourselves a minimum of 1 culture to avoid taking the log of 0
+			int culture = Math.Max(1, GetCulture());
+
+			// Take the log10 of culture, rounding down (so a culture of 123
+			// would be 2, a culture of 5 would be 0, etc) and then add one to
+			// get the expansion level. With 0-9 culture our culture goal is 10^1
+			// and we have one tile of borders, with 10-99 our culture goal is
+			// 10^2 and we have two tiles of borders.
+			return (int)Math.Floor(Math.Log10(culture)) + 1;
 		}
 	}
 }

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -523,6 +523,13 @@ namespace C7GameData {
 					foodNeededToGrow = 20, // HACK: don't know where to find this
 				};
 
+				List<int> culturePerLeader = city.GetCulturePerLeader();
+				for (int j = 0; j < 32; ++j) {
+					if (culturePerLeader[j] > 0 || j == city.Owner) {
+						saveCity.perPlayerCulture.Add(save.Players[j].id.ToString(), culturePerLeader[j]);
+					}
+				}
+
 				foreach (QueryCiv3.Sav.CTZN ctzn in savData.CityCtzn[i]) {
 					if (ctzn.Type == 4) {  // Specialist
 						SaveCityResident scr = new();
@@ -578,6 +585,7 @@ namespace C7GameData {
 					foodStored = 0,
 					foodNeededToGrow = 20, // HACK: don't know where to find this
 				};
+				saveCity.perPlayerCulture.Add(player.id.ToString(), city.Culture);
 
 				save.Cities.Add(saveCity);
 			}

--- a/C7GameData/Save/SaveCity.cs
+++ b/C7GameData/Save/SaveCity.cs
@@ -20,6 +20,7 @@ namespace C7GameData.Save {
 		public ProducibleType producibleType;
 		public string name;
 		public int size;
+		public Dictionary<string, int> perPlayerCulture = new();
 		public int shieldsStored;
 		public int foodStored;
 		public int foodNeededToGrow;
@@ -49,6 +50,9 @@ namespace C7GameData.Save {
 					tileWorked = new TileLocation(resident.tileWorked),
 				};
 			});
+			foreach (KeyValuePair<Player, int> keyValuePair in city.perPlayerCulture) {
+				perPlayerCulture.Add(keyValuePair.Key.id.ToString(), keyValuePair.Value);
+			}
 		}
 
 		public City ToCity(GameMap gameMap,
@@ -73,6 +77,10 @@ namespace C7GameData.Save {
 				foodNeededToGrow = foodNeededToGrow,
 				capital = capital,
 			};
+
+			foreach (KeyValuePair<string, int> keyValuePair in perPlayerCulture) {
+				city.perPlayerCulture.Add(players.Find(x => x.id.ToString() == keyValuePair.Key), keyValuePair.Value);
+			}
 
 			city.residents = residents.ConvertAll(resident => {
 				return new CityResident {

--- a/QueryCiv3/SavSections/City.cs
+++ b/QueryCiv3/SavSections/City.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 namespace QueryCiv3.Sav {
@@ -33,7 +34,10 @@ namespace QueryCiv3.Sav {
 		public int ConstructingType; // 0: wealth, 1: building, 2: unit
 		public int YearBuilt;
 		private fixed byte UnknownBuffer2[4];
-		public int Culture;
+
+		// The power of 10 that will result in the next culture expansion.
+		// 1 = 10, 2=100, 3=1000, etc.
+		public int NextCultureExpansionPower;
 		public int MilitaryPolice;
 		public int LuxuryConnectedCount;
 		public IntBitmap LuxuryConnectedBits;
@@ -58,7 +62,17 @@ namespace QueryCiv3.Sav {
 		private fixed byte HeaderText4[4];
 		public int Length4;
 		public int CulturePerTurn;
-		public fixed int CulturePerLead[32];
+		private fixed int CulturePerLead[32];
+
+		// The amount of culture this city has for each player. This is tracked
+		// per leader because recaptured cities regain their previous culture.
+		public List<int> GetCulturePerLeader() {
+			List<int> result = new();
+			for (int i = 0; i < 32; ++i) {
+				result.Add(CulturePerLead[i]);
+			}
+			return result;
+		}
 		private fixed byte UnknownBuffer7[8];
 		public int FoodPerTurn;
 		public int ShieldsPerTurn;


### PR DESCRIPTION
This doesn't yet handle per-turn culture (we'll need building for that) but it should allow us to determine the proper border expansion levels in a following PR, as well as improve the tile assignment logic to restrict things to the BFC.

#541

Scenario: 
![image](https://github.com/user-attachments/assets/f2cb6dc1-c64e-4424-bc01-c4b9ee19dbd6)

Save: 
![image](https://github.com/user-attachments/assets/ae0af1fb-5bb7-4600-a08c-659189a47440)
