### PR TITLE
Define an EdgeWalker that is aware of unit movement costs

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -538,7 +538,7 @@ public partial class Game : Node2D {
 				// different than the tile the unit is on, calculate the path to move there.
 				MapUnit unit = tile == null ? null : gameDataAccess.gameData.GetUnit(CurrentlySelectedUnit.id);
 				if (unit != null && unit.location != tile) {
-					TilePath path = PathingAlgorithmChooser.GetAlgorithm(unit.IsLandUnit()).PathFrom(unit.location, tile);
+					TilePath path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, tile);
 					gotoInfo.moveCost = path.PathCost(unit.location, unit.unitType.movement, unit.movementPoints.remaining);
 					gotoInfo.pathCoords = path.GetPathCoords();
 				} else {

--- a/C7Engine/AI/Pathing/AStarAlgorithm.cs
+++ b/C7Engine/AI/Pathing/AStarAlgorithm.cs
@@ -20,7 +20,7 @@ namespace C7Engine.Pathing {
 	// for some useful details.
 	public class AStarAlgorithm : PathingAlgorithm {
 		private readonly EdgeWalker<Tile> edgeWalker;
-		
+
 		// An estimate of the cost between two tiles, usually between a tile in
 		// the search and the destination tile. This allows targeting the search
 		// by doing things like focusing the search in the cardinal direction of

--- a/C7Engine/AI/Pathing/EdgeWalker.cs
+++ b/C7Engine/AI/Pathing/EdgeWalker.cs
@@ -6,36 +6,54 @@ namespace C7Engine.Pathing {
 		public abstract IEnumerable<Edge<TNode>> getEdges(TNode node);
 	}
 
-	public class WalkerOnLand : EdgeWalker<Tile> {
-		public override IEnumerable<Edge<Tile>> getEdges(Tile node) {
-			List<Edge<Tile>> result = new List<Edge<Tile>>();
-			foreach (KeyValuePair<TileDirection, Tile> pair in node.neighbors) {
-				TileDirection direction = pair.Key;
-				Tile neighbor = pair.Value;
-				if (neighbor.IsLand()) {
-					float movementCost = TilePath.getMovementCost(node, direction, neighbor);
-					result.Add(new Edge<Tile>(node, neighbor, movementCost));
-				}
-			}
-			return result;
+	public class UnitWalker : EdgeWalker<Tile> {
+		private MapUnit unit;
+
+		public UnitWalker(MapUnit unit) {
+			this.unit = unit;
 		}
-	}
 
-	public class WalkerOnWater : EdgeWalker<Tile> {
 		public override IEnumerable<Edge<Tile>> getEdges(Tile node) {
+			bool landUnit = unit.IsLandUnit();
+
 			List<Edge<Tile>> result = new List<Edge<Tile>>();
 			foreach (KeyValuePair<TileDirection, Tile> pair in node.neighbors) {
 				TileDirection direction = pair.Key;
 				Tile neighbor = pair.Value;
+				bool neighborHasCityWithSameOwner = neighbor.cityAtTile != null && neighbor.cityAtTile.owner == unit.owner;
 
-				// Allow navigating to water tiles or tiles with a city, to support
-				// costal and canal cities.
+
+				// Land units can only go on to land.
+				if (landUnit && !neighbor.IsLand()) {
+					continue;
+				}
+
+				// Water units can only go on water or coastal cities with the
+				// same owner (to support canals).
+				if (!landUnit && !(neighbor.IsWater() || neighborHasCityWithSameOwner)) {
+					continue;
+				}
+
+				float tileMovementCost = TilePath.getMovementCost(node, direction, neighbor);
+				float unitMovementPoints = unit.unitType.movement;
+
+				// If this tile would consume all of the movement points of this
+				// unit, it has a cost of 1 turn. Otherwise we use the fraction
+				// of a turn it would use as the cost.
 				//
-				// If the unit can't enter the city (for example an enemy city), we
-				// will path right next to it and then refuse to actually enter it.
-				if (neighbor.IsWater() || neighbor.HasCity) {
-					float movementCost = TilePath.getMovementCost(node, direction, neighbor);
-					result.Add(new Edge<Tile>(node, neighbor, movementCost));
+				// Examples:
+				//  - Warrior (1mp) moving onto Grassland (cost 1) => 1 turn
+				//  - Warrior (1mp) moving onto Hills (cost 2) => 1 turn
+				//  - Warrior (1mp) moving onto Jungle (cost 3) => 1 turn
+				//
+				//  - Cavalry (3mp) moving onto Grassland (cost 1) => 1/3
+				//  - Cavalry (3mp) moving onto Hills (cost 2) => 2/3
+				//  - Cavalry (3mp) moving onto Jungle (cost 3) => 3/3
+				//
+				if (tileMovementCost >= unitMovementPoints) {
+					result.Add(new Edge<Tile>(node, neighbor, 1));
+				} else {
+					result.Add(new Edge<Tile>(node, neighbor, tileMovementCost / unitMovementPoints));
 				}
 			}
 			return result;

--- a/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
+++ b/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
@@ -3,29 +3,26 @@ using C7GameData;
 namespace C7Engine.Pathing {
 	/**
 	 * Returns a pathing algorithm to use.
-	 * Eventually, this will depend on some map considerations.
-	 * For now, just return the first one.
 	 */
 	public class PathingAlgorithmChooser {
-		private static PathingAlgorithm landAlgorithm = new AStarAlgorithm(new WalkerOnLand(), (Tile from, Tile to) => {
-			// HACK: for land-based movement we have to deal with railroads,
-			// which have zero movement cost. If our heuristic is too strong it
-			// will result in units taking a direct path between points A and B,
-			// even if a more indirect path could be taken entirely by railroad.
-			// To avoid this problem we scale our heuristic function down by a
-			// constant (arbitraily chosen to work well in practice) so that a 
-			// typical tile movement cost (around 1/3 to 3, depending on roads
-			// and terrain) dwarfs the heuristic. The heuristic is still enough
-			// to point the search in the proper direction, and since it is 
-			// still an underestimate in most cases, it works properly.
-			return from.distanceTo(to) / 100.0;
-		});
-		private static PathingAlgorithm waterAlgorithm = new AStarAlgorithm(new WalkerOnWater(), (Tile from, Tile to) => {
-			return from.distanceTo(to);
-		});
+		public static PathingAlgorithm GetAlgorithm(MapUnit unit) {
+			return new AStarAlgorithm(new UnitWalker(unit), (Tile from, Tile to) => {
+				// HACK: for land-based movement we have to deal with railroads,
+				// which have zero movement cost. If our heuristic is too strong it
+				// will result in units taking a direct path between points A and B,
+				// even if a more indirect path could be taken entirely by railroad.
+				// To avoid this problem we scale our heuristic function down by a
+				// constant (arbitraily chosen to work well in practice) so that a 
+				// typical tile movement cost (around 1/3 to 3, depending on roads
+				// and terrain) dwarfs the heuristic. The heuristic is still enough
+				// to point the search in the proper direction, and since it is 
+				// still an underestimate in most cases, it works properly.
+				if (unit.IsLandUnit()) {
+					return from.distanceTo(to) / 100.0;
+				}
 
-		public static PathingAlgorithm GetAlgorithm(bool isLandUnit) {
-			return isLandUnit ? landAlgorithm : waterAlgorithm;
+				return from.distanceTo(to);
+			});
 		}
 	}
 }

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -79,7 +79,7 @@ namespace C7Engine {
 						settlerAiData.goal = SettlerAIData.SettlerGoal.JOIN_CITY;
 						log.Information("Set AI for unit to JOIN_CITY due to lack of locations to settle");
 					} else {
-						PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit.IsLandUnit());
+						PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
 						settlerAiData.pathToDestination = algorithm.PathFrom(unit.location, settlerAiData.destination);
 						log.Information("Set AI for unit to BUILD_CITY with destination of " + settlerAiData.destination);
 					}
@@ -157,7 +157,7 @@ namespace C7Engine {
 						newUnitAIData.destination = nearestCityToDefend.location;
 						newUnitAIData.goal = DefenderAIData.DefenderGoal.DEFEND_CITY;
 
-						PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit.IsLandUnit());
+						PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
 						newUnitAIData.pathToDestination = algorithm.PathFrom(unit.location, newUnitAIData.destination);
 
 						log.Information($"Unit {unit} tasked with defending {nearestCityToDefend.name}");
@@ -188,7 +188,7 @@ namespace C7Engine {
 			if (closestBarbDistance <= 3) {
 				CombatAIData caid = new CombatAIData();
 
-				PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit.IsLandUnit());
+				PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
 				caid.path = algorithm.PathFrom(unit.location, closestBarbCamp);
 				unit.currentAIData = caid;
 				return true;

--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -90,7 +90,7 @@ namespace C7Engine {
 			int lowestDistance = int.MaxValue;
 			TilePath chosenPath = null;
 
-			PathingAlgorithm algo = PathingAlgorithmChooser.GetAlgorithm(unit.IsLandUnit());
+			PathingAlgorithm algo = PathingAlgorithmChooser.GetAlgorithm(unit);
 			log.Debug("Explorer pathing from " + unit.location + " with " + unit.unitType);
 			foreach (Tile t in validExplorerTiles) {
 				if (t.distanceTo(unit.location) > lowestDistance) {

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -382,7 +382,7 @@ namespace C7Engine {
 		}
 
 		public static void setUnitPath(this MapUnit unit, Tile dest) {
-			unit.path = PathingAlgorithmChooser.GetAlgorithm(unit.IsLandUnit()).PathFrom(unit.location, dest);
+			unit.path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, dest);
 			if (unit.path == TilePath.NONE) {
 				log.Warning("Cannot move unit to " + dest + ", path is NONE!");
 			}

--- a/EngineTests/AI/Pathing/EdgeWalkerTest.cs
+++ b/EngineTests/AI/Pathing/EdgeWalkerTest.cs
@@ -6,7 +6,17 @@ using Xunit;
 
 namespace EngineTests {
 	public class WalkerOnLandTest {
-		private WalkerOnLand walker = new();
+		private static MapUnit MakeLandUnit() {
+			MapUnit result = new(ID.None("")) {
+				unitType = new UnitPrototype() {
+					movement = 2,
+				},
+			};
+			result.unitType.categories.Add("Land");
+			return result;
+		}
+
+		private UnitWalker walker = new(MakeLandUnit());
 		private Tile mountain  = new(ID.None("")) {
 			baseTerrainType = new() {
 				Key = "mountains"
@@ -57,8 +67,8 @@ namespace EngineTests {
 			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
 			Assert.Equal(2, edges.Count());
 
-			Assert.Contains(edges, item => item.current == mountain && item.distanceToCurrent == 3);
-			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1);
+			Assert.Contains(edges, item => item.current == mountain && item.distanceToCurrent == 1);
+			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1 / 2.0f);
 		}
 
 		[Fact]
@@ -73,7 +83,7 @@ namespace EngineTests {
 			// The road shouldn't matter, since we don't have a road.
 			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
 			Assert.Single(edges);
-			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1);
+			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1 / 2.0f);
 		}
 
 		[Fact]
@@ -88,7 +98,7 @@ namespace EngineTests {
 			// The road shouldn't matter, since the destination doesn't have a road.
 			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
 			Assert.Single(edges);
-			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1);
+			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1 / 2.0f);
 		}
 
 		[Fact]
@@ -104,12 +114,22 @@ namespace EngineTests {
 			// The cost should be adjusted because we both have a road.
 			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
 			Assert.Single(edges);
-			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1.0f / 3.0f);
+			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1.0f / 3.0f / 2.0f);
 		}
 	}
 
 	public class WalkerOnWaterTest {
-		private WalkerOnWater walker = new();
+		private static MapUnit MakeWaterUnit() {
+			MapUnit result = new(ID.None("")) {
+				unitType = new UnitPrototype() {
+					movement = 2,
+				},
+			};
+			return result;
+		}
+
+		private Player player = new();
+		private MapUnit nonLandUnit = MakeWaterUnit();
 		private Tile hill  = new(ID.None("")) {
 			baseTerrainType = new() {
 				Key = "hills"
@@ -140,6 +160,7 @@ namespace EngineTests {
 
 		[Fact]
 		void testIgnoresLand() {
+			UnitWalker walker = new(nonLandUnit);
 			Tile start = coast;
 
 			// Add 2 neighbors, one of which is land.
@@ -150,16 +171,19 @@ namespace EngineTests {
 			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
 			Assert.Single(edges);
 
-			Assert.Contains(edges, item => item.current == sea && item.distanceToCurrent == 1);
+			Assert.Contains(edges, item => item.current == sea && item.distanceToCurrent == 1 / 2.0f);
 		}
 
 		[Fact]
-		void testLandIncludedIfItHasCity() {
+		void testLandIncludedIfItHasCityWithSameOwner() {
+			UnitWalker walker = new(nonLandUnit);
+			nonLandUnit.owner = player;
+
 			Tile start = coast;
 
-			// Set up a neighbor on land with a city.
+			// Set up a neighbor on land with a city of the same owner.
 			Tile end = hill;
-			end.cityAtTile = new City(Tile.NONE, null, "", ID.None(""));
+			end.cityAtTile = new City(Tile.NONE, player, "", ID.None(""));
 			start.neighbors[TileDirection.NORTH] = end;
 
 			// The city tile should be included, to allow for canals, and so
@@ -169,7 +193,28 @@ namespace EngineTests {
 			// movement costs don't make sense to apply to ships.
 			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
 			Assert.Single(edges);
-			Assert.Contains(edges, item => item.current == hill && item.distanceToCurrent == 1);
+			Assert.Contains(edges, item => item.current == hill && item.distanceToCurrent == 1 / 2.0f);
+		}
+
+		[Fact]
+		void testCityWithDifferentOwnerNotIncluded() {
+			UnitWalker walker = new(nonLandUnit);
+			Tile start = coast;
+			nonLandUnit.owner = player;
+			Player otherPlayer =new();
+
+			// Set up a neighbor on land with a city of the same owner.
+			Tile end = hill;
+			end.cityAtTile = new City(Tile.NONE, otherPlayer, "", ID.None(""));
+			start.neighbors[TileDirection.NORTH] = end;
+
+			// The city tile should be included, to allow for canals, and so
+			// that ships can go back into harbors.
+			//
+			// The cost should be 1, despite the city being on a hill. Land
+			// movement costs don't make sense to apply to ships.
+			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
+			Assert.Equal(edges.Count(), 0);
 		}
 	}
 }


### PR DESCRIPTION
This avoids weird pathing where a warrior will walk the long way around a jungle, taking multiple moves to walk across grassland, because the movement cost of the jungle is 3.
