### PR TITLE
Tune the A* land distance cost heuristic to handle railroads better

### DIFF
--- a/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
+++ b/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
@@ -8,7 +8,17 @@ namespace C7Engine.Pathing {
 	 */
 	public class PathingAlgorithmChooser {
 		private static PathingAlgorithm landAlgorithm = new AStarAlgorithm(new WalkerOnLand(), (Tile from, Tile to) => {
-			return from.distanceTo(to);
+			// HACK: for land-based movement we have to deal with railroads,
+			// which have zero movement cost. If our heuristic is too strong it
+			// will result in units taking a direct path between points A and B,
+			// even if a more indirect path could be taken entirely by railroad.
+			// To avoid this problem we scale our heuristic function down by a
+			// constant (arbitraily chosen to work well in practice) so that a 
+			// typical tile movement cost (around 1/3 to 3, depending on roads
+			// and terrain) dwarfs the heuristic. The heuristic is still enough
+			// to point the search in the proper direction, and since it is 
+			// still an underestimate in most cases, it works properly.
+			return from.distanceTo(to) / 100.0;
 		});
 		private static PathingAlgorithm waterAlgorithm = new AStarAlgorithm(new WalkerOnWater(), (Tile from, Tile to) => {
 			return from.distanceTo(to);


### PR DESCRIPTION
This ensures that if we have railroads in a large "C" shape, units will follow the "C", instead of taking the more direct (and expensive) path.