### PR TITLE
Implement the "explore" and "automate worker" actions

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -279,7 +279,8 @@ public partial class Game : Node2D {
 					if ((CurrentlySelectedUnit != MapUnit.NONE) &&
 						(((!CurrentlySelectedUnit.movementPoints.canMove || CurrentlySelectedUnit.hitPointsRemaining <= 0) &&
 						  !animTracker.getUnitAppearance(CurrentlySelectedUnit).DeservesPlayerAttention()) ||
-						 (CurrentlySelectedUnit.isFortified && !KeepCSUWhenFortified)))
+						 (CurrentlySelectedUnit.isFortified && !KeepCSUWhenFortified) ||
+						 CurrentlySelectedUnit.isAutomated))
 						GetNextAutoselectedUnit(gameData);
 				}
 				//Listen to keys.  There is a C# Mono Godot bug where e.g. Godot.Key.F1 (etc.) doesn't work
@@ -342,9 +343,15 @@ public partial class Game : Node2D {
 			unit.path = TilePath.NONE;
 		}
 
-		// clear the current WorkerJob
+		// Allow cancellation of active worker jobs by clicking on the unit.
 		if (unit.WorkerJob != null) {
 			unit.resetWorkerJob();
+		}
+
+		// Allow cancellation automation via clicking on the unit.
+		if (unit.isAutomated) {
+			unit.isAutomated = false;
+			unit.currentAI = null;
 		}
 
 		this.CurrentlySelectedUnit = unit;
@@ -689,8 +696,12 @@ public partial class Game : Node2D {
 			setGotoMode(true);
 		}
 
