### PR TITLE
Process multi-turn moves during the unit's order, not end-of-turn

### DIFF
--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -216,21 +216,28 @@ namespace C7Engine {
 	}
 
 	public class MsgEndTurn : MessageToEngine {
-
 		private ILogger log = Log.ForContext<MsgEndTurn>();
 
 		public override void process() {
 			Player controller = EngineStorage.gameData.GetPlayer(EngineStorage.uiControllerID);
 
-			foreach (MapUnit unit in controller.units) {
-				log.Debug($"{unit}, path length: {unit.path?.PathLength() ?? 0}");
-				if (unit.path?.PathLength() > 0) {
-					unit.moveAlongPath();
-				}
-			}
+			// Reorder the unit list so that non-busy units will be selected
+			// first.
+			controller.units.Sort((x, y) => x.IsBusy().CompareTo(y.IsBusy()));
 
 			controller.hasPlayedThisTurn = true;
 			TurnHandling.AdvanceTurn();
+		}
+	}
+
+	public class MsgPerformUnitAction : MessageToEngine {
+		private MapUnit unit;
+		public MsgPerformUnitAction(MapUnit unit) {
+			this.unit = unit;
+		}
+
+		public override void process() {
+			unit.PerformBusyAction();
 		}
 	}
 

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -15,7 +15,12 @@ namespace C7Engine {
 				//TODO: Should pass in a player GUID instead of checking for human
 				//This current limits us to one human player, although it's better
 				//than the old limit of one non-barbarian player.
-				foreach (MapUnit unit in player.units.Where(u => u.movementPoints.canMove && !u.IsBusy())) {
+				foreach (MapUnit unit in player.units.Where(u => u.movementPoints.canMove)) {
+					if (unit.IsBusy()) {
+						new MsgPerformUnitAction(unit).send();
+						continue;
+					}
+
 					if (!waitQueue.Contains(unit)) {
 						return unit;
 					}

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -402,6 +402,18 @@ namespace C7Engine {
 			return true;
 		}
 
+		public static void PerformBusyAction(this MapUnit unit) {
+			if (unit.isFortified) {
+				return;
+			}
+
+			if (unit.path != null && unit.path.PathLength() > 0) {
+				unit.moveAlongPath();
+				return;
+			}
+
+			// TODO: Handle worker automation and unit exploration here.
+		}
 
 		public static void moveAlongPath(this MapUnit unit) {
 			while (unit.movementPoints.canMove && unit.path?.PathLength() > 0) {


### PR DESCRIPTION
This better matches the base game, where if I have two units, a settler and a worker, and have the settler go on a multi-turn move, the next turn the worker will be selected. If I then press wait, the settler will do its movement phase.

This also is necessary for the single player "road-to"+"wait" hack, where cycling through the full list of units will result in a road being completed, which can then be used a turn early.
