### PR TITLE
Fix black spots on loaded PCX textures

### DIFF
--- a/C7/Map/BorderLayer.cs
+++ b/C7/Map/BorderLayer.cs
@@ -24,7 +24,11 @@ namespace C7.Map {
 			//   (rendering logic for textures of the second column is not yet implemented).
 			for (int j = 0; j < 4; j++) {
 				for (int k = 0; k < 2; k++) {
-					borderGraphics[j * 2 + k] = PCXToGodot.getImageTextureFromPCX(texturePcx, k * textureWidth, j * textureHeight, textureWidth, textureHeight, true);
+					borderGraphics[j * 2 + k] = PCXToGodot.getImageTextureFromPCX(
+						texturePcx,
+						new(k * textureWidth, j * textureHeight, textureWidth, textureHeight),
+						new(true, [1, 254, 255])
+					);
 				}
 			}
 		}

--- a/C7/Map/CityLabelScene.cs
+++ b/C7/Map/CityLabelScene.cs
@@ -57,7 +57,7 @@ namespace C7.Map {
 			//Must set the FixedSize so Godot can calculate the width of the font for city labels
 			smallFont.FixedSize = 11;
 
-			nonEmbassyStar = PCXToGodot.getImageFromPCX(cityIcons, 20, 1, 18, 18);
+			nonEmbassyStar = PCXToGodot.getImageFromPCX(cityIcons, new(20, 1, 18, 18));
 		}
 
 		public CityLabelScene(City city, Tile tile, Vector2I tileCenter) {

--- a/C7/PCXToGodot.cs
+++ b/C7/PCXToGodot.cs
@@ -4,24 +4,48 @@ using ConvertCiv3Media;
 using System.Collections.Generic;
 
 public partial class PCXToGodot : GodotObject {
-	// The set of color indexes considered transparent when loading a Civ3 PCX
-	private static readonly HashSet<int> transparentColorIndexes = new() { 1, 254, 255 };
+	public readonly record struct CropRegion(int LeftStart, int TopStart, int CroppedWidth, int CroppedHeight);
+
+	public struct ColorOptions {
+		public static readonly ColorOptions Default = new();
+
+		// The set of color indexes considered transparent when loading a Civ3 PCX
+		public HashSet<int> transparentColorIndexes = [254, 255];
+
+		public bool shadows = true;
+
+		public ColorOptions(bool shadows, HashSet<int> transparentColorIndexes) {
+			this.shadows = shadows;
+			this.transparentColorIndexes = transparentColorIndexes;
+		}
+
+		public ColorOptions(bool shadows) {
+			this.shadows = shadows;
+		}
+
+		public ColorOptions() { }
+
+		// Implicit conversion to initialize ColorOptions with a custom 'shadows' value
+		public static implicit operator ColorOptions(bool value) => new(value);
+	}
 
 	public static ImageTexture getImageTextureFromPCX(Pcx pcx) {
 		Image ImgTxtr = ByteArrayToImage(pcx.ColorIndices, pcx.Palette, pcx.Width, pcx.Height);
 		return getImageTextureFromImage(ImgTxtr);
 	}
 
-	public static ImageTexture getImageTextureFromPCX(Pcx pcx, int leftStart, int topStart, int croppedWidth, int croppedHeight, bool shadows = true) {
-		Image image = getImageFromPCX(pcx, leftStart, topStart, croppedWidth, croppedHeight, shadows);
+	public static ImageTexture getImageTextureFromPCX(Pcx pcx, CropRegion cropRegion, ColorOptions colorOptions) {
+		Image image = getImageFromPCX(pcx, cropRegion, colorOptions);
 		return getImageTextureFromImage(image);
 	}
 
 	/**
 	 * This method is for cases where we want to use components of multiple PCXs in a texture, such as for the popup background.
 	 **/
-	public static Image getImageFromPCX(Pcx pcx, int leftStart, int topStart, int croppedWidth, int croppedHeight, bool shadows = true) {
-		int[] ColorData = loadPalette(pcx.Palette, shadows);
+	public static Image getImageFromPCX(Pcx pcx, CropRegion cropRegion, ColorOptions colorOptions) {
+		var (leftStart, topStart, croppedWidth, croppedHeight) = cropRegion;
+
+		int[] ColorData = loadPalette(pcx.Palette, colorOptions);
 		int[] BufferData = new int[croppedWidth * croppedHeight];
 
 		int DataIndex = 0;
@@ -34,6 +58,10 @@ public partial class PCXToGodot : GodotObject {
 		}
 
 		return getImageFromBufferData(croppedWidth, croppedHeight, BufferData);
+	}
+
+	public static Image getImageFromPCX(Pcx pcx, CropRegion cropRegion) {
+		return getImageFromPCX(pcx, cropRegion, ColorOptions.Default);
 	}
 
 	public static ImageTexture getPureAlphaFromPCX(Pcx alphaPcx) {
@@ -146,7 +174,7 @@ public partial class PCXToGodot : GodotObject {
 		return ImageTexture.CreateFromImage(image);
 	}
 
-	private static int[] loadPalette(byte[,] palette, bool shadows) {
+	private static int[] loadPalette(byte[,] palette, ColorOptions colorOptions) {
 		int Red, Green, Blue;
 		int[] ColorData = new int[256];
 
@@ -155,12 +183,12 @@ public partial class PCXToGodot : GodotObject {
 			Green = palette[i, 1] << 8;
 			Blue = palette[i, 2] << 16;
 
-			int Alpha = transparentColorIndexes.Contains(i) ? 0 : 255 << 24;
+			int Alpha = colorOptions.transparentColorIndexes.Contains(i) ? 0 : 255 << 24;
 
 			ColorData[i] = Red + Green + Blue + Alpha;
 		}
 
-		if (shadows) {
+		if (colorOptions.shadows) {
 			for (int i = 240; i < 256; i++) {
 				ColorData[i] = ((255 - i) * 16) << 24;
 			}

--- a/C7/UIElements/Popups/Popup.cs
+++ b/C7/UIElements/Popups/Popup.cs
@@ -127,15 +127,15 @@ public partial class Popup : TextureRect {
 		//The pop-up part is the tricky part
 		Stopwatch imageTimer = new Stopwatch();
 		imageTimer.Start();
-		Image topLeftPopup = PCXToGodot.getImageFromPCX(popupborders, 251, 1, 61, 44);
-		Image topCenterPopup = PCXToGodot.getImageFromPCX(popupborders, 313, 1, 61, 44);
-		Image topRightPopup = PCXToGodot.getImageFromPCX(popupborders, 375, 1, 61, 44);
-		Image middleLeftPopup = PCXToGodot.getImageFromPCX(popupborders, 251, 46, 61, 44);
-		Image middleCenterPopup = PCXToGodot.getImageFromPCX(popupborders, 313, 46, 61, 44);
-		Image middleRightPopup = PCXToGodot.getImageFromPCX(popupborders, 375, 46, 61, 44);
-		Image bottomLeftPopup = PCXToGodot.getImageFromPCX(popupborders, 251, 91, 61, 44);
-		Image bottomCenterPopup = PCXToGodot.getImageFromPCX(popupborders, 313, 91, 61, 44);
-		Image bottomRightPopup = PCXToGodot.getImageFromPCX(popupborders, 375, 91, 61, 44);
+		Image topLeftPopup = PCXToGodot.getImageFromPCX(popupborders, new(251, 1, 61, 44));
+		Image topCenterPopup = PCXToGodot.getImageFromPCX(popupborders, new(313, 1, 61, 44));
+		Image topRightPopup = PCXToGodot.getImageFromPCX(popupborders, new(375, 1, 61, 44));
+		Image middleLeftPopup = PCXToGodot.getImageFromPCX(popupborders, new(251, 46, 61, 44));
+		Image middleCenterPopup = PCXToGodot.getImageFromPCX(popupborders, new(313, 46, 61, 44));
+		Image middleRightPopup = PCXToGodot.getImageFromPCX(popupborders, new(375, 46, 61, 44));
+		Image bottomLeftPopup = PCXToGodot.getImageFromPCX(popupborders, new(251, 91, 61, 44));
+		Image bottomCenterPopup = PCXToGodot.getImageFromPCX(popupborders, new(313, 91, 61, 44));
+		Image bottomRightPopup = PCXToGodot.getImageFromPCX(popupborders, new(375, 91, 61, 44));
 		imageTimer.Stop();
 		TimeSpan stopwatchElapsed = imageTimer.Elapsed;
 		log.Debug("Image creation time: " + Convert.ToInt32(stopwatchElapsed.TotalMilliseconds) + " ms");

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -200,7 +200,7 @@ public partial class Util {
 			return textureCache[key];
 		}
 		Pcx NewPCX = LoadPCX(relPath);
-		ImageTexture texture = PCXToGodot.getImageTextureFromPCX(NewPCX, leftStart, topStart, width, height, shadows);
+		ImageTexture texture = PCXToGodot.getImageTextureFromPCX(NewPCX, new(leftStart, topStart, width, height), shadows);
 		textureCache[key] = texture;
 		return texture;
 	}


### PR DESCRIPTION
The issue fixed by this commit was introduced in PR #504. It was caused by the addition of a new color index to the set of transparent colors. This new index was required to correctly display border textures, however, when applied to other textures it produced black spots in areas that should have remained opaque.

This commit modifies the methods for loading PCX textures, so they can accept a custom set of transparent color indexes. To improve readability, two new structs are introduced:

- ColorOptions: Encapsulates transparency and shadows settings.
- CropRegion: Defines a cropped section of a texture.