-		if (currentAction == C7Action.UnitExplore) {
-			// unimplemented
+		if (currentAction == C7Action.UnitExplore && CurrentlySelectedUnit != MapUnit.NONE) {
+			new ActionToEngineMsg(() => CurrentlySelectedUnit?.explore()).send();
+		}
+
+		if (currentAction == C7Action.UnitAutomate && CurrentlySelectedUnit != MapUnit.NONE) {
+			new ActionToEngineMsg(() => CurrentlySelectedUnit?.automate()).send();
 		}
 
 		if (currentAction == C7Action.UnitSentry) {
@@ -701,7 +712,7 @@ public partial class Game : Node2D {
 			// unimplemented
 		}
 
-		if (currentAction == C7Action.UnitBuildCity && CurrentlySelectedUnit.canBuildCity()) {
+		if (currentAction == C7Action.UnitBuildCity && (CurrentlySelectedUnit?.canBuildCity() ?? false)) {
 			using (var gameDataAccess = new UIGameDataAccess()) {
 				MapUnit currentUnit = gameDataAccess.gameData.GetUnit(CurrentlySelectedUnit.id);
 				log.Debug(currentUnit.Describe());
@@ -711,15 +722,15 @@ public partial class Game : Node2D {
 			}
 		}
 
-		if (currentAction == C7Action.UnitBuildRoad && CurrentlySelectedUnit.canBuildRoad()) {
+		if (currentAction == C7Action.UnitBuildRoad && (CurrentlySelectedUnit?.canBuildRoad() ?? false)) {
 			new ActionToEngineMsg(() => CurrentlySelectedUnit?.buildRoad()).send();
 		}
 
-		if (currentAction == C7Action.UnitBuildMine && CurrentlySelectedUnit.canBuildMine()) {
+		if (currentAction == C7Action.UnitBuildMine && (CurrentlySelectedUnit?.canBuildMine() ?? false)) {
 			new ActionToEngineMsg(() => CurrentlySelectedUnit?.buildMine()).send();
 		}
 
-		if (currentAction == C7Action.UnitIrrigate && CurrentlySelectedUnit.canIrrigate()) {
+		if (currentAction == C7Action.UnitIrrigate && (CurrentlySelectedUnit?.canIrrigate() ?? false)) {
 			new ActionToEngineMsg(() => CurrentlySelectedUnit?.irrigate()).send();
 		}
 

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -58686,7 +58686,8 @@
       "facingDirection": "north",
       "experience": "Regular",
       "workerProgressTowardsJob": 0,
-      "workerJob": -1
+      "workerJob": -1,
+      "isAutomated": false
     },
     {
       "id": "Worker-1",
@@ -58705,7 +58706,8 @@
       "facingDirection": "north",
       "experience": "Regular",
       "workerProgressTowardsJob": 0,
-      "workerJob": -1
+      "workerJob": -1,
+      "isAutomated": false
     },
     {
       "id": "Settler-2",
@@ -58724,7 +58726,8 @@
       "facingDirection": "north",
       "experience": "Regular",
       "workerProgressTowardsJob": 0,
-      "workerJob": -1
+      "workerJob": -1,
+      "isAutomated": false
     },
     {
       "id": "Worker-2",
@@ -58743,7 +58746,8 @@
       "facingDirection": "north",
       "experience": "Regular",
       "workerProgressTowardsJob": 0,
-      "workerJob": -1
+      "workerJob": -1,
+      "isAutomated": false
     },
     {
       "id": "Scout-1",
@@ -58762,7 +58766,8 @@
       "facingDirection": "north",
       "experience": "Regular",
       "workerProgressTowardsJob": 0,
-      "workerJob": -1
+      "workerJob": -1,
+      "isAutomated": false
     },
     {
       "id": "Settler-3",
@@ -58781,7 +58786,8 @@
       "facingDirection": "north",
       "experience": "Regular",
       "workerProgressTowardsJob": 0,
-      "workerJob": -1
+      "workerJob": -1,
+      "isAutomated": false
     },
     {
       "id": "Worker-3",
@@ -58800,7 +58806,8 @@
       "facingDirection": "north",
       "experience": "Regular",
       "workerProgressTowardsJob": 0,
-      "workerJob": -1
+      "workerJob": -1,
+      "isAutomated": false
     },
     {
       "id": "Settler-4",
@@ -58819,7 +58826,8 @@
       "facingDirection": "north",
       "experience": "Regular",
       "workerProgressTowardsJob": 0,
-      "workerJob": -1
+      "workerJob": -1,
+      "isAutomated": false
     },
     {
       "id": "Worker-4",
@@ -58838,7 +58846,8 @@
       "facingDirection": "north",
       "experience": "Regular",
       "workerProgressTowardsJob": 0,
-      "workerJob": -1
+      "workerJob": -1,
+      "isAutomated": false
     },
     {
       "id": "Scout-2",
@@ -58857,7 +58866,8 @@
       "facingDirection": "north",
       "experience": "Regular",
       "workerProgressTowardsJob": 0,
-      "workerJob": -1
+      "workerJob": -1,
+      "isAutomated": false
     },
     {
       "id": "Settler-5",
@@ -58876,7 +58886,8 @@
       "facingDirection": "north",
       "experience": "Regular",
       "workerProgressTowardsJob": 0,
-      "workerJob": -1
+      "workerJob": -1,
+      "isAutomated": false
     },
     {
       "id": "Worker-5",
@@ -58895,7 +58906,8 @@
       "facingDirection": "north",
       "experience": "Regular",
       "workerProgressTowardsJob": 0,
-      "workerJob": -1
+      "workerJob": -1,
+      "isAutomated": false
     },
     {
       "id": "Settler-6",
@@ -58914,7 +58926,8 @@
       "facingDirection": "north",
       "experience": "Regular",
       "workerProgressTowardsJob": 0,
-      "workerJob": -1
+      "workerJob": -1,
+      "isAutomated": false
     },
     {
       "id": "Worker-6",
@@ -58933,7 +58946,8 @@
       "facingDirection": "north",
       "experience": "Regular",
       "workerProgressTowardsJob": 0,
-      "workerJob": -1
+      "workerJob": -1,
+      "isAutomated": false
     },
     {
       "id": "Settler-7",
@@ -58952,7 +58966,8 @@
       "facingDirection": "north",
       "experience": "Regular",
       "workerProgressTowardsJob": 0,
-      "workerJob": -1
+      "workerJob": -1,
+      "isAutomated": false
     },
     {
       "id": "Worker-7",
@@ -58971,7 +58986,8 @@
       "facingDirection": "north",
       "experience": "Regular",
       "workerProgressTowardsJob": 0,
-      "workerJob": -1
+      "workerJob": -1,
+      "isAutomated": false
     }
   ],
   "unitPrototypes": [
@@ -58994,7 +59010,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59018,7 +59035,9 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore",
+        "unit_automate"
       ]
     },
     {
@@ -59039,7 +59058,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59060,7 +59080,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59081,12 +59102,13 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Modern Paratrooper",
-      "artName": "Modern Paratrooper",
+      "artName": "Paratrooper",
       "shieldCost": 110,
       "populationCost": 0,
       "attack": 6,
@@ -59102,7 +59124,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59123,7 +59146,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59144,7 +59168,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59165,7 +59190,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59186,12 +59212,13 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Chariot",
-      "artName": "Chariot",
+      "artName": "chariot",
       "shieldCost": 20,
       "populationCost": 0,
       "attack": 1,
@@ -59207,7 +59234,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59228,7 +59256,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59249,7 +59278,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59270,7 +59300,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59291,7 +59322,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59312,7 +59344,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59333,7 +59366,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59354,7 +59388,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59375,7 +59410,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59396,7 +59432,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59417,7 +59454,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59438,7 +59476,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59460,7 +59499,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59482,7 +59522,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59504,7 +59545,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59526,7 +59568,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59570,7 +59613,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59613,7 +59657,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59634,7 +59679,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59656,7 +59702,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59677,7 +59724,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59699,7 +59747,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59720,7 +59769,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59741,7 +59791,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59762,7 +59813,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59784,7 +59836,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59806,7 +59859,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59828,7 +59882,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59849,7 +59904,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -59990,7 +60046,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60011,7 +60068,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60032,7 +60090,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60053,7 +60112,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60074,7 +60134,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60095,7 +60156,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60116,7 +60178,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60137,7 +60200,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60158,7 +60222,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60179,7 +60244,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60200,7 +60266,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60221,7 +60288,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60242,7 +60310,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60263,7 +60332,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60284,7 +60354,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60305,7 +60376,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60327,7 +60399,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60368,7 +60441,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60389,7 +60463,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60410,7 +60485,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60431,7 +60507,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60452,12 +60529,13 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Gallic Swordsman",
-      "artName": "Gallic Swordsman",
+      "artName": "gallic swordsman",
       "shieldCost": 40,
       "populationCost": 0,
       "attack": 3,
@@ -60473,12 +60551,13 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Ansar Warrior",
-      "artName": "Ansar Warrior",
+      "artName": "ansar warrior",
       "shieldCost": 60,
       "populationCost": 0,
       "attack": 4,
@@ -60494,12 +60573,13 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Numidian Mercenary",
-      "artName": "Numidian Mercenary",
+      "artName": "Libyan Mercenary",
       "shieldCost": 30,
       "populationCost": 0,
       "attack": 2,
@@ -60515,12 +60595,13 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Hwach\u0027a",
-      "artName": "Hwach\u0027a",
+      "artName": "Hwacha",
       "shieldCost": 40,
       "populationCost": 0,
       "attack": 0,
@@ -60537,7 +60618,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60558,7 +60640,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60579,7 +60662,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -60603,7 +60687,7 @@
     },
     {
       "name": "Lincoln",
-      "artName": "Lincoln",
+      "artName": "King American",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60618,12 +60702,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Hammurabi",
-      "artName": "Hammurabi",
+      "artName": "King Babylonian",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60638,12 +60723,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Mao",
-      "artName": "Mao",
+      "artName": "King Chinese",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60658,12 +60744,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Bismarck",
-      "artName": "Bismarck",
+      "artName": "King German",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60678,12 +60765,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Alexander",
-      "artName": "Alexander",
+      "artName": "King Greek",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60698,12 +60786,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Caesar",
-      "artName": "Caesar",
+      "artName": "King Roman",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60718,12 +60807,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Xerxes",
-      "artName": "Xerxes",
+      "artName": "King Persian",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60738,12 +60828,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Hiawatha",
-      "artName": "Hiawatha",
+      "artName": "King Iroquois",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60758,12 +60849,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Shaka",
-      "artName": "Shaka",
+      "artName": "King Zulu",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60778,12 +60870,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Montezuma",
-      "artName": "Montezuma",
+      "artName": "King Aztec",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60798,12 +60891,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Cleopatra",
-      "artName": "Cleopatra",
+      "artName": "King Egyptian",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60818,12 +60912,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Elizabeth",
-      "artName": "Elizabeth",
+      "artName": "King English",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60838,12 +60933,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Catherine",
-      "artName": "Catherine",
+      "artName": "King Russian",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60858,12 +60954,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Abu",
-      "artName": "Abu",
+      "artName": "King Arab",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60878,12 +60975,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Hannibal",
-      "artName": "Hannibal",
+      "artName": "King Carthaginian",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60898,12 +60996,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Osman",
-      "artName": "Osman",
+      "artName": "King Ottoman",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60918,12 +61017,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Temujin",
-      "artName": "Temujin",
+      "artName": "King Mongol",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60938,12 +61038,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Gandhi",
-      "artName": "Gandhi",
+      "artName": "King Indian",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60958,12 +61059,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Ragnar",
-      "artName": "Ragnar",
+      "artName": "King Viking",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60978,12 +61080,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Brennus",
-      "artName": "Brennus",
+      "artName": "King Celtic",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60998,12 +61101,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Tokugawa",
-      "artName": "Tokugawa",
+      "artName": "King Japanese",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61018,12 +61122,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Joan d\u0027Arc",
-      "artName": "Joan d\u0027Arc",
+      "artName": "King French",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61038,12 +61143,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Wang Kon",
-      "artName": "Wang Kon",
+      "artName": "King Korean",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61058,12 +61164,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Isabella",
-      "artName": "Isabella",
+      "artName": "King Spanish",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61078,7 +61185,8 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -61099,12 +61207,13 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Three-Man Chariot",
-      "artName": "Three-Man Chariot",
+      "artName": "Three Man Chariot",
       "shieldCost": 30,
       "populationCost": 0,
       "attack": 2,
@@ -61120,12 +61229,13 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Mursilis",
-      "artName": "Mursilis",
+      "artName": "King Hatti",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61140,12 +61250,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Gilgamesh",
-      "artName": "Gilgamesh",
+      "artName": "King Sumeria",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61160,12 +61271,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Henry",
-      "artName": "Henry",
+      "artName": "King Portugal",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61180,7 +61292,8 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -61201,7 +61314,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -61222,12 +61336,13 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "William of Orange",
-      "artName": "William of Orange",
+      "artName": "King Netherlands",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61242,7 +61357,8 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -61264,12 +61380,13 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Pachacuti",
-      "artName": "Pachacuti",
+      "artName": "King Incan",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61284,12 +61401,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Smoke-Jaguar",
-      "artName": "Smoke-Jaguar",
+      "artName": "King Mayan",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61304,12 +61422,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Theodora",
-      "artName": "Theodora",
+      "artName": "King Byzantines",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61324,12 +61443,13 @@
         "unit_hold",
         "unit_wait",
         "unit_fortify",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Chasqui Scout",
-      "artName": "Chasqui Scout",
+      "artName": "Chasquis Scout",
       "shieldCost": 20,
       "populationCost": 0,
       "attack": 1,
@@ -61345,7 +61465,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -61366,7 +61487,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -61388,7 +61510,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -61410,7 +61533,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -61431,7 +61555,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -61452,7 +61577,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -61473,12 +61599,13 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
       "name": "Paratrooper",
-      "artName": "Paratrooper",
+      "artName": "WWII Paratrooper",
       "shieldCost": 90,
       "populationCost": 0,
       "attack": 4,
@@ -61494,7 +61621,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -61515,7 +61643,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -61536,7 +61665,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     },
     {
@@ -61557,7 +61687,8 @@
         "unit_wait",
         "unit_fortify",
         "unit_disband",
-        "unit_goto"
+        "unit_goto",
+        "unit_explore"
       ]
     }
   ],

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -67,7 +67,7 @@ public partial class UnitButtons : VBoxContainer {
 		AddNewButton(specializedControls, new UnitControlButton("chopJungle", 4, 3, onButtonPressed));
 		AddNewButton(specializedControls, new UnitControlButton("plantForest", 5, 3, onButtonPressed));
 		AddNewButton(specializedControls, new UnitControlButton("clearDamage", 6, 3, onButtonPressed));
-		AddNewButton(specializedControls, new UnitControlButton("automate", 7, 3, onButtonPressed));
+		AddNewButton(specializedControls, new UnitControlButton(C7Action.UnitAutomate, 7, 3, onButtonPressed));
 
 		// Row index 4 and later not yet added
 	}

--- a/C7/project.godot
+++ b/C7/project.godot
@@ -163,6 +163,11 @@ unit_explore={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"echo":false,"script":null)
 ]
 }
