### PR TITLE
Properly calculate city borders based on culture

### DIFF
--- a/C7/Map/BorderLayer.cs
+++ b/C7/Map/BorderLayer.cs
@@ -16,11 +16,11 @@ namespace C7.Map {
 			int textureWidth = 128;
 			int textureHeight = 72;
 
-			// This loops slices the PCX image into separate border textures. 
+			// This loops slices the PCX image into separate border textures.
 			// The PCX image contains 4 rows and 2 columns:
 			// - Each row corresponds to a border direction.
 			// - The first column contains border textures for regular terrain.
-			// - The second column contains border textures for hills and mountains 
+			// - The second column contains border textures for hills and mountains
 			//   (rendering logic for textures of the second column is not yet implemented).
 			for (int j = 0; j < 4; j++) {
 				for (int k = 0; k < 2; k++) {
@@ -63,7 +63,7 @@ namespace C7.Map {
 		}
 
 		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
-			if (tile.owner is null) {
+			if (tile.owningCity is null) {
 				return;
 			}
 
@@ -75,10 +75,10 @@ namespace C7.Map {
 					{ TileDirection.SOUTHEAST, 6 }
 				};
 
-			Color borderColor = Util.LoadColor(tile.owner.colorIndex);
+			Color borderColor = Util.LoadColor(tile.owningCity.owner.colorIndex);
 
 			foreach (var entry in directionToTextureIdx) {
-				if (tile.neighbors[entry.Key].owner != tile.owner) {
+				if (tile.neighbors[entry.Key].owningCity?.owner != tile.owningCity?.owner) {
 					ImageTexture texture = GetBorderTexture(entry.Value, borderColor);
 					Vector2 offset = texture.GetSize() * 0.5f;
 

--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -78,6 +78,11 @@ public partial class CityScreen : CenterContainer {
 	private void HandleReassignment(Tile tile) {
 		City city = tileAssignmentLayer.city;
 
+		// We only support clicking on workable tiles or the city center.
+		if (!city.GetWorkableTiles().Contains(tile) && tile != city.location) {
+			return;
+		}
+
 		// We can't assign citizens to other cities.
 		if (tile.cityAtTile != null && tile.cityAtTile != city) {
 			return;

--- a/C7Engine/AI/CityTileAssignmentAI.cs
+++ b/C7Engine/AI/CityTileAssignmentAI.cs
@@ -21,11 +21,9 @@ namespace C7Engine.AI {
 			int desiredFoodRate = city.size * FOOD_PER_CITIZEN + DesiredFoodSurplusPerTurn;
 			int targetTileFoodAmount = desiredFoodRate - foodYield;
 
-			Tile cityCenter = city.location;
-
 			double maxScore = 0;
 			Tile preferredTile = Tile.NONE;
-			foreach (Tile t in cityCenter.neighbors.Values) {
+			foreach (Tile t in city.GetWorkableTiles()) {
 				if (t.personWorkingTile == null) {
 					double score = CalculateTileYieldScore(t, targetTileFoodAmount, city.owner);
 					log.Debug($"Tile {t} scored {score}");

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using C7Engine.AI;
 
 namespace C7Engine {
+	using System;
 	using C7GameData;
 
 	public class CityInteractions {
@@ -10,11 +11,6 @@ namespace C7Engine {
 			Player owner = gameData.GetPlayer(playerID);
 			Tile tileWithNewCity = gameData.map.tileAt(X, Y);
 			City newCity = new City(tileWithNewCity, owner, name, gameData.ids.CreateID("city"));
-			CityResident firstResident = new CityResident();
-			firstResident.city = newCity;
-			firstResident.citizenType = gameData.citizenTypes.Find(x => x.IsDefaultCitizen);
-			CityTileAssignmentAI.AssignNewCitizenToTile(firstResident);
-			newCity.SetItemBeingProduced(CityProductionAI.GetNextItemToBeProduced(newCity, null));
 			if (owner.cities.Count == 0) {
 				newCity.capital = true;
 			}
@@ -22,13 +18,22 @@ namespace C7Engine {
 			owner.cities.Add(newCity);
 			tileWithNewCity.cityAtTile = newCity;
 
+			// Update owners before we assign the citizen so the tile owners are
+			// accurate.
+			gameData.UpdateTileOwners();
+
+			CityResident firstResident = new CityResident();
+			firstResident.city = newCity;
+			firstResident.citizenType = gameData.citizenTypes.Find(x => x.IsDefaultCitizen);
+			CityTileAssignmentAI.AssignNewCitizenToTile(firstResident);
+			newCity.SetItemBeingProduced(CityProductionAI.GetNextItemToBeProduced(newCity, null));
+
 			// Cities are treated as though they have a road, but if
 			// a city is build on a mine, the mine should be removed.
 			tileWithNewCity.overlays.road = true;
 			tileWithNewCity.overlays.mine = false;
 			tileWithNewCity.overlays.irrigation = false;
 
-			gameData.UpdateTileOwners();
 			return newCity;
 		}
 

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -46,7 +46,6 @@ namespace C7Engine {
 				// player's city, instead of over all cities, irrespective of
 				// player order? See also https://github.com/C7-Game/Prototype/pull/529#discussion_r1935006632
 				HandleCityResults(gameData);
-				gameData.UpdateTileOwners();
 
 				gameData.turn++;
 				foreach (Player player in gameData.players) {
@@ -160,6 +159,9 @@ namespace C7Engine {
 						city.RemoveCitizens(diff);
 					}
 				}
+
+				// TODO: Update culture and check for border expansion. Call
+				// gameData.UpdateTileOwners if borders did expand.
 
 				IProducible producedItem = city.ComputeTurnProduction();
 				if (producedItem != null) {

--- a/C7GameData/City.cs
+++ b/C7GameData/City.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Serilog;
 
 namespace C7GameData {
@@ -175,6 +176,71 @@ namespace C7GameData {
 			// and we have one tile of borders, with 10-99 our culture goal is
 			// 10^2 and we have two tiles of borders.
 			return (int)Math.Floor(Math.Log10(culture)) + 1;
+		}
+
+		// The list of tiles that could be worked by this city.
+		// This isn't necessarily a subset of our borders, because we're allowed
+		// to work tiles owned by our civ in our big fat cross, even if our
+		// borders haven't expanded yet.
+		//
+		// TODO: we should make this configurable to allow for the bigger cross
+		// if a mod wants it.
+		public HashSet<Tile> GetWorkableTiles() {
+			HashSet<Tile> result = new();
+			foreach (Tile t in GetTilesOfRank(2)) {
+				// Skip tiles not owned by this player.
+				if (t.owningCity == null || t.owningCity.owner != this.owner) {
+					continue;
+				}
+
+				// Skip tiles with cities on them.
+				if (t.HasCity) {
+					continue;
+				}
+
+				result.Add(t);
+			}
+			return result;
+		}
+
+		// The list of tiles that are within the borders of this city, without
+		// taking into account border collisions with other cities.
+		public HashSet<Tile> GetTilesWithinBorders() {
+			return GetTilesOfRank(GetBorderExpansionLevel());
+		}
+
+		private HashSet<Tile> GetTilesOfRank(int rank) {
+			HashSet<Tile> result = new();
+			HashSet<Tile> knownTiles = new();
+
+			Stack<Tile> toCheck = new();
+			toCheck.Push(location);
+			knownTiles.Add(location);
+
+			while (toCheck.Count > 0) {
+				Tile t = toCheck.Pop();
+
+				// Skip tiles that are too far away.
+				if (location.rankDistanceTo(t) > rank) {
+					continue;
+				}
+
+				// Ocean tiles may only hold claims of rank 2.
+				if (t.baseTerrainTypeKey == "ocean" && rank > 2) {
+					continue;
+				}
+
+				// Otherwise this tile is close enough. Check its neighbors next.
+				result.Add(t);
+				foreach (Tile neighbor in t.neighbors.Values) {
+					if (!knownTiles.Contains(neighbor)) {
+						toCheck.Push(neighbor);
+						knownTiles.Add(t);
+					}
+				}
+			}
+
+			return result;
 		}
 	}
 }

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -82,22 +82,56 @@ namespace C7GameData {
 					continue; // skip destroyed cities
 				}
 
-				city.location.owner = city.owner;
+				city.location.owningCity = city;
 
-				foreach (Tile tile in city.location.neighbors.Values) {
-					tile.owner = city.owner;
+				foreach (Tile t in city.GetTilesWithinBorders()) {
+					// If another city has claim to this tile, we need to resolve
+					// that conflict.
+					if (t.owningCity != null) {
+						t.owningCity = ResolveTileOwnershipConflict(t.owningCity, city, t);
+						t.owningCity.owner.tileKnowledge.AddTilesToKnown(t);
+						continue;
+					}
+
+					t.owningCity = city;
+					t.owningCity.owner.tileKnowledge.AddTilesToKnown(t);
 				}
 			}
 		}
 
 		public void UpdateTileOwnersOnCityDestruction(City city) {
-			city.location.owner = null;
+			city.location.owningCity = null;
 
-			foreach (Tile tile in city.location.neighbors.Values) {
-				tile.owner = null;
+			foreach (Tile tile in city.GetTilesWithinBorders()) {
+				tile.owningCity = null;
 			}
 
 			UpdateTileOwners();
+		}
+
+		// Rules taken from https://forums.civfanatics.com/threads/the-eight-laws-of-border-dynamics.106882/
+
+		private City ResolveTileOwnershipConflict(City a, City b, Tile t) {
+			int aRank = a.location.rankDistanceTo(t);
+			int bRank = b.location.rankDistanceTo(t);
+
+			// The city with the lowest rank claim gets the tile.
+			if (aRank > bRank) {
+				return b;
+			} else if (aRank < bRank) {
+				return a;
+			}
+
+			// If the ranks are equal, the city with more culture gets the tile.
+			if (a.GetCulture() < b.GetCulture()) {
+				return b;
+			} else if (a.GetCulture() > b.GetCulture()) {
+				return a;
+			}
+
+			// If the cultures are equal the oldest city gets the tile.
+			// TODO: track city age - for now we just return the first.
+			return a;
 		}
 
 		/**

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -10,7 +10,7 @@ namespace C7GameData {
 		public Civ3ExtraInfo ExtraInfo;
 		public int XCoordinate;
 		public int YCoordinate;
-		public Player owner; // Represents a civilization within which border the tile is located
+		public City owningCity; // The city whose border contains this tile
 		public string baseTerrainTypeKey { get; set; }
 		[JsonIgnore]
 		public TerrainType baseTerrainType = TerrainType.NONE;
@@ -171,6 +171,22 @@ namespace C7GameData {
 		 */
 		public int distanceTo(Tile other) {
 			return (Math.Abs(other.XCoordinate - this.XCoordinate) + Math.Abs(other.YCoordinate - this.YCoordinate)) / 2;
+		}
+
+		// Returns the number of "ranks" to another tile, where each rank is a
+		// border expansion due to culture. So rank 1 is immediate neighbors,
+		// rank 2 is the "big fat cross", etc.
+		public int rankDistanceTo(Tile other) {
+			// We use sqrt(2) to try and "unskew" issues caused by the rotated
+			// rectangular grid. We need N/E/S/W tiles to be slightly further
+			// away than NE/SE/NW/SW tiles.
+			double deltaX = Math.Abs(other.XCoordinate - this.XCoordinate) * Math.Sqrt(2);
+			double deltaY = Math.Abs(other.YCoordinate - this.YCoordinate) * Math.Sqrt(2);
+
+			// Calculating the euclidian distance with an exponent of 1.8 instead
+			// of 2 gives us the correct results up to 99k culture (20k is a
+			// victory condition). Credit to KulkoBSW for this observation.
+			return (int)Math.Round(Math.Pow(Math.Pow(deltaX, 1.8) + Math.Pow(deltaY, 1.8), 1 / 1.8) / 2);
 		}
 
 		// TODO: This is innacurate for city centers.


### PR DESCRIPTION
We now have nearly tile-for-tile accuracy with the real game for loaded save files!  There is 1 tile that is different from the real game to C7 in the screenshot below, which I've circled.

The difference I suspect is due to rules 7/8 from https://forums.civfanatics.com/threads/the-eight-laws-of-border-dynamics.106882/:
 - > VII. If an unassigned tile finds a tile of a single civ directly adjacent to both the NW and SE, it is assigned to that civ.
 - > VII. If an unassigned tile finds a tile of a single civ directly adjacent to both the NW and SE, it is assigned to that civ.

I'm not sure the best way to implement this without doing a second pass over all the tiles, but that may be what we need to do.

![image](https://github.com/user-attachments/assets/41ec35f9-6ab2-4145-b92b-b7068b2760cd)

![image](https://github.com/user-attachments/assets/84032b27-517a-48ee-8950-ae91c7bef3f2)

---

This change required changing how we track tile owners, from a player owner to a city owner, so that we can correctly check rank and culture comparisons.

#288