### PR TITLE
Support cancelling multi-turn moves 

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -6,6 +6,7 @@ using C7GameData;
 using Serilog;
 using C7Engine.Pathing;
 using System.Collections.Generic;
+using System.Linq;
 using C7Engine.AI;
 
 public partial class Game : Node2D {
@@ -330,8 +331,10 @@ public partial class Game : Node2D {
 	 * Currently (11/14/2021), all unit selection goes through here.
 	 * Both code paths are in Game.cs for now, so it's local, but we may
 	 * want to change it event driven.
+	 *
+	 * Returns whether the selected unit has remaining moves.
 	 **/
-	public void setSelectedUnit(MapUnit unit) {
+	public bool setSelectedUnit(MapUnit unit) {
 		unit.availableActions = UnitInteractions.GetAvailableActions(unit);
 
 		if ((unit.path?.PathLength() ?? -1) > 0) {
@@ -351,12 +354,18 @@ public partial class Game : Node2D {
 			ensureLocationIsInView(unit.location);
 		}
 
+		if (unit != MapUnit.NONE && !unit.movementPoints.canMove) {
+			return false;
+		}
+
 		// Also emit the signal for a new unit being selected, so other areas such as Game Status and Unit Buttons can update
 		if (CurrentlySelectedUnit != MapUnit.NONE) {
 			ParameterWrapper<MapUnit> wrappedUnit = new ParameterWrapper<MapUnit>(CurrentlySelectedUnit);
 			EmitSignal(SignalName.NewAutoselectedUnit, wrappedUnit);
+			return true;
 		} else {
 			EmitSignal(SignalName.NoMoreAutoselectableUnits);
+			return false;
 		}
 	}
 
@@ -461,9 +470,17 @@ public partial class Game : Node2D {
 						using (var gameDataAccess = new UIGameDataAccess()) {
 							var tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
 							if (tile != null) {
-								MapUnit to_select = tile.unitsOnTile.Find(u => u.movementPoints.canMove);
-								if (to_select != null && to_select.owner == controller)
-									setSelectedUnit(to_select);
+								// TODO: This should really be the top unit.
+								MapUnit to_select = tile.unitsOnTile.FirstOrDefault();
+								if (to_select != null && to_select.owner == controller) {
+									bool canMove = setSelectedUnit(to_select);
+									if (!canMove) {
+										TemporaryPopup popup = new("This unit has already moved.", 1);
+										popup.SetPosition(eventMouseButton.Position + new Vector2(0, -64));
+										AddChild(popup);
+										popup.ShowPopup();
+									}
+								}
 							}
 						}
 

--- a/C7/UIElements/Popups/TemporaryPopup.cs
+++ b/C7/UIElements/Popups/TemporaryPopup.cs
@@ -1,0 +1,29 @@
+using Godot;
+using System;
+using System.Threading.Tasks;
+
+public partial class TemporaryPopup : Label {
+	private int durationInMillis;
+
+	public TemporaryPopup(string text, float durationInSec) {
+		Text = text;
+		this.durationInMillis = (int)(durationInSec * 1000);
+
+		StyleBoxFlat styleBox = new();
+		styleBox.ContentMarginLeft = 5;
+		styleBox.ContentMarginRight = 5;
+		styleBox.ContentMarginTop = 2;
+		styleBox.ContentMarginBottom = 2;
+		styleBox.BgColor = Color.FromHtml("1C1C1C");
+		AddThemeStyleboxOverride("normal", styleBox);
+		AddThemeColorOverride("font_color", Colors.White);
+	}
+
+	public async void ShowPopup() {
+		// Wait until we hit our duration then destroy ourself.
+		await Task.Delay(durationInMillis);
+
+		Visible = false;
+		QueueFree();
+	}
+}

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -100,6 +100,13 @@ public partial class RightClickMenu : VBoxContainer {
 			this.AcceptEvent();
 		}
 	}
+
+	public void ShowCannotMovePopup() {
+		TemporaryPopup popup = new("This unit has already moved.", 1);
+		popup.SetPosition(position + new Vector2(0, -64));
+		GetParent().AddChild(popup);
+		popup.ShowPopup();
+	}
 }
 
 public partial class RightClickTileMenu : RightClickMenu {
@@ -181,7 +188,10 @@ public partial class RightClickTileMenu : RightClickMenu {
 		using (var gameDataAccess = new UIGameDataAccess()) {
 			MapUnit toSelect = gameDataAccess.gameData.mapUnits.Find(u => u.id == id);
 			if (toSelect != null && toSelect.owner == game.controller) {
-				game.setSelectedUnit(toSelect);
+				bool canMove = game.setSelectedUnit(toSelect);
+				if (!canMove) {
+					ShowCannotMovePopup();
+				}
 				new MsgSetFortification(toSelect.id, false).send();
 				ResetItems(toSelect.location, new Dictionary<ID, bool>() { { toSelect.id, false } });
 			}
@@ -202,7 +212,10 @@ public partial class RightClickTileMenu : RightClickMenu {
 					new MsgSetFortification(unit.id, isFortify).send();
 
 					if (!hasSelectedUnit && !isFortify) {
-						game.setSelectedUnit(unit);
+						bool canMove = game.setSelectedUnit(unit);
+						if (!canMove) {
+							ShowCannotMovePopup();
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This also adds the "This unit has already moved" popup.

![image](https://github.com/user-attachments/assets/b309d93e-2f59-4b65-b528-a6fa45de81a9)

Being able to cancel multi-turn moves is important, as players should be able to change their minds. This will also be important for breaking out of worker moves, automation, and exploring.