### PR TITLE
Fix city border alignment

### DIFF
--- a/C7/Map/BorderLayer.cs
+++ b/C7/Map/BorderLayer.cs
@@ -83,8 +83,8 @@ namespace C7.Map {
 					Vector2 size = texture.GetSize();
 					Vector2 offset = size/2;
 					// these values were found experimentally to alignment with the grid
-					offset.X += size.X * 0.01f;
-					offset.Y += size.Y * 0.05f;
+					offset.X += size.X * 0.00f;
+					offset.Y += size.Y * 0.055f;
 
 					looseView.DrawTexture(texture, tileCenter - offset);
 				}

--- a/C7/Map/BorderLayer.cs
+++ b/C7/Map/BorderLayer.cs
@@ -82,6 +82,7 @@ namespace C7.Map {
 					ImageTexture texture = GetBorderTexture(entry.Value, borderColor);
 					Vector2 size = texture.GetSize();
 					Vector2 offset = size/2;
+					// these values were found experimentally to alignment with the grid
 					offset.X += size.X * 0.01f;
 					offset.Y += size.Y * 0.05f;
 

--- a/C7/Map/BorderLayer.cs
+++ b/C7/Map/BorderLayer.cs
@@ -80,9 +80,10 @@ namespace C7.Map {
 			foreach (var entry in directionToTextureIdx) {
 				if (tile.neighbors[entry.Key].owningCity?.owner != tile.owningCity?.owner) {
 					ImageTexture texture = GetBorderTexture(entry.Value, borderColor);
-					Vector2 offset = texture.GetSize()/2;
-					offset.X += texture.GetSize().X * 0.01f;
-					offset.Y += texture.GetSize().Y * 0.05f;
+					Vector2 size = texture.GetSize();
+					Vector2 offset = size/2;
+					offset.X += size.X * 0.01f;
+					offset.Y += size.Y * 0.05f;
 
 					looseView.DrawTexture(texture, tileCenter - offset);
 				}

--- a/C7/Map/BorderLayer.cs
+++ b/C7/Map/BorderLayer.cs
@@ -82,8 +82,7 @@ namespace C7.Map {
 					ImageTexture texture = GetBorderTexture(entry.Value, borderColor);
 					Vector2 size = texture.GetSize();
 					Vector2 offset = size/2;
-					// these values were found experimentally to alignment with the grid
-					offset.X += size.X * 0.00f;
+					// this value were found experimentally to improve alignment with the grid
 					offset.Y += size.Y * 0.055f;
 
 					looseView.DrawTexture(texture, tileCenter - offset);

--- a/C7/Map/BorderLayer.cs
+++ b/C7/Map/BorderLayer.cs
@@ -80,7 +80,9 @@ namespace C7.Map {
 			foreach (var entry in directionToTextureIdx) {
 				if (tile.neighbors[entry.Key].owningCity?.owner != tile.owningCity?.owner) {
 					ImageTexture texture = GetBorderTexture(entry.Value, borderColor);
-					Vector2 offset = texture.GetSize() * 0.5f;
+					Vector2 offset = texture.GetSize()/2;
+					offset.X += texture.GetSize().X * 0.01f;
+					offset.Y += texture.GetSize().Y * 0.05f;
 
 					looseView.DrawTexture(texture, tileCenter - offset);
 				}


### PR DESCRIPTION
Here is a very small PR to fix city border misalignment with the grid.

Before:
![image](https://github.com/user-attachments/assets/2e01cbe9-ef42-4f20-ab91-a85fe697373c)

After:
![image](https://github.com/user-attachments/assets/68822a05-fbee-4be1-bf80-72ca9d5bb0e6)


