### PR TITLE
Have the UnitAI instances hold their own state, rather than requiring casts

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -366,7 +366,17 @@ public partial class Game : Node2D {
 	private void OnPlayerStartTurn() {
 		log.Information("Starting player turn");
 		using (var gameDataAccess = new UIGameDataAccess()) {
-			EmitSignal(SignalName.TurnStarted);
+			int turnNumber = TurnHandling.GetTurnNumber();
+			Player player = controller;
+
+			EmitSignal(SignalName.TurnStarted, turnNumber, player.gold, /*goldPerTurn=*/0);
+
+			Tech tech = gameDataAccess.gameData.techs.Find(x => x.id == player.currentlyResearchedTech);
+			if (tech != null) {
+				EmitSignal(SignalName.UpdateTechProgress, tech.Name, player.EstimateTurnsToResearch(tech));
+			} else {
+				EmitSignal(SignalName.UpdateTechProgress, "Not selected", int.MaxValue);
+			}
 			CurrentState = GameState.PlayerTurn;
 
 			GetNextAutoselectedUnit(gameDataAccess.gameData);
@@ -495,7 +505,9 @@ public partial class Game : Node2D {
 						if (tile.unitsOnTile.Count > 0) {
 							foreach (MapUnit unit in tile.unitsOnTile) {
 								log.Debug("  Unit on tile: " + unit);
-								log.Debug("  Strategy: " + unit.currentAIData);
+								if (unit.currentAI != null) {
+									log.Debug("  Strategy: " + unit.currentAI.SummarizePlan());
+								}
 							}
 						}
 					} else {

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -53,16 +53,14 @@ namespace C7Engine {
 				int attempts = 0;
 				int maxAttempts = 2;    //safety valve so we don't freeze the UI if SetAIForUnit returns something that fails
 				while (!unitDone) {
-					if (unit.currentAIData == null || attempts > 0) {
-						SetAIForUnit(unit, player);
+					if (unit.currentAI == null || attempts > 0) {
+						unit.currentAI = GetAIForUnit(unit, player);
 					}
 
-					UnitAI artificialIntelligence = getAIForUnitStrategy(unit.currentAIData);
-					unitDone = artificialIntelligence.PlayTurn(player, unit);
-
+					unitDone = unit.currentAI.PlayTurn(player, unit);
 					attempts++;
 					if (!unitDone && attempts >= maxAttempts) {
-						log.Warning($"Hit max AI attempts of {maxAttempts} for unit {unit} at {unit.location} without succeeding.  This indicates SetAIForUnit returned an impossible task, and should be debugged.");
+						log.Warning($"Hit max AI attempts of {maxAttempts} for unit {unit} at {unit.location} without succeeding.  This indicates GetAIForUnit returned an impossible task, and should be debugged.");
 						break;
 					}
 				}
@@ -71,58 +69,31 @@ namespace C7Engine {
 			}
 		}
 
-		public static void SetAIForUnit(MapUnit unit, Player player) {
+		public static UnitAI GetAIForUnit(MapUnit unit, Player player) {
 			//figure out an AI behavior
 			//TODO: Use strategies, not names
 			if (unit.unitType.name == "Settler") {
-				SettlerAIData settlerAiData = new SettlerAIData();
-				settlerAiData.goal = SettlerAIData.SettlerGoal.BUILD_CITY;
-				//If it's the starting settler, have it settle in place.  Otherwise, use an AI to find a location.
-				if (player.cities.Count == 0 && unit.location.cityAtTile == null) {
-					settlerAiData.destination = unit.location;
-					log.Information("No cities yet!  Set AI for unit to settler AI with destination of " + settlerAiData.destination);
-				} else {
-					settlerAiData.destination = SettlerLocationAI.findSettlerLocation(unit.location, player);
-					if (settlerAiData.destination == Tile.NONE) {
-						//This is possible if all tiles within 4 tiles of a city are either not land, or already claimed
-						//by another colonist.  Longer-term, the AI shouldn't be building settlers if that is the case,
-						//but right now we'll just spike the football to stop the clock and avoid building immediately next to another city.
-						settlerAiData.goal = SettlerAIData.SettlerGoal.JOIN_CITY;
-						log.Information("Set AI for unit to JOIN_CITY due to lack of locations to settle");
-					} else {
-						PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
-						settlerAiData.pathToDestination = algorithm.PathFrom(unit.location, settlerAiData.destination);
-						log.Information("Set AI for unit to BUILD_CITY with destination of " + settlerAiData.destination);
-					}
-				}
-				unit.currentAIData = settlerAiData;
+				return new SettlerAI(SettlerAI.MakeAiData(unit, player));
 			} else if (unit.location.cityAtTile != null && unit.location.unitsOnTile.Count(u => u.unitType.defense > 0 && u != unit) == 0) {
-				DefenderAIData ai = new DefenderAIData();
-				ai.goal = DefenderAIData.DefenderGoal.DEFEND_CITY;
-				ai.destination = unit.location;
-				log.Information("Set defender AI for " + unit + " with destination of " + ai.destination);
-				unit.currentAIData = ai;
-			} else if (UnitCanAttackNearbyBarbCamp(unit, player)) {
+				return new DefenderAI(DefenderAI.MakeAiData(unit, player));
+			} else if (GetCombatAIIfUnitCanAttackNearbyBarbCamp(unit, player) is UnitAI unitAI && unitAI != null) {
 				log.Information("Set unit " + unit + " to take out barb camp");
+				return unitAI;
 			} else if (unit.unitType.name == "Catapult") {
 				//For now tell catapults to sit tight.  It's getting really annoying watching them pointlessly bombard barb camps forever
-				DefenderAIData ai = new DefenderAIData();
-				ai.goal = DefenderAIData.DefenderGoal.DEFEND_CITY;
-				ai.destination = unit.location;
-				log.Information("Set defender AI for " + unit + " with destination of " + ai.destination);
-				unit.currentAIData = ai;
+				return new DefenderAI(DefenderAI.MakeAiData(unit, player));
 			} else {
 				if (unit.unitType.categories.Contains("Sea")) {
 					ExplorerAIData ai = new ExplorerAIData();
 					ai.type = ExplorerAIData.ExplorationType.COASTLINE;
-					unit.currentAIData = ai;
 					log.Information("Set coastline exploration AI for " + unit);
+					return new ExplorerAI(ai);
 				} else if (unit.location.unitsOnTile.Exists((x) => x.unitType.categories.Contains("Sea"))) {
 					ExplorerAIData ai = new ExplorerAIData();
 					ai.type = ExplorerAIData.ExplorationType.ON_A_BOAT;
-					unit.currentAIData = ai;
 					//TODO: Actually put the unit on the boat
 					log.Information("Set ON_A_BOAT exploration AI for " + unit);
+					return new ExplorerAI(ai);
 				} else {
 					//Isn't a Settler.  If there's a city at the location, it's defended.  No boats involved.  What's our priority?
 					//If there is land to explore, we'll try to explore it.
@@ -133,8 +104,8 @@ namespace C7Engine {
 						//What type of exploration should we do?
 						int nearbyExplorers = 0;
 						foreach (MapUnit mapUnit in player.units) {
-							if (mapUnit.currentAIData is ExplorerAIData explorerAI) {
-								if (explorerAI.type == ExplorerAIData.ExplorationType.NEAR_CITIES) {
+							if (mapUnit.currentAI is ExplorerAI explorerAI) {
+								if (explorerAI.explorerData.type == ExplorerAIData.ExplorationType.NEAR_CITIES) {
 									nearbyExplorers++;
 								}
 							}
@@ -144,8 +115,8 @@ namespace C7Engine {
 						} else {
 							ai.type = ExplorerAIData.ExplorationType.RANDOM;
 						}
-						unit.currentAIData = ai;
 						log.Information($"Set {ai.type} exploration AI for {unit}");
+						return new ExplorerAI(ai);
 					} else {
 						//Nowhere to explore.  What to do now?
 						//Priority 1: Adequate defense of cities.
@@ -171,15 +142,15 @@ namespace C7Engine {
 						newUnitAIData.pathToDestination = algorithm.PathFrom(unit.location, newUnitAIData.destination);
 
 						log.Information($"Unit {unit} tasked with defending {nearestCityToDefend.name}");
-						unit.currentAIData = newUnitAIData;
+						return new DefenderAI(newUnitAIData);
 					}
 				}
 			}
 		}
 
-		private static bool UnitCanAttackNearbyBarbCamp(MapUnit unit, Player player) {
+		private static UnitAI GetCombatAIIfUnitCanAttackNearbyBarbCamp(MapUnit unit, Player player) {
 			if (unit.unitType.attack <= 0) {
-				return false;
+				return null;
 			}
 
 			List<Tile> reachableBarbCampsTiles = player.tileKnowledge.AllKnownTiles()
@@ -200,10 +171,9 @@ namespace C7Engine {
 
 				PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
 				caid.path = algorithm.PathFrom(unit.location, closestBarbCamp);
-				unit.currentAIData = caid;
-				return true;
+				return new CombatAI(caid);
 			}
-			return false;
+			return null;
 		}
 
 		/**
@@ -236,32 +206,6 @@ namespace C7Engine {
 				}
 			}
 			return nearestCityToDefend;
-		}
-
-		/**
-		 * Medium-term solution to the problem of getting instances of the AI classes for polymorphic
-		 * methods.
-		 *
-		 * Only the data will be stored on save, so only the data is guaranteed to be on the unit.
-		 * There are several options - attach an instance whenever we need one, for example.
-		 * But the AI implementations should be singletons that behave differently based on the
-		 * data (and perhaps probability), so multiple instances doesn't really make sense.
-		 *
-		 * I fully expect this to evolve; at some point it might grab a Lua AI instead of a C# one
-		 * too, for example, and one AIData class might be able to call up multiple types of AIs.
-		 * It also likely will become mod-supporting someday, but we can't add everything on day one.
-		 **/
-		public static UnitAI getAIForUnitStrategy(UnitAIData aiData) {
-			if (aiData is SettlerAIData sai) {
-				return new SettlerAI();
-			} else if (aiData is DefenderAIData dai) {
-				return new DefenderAI();
-			} else if (aiData is ExplorerAIData eai) {
-				return new ExplorerAI();
-			} else if (aiData is CombatAIData cai) {
-				return new CombatAI();
-			}
-			throw new Exception("AI data not recognized" + aiData);
 		}
 
 		private static Tech PickTechToResearch(Player player, List<Tech> techs) {

--- a/C7Engine/AI/UnitAI/CombatAI.cs
+++ b/C7Engine/AI/UnitAI/CombatAI.cs
@@ -10,14 +10,16 @@ namespace C7Engine.AI.UnitAI {
 	/// This is likely to evolve significantly, and likely have sub-classes; this is the very first iteration.
 	/// This first iteration is focused on defeating barbarians.
 	/// </summary>
-	public class CombatAI : C7Engine.UnitAI {
-		private Tile target;
+	public class CombatAI : C7GameData.UnitAI {
+		private CombatAIData combatAIData;
 
 		private ILogger log = Log.ForContext<CombatAI>();
 
-		public bool PlayTurn(Player player, MapUnit unit) {
-			CombatAIData combatAIData = (CombatAIData)unit.currentAIData;
+		public CombatAI(CombatAIData d) {
+			combatAIData = d;
+		}
 
+		public bool PlayTurn(Player player, MapUnit unit) {
 			//Move along the path to the place where the unit plans to enter combat.
 			//This might initiate combat.
 			//Once there are more combat goals than run to a barbarian camp,
@@ -25,6 +27,10 @@ namespace C7Engine.AI.UnitAI {
 			unit.path = combatAIData.path;
 			unit.moveAlongPath();
 			return true;
+		}
+
+		public string SummarizePlan() {
+			return "CombateAI: " + combatAIData.ToString();
 		}
 	}
 }

--- a/C7Engine/AI/UnitAI/DefenderAI.cs
+++ b/C7Engine/AI/UnitAI/DefenderAI.cs
@@ -3,12 +3,23 @@ using C7GameData.AIData;
 using Serilog;
 
 namespace C7Engine.AI.UnitAI {
-	class DefenderAI : C7Engine.UnitAI {
+	class DefenderAI : C7GameData.UnitAI {
+		private static ILogger log = Log.ForContext<DefenderAI>();
+		private DefenderAIData defenderAI;
 
-		private ILogger log = Log.ForContext<DefenderAI>();
+		public static DefenderAIData MakeAiData(MapUnit unit, Player player) {
+			DefenderAIData ai = new DefenderAIData();
+			ai.goal = DefenderAIData.DefenderGoal.DEFEND_CITY;
+			ai.destination = unit.location;
+			log.Information("Set defender AI for " + unit + " with destination of " + ai.destination);
+			return ai;
+		}
+
+		public DefenderAI(DefenderAIData d) {
+			defenderAI = d;
+		}
 
 		public bool PlayTurn(Player player, MapUnit unit) {
-			DefenderAIData defenderAI = (DefenderAIData)unit.currentAIData;
 			if (defenderAI.destination == unit.location) {
 				if (!unit.isFortified) {
 					unit.fortify();
@@ -32,6 +43,10 @@ namespace C7Engine.AI.UnitAI {
 				}
 			}
 			return true;
+		}
+
+		public string SummarizePlan() {
+			return "DefenderAI: " + defenderAI.ToString();
 		}
 	}
 }

--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -8,11 +8,15 @@ using C7Engine.Pathing;
 using Serilog;
 
 namespace C7Engine {
-	public class ExplorerAI : UnitAI {
+	public class ExplorerAI : C7GameData.UnitAI {
 		private static ILogger log = Log.ForContext<ExplorerAI>();
+		public ExplorerAIData explorerData;
+
+		public ExplorerAI(ExplorerAIData d) {
+			explorerData = d;
+		}
 
 		public bool PlayTurn(Player player, MapUnit unit) {
-			ExplorerAIData explorerData = (ExplorerAIData)unit.currentAIData;
 			if (MovingToNewExplorationArea(explorerData)) {
 				return MoveToNextTileOnPath(explorerData, unit);
 			} else {
@@ -30,6 +34,10 @@ namespace C7Engine {
 				}
 			}
 			return false;
+		}
+
+		public string SummarizePlan() {
+			return "ExplorerAI: " + explorerData.ToString();
 		}
 
 		private static bool MoveToNextTileOnPath(ExplorerAIData explorerData, MapUnit unit) {

--- a/C7Engine/AI/UnitAI/SettlerAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerAI.cs
@@ -5,20 +5,46 @@ using C7GameData.AIData;
 using Serilog;
 
 namespace C7Engine {
-	public class SettlerAI : UnitAI {
+	public class SettlerAI : C7GameData.UnitAI {
+		private static ILogger log = Log.ForContext<SettlerAI>();
+		public SettlerAIData settlerAi;
 
-		private ILogger log = Log.ForContext<SettlerAI>();
+		public static SettlerAIData MakeAiData(MapUnit unit, Player player) {
+			SettlerAIData settlerAiData = new SettlerAIData();
+			settlerAiData.goal = SettlerAIData.SettlerGoal.BUILD_CITY;
+			//If it's the starting settler, have it settle in place.  Otherwise, use an AI to find a location.
+			if (player.cities.Count == 0 && unit.location.cityAtTile == null) {
+				settlerAiData.destination = unit.location;
+				log.Information("No cities yet!  Set AI for unit to settler AI with destination of " + settlerAiData.destination);
+			} else {
+				settlerAiData.destination = SettlerLocationAI.findSettlerLocation(unit.location, player);
+				if (settlerAiData.destination == Tile.NONE) {
+					//This is possible if all tiles within 4 tiles of a city are either not land, or already claimed
+					//by another colonist.  Longer-term, the AI shouldn't be building settlers if that is the case,
+					//but right now we'll just spike the football to stop the clock and avoid building immediately next to another city.
+					settlerAiData.goal = SettlerAIData.SettlerGoal.JOIN_CITY;
+					log.Information("Set AI for unit to JOIN_CITY due to lack of locations to settle");
+				} else {
+					PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
+					settlerAiData.pathToDestination = algorithm.PathFrom(unit.location, settlerAiData.destination);
+					log.Information("Set AI for unit to BUILD_CITY with destination of " + settlerAiData.destination);
+				}
+			}
+			return settlerAiData;
+		}
+
+		public SettlerAI(SettlerAIData d) {
+			settlerAi = d;
+		}
 
 		public bool PlayTurn(Player player, MapUnit unit) {
-			SettlerAIData settlerAi = (SettlerAIData)unit.currentAIData;
 start:
 			switch (settlerAi.goal) {
 				case SettlerAIData.SettlerGoal.BUILD_CITY:
 					if (IsInvalidCityLocation(settlerAi.destination)) {
 						log.Information("Seeking new destination for settler " + unit.id + "headed to " + settlerAi.destination);
-						PlayerAI.SetAIForUnit(unit, player);
 						//Make sure we're using the new settler AI going forward, including this turn
-						settlerAi = (SettlerAIData)unit.currentAIData;
+						settlerAi = MakeAiData(unit, player);
 						//Re-process since the unit's goal may have changed.
 						//TODO: In theory in the future, it might even have a non-settler AI.  Maybe we should instead return false,
 						//and have the PlayerAI re-kick the unit based on a possibly different AI class?
@@ -80,6 +106,10 @@ start:
 				}
 			}
 			return false;
+		}
+
+		public string SummarizePlan() {
+			return "SettlerAI: " + settlerAi.ToString();
 		}
 	}
 }

--- a/C7Engine/AI/UnitAI/SettlerLocationAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerLocationAI.cs
@@ -125,14 +125,15 @@ namespace C7Engine {
 		/// <returns></returns>
 		public static bool SettlerAlreadyMovingTowardsTile(Tile tile, List<MapUnit> playerSettlers) {
 			foreach (MapUnit otherSettler in playerSettlers) {
-				if (otherSettler.currentAIData is SettlerAIData otherSettlerAI) {
-					if (otherSettlerAI.destination == tile) {
+				if (otherSettler.currentAI is SettlerAI otherSettlerAI) {
+					Tile otherDestination = ((SettlerAI)(otherSettler.currentAI)).settlerAi.destination;
+					if (otherDestination == tile) {
 						return true;
 					}
-					if (otherSettlerAI.destination.GetLandNeighbors().Exists(innerRingTile => innerRingTile == tile)) {
+					if (otherDestination.GetLandNeighbors().Exists(innerRingTile => innerRingTile == tile)) {
 						return true;
 					}
-					foreach (Tile innerRingTile in otherSettlerAI.destination.GetLandNeighbors()) {
+					foreach (Tile innerRingTile in otherDestination.GetLandNeighbors()) {
 						if (innerRingTile.GetLandNeighbors().Exists(outerRingTile => outerRingTile == tile)) {
 							return true;
 						}

--- a/C7GameData/MapUnit.cs
+++ b/C7GameData/MapUnit.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using C7GameData.AIData;
 
 namespace C7GameData {
 	/**
@@ -41,7 +40,7 @@ namespace C7GameData {
 
 		[JsonIgnore]
 		public List<string> availableActions = new List<string>();
-		public UnitAIData currentAIData;
+		public UnitAI currentAI;
 
 		public MapUnit(ID id) {
 			this.id = id;

--- a/C7GameData/UnitAI.cs
+++ b/C7GameData/UnitAI.cs
@@ -1,12 +1,15 @@
 using C7GameData;
 using C7GameData.AIData;
 
-namespace C7Engine {
+namespace C7GameData {
 	//Not-fully-fleshed out player unit AI.
 	//Right now it's kind of random to just add some appearance
 	//of stuff being done.  I.e. it kinda sucks.  But that's okay.
 	//It has to start somewhere, right?
 	public interface UnitAI {
 		bool PlayTurn(Player player, MapUnit unit);
+
+		// Provide a string representation of the current AI plan.
+		string SummarizePlan();
 	}
 }


### PR DESCRIPTION
This allows us to push more logic into the ai classes themselves, rather than having tons of it piling up in `PlayerAI.cs`. To do this I had to move `UnitAI.cs` over to `C7GameData` to avoid a dependency cycle, but declaring the interface there seems fine.

To test this I ran in observer mode for a while (which required fixing a small bug in Game.cs)
