### PR TITLE
ExplorerAI: Tune the "near city" exploration to be more useful

### DIFF
--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -199,7 +199,11 @@ namespace C7Engine {
 							distanceToNearestCity = distance;
 						}
 					}
-					explorationScore[t] = 100 - 4 * distanceToNearestCity * distanceToNearestCity + baseScore;
+
+					// Ensure we don't stray too far from the nearest city, but
+					// don't weight the distance too much or we don't do useful
+					// exploring.
+					explorationScore[t] = 100 - distanceToNearestCity + baseScore;
 					log.Verbose($"Exploration score for {t}: {explorationScore[t]}");
 				} else {
 					explorationScore[t] = baseScore;


### PR DESCRIPTION
The previous distance penalty was way too high. Here's what we got after 20 turns of exploring with one unit prior to this PR.

![image](https://github.com/user-attachments/assets/bc8b3d96-bd56-4e61-baeb-47174b7dae4b)

And here is the same 20 turns with this PR:

![image](https://github.com/user-attachments/assets/369e4969-9ba1-4229-90fe-b984a885df57)

We have covered significantly more ground, and the AI player has managed to meet us - which is much more interesting for the player.