### PR TITLE
Simplify the logic for the lower right info box so it stays up to date

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -276,8 +276,6 @@ visible = false
 [connection signal="ShowCityScreen" from="." to="CanvasLayer/CityScreen" method="OnShowCityScreen"]
 [connection signal="ShowSpecificAdvisor" from="." to="CanvasLayer/Advisor" method="OnShowSpecificAdvisor"]
 [connection signal="TurnEnded" from="." to="CanvasLayer/Control/GameStatus" method="OnTurnEnded"]
-[connection signal="TurnStarted" from="." to="CanvasLayer/Control/GameStatus" method="OnTurnStarted"]
-[connection signal="UpdateTechProgress" from="." to="CanvasLayer/Control/GameStatus" method="OnUpdateTechProgress"]
 [connection signal="BuildCity" from="CanvasLayer/PopupOverlay" to="." method="OnBuildCity"]
 [connection signal="HidePopup" from="CanvasLayer/PopupOverlay" to="CanvasLayer/PopupOverlay" method="OnHidePopup"]
 [connection signal="Quit" from="CanvasLayer/PopupOverlay" to="." method="OnQuitTheGame"]

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -239,14 +239,6 @@ public partial class Game : Node2D {
 					// F6 is the science advisor.
 					// TODO: Move the F* key strings to a set of constants/enum.
 					EmitSignal(SignalName.ShowSpecificAdvisor, "F6");
-					Player player = gameData.GetHumanPlayers()[0];
-					Tech tech = gameData.techs.Find(x => x.id == player.currentlyResearchedTech);
-
-					if (tech != null) {
-						EmitSignal(SignalName.UpdateTechProgress, tech.Name, player.EstimateTurnsToResearch(tech));
-					} else {
-						EmitSignal(SignalName.UpdateTechProgress, "Not selected", int.MaxValue);
-					}
 					break;
 				case MsgUpdateUiAfterSliderChange mUUASC:
 					// F1 is the science advisor.
@@ -374,17 +366,7 @@ public partial class Game : Node2D {
 	private void OnPlayerStartTurn() {
 		log.Information("Starting player turn");
 		using (var gameDataAccess = new UIGameDataAccess()) {
-			int turnNumber = TurnHandling.GetTurnNumber();
-			Player player = gameDataAccess.gameData.GetHumanPlayers()[0];
-
-			EmitSignal(SignalName.TurnStarted, turnNumber, player.gold, /*goldPerTurn=*/0);
-
-			Tech tech = gameDataAccess.gameData.techs.Find(x => x.id == player.currentlyResearchedTech);
-			if (tech != null) {
-				EmitSignal(SignalName.UpdateTechProgress, tech.Name, player.EstimateTurnsToResearch(tech));
-			} else {
-				EmitSignal(SignalName.UpdateTechProgress, "Not selected", int.MaxValue);
-			}
+			EmitSignal(SignalName.TurnStarted);
 			CurrentState = GameState.PlayerTurn;
 
 			GetNextAutoselectedUnit(gameDataAccess.gameData);

--- a/C7/UIElements/GameStatus/GameStatus.cs
+++ b/C7/UIElements/GameStatus/GameStatus.cs
@@ -29,16 +29,7 @@ public partial class GameStatus : MarginContainer {
 		LowerRightInfoBox.StopToggling();
 	}
 
-	private void OnTurnStarted(int turnNumber, int gold, int goldPerTurn) {
-		//Oh hai, we do need this handler here!
-		LowerRightInfoBox.SetTurnAndGold(turnNumber, gold, goldPerTurn);
-	}
-
 	private void OnNoMoreAutoselectableUnits() {
 		LowerRightInfoBox.SetEndOfTurnStatus();
-	}
-
-	private void OnUpdateTechProgress(string techName, int turnsRemaining) {
-		LowerRightInfoBox.UpdateTechProgress(techName, turnsRemaining);
 	}
 }

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -2,6 +2,7 @@ using Godot;
 using ConvertCiv3Media;
 using C7GameData;
 using Serilog;
+using C7Engine;
 
 public partial class LowerRightInfoBox : TextureRect {
 	private ILogger log = LogManager.ForContext<LowerRightInfoBox>();
@@ -11,6 +12,7 @@ public partial class LowerRightInfoBox : TextureRect {
 	ImageTexture nextTurnOffTexture;
 	ImageTexture nextTurnBlinkTexture;
 
+	Label civAndGovt = new();
 	Label lblUnitSelected = new Label();
 	Label attackDefenseMovement = new Label();
 	Label terrainType = new Label();
@@ -69,7 +71,6 @@ public partial class LowerRightInfoBox : TextureRect {
 		terrainType.OffsetRight = -30;
 		boxRightRectangle.AddChild(terrainType);
 
-		Label civAndGovt = new Label();
 		civAndGovt.SetPosition(new Vector2(0, 75));
 		boxRightRectangle.AddChild(civAndGovt);
 		SetTextAndCenterLabel(civAndGovt, "Carthage - Despotism (5.5.0)");
@@ -141,22 +142,45 @@ public partial class LowerRightInfoBox : TextureRect {
 		attackDefenseMovement.Visible = true;
 	}
 
-	///This is going to evolve a lot over time.  Probably this info box will need to keep some local state.
-	///But for now it'll show the changing turn number, providing some interactivity
-	public void SetTurnAndGold(int turnNumber, int gold, int goldPerTurn) {
-		if (goldPerTurn >= 0) {
-			yearAndGold.Text = $"Turn {turnNumber}  {gold} Gold (+{goldPerTurn} per turn)";
-		} else {
-			yearAndGold.Text = $"Turn {turnNumber}  {gold} Gold (-{goldPerTurn} per turn)";
-		}
-	}
+	public override void _Process(double delta) {
+		// Update our information each time we're drawn, just like the tile and
+		// city scenes.
+		using (UIGameDataAccess gameDataAccess = new()) {
+			GameData gD = gameDataAccess.gameData;
+			// There may be no human players in observer mode.
+			Player player = gD.GetHumanPlayers().Count > 0 ? gD.GetHumanPlayers()[0] : gD.players[1];
 
-	public void UpdateTechProgress(string techName, int turnsRemaining) {
-		if (turnsRemaining >= int.MaxValue) {
-			SetTextAndCenterLabel(scienceProgress, $"{techName} (-- turns)");
-		} else {
-			SetTextAndCenterLabel(scienceProgress, $"{techName} ({turnsRemaining} turns)");
+			// Gold per turn and turn indicator.
+			{
+				int turnNumber = TurnHandling.GetTurnNumber();
+				int gold = player.gold;
+				int goldPerTurn = player.CalculateGoldPerTurn();
+
+				if (goldPerTurn >= 0) {
+					yearAndGold.Text = $"Turn {turnNumber}  {gold} Gold (+{goldPerTurn} per turn)";
+				} else {
+					yearAndGold.Text = $"Turn {turnNumber}  {gold} Gold (-{goldPerTurn} per turn)";
+				}
+			}
+
+			// Tech progress.
+			{
+				Tech tech = gD.techs.Find(x => x.id == player.currentlyResearchedTech);
+				string techName = tech == null ? "Not selected" : tech.Name;
+				int turnsRemaining = tech == null ? int.MaxValue : player.EstimateTurnsToResearch(tech);
+
+				if (turnsRemaining >= int.MaxValue) {
+					SetTextAndCenterLabel(scienceProgress, $"{techName} (-- turns)");
+				} else {
+					SetTextAndCenterLabel(scienceProgress, $"{techName} ({turnsRemaining} turns)");
+				}
+			}
+
+			// Civ and government.
+			SetTextAndCenterLabel(civAndGovt, $"{player.civilization.name} - Despotism (5.5.0)");
 		}
+
+		base._Process(delta);
 	}
 
 	private void SetTextAndCenterLabel(Label label, string text) {

--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -119,6 +119,14 @@ namespace C7GameData {
 			return "";
 		}
 
+		public int CalculateGoldPerTurn() {
+			int result = 0;
+			foreach (City city in cities) {
+				result += city.CurrentCommerceYield().taxes;
+			}
+			return result;
+		}
+
 		public int EstimateTurnsToResearch(Tech tech) {
 			// Cost formula from https://forums.civfanatics.com/threads/research-cost-formula-v1-29f.29485/.
 			// Research Cost = [MM * [10*COST * (1 - N/[CL*1.75])]/(CF * 10)] - progress


### PR DESCRIPTION
For the city scene, where we show the name, what's produced, and how many turns are left until production/growth, we just grab information from the game data when drawn. We can do that for the lower right info box as well, ensuring that things are up to day whenever something happens, like a road being finished or a citizen being moved to a different tile.

This allows us to get rid of some unneeded event logic.

This also made a couple of other fixes trivial
 - properly displaying gold per turn to the treasury
 - properly displaying the name of the civ we're playing as