+unit_automate={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"echo":false,"script":null)
+]
+}
 unit_sentry={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":89,"key_label":0,"unicode":121,"echo":false,"script":null)

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -67,6 +67,14 @@ namespace C7Engine {
 				result.Add(C7Action.UnitIrrigate);
 			}
 
+			if (unit.canExplore()) {
+				result.Add(C7Action.UnitExplore);
+			}
+
+			if (unit.canAutomate()) {
+				result.Add(C7Action.UnitAutomate);
+			}
+
 			// Eventually we will have advanced actions too, whose availability will rely on their base actions' availability.
 			// unit.availableActions.Add("rename");
 

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -7,6 +7,7 @@ namespace C7Engine {
 	using Pathing;
 	using C7GameData;
 	using C7GameData.Save;
+	using C7GameData.AIData;
 
 	//We should document why we're putting things in the extensions methods.  We discussed it a month or so ago, but I forget why at this point.
 	//Coming from an OO background, I'm wondering why these aren't on the MapUnit class... data access?  Modding?  Some other benefit?
@@ -412,7 +413,10 @@ namespace C7Engine {
 				return;
 			}
 
-			// TODO: Handle worker automation and unit exploration here.
+			if (unit.isAutomated) {
+				unit.playAutomatedTurn();
+				return;
+			}
 		}
 
 		public static void moveAlongPath(this MapUnit unit) {
@@ -555,6 +559,49 @@ namespace C7Engine {
 			unit.WorkerJob = null;
 			unit.WorkerProgressTowardsJob = 0;
 			unit.animate(MapUnit.AnimatedAction.BLANK, false, AnimationEnding.Repeat);
+		}
+
+		public static bool canAutomate(this MapUnit unit) {
+			return unit.unitType.actions.Contains(C7Action.UnitAutomate);
+		}
+
+		public static void automate(this MapUnit unit) {
+			unit.isAutomated = true;
+			WorkerAIData? maybeAiData = WorkerAI.MakeAiData(unit, unit.owner);
+			if (maybeAiData == null) {
+				log.Information($"Could not find anything to automate for {unit} owned by {unit.owner}");
+				unit.isAutomated = false;
+				return;
+			}
+			unit.currentAI = new WorkerAI(maybeAiData);
+			unit.playAutomatedTurn();
+		}
+
+		public static bool canExplore(this MapUnit unit) {
+			return unit.unitType.actions.Contains(C7Action.UnitExplore);
+		}
+
+		public static void explore(this MapUnit unit) {
+			unit.isAutomated = true;
+			ExplorerAIData? maybeAiData = ExplorerAI.MaybeMakeAiData(unit, unit.owner);
+			if (maybeAiData == null) {
+				log.Information($"Could not find anything to explore for {unit} owned by {unit.owner}");
+				unit.isAutomated = false;
+				return;
+			}
+			unit.currentAI = new ExplorerAI(maybeAiData);
+			unit.playAutomatedTurn();
+		}
+
+		public static void playAutomatedTurn(this MapUnit unit) {
+			bool done = !unit.currentAI.PlayTurn(unit.owner, unit);
+			if (done) {
+				if (unit.currentAI is WorkerAI) {
+					unit.automate();
+				} else if (unit.currentAI is ExplorerAI) {
+					unit.explore();
+				}
+			}
 		}
 	}
 }

