### PR TITLE
Add a basic worker AI, and fix the other AIs to actually use roads

### DIFF
--- a/C7/Map/CityLayer.cs
+++ b/C7/Map/CityLayer.cs
@@ -12,7 +12,9 @@ namespace C7.Map {
 
 		public void UpdateAfterCityDestruction(City city) {
 			citySceneLookup.Remove(city, out CityScene cityScene);
-			cityScene.Hide();
+			if (cityScene != null) {
+				cityScene.Hide();
+			}
 		}
 
 		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -74,6 +74,8 @@ namespace C7Engine {
 			//TODO: Use strategies, not names
 			if (unit.unitType.name == "Settler") {
 				return new SettlerAI(SettlerAI.MakeAiData(unit, player));
+			} else if (unit.unitType.name == "Worker") {
+				return new WorkerAI(WorkerAI.MakeAiData(unit, player));
 			} else if (unit.location.cityAtTile != null && unit.location.unitsOnTile.Count(u => u.unitType.defense > 0 && u != unit) == 0) {
 				return new DefenderAI(DefenderAI.MakeAiData(unit, player));
 			} else if (GetCombatAIIfUnitCanAttackNearbyBarbCamp(unit, player) is UnitAI unitAI && unitAI != null) {

--- a/C7Engine/AI/UnitAI/CombatAI.cs
+++ b/C7Engine/AI/UnitAI/CombatAI.cs
@@ -19,7 +19,7 @@ namespace C7Engine.AI.UnitAI {
 			combatAIData = d;
 		}
 
-		public bool PlayTurn(Player player, MapUnit unit) {
+		public bool PlayTurnImpl(Player player, MapUnit unit) {
 			//Move along the path to the place where the unit plans to enter combat.
 			//This might initiate combat.
 			//Once there are more combat goals than run to a barbarian camp,

--- a/C7Engine/AI/UnitAI/DefenderAI.cs
+++ b/C7Engine/AI/UnitAI/DefenderAI.cs
@@ -19,7 +19,7 @@ namespace C7Engine.AI.UnitAI {
 			defenderAI = d;
 		}
 
-		public bool PlayTurn(Player player, MapUnit unit) {
+		bool C7GameData.UnitAI.PlayTurnImpl(Player player, MapUnit unit) {
 			if (defenderAI.destination == unit.location) {
 				if (!unit.isFortified) {
 					unit.fortify();
@@ -30,7 +30,7 @@ namespace C7Engine.AI.UnitAI {
 
 				Tile nextTile = defenderAI.pathToDestination.Next();
 				if (nextTile != Tile.NONE) {
-					unit.move(unit.location.directionTo(nextTile));
+					return unit.move(unit.location.directionTo(nextTile));
 				} else {
 					//Got a crash due to trying to move to (or less likely from) Tile.NONE.
 					//However, from the logs, the destination was [15, 55], so somehow the path
@@ -40,8 +40,10 @@ namespace C7Engine.AI.UnitAI {
 					//likely affect its pathing.  Put a breakpoint here while debugging!
 					//This should be a higher severity Serilog error
 					log.Error("ERROR: Unit pathed via Tile.NONE");
+					return false;
 				}
 			}
+
 			return true;
 		}
 

--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -16,7 +16,7 @@ namespace C7Engine {
 			explorerData = d;
 		}
 
-		public bool PlayTurn(Player player, MapUnit unit) {
+		bool UnitAI.PlayTurnImpl(Player player, MapUnit unit) {
 			if (MovingToNewExplorationArea(explorerData)) {
 				return MoveToNextTileOnPath(explorerData, unit);
 			} else {
@@ -29,8 +29,7 @@ namespace C7Engine {
 				//We prefer nearest because the one that allows the most discovery might be pretty far away
 				bool foundNewPath = FindPathToNewExplorationArea(player, explorerData, unit);
 				if (foundNewPath) {
-					MoveToNextTileOnPath(explorerData, unit);
-					return true;
+					return MoveToNextTileOnPath(explorerData, unit);
 				}
 			}
 			return false;
@@ -44,8 +43,7 @@ namespace C7Engine {
 			Tile next = explorerData.path.Next();
 			foreach (KeyValuePair<TileDirection, Tile> neighbor in unit.location.neighbors) {
 				if (neighbor.Value == next) {
-					unit.move(neighbor.Key);
-					return true;
+					return unit.move(neighbor.Key);
 				}
 			}
 			//In the future, it might no longer be possible to go to the correct neighbor, perhaps
@@ -64,8 +62,7 @@ namespace C7Engine {
 			Tile newLocation = topScoringTile.Key;
 
 			if (newLocation != Tile.NONE && topScoringTile.Value > 0) {
-				unit.move(unit.location.directionTo(newLocation));
-				return true;
+				return unit.move(unit.location.directionTo(newLocation));
 			}
 			return false;
 		}

--- a/C7Engine/AI/UnitAI/SettlerAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerAI.cs
@@ -37,7 +37,7 @@ namespace C7Engine {
 			settlerAi = d;
 		}
 
-		public bool PlayTurn(Player player, MapUnit unit) {
+		bool UnitAI.PlayTurnImpl(Player player, MapUnit unit) {
 start:
 			switch (settlerAi.goal) {
 				case SettlerAIData.SettlerGoal.BUILD_CITY:
@@ -73,6 +73,7 @@ start:
 							//TODO: #213 - If the path cannot be completed, we should create a different path instead.
 							//But to do that, the pathing algorithm will need to be enhanced to be aware of when rival units are in the way.
 							log.Warning("#213 - Could not get next part of path for unit " + settlerAi + ", " + ex.Message);
+							return false;
 						}
 					}
 					break;
@@ -91,6 +92,7 @@ start:
 					log.Warning("Unknown strategy of " + settlerAi.goal + " for unit");
 					break;
 			}
+
 			return true;
 		}
 

--- a/C7Engine/AI/UnitAI/WorkerAI.cs
+++ b/C7Engine/AI/UnitAI/WorkerAI.cs
@@ -1,0 +1,170 @@
+using System;
+using C7Engine.Pathing;
+using C7GameData;
+using System.Collections.Generic;
+using System.Linq;
+using C7GameData.AIData;
+using C7Engine.AI;
+using Serilog;
+
+namespace C7Engine {
+	public class WorkerAI : UnitAI {
+		private static ILogger log = Log.ForContext<WorkerAI>();
+		private WorkerAIData data;
+
+		public WorkerAI(WorkerAIData d) {
+			data = d;
+		}
+
+		public static WorkerAIData MakeAiData(MapUnit unit, Player player) {
+			// First, check if there are any tiles our civ works that we can
+			// improve.
+			List<Tile> workedTiles = new();
+			foreach (City city in player.cities) {
+				foreach (CityResident cr in city.residents) {
+					if (cr.tileWorked != Tile.NONE) {
+						workedTiles.Add(cr.tileWorked);
+					}
+				}
+			}
+			WorkerAIData? result = GetPlanToImproveNearestUnimproved(unit, player, workedTiles);
+			if (result != null) {
+				return result;
+			}
+
+			// If all our worked tiles are improved, improve the nearest owned
+			// tile.
+			List<Tile> ownedTiles = new();
+			foreach (City city in player.cities) {
+				foreach (Tile tile in city.GetTilesWithinBorders()) {
+					ownedTiles.Add(tile);
+				}
+			}
+			return GetPlanToImproveNearestUnimproved(unit, player, ownedTiles);
+		}
+
+		public string SummarizePlan() {
+			return "WorkerAI: " + data.ToString();
+		}
+
+		bool UnitAI.PlayTurnImpl(Player player, MapUnit unit) {
+			if (data == null) {
+				return false;
+			}
+
+			// If we're at the destination, do our planned move.
+			if (unit.location == data.destination) {
+				return PerformWorkerMove(unit, data.workerMove);
+			}
+
+			// Otherwise we're moving towards our actual goal. To avoid wasting
+			// worker moves, see if there's anything we can do on this tile
+			// before moving to the next.
+			//
+			// This also functions as a way to build a road network, since we
+			// will eventually road between all worked tiles of all cities.
+			string? improvement = GetTileImprovement(unit.location, unit.owner);
+			if (improvement != null) {
+				return PerformWorkerMove(unit, improvement);
+			}
+
+			// Finally, if we've done all the worker moves locally, continue on
+			// towards our actual goal.
+			Tile nextTile = data.pathToDestination.Next();
+			if (nextTile == Tile.NONE) {
+				log.Warning($"Worker at {unit.location} owned by {unit.owner.civilization.name} was trying to get to {data.destination} to {data.workerMove} but could not get there.");
+				return false;
+			}
+			unit.move(unit.location.directionTo(nextTile));
+
+			return true;
+		}
+
+		private static string? GetTileImprovement(Tile t, Player player) {
+			if (!t.IsLand()) {
+				return null;
+			}
+
+			// "Mine green, irrigate brown"
+			if (t.overlayTerrainType.Key == "grassland" || t.overlayTerrainType.Key == "hills" || t.overlayTerrainType.Key == "mountains") {
+				if (t.CanBeMined()) {
+					return C7Action.UnitBuildMine;
+				}
+				if (t.CanBeRoaded()) {
+					return C7Action.UnitBuildRoad;
+				}
+				return null;
+			}
+
+			if (t.overlayTerrainType.Key == "desert" || t.overlayTerrainType.Key == "plains" || t.overlayTerrainType.Key == "flood plain") {
+				if (t.CanBeIrrigated(player)) {
+					return C7Action.UnitIrrigate;
+				} else {
+					// TODO: We should check to see if we can chain irrigate.
+				}
+				if (t.CanBeRoaded()) {
+					return C7Action.UnitBuildRoad;
+				}
+				if (t.CanBeMined()) {
+					return C7Action.UnitBuildMine;
+				}
+				return null;
+			}
+
+			// TODO: handle clearing forest/jungle/marsh
+			if (t.CanBeRoaded()) {
+				return C7Action.UnitBuildRoad;
+			}
+			return null;
+		}
+
+		private bool PerformWorkerMove(MapUnit unit, string workerMove) {
+			if (workerMove == C7Action.UnitBuildRoad) {
+				if (unit.canBuildRoad()) {
+					unit.buildRoad();
+					return true;
+				}
+				return false;
+			} else if (workerMove == C7Action.UnitBuildMine) {
+				if (unit.canBuildMine()) {
+					unit.buildMine();
+					return true;
+				}
+				return false;
+			} else if (workerMove == C7Action.UnitIrrigate) {
+				if (unit.canIrrigate()) {
+					unit.irrigate();
+					return true;
+				}
+				return false;
+			} else {
+				throw new ArgumentOutOfRangeException("Invalid worker move" + data.workerMove);
+			}
+		}
+
+		// Given a list of tile candidates, return a plan to improve the nearest
+		// unimproved tile.
+		private static WorkerAIData? GetPlanToImproveNearestUnimproved(MapUnit unit, Player player, List<Tile> tiles) {
+			List<Tile> nearestWorkedTiles =
+				tiles.OrderBy(x => x.distanceTo(unit.location))
+					.ThenByDescending(x => CityTileAssignmentAI.CalculateTileYieldScore(x, 2, player))
+					.ToList();
+			foreach (Tile t in nearestWorkedTiles) {
+				string? improvement = GetTileImprovement(t, unit.owner);
+				if (improvement != null) {
+					WorkerAIData result = new () {
+						workerMove = improvement,
+						destination = t,
+					};
+					log.Information($"Set AI for unit at {unit.location} to {improvement} with destination of " + result.destination);
+
+					PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
+					result.pathToDestination = algorithm.PathFrom(unit.location, result.destination);
+
+					return result;
+				}
+			}
+			return null;
+		}
+	}
+}

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -396,6 +396,8 @@ namespace C7Engine {
 				unit.location = newLoc;
 				unit.movementPoints.onUnitMove(movementCost);
 				unit.animate(MapUnit.AnimatedAction.RUN, wait);
+			} else {
+				return false;
 			}
 			return true;
 		}
@@ -426,6 +428,7 @@ namespace C7Engine {
 			// Set unit's hit points to zero to indicate that it's no longer alive. Ultimately we may not want to do this. I'm only doing it right
 			// now since this way all the UI needs to do to check if the selected unit has been destroyed is to check its hit points.
 			unit.hitPointsRemaining = 0;
+			unit.movementPoints.onConsumeAll();
 
 			// EngineStorage.animTracker.endAnimation(unit, false);   TODO: Must send message instead of call directly
 			unit.location.unitsOnTile.Remove(unit);

--- a/C7GameData/AIData/WorkerAIData.cs
+++ b/C7GameData/AIData/WorkerAIData.cs
@@ -1,0 +1,11 @@
+namespace C7GameData.AIData {
+	public class WorkerAIData : UnitAIData {
+		public string workerMove;
+		public Tile destination;
+		public TilePath pathToDestination;
+
+		public override string ToString() {
+			return workerMove + " at " + destination;
+		}
+	}
+}

--- a/C7GameData/UnitAI.cs
+++ b/C7GameData/UnitAI.cs
@@ -1,5 +1,6 @@
 using C7GameData;
 using C7GameData.AIData;
+using System;
 
 namespace C7GameData {
 	//Not-fully-fleshed out player unit AI.
@@ -7,7 +8,18 @@ namespace C7GameData {
 	//of stuff being done.  I.e. it kinda sucks.  But that's okay.
 	//It has to start somewhere, right?
 	public interface UnitAI {
-		bool PlayTurn(Player player, MapUnit unit);
+		public bool PlayTurn(Player player, MapUnit unit) {
+			do {
+				bool wasSuccessful = PlayTurnImpl(player, unit);
+				if (!wasSuccessful) {
+					return false;
+				}
+			} while (unit.movementPoints.canMove && !unit.isFortified);
+			return true;
+		}
+
+		// To be implemented by each AI subclass.
+		protected abstract bool PlayTurnImpl(Player player, MapUnit unit);
 
 		// Provide a string representation of the current AI plan.
 		string SummarizePlan();


### PR DESCRIPTION
This also fixed the issue of chariots (and any other multi-move units) actually moving multiple tiles in one turn.

The basic idea of the worker AI is to ensure that all worked tiles have been improved, aiming to mine green and irrigate brown. To build a road network, we then have the worker improve every tile on it's path walking to the next worked tile, which incidentally connects most cities by roads.

Possible future improvements include:
 - avoiding excessive improvements for tiles outside of borders
 - roading directly towards any strategic resources we control
 - avoiding units from civs we're at war with
 - clearing forests/marching/jungles

Here's a screenshot after running in observer mode for a bunch of turns - we can see some reasonable tile improvements, a road network, etc.

![image](https://github.com/user-attachments/assets/79439f72-bb10-429f-a3e2-13d0718dae38)

