### PR TITLE
Fix a bug in the CityProductionAI to avoid wasting settlers

### DIFF
--- a/C7Engine/AI/CityProductionAI.cs
+++ b/C7Engine/AI/CityProductionAI.cs
@@ -47,10 +47,14 @@ namespace C7Engine {
 				float flatAdjustedScore = baseScore + flatAdjuster;
 				log.Debug($"  Flat-adjusted score for {unitPrototype} is {flatAdjustedScore}");
 
-
-				//Exclude naval units from land-only cities
+				// Exclude naval units from land-only cities
 				if (unitPrototype.categories.Contains("Sea") && !city.location.NeighborsWater()) {
 					flatAdjustedScore = 0.0f;
+				}
+
+				// Exclude settlers if we don't have anywhere to build a city.
+				if (unitPrototype.actions.Contains("unit_build_city") && SettlerLocationAI.findSettlerLocation(city.location, city.owner) == Tile.NONE) {
+					flatAdjustedScore = 0;
 				}
 
 				// Below here are multiplicative adjusters

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -112,7 +112,6 @@ namespace C7Engine {
 				log.Information("Set defender AI for " + unit + " with destination of " + ai.destination);
 				unit.currentAIData = ai;
 			} else {
-
 				if (unit.unitType.categories.Contains("Sea")) {
 					ExplorerAIData ai = new ExplorerAIData();
 					ai.type = ExplorerAIData.ExplorationType.COASTLINE;

--- a/C7GameData/MapUnit.cs
+++ b/C7GameData/MapUnit.cs
@@ -59,7 +59,7 @@ namespace C7GameData {
 
 		public override string ToString() {
 			if (this != MapUnit.NONE) {
-				return this.owner + " " + unitType.name + "at (" + location.XCoordinate + ", " + location.YCoordinate + ") with " + movementPoints.getMixedNumber() + " MP and " + hitPointsRemaining + " HP, id = " + id;
+				return this.owner + " " + unitType.name + " at (" + location.XCoordinate + ", " + location.YCoordinate + ") with " + movementPoints.getMixedNumber() + " MP and " + hitPointsRemaining + " HP, id = " + id;
 			} else {
 				return "This is the NONE unit";
 			}


### PR DESCRIPTION
Previously when running in observer mode the log would show multiple instances of building settlers and then destroying them via the `JOIN_CITY` decision. This was because we produced the settler without having any idea where it would go, and once the settler arrived, we still didn't have a place to put it.

By only producing settlers once we have a candidate location we avoid this problem, and it seems to significantly speed up the AI's expansion rate.