--- a/C7GameData/Actions.cs
+++ b/C7GameData/Actions.cs
@@ -19,6 +19,7 @@ namespace C7GameData {
 		public const string UnitBuildRoad = "unit_build_road";
 		public const string UnitBuildMine = "unit_build_mine";
 		public const string UnitIrrigate = "unit_irrigate";
+		public const string UnitAutomate = "unit_automate";
 		public const string UnitDisband = "unit_disband";
 		public const string UnitExplore = "unit_explore";
 		public const string UnitFortify = "unit_fortify";

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -485,6 +485,7 @@ namespace C7GameData {
 					movePointsRemaining = (float)prototype.Movement - (unit.MovementUsed / 3f),
 					WorkerProgressTowardsJob = unit.WorkerProgressTowardsJob,
 					WorkerJob = unit.WorkerJob,
+					isAutomated = unit.IsAutomated,
 				};
 				if (unit.Fortified) {
 					saveUnit.action = "fortified";
@@ -704,6 +705,12 @@ namespace C7GameData {
 				}
 				if (prto.GoTo) {
 					prototype.actions.Add(C7Action.UnitGoto);
+				}
+				if (prto.Explore) {
+					prototype.actions.Add(C7Action.UnitExplore);
+				}
+				if (prto.Automate) {
+					prototype.actions.Add(C7Action.UnitAutomate);
 				}
 				//Temporary check until #329/#330 are finished
 				if (!save.UnitPrototypes.Where(p => p.name == prototype.name).Any()) {

--- a/C7GameData/MapUnit.cs
+++ b/C7GameData/MapUnit.cs
@@ -33,6 +33,9 @@ namespace C7GameData {
 			}
 		}
 		public bool isFortified { get; set; }
+
+		public bool isAutomated { get; set; }
+
 		//sentry, etc. will come later.  For now, let's just have a couple things so we can cycle through units that aren't fortified.
 		public int defensiveBombardsRemaining;
 
@@ -53,7 +56,7 @@ namespace C7GameData {
 		internal MapUnit() { }
 
 		public bool IsBusy() {
-			return isFortified || (path != null && path.PathLength() > 0) || WorkerJob != null;
+			return isFortified || (path != null && path.PathLength() > 0) || WorkerJob != null || isAutomated;
 		}
 
 		public bool IsLandUnit() {

--- a/C7GameData/Save/SaveUnit.cs
+++ b/C7GameData/Save/SaveUnit.cs
@@ -18,6 +18,10 @@ namespace C7GameData.Save {
 		public int WorkerProgressTowardsJob;
 		public int WorkerJob;
 
+		// True for multiple types of automation, including worker automation
+		// and automated exploring.
+		public bool isAutomated;
+
 		public SaveUnit() { }
 
 		public SaveUnit(MapUnit unit, GameMap map) {
@@ -33,6 +37,7 @@ namespace C7GameData.Save {
 			}
 			hitPointsRemaining = unit.hitPointsRemaining;
 			action = unit.isFortified ? "fortified" : "";
+			isAutomated = unit.isAutomated;
 			facingDirection = unit.facingDirection;
 			experience = unit.experienceLevelKey;
 			movePointsRemaining = unit.movementPoints.remaining;
@@ -53,6 +58,7 @@ namespace C7GameData.Save {
 				hitPointsRemaining = hitPointsRemaining,
 				movementPoints = new MovementPoints(),
 				isFortified = action == "fortified",
+				isAutomated = isAutomated,
 			};
 			unit.location.unitsOnTile.Add(unit);
 			unit.movementPoints.reset(movePointsRemaining);

--- a/QueryCiv3/SavSections/Unit.cs
+++ b/QueryCiv3/SavSections/Unit.cs
@@ -31,16 +31,30 @@ namespace QueryCiv3.Sav {
 		// a foreign worker (configurable via PRTO::WorkerStrength).
 		public int WorkerProgressTowardsJob;
 		public int WorkerJob; // Index into TFRM, -1 if idle
-		private fixed byte UnknownBuffer2[4];
+		private int UnknownBuffer2;
 		public int LoadedOnUnitId;
 
 		private fixed byte Flags2[12];
 		public bool Fortified { get => Util.GetFlag(Flags2[0], 0); }
 
-		// Note: this doesn't appear to correlate with whether a worker is
-		// performing an action - use `WorkerJob != -1` for that.
-		public bool Working { get => Util.GetFlag(Flags2[0], 3); }
-		public bool GoTo { get => Util.GetFlag(Flags2[0], 4); }
+		// Appears to be true for multiple types of automation, including
+		// exploring.
+		public bool IsAutomated { get => Util.GetFlag(Flags2[0], 4); }
+
+		// A utility for trying to understand the values of the various flags.
+		public string DumpFlags() {
+			string result = "";
+			for (int i = 0; i < 4; ++i) {
+				result += Flags[i] + " : ";
+			}
+			for (int i = 0; i < 12; ++i) {
+				result += Flags2[i] + " : ";
+			}
+			for (int i = 0; i < 4; ++i) {
+				result += Flags3[i] + " : ";
+			}
+			return result;
+		}
 
 		public int UseName;
 


### PR DESCRIPTION
These use the explorer and worker AI classes, so in addition to giving us useful functionality, it gives us an easier way to test the explorer logic.

While these behaviors can be observed in observer mode (ctrl+alt+shift+O), observer mode doesn't show tile knowledge, so judging the usefulness of the explorer ai is hard. With this PR we can see that it's not that great (choosing moves that reveal none or only a single tile), and will allow us to improve it.

Both of these automated actions can be cancelled by clicking on the unit, just like in civ3.