### PR TITLE
Fixing the transition of the fog of war

### DIFF
--- a/C7/Map/FogOfWarLayer.cs
+++ b/C7/Map/FogOfWarLayer.cs
@@ -15,7 +15,8 @@ namespace C7.Map {
 		}
 
 		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
-			Rect2 screenTarget = new Rect2(tileCenter - tileSize / 2, tileSize);
+			Vector2 fogOrigin = new(tileCenter.X - tileSize.X/2, tileCenter.Y);
+			Rect2 screenTarget = new Rect2(fogOrigin, tileSize);
 			TileKnowledge tileKnowledge = gameData.GetHumanPlayers()[0].tileKnowledge;
 			//N.B. FogOfWar.pcx handles both totally unknown and fogged tiles, indexed in the same file.
 			//Hence the trinary math rather than the more commonplace binary.

--- a/C7/Map/FogOfWarLayer.cs
+++ b/C7/Map/FogOfWarLayer.cs
@@ -19,7 +19,7 @@ namespace C7.Map {
 			TileKnowledge tileKnowledge = gameData.GetHumanPlayers()[0].tileKnowledge;
 			//N.B. FogOfWar.pcx handles both totally unknown and fogged tiles, indexed in the same file.
 			//Hence the trinary math rather than the more commonplace binary.
-			if (!tileKnowledge.isTileKnown(tile) || tileKnowledge.isBorderOfTileKnowleged(tile)) {
+			if (!tileKnowledge.isTileKnown(tile) || tileKnowledge.isBorderOfTileKnowlege(tile)) {
 				int sum = 0;
 				if (tileKnowledge.isTileKnown(tile.neighbors[TileDirection.NORTH]) || tileKnowledge.isTileKnown(tile.neighbors[TileDirection.NORTHWEST]) || tileKnowledge.isTileKnown(tile.neighbors[TileDirection.NORTHEAST]))
 					sum += 1 * 2;

--- a/C7/Map/FogOfWarLayer.cs
+++ b/C7/Map/FogOfWarLayer.cs
@@ -38,7 +38,8 @@ namespace C7.Map {
 		private Rect2 getRect(int sum) {
 			int row = sum / 9;
 			int col = sum % 9;
-			return new Rect2(col * tileSize.X, row * tileSize.Y, tileSize);
+			// The 0.999f scaling is a hack to prevent "seams".
+			return new Rect2(col * tileSize.X, row * tileSize.Y, tileSize * 0.999f);
 		}
 	}
 }

--- a/C7/Map/FogOfWarLayer.cs
+++ b/C7/Map/FogOfWarLayer.cs
@@ -19,7 +19,7 @@ namespace C7.Map {
 			TileKnowledge tileKnowledge = gameData.GetHumanPlayers()[0].tileKnowledge;
 			//N.B. FogOfWar.pcx handles both totally unknown and fogged tiles, indexed in the same file.
 			//Hence the trinary math rather than the more commonplace binary.
-			if (!tileKnowledge.isTileKnown(tile)) {
+			if (!tileKnowledge.isTileKnown(tile) || tileKnowledge.isBorderOfTileKnowleged(tile)) {
 				int sum = 0;
 				if (tileKnowledge.isTileKnown(tile.neighbors[TileDirection.NORTH]) || tileKnowledge.isTileKnown(tile.neighbors[TileDirection.NORTHWEST]) || tileKnowledge.isTileKnown(tile.neighbors[TileDirection.NORTHEAST]))
 					sum += 1 * 2;
@@ -29,9 +29,8 @@ namespace C7.Map {
 					sum += 9 * 2;
 				if (tileKnowledge.isTileKnown(tile.neighbors[TileDirection.SOUTH]) || tileKnowledge.isTileKnown(tile.neighbors[TileDirection.SOUTHWEST]) || tileKnowledge.isTileKnown(tile.neighbors[TileDirection.SOUTHEAST]))
 					sum += 27 * 2;
-				if (sum != 0) {
-					looseView.DrawTextureRectRegion(fogOfWarTexture, screenTarget, getRect(sum));
-				}
+
+				looseView.DrawTextureRectRegion(fogOfWarTexture, screenTarget, getRect(sum));
 			}
 			//do nothing if the tile is known (equiv to the lower-right)
 		}

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -518,7 +518,7 @@ public partial class LooseView : Node2D {
 			return true;
 		}
 		TileKnowledge knowledge = gameDataAccess.gameData.GetHumanPlayers()[0].tileKnowledge;
-		return tile != Tile.NONE && (knowledge.isTileKnown(tile) || knowledge.isBorderOfTileKnowleged(tile));
+		return tile != Tile.NONE && (knowledge.isTileKnown(tile) || knowledge.isBorderOfTileKnowlege(tile));
 	}
 }
 

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -517,7 +517,8 @@ public partial class LooseView : Node2D {
 		if (gameDataAccess.gameData.observerMode) {
 			return true;
 		}
-		return tile != Tile.NONE && gameDataAccess.gameData.GetHumanPlayers()[0].tileKnowledge.isTileKnown(tile);
+		TileKnowledge knowledge = gameDataAccess.gameData.GetHumanPlayers()[0].tileKnowledge;
+		return tile != Tile.NONE && (knowledge.isTileKnown(tile) || knowledge.isBorderOfTileKnowleged(tile));
 	}
 }
 

--- a/C7/PCXToGodot.cs
+++ b/C7/PCXToGodot.cs
@@ -47,7 +47,7 @@ public partial class PCXToGodot : GodotObject {
 			for (int x = 0; x < alphaPcx.Width; x++, dataIndex++) {
 				int index = alphaPcx.ColorIndexAt(x, y);
 
-					bufferData[dataIndex] = (255 - alphaData[index]) << 24;
+				bufferData[dataIndex] = (255 - alphaData[index]) << 24;
 
 			}
 		}

--- a/C7/PCXToGodot.cs
+++ b/C7/PCXToGodot.cs
@@ -46,11 +46,9 @@ public partial class PCXToGodot : GodotObject {
 		for (int y = 0; y < alphaPcx.Height; y++) {
 			for (int x = 0; x < alphaPcx.Width; x++, dataIndex++) {
 				int index = alphaPcx.ColorIndexAt(x, y);
-				if (transparentColorIndexes.Contains(index)) {
-					bufferData[dataIndex] = 0;
-				} else {
-					bufferData[dataIndex] = alphaData[index] << 24;
-				}
+
+					bufferData[dataIndex] = (255 - alphaData[index]) << 24;
+
 			}
 		}
 

--- a/C7/project.godot
+++ b/C7/project.godot
@@ -205,5 +205,5 @@ limits/debugger_stdout/max_chars_per_second=65535
 [rendering]
 
 textures/canvas_textures/default_texture_filter=0
-environment/defaults/default_clear_color=Color(0.301961, 0.301961, 0.301961, 1)
+environment/defaults/default_clear_color=Color(0, 0, 0, 1)
 environment/default_environment="res://default_env.tres"

--- a/C7GameData/AIData/TileKnowledge.cs
+++ b/C7GameData/AIData/TileKnowledge.cs
@@ -3,23 +3,46 @@ using System.Collections.Generic;
 namespace C7GameData {
 	public class TileKnowledge {
 		HashSet<Tile> knownTiles = new HashSet<Tile>();
+		HashSet<Tile> borderTiles = new HashSet<Tile>();
 		HashSet<Tile> visibleTiles = new HashSet<Tile>();
 
 		public void AddTilesToKnown(Tile unitLocation) {
 			knownTiles.Add(unitLocation);
+			borderTiles.Remove(unitLocation);
+
 			foreach (Tile t in unitLocation.neighbors.Values) {
 				knownTiles.Add(t);
+				borderTiles.Remove(t);
+
+				foreach (Tile border in t.neighbors.Values) {
+					if (!knownTiles.Contains(border)) {
+						borderTiles.Add(border);
+					}
+				}
 			}
 		}
 
 		// neighboring tiles should not be added when loading tile knowledge
 		// from a .sav file
 		internal bool AddTileToKnown(Tile unitLocation) {
-			return knownTiles.Add(unitLocation);
+			bool added = knownTiles.Add(unitLocation);
+			borderTiles.Remove(unitLocation);
+
+			foreach (Tile border in unitLocation.neighbors.Values) {
+				if (!knownTiles.Contains(border)) {
+					borderTiles.Add(border);
+				}
+			}
+
+			return added;
 		}
 
 		public bool isTileKnown(Tile t) {
 			return knownTiles.Contains(t);
+		}
+
+		public bool isBorderOfTileKnowleged(Tile t) {
+			return borderTiles.Contains(t);
 		}
 
 		/**

--- a/C7GameData/AIData/TileKnowledge.cs
+++ b/C7GameData/AIData/TileKnowledge.cs
@@ -41,7 +41,7 @@ namespace C7GameData {
 			return knownTiles.Contains(t);
 		}
 
-		public bool isBorderOfTileKnowleged(Tile t) {
+		public bool isBorderOfTileKnowlege(Tile t) {
 			return borderTiles.Contains(t);
 		}
 


### PR DESCRIPTION
This MR tries to fix the fog of war. 
before:
![image](https://github.com/user-attachments/assets/ce85cd60-29cb-41ef-a96f-0c00229fd158)

after:
![image](https://github.com/user-attachments/assets/66849ded-611a-4cfe-b4a0-b09a335421eb)

~~it's not perfect, though...
When zooming in and out, artifacts may appear:
![image](https://github.com/user-attachments/assets/14ce2c06-412f-4f3d-9c31-b785c2038fb6)
I don't think that's directly related to the fog of war; it's more like a floating-point error in tile placement.~~
It should be fixed now.

The end of aren't well handled, yet (north and south).
![image](https://github.com/user-attachments/assets/d11f9258-1926-4ed6-bb18-a0293222d17e)
![image](https://github.com/user-attachments/assets/eac41dce-f4b6-4b53-aaa3-a7caee625685)
I don't know the reason 🤷🏻 

Known but not actively visible tiles aren't handled.
