### PR TITLE
MapUnitExtensions: Move can road/irrigate/mine into the Tile class

### DIFF
--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -462,7 +462,7 @@ namespace C7Engine {
 		}
 
 		public static bool canBuildRoad(this MapUnit unit) {
-			return unit.unitType.actions.Contains(C7Action.UnitBuildRoad) && unit.location.IsLand() && !unit.location.overlays.road;
+			return unit.unitType.actions.Contains(C7Action.UnitBuildRoad) && unit.location.CanBeRoaded();
 		}
 
 		public static void buildRoad(this MapUnit unit) {
@@ -480,10 +480,7 @@ namespace C7Engine {
 			// Mines can only be built on tiles with a mining bonus, if there is
 			// no mine/irrigation already there, and if there isn't a city.
 			return unit.unitType.actions.Contains(C7Action.UnitBuildMine) &&
-				unit.location.overlayTerrainType.miningBonus > 0 &&
-				!unit.location.overlays.mine &&
-				!unit.location.overlays.irrigation &&
-				unit.location.cityAtTile == null;
+				unit.location.CanBeMined();
 		}
 
 		public static void buildMine(this MapUnit unit) {
@@ -497,49 +494,8 @@ namespace C7Engine {
 			unit.movementPoints.onConsumeAll();
 		}
 
-		// TODO: This method doesn't handle two important irrigation cases:
-		//  - inland lakes/seas: we need to figure out what is fresh/salt water
-		//  - Electricity tech, to allow irrigating w/o fresh water access
 		public static bool canIrrigate(this MapUnit unit) {
-			// Irrigation can't be done if the unit doesn't have the action, if
-			// there is no irrigation bonus for the tile, or if there's already
-			// an improvement or city on the tile.
-			if (!unit.unitType.actions.Contains(C7Action.UnitIrrigate) ||
-				unit.location.overlayTerrainType.irrigationBonus == 0 ||
-				unit.location.overlays.mine ||
-				unit.location.overlays.irrigation ||
-				unit.location.cityAtTile != null) {
-				return false;
-			}
-
-			// If a tile borders a river, it has fresh water access.
-			if (unit.location.BordersRiver()) {
-				return true;
-			}
-
-			foreach (KeyValuePair<TileDirection, Tile> dirToTile in unit.location.neighbors) {
-				// If a neighboring tile is irrigated, this tile has fresh water access.
-				if (dirToTile.Value.overlays.irrigation) {
-					return true;
-				}
-
-				// Special case, if we are neighboring the worker's city, check
-				// if the city can act as part of an irrigation chain.
-				if (dirToTile.Value.cityAtTile?.owner == unit.owner) {
-					if (dirToTile.Value.BordersRiver()) {
-						return true;
-					}
-
-					foreach (var (dir, tile) in dirToTile.Value.neighbors) {
-						if (tile.overlays.irrigation) {
-							return true;
-						}
-					}
-				}
-			}
-
-			return false;
-
+			return unit.unitType.actions.Contains(C7Action.UnitIrrigate) && unit.location.CanBeIrrigated(unit.owner);
 		}
 
 		public static void irrigate(this MapUnit unit) {

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -301,6 +301,56 @@ namespace C7GameData {
 			return riverNorth || riverNortheast || riverEast || riverSoutheast || riverSouth || riverSouthwest || riverWest || riverNorthwest;
 		}
 
+		public bool CanBeMined() {
+			return overlayTerrainType.miningBonus > 0 && !overlays.mine && !overlays.irrigation && cityAtTile == null;
+		}
+
+		public bool CanBeRoaded() {
+			return IsLand() && !overlays.road;
+		}
+
+		// TODO: This method doesn't handle two important irrigation cases:
+		//  - inland lakes/seas: we need to figure out what is fresh/salt water
+		//  - Electricity tech, to allow irrigating w/o fresh water access
+		public bool CanBeIrrigated(Player player) {
+			// Irrigation can't be done if there is no irrigation bonus for the 
+			// tile or if there's already an improvement or city on the tile.
+			if (overlayTerrainType.irrigationBonus == 0 ||
+				overlays.mine ||
+				overlays.irrigation ||
+				cityAtTile != null) {
+				return false;
+			}
+
+			// If a tile borders a river, it has fresh water access.
+			if (BordersRiver()) {
+				return true;
+			}
+
+			foreach (KeyValuePair<TileDirection, Tile> dirToTile in neighbors) {
+				// If a neighboring tile is irrigated, this tile has fresh water access.
+				if (dirToTile.Value.overlays.irrigation) {
+					return true;
+				}
+
+				// Special case, if we are neighboring a city, check
+				// if the city can act as part of an irrigation chain.
+				if (dirToTile.Value.cityAtTile != null) {
+					if (dirToTile.Value.BordersRiver()) {
+						return true;
+					}
+
+					foreach (var (dir, tile) in dirToTile.Value.neighbors) {
+						if (tile.overlays.irrigation) {
+							return true;
+						}
+					}
+				}
+			}
+
+			return false;
+		}
+
 		//Convenience method for printing the yield
 		public string YieldString(Player player) {
 			return $"{foodYield(player)}/{productionYield(player)}/{commerceYield(player)})";


### PR DESCRIPTION
This will let the worker AI check if a tile improvement can be performed without needing to be standing on the tile first.
