### PR TITLE
Load requirements for building and unit production

### DIFF
--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -59015,6 +59015,7 @@
       "artName": "Explorer",
       "shieldCost": 20,
       "populationCost": 0,
+      "requiredTech": "tech-33",
       "attack": 0,
       "defense": 0,
       "bombard": 0,
@@ -59036,6 +59037,7 @@
       "artName": "Marine",
       "shieldCost": 120,
       "populationCost": 0,
+      "requiredTech": "tech-60",
       "attack": 12,
       "defense": 6,
       "bombard": 0,
@@ -59057,6 +59059,7 @@
       "artName": "Modern Paratrooper",
       "shieldCost": 110,
       "populationCost": 0,
+      "requiredTech": "tech-74",
       "attack": 6,
       "defense": 11,
       "bombard": 0,
@@ -59099,6 +59102,7 @@
       "artName": "Archer",
       "shieldCost": 20,
       "populationCost": 0,
+      "requiredTech": "tech-6",
       "attack": 2,
       "defense": 1,
       "bombard": 1,
@@ -59120,6 +59124,7 @@
       "artName": "Spearman",
       "shieldCost": 20,
       "populationCost": 0,
+      "requiredTech": "tech-1",
       "attack": 1,
       "defense": 2,
       "bombard": 0,
@@ -59141,6 +59146,7 @@
       "artName": "Swordsman",
       "shieldCost": 30,
       "populationCost": 0,
+      "requiredTech": "tech-8",
       "attack": 3,
       "defense": 2,
       "bombard": 0,
@@ -59162,6 +59168,7 @@
       "artName": "Chariot",
       "shieldCost": 20,
       "populationCost": 0,
+      "requiredTech": "tech-5",
       "attack": 1,
       "defense": 1,
       "bombard": 0,
@@ -59183,6 +59190,7 @@
       "artName": "Horseman",
       "shieldCost": 30,
       "populationCost": 0,
+      "requiredTech": "tech-16",
       "attack": 2,
       "defense": 1,
       "bombard": 0,
@@ -59204,6 +59212,7 @@
       "artName": "Pikeman",
       "shieldCost": 30,
       "populationCost": 0,
+      "requiredTech": "tech-23",
       "attack": 1,
       "defense": 3,
       "bombard": 0,
@@ -59225,6 +59234,7 @@
       "artName": "Longbowman",
       "shieldCost": 40,
       "populationCost": 0,
+      "requiredTech": "tech-27",
       "attack": 4,
       "defense": 1,
       "bombard": 2,
@@ -59246,6 +59256,7 @@
       "artName": "Musketman",
       "shieldCost": 60,
       "populationCost": 0,
+      "requiredTech": "tech-31",
       "attack": 2,
       "defense": 4,
       "bombard": 0,
@@ -59267,6 +59278,7 @@
       "artName": "Knight",
       "shieldCost": 70,
       "populationCost": 0,
+      "requiredTech": "tech-26",
       "attack": 4,
       "defense": 3,
       "bombard": 0,
@@ -59288,6 +59300,7 @@
       "artName": "Rifleman",
       "shieldCost": 80,
       "populationCost": 0,
+      "requiredTech": "tech-44",
       "attack": 4,
       "defense": 6,
       "bombard": 0,
@@ -59309,6 +59322,7 @@
       "artName": "Cavalry",
       "shieldCost": 80,
       "populationCost": 0,
+      "requiredTech": "tech-43",
       "attack": 6,
       "defense": 3,
       "bombard": 0,
@@ -59330,6 +59344,7 @@
       "artName": "Infantry",
       "shieldCost": 90,
       "populationCost": 0,
+      "requiredTech": "tech-58",
       "attack": 6,
       "defense": 10,
       "bombard": 0,
@@ -59351,6 +59366,7 @@
       "artName": "Tank",
       "shieldCost": 100,
       "populationCost": 0,
+      "requiredTech": "tech-63",
       "attack": 16,
       "defense": 8,
       "bombard": 0,
@@ -59372,6 +59388,7 @@
       "artName": "Mech Infantry",
       "shieldCost": 110,
       "populationCost": 0,
+      "requiredTech": "tech-67",
       "attack": 12,
       "defense": 18,
       "bombard": 0,
@@ -59393,6 +59410,7 @@
       "artName": "Modern Armor",
       "shieldCost": 120,
       "populationCost": 0,
+      "requiredTech": "tech-74",
       "attack": 24,
       "defense": 16,
       "bombard": 0,
@@ -59414,6 +59432,7 @@
       "artName": "Catapult",
       "shieldCost": 20,
       "populationCost": 0,
+      "requiredTech": "tech-11",
       "attack": 0,
       "defense": 0,
       "bombard": 4,
@@ -59436,6 +59455,7 @@
       "artName": "Cannon",
       "shieldCost": 40,
       "populationCost": 0,
+      "requiredTech": "tech-39",
       "attack": 0,
       "defense": 0,
       "bombard": 8,
@@ -59458,6 +59478,7 @@
       "artName": "Artillery",
       "shieldCost": 80,
       "populationCost": 0,
+      "requiredTech": "tech-58",
       "attack": 0,
       "defense": 0,
       "bombard": 12,
@@ -59480,6 +59501,7 @@
       "artName": "Radar Artillery",
       "shieldCost": 120,
       "populationCost": 0,
+      "requiredTech": "tech-80",
       "attack": 0,
       "defense": 0,
       "bombard": 16,
@@ -59502,6 +59524,7 @@
       "artName": "Cruise Missile",
       "shieldCost": 60,
       "populationCost": 0,
+      "requiredTech": "tech-65",
       "attack": 0,
       "defense": 0,
       "bombard": 16,
@@ -59524,6 +59547,7 @@
       "artName": "Tactical Nuke",
       "shieldCost": 300,
       "populationCost": 0,
+      "requiredTech": "tech-69",
       "attack": 0,
       "defense": 0,
       "bombard": 0,
@@ -59546,6 +59570,7 @@
       "artName": "ICBM",
       "shieldCost": 500,
       "populationCost": 0,
+      "requiredTech": "tech-75",
       "attack": 0,
       "defense": 0,
       "bombard": 0,
@@ -59568,6 +59593,7 @@
       "artName": "Galley",
       "shieldCost": 30,
       "populationCost": 0,
+      "requiredTech": "tech-15",
       "attack": 1,
       "defense": 1,
       "bombard": 0,
@@ -59589,6 +59615,7 @@
       "artName": "Caravel",
       "shieldCost": 40,
       "populationCost": 0,
+      "requiredTech": "tech-33",
       "attack": 1,
       "defense": 2,
       "bombard": 0,
@@ -59610,6 +59637,7 @@
       "artName": "Frigate",
       "shieldCost": 60,
       "populationCost": 0,
+      "requiredTech": "tech-42",
       "attack": 2,
       "defense": 2,
       "bombard": 3,
@@ -59632,6 +59660,7 @@
       "artName": "Galleon",
       "shieldCost": 50,
       "populationCost": 0,
+      "requiredTech": "tech-42",
       "attack": 1,
       "defense": 2,
       "bombard": 0,
@@ -59653,6 +59682,7 @@
       "artName": "Ironclad",
       "shieldCost": 90,
       "populationCost": 0,
+      "requiredTech": "tech-82",
       "attack": 5,
       "defense": 6,
       "bombard": 6,
@@ -59675,6 +59705,7 @@
       "artName": "Transport",
       "shieldCost": 100,
       "populationCost": 0,
+      "requiredTech": "tech-57",
       "attack": 1,
       "defense": 2,
       "bombard": 0,
@@ -59696,6 +59727,7 @@
       "artName": "Carrier",
       "shieldCost": 180,
       "populationCost": 0,
+      "requiredTech": "tech-61",
       "attack": 1,
       "defense": 8,
       "bombard": 0,
@@ -59717,6 +59749,7 @@
       "artName": "Submarine",
       "shieldCost": 100,
       "populationCost": 0,
+      "requiredTech": "tech-61",
       "attack": 8,
       "defense": 4,
       "bombard": 0,
@@ -59738,6 +59771,7 @@
       "artName": "Destroyer",
       "shieldCost": 120,
       "populationCost": 0,
+      "requiredTech": "tech-57",
       "attack": 12,
       "defense": 8,
       "bombard": 6,
@@ -59760,6 +59794,7 @@
       "artName": "Battleship",
       "shieldCost": 200,
       "populationCost": 0,
+      "requiredTech": "tech-61",
       "attack": 18,
       "defense": 12,
       "bombard": 8,
@@ -59782,6 +59817,7 @@
       "artName": "AEGIS Cruiser",
       "shieldCost": 160,
       "populationCost": 0,
+      "requiredTech": "tech-80",
       "attack": 15,
       "defense": 10,
       "bombard": 6,
@@ -59804,6 +59840,7 @@
       "artName": "Nuclear Submarine",
       "shieldCost": 140,
       "populationCost": 0,
+      "requiredTech": "tech-66",
       "attack": 8,
       "defense": 4,
       "bombard": 0,
@@ -59825,6 +59862,7 @@
       "artName": "Fighter",
       "shieldCost": 80,
       "populationCost": 0,
+      "requiredTech": "tech-59",
       "attack": 4,
       "defense": 2,
       "bombard": 3,
@@ -59845,6 +59883,7 @@
       "artName": "Bomber",
       "shieldCost": 100,
       "populationCost": 0,
+      "requiredTech": "tech-59",
       "attack": 0,
       "defense": 2,
       "bombard": 12,
@@ -59865,6 +59904,7 @@
       "artName": "Helicopter",
       "shieldCost": 100,
       "populationCost": 0,
+      "requiredTech": "tech-64",
       "attack": 0,
       "defense": 2,
       "bombard": 0,
@@ -59885,6 +59925,7 @@
       "artName": "Jet Fighter",
       "shieldCost": 100,
       "populationCost": 0,
+      "requiredTech": "tech-65",
       "attack": 8,
       "defense": 4,
       "bombard": 3,
@@ -59905,6 +59946,7 @@
       "artName": "Stealth Fighter",
       "shieldCost": 120,
       "populationCost": 0,
+      "requiredTech": "tech-78",
       "attack": 8,
       "defense": 6,
       "bombard": 6,
@@ -59925,6 +59967,7 @@
       "artName": "Stealth Bomber",
       "shieldCost": 240,
       "populationCost": 0,
+      "requiredTech": "tech-78",
       "attack": 0,
       "defense": 5,
       "bombard": 18,
@@ -59942,7 +59985,7 @@
     },
     {
       "name": "Leader",
-      "artName": "Leader",
+      "artName": "Leader Modern Times",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 0,
@@ -59963,7 +60006,7 @@
     },
     {
       "name": "Army",
-      "artName": "Army",
+      "artName": "Army Modern Times",
       "shieldCost": 400,
       "populationCost": 0,
       "attack": 0,
@@ -59987,6 +60030,7 @@
       "artName": "Jaguar Warrior",
       "shieldCost": 15,
       "populationCost": 0,
+      "requiredTech": "tech-6",
       "attack": 1,
       "defense": 1,
       "bombard": 0,
@@ -60008,6 +60052,7 @@
       "artName": "Bowman",
       "shieldCost": 20,
       "populationCost": 0,
+      "requiredTech": "tech-6",
       "attack": 2,
       "defense": 2,
       "bombard": 1,
@@ -60029,6 +60074,7 @@
       "artName": "Hoplite",
       "shieldCost": 20,
       "populationCost": 0,
+      "requiredTech": "tech-1",
       "attack": 1,
       "defense": 3,
       "bombard": 0,
@@ -60050,6 +60096,7 @@
       "artName": "Impi",
       "shieldCost": 20,
       "populationCost": 0,
+      "requiredTech": "tech-1",
       "attack": 1,
       "defense": 2,
       "bombard": 0,
@@ -60071,6 +60118,7 @@
       "artName": "Legionary",
       "shieldCost": 30,
       "populationCost": 0,
+      "requiredTech": "tech-8",
       "attack": 3,
       "defense": 3,
       "bombard": 0,
@@ -60092,6 +60140,7 @@
       "artName": "Immortals",
       "shieldCost": 30,
       "populationCost": 0,
+      "requiredTech": "tech-8",
       "attack": 4,
       "defense": 2,
       "bombard": 0,
@@ -60113,6 +60162,7 @@
       "artName": "War Chariot",
       "shieldCost": 20,
       "populationCost": 0,
+      "requiredTech": "tech-5",
       "attack": 2,
       "defense": 1,
       "bombard": 0,
@@ -60134,6 +60184,7 @@
       "artName": "Rider",
       "shieldCost": 70,
       "populationCost": 0,
+      "requiredTech": "tech-26",
       "attack": 4,
       "defense": 3,
       "bombard": 0,
@@ -60155,6 +60206,7 @@
       "artName": "Mounted Warrior",
       "shieldCost": 30,
       "populationCost": 0,
+      "requiredTech": "tech-16",
       "attack": 3,
       "defense": 1,
       "bombard": 0,
@@ -60176,6 +60228,7 @@
       "artName": "Musketeer",
       "shieldCost": 60,
       "populationCost": 0,
+      "requiredTech": "tech-31",
       "attack": 2,
       "defense": 5,
       "bombard": 2,
@@ -60197,6 +60250,7 @@
       "artName": "Samurai",
       "shieldCost": 70,
       "populationCost": 0,
+      "requiredTech": "tech-26",
       "attack": 4,
       "defense": 4,
       "bombard": 0,
@@ -60218,6 +60272,7 @@
       "artName": "War Elephant",
       "shieldCost": 70,
       "populationCost": 0,
+      "requiredTech": "tech-26",
       "attack": 4,
       "defense": 3,
       "bombard": 0,
@@ -60239,6 +60294,7 @@
       "artName": "Cossack",
       "shieldCost": 90,
       "populationCost": 0,
+      "requiredTech": "tech-43",
       "attack": 6,
       "defense": 3,
       "bombard": 0,
@@ -60260,6 +60316,7 @@
       "artName": "Panzer",
       "shieldCost": 100,
       "populationCost": 0,
+      "requiredTech": "tech-63",
       "attack": 16,
       "defense": 8,
       "bombard": 0,
@@ -60281,6 +60338,7 @@
       "artName": "Man-O-War",
       "shieldCost": 65,
       "populationCost": 0,
+      "requiredTech": "tech-42",
       "attack": 4,
       "defense": 2,
       "bombard": 4,
@@ -60303,6 +60361,7 @@
       "artName": "F-15",
       "shieldCost": 100,
       "populationCost": 0,
+      "requiredTech": "tech-65",
       "attack": 8,
       "defense": 4,
       "bombard": 6,
@@ -60323,6 +60382,7 @@
       "artName": "Privateer",
       "shieldCost": 50,
       "populationCost": 0,
+      "requiredTech": "tech-42",
       "attack": 2,
       "defense": 1,
       "bombard": 3,
@@ -60344,6 +60404,7 @@
       "artName": "Keshik",
       "shieldCost": 60,
       "populationCost": 0,
+      "requiredTech": "tech-26",
       "attack": 4,
       "defense": 2,
       "bombard": 0,
@@ -60365,6 +60426,7 @@
       "artName": "Conquistador",
       "shieldCost": 70,
       "populationCost": 0,
+      "requiredTech": "tech-33",
       "attack": 3,
       "defense": 2,
       "bombard": 0,
@@ -60386,6 +60448,7 @@
       "artName": "Berserk",
       "shieldCost": 70,
       "populationCost": 0,
+      "requiredTech": "tech-27",
       "attack": 6,
       "defense": 2,
       "bombard": 0,
@@ -60407,6 +60470,7 @@
       "artName": "Sipahi",
       "shieldCost": 100,
       "populationCost": 0,
+      "requiredTech": "tech-43",
       "attack": 8,
       "defense": 3,
       "bombard": 0,
@@ -60425,9 +60489,10 @@
     },
     {
       "name": "Gallic Swordsman",
-      "artName": "Gallic Swordsman",
+      "artName": "gallic swordsman",
       "shieldCost": 40,
       "populationCost": 0,
+      "requiredTech": "tech-8",
       "attack": 3,
       "defense": 2,
       "bombard": 0,
@@ -60446,9 +60511,10 @@
     },
     {
       "name": "Ansar Warrior",
-      "artName": "Ansar Warrior",
+      "artName": "ansar warrior",
       "shieldCost": 60,
       "populationCost": 0,
+      "requiredTech": "tech-26",
       "attack": 4,
       "defense": 2,
       "bombard": 0,
@@ -60467,9 +60533,10 @@
     },
     {
       "name": "Numidian Mercenary",
-      "artName": "Numidian Mercenary",
+      "artName": "Libyan Mercenary",
       "shieldCost": 30,
       "populationCost": 0,
+      "requiredTech": "tech-1",
       "attack": 2,
       "defense": 3,
       "bombard": 0,
@@ -60488,9 +60555,10 @@
     },
     {
       "name": "Hwach\u0027a",
-      "artName": "Hwach\u0027a",
+      "artName": "Hwacha",
       "shieldCost": 40,
       "populationCost": 0,
+      "requiredTech": "tech-39",
       "attack": 0,
       "defense": 0,
       "bombard": 8,
@@ -60513,6 +60581,7 @@
       "artName": "Medieval Infantry",
       "shieldCost": 40,
       "populationCost": 0,
+      "requiredTech": "tech-23",
       "attack": 4,
       "defense": 2,
       "bombard": 0,
@@ -60534,6 +60603,7 @@
       "artName": "Guerilla",
       "shieldCost": 90,
       "populationCost": 0,
+      "requiredTech": "tech-58",
       "attack": 6,
       "defense": 6,
       "bombard": 3,
@@ -60571,7 +60641,7 @@
     },
     {
       "name": "Lincoln",
-      "artName": "Lincoln",
+      "artName": "King American",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60591,7 +60661,7 @@
     },
     {
       "name": "Hammurabi",
-      "artName": "Hammurabi",
+      "artName": "King Babylonian",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60611,7 +60681,7 @@
     },
     {
       "name": "Mao",
-      "artName": "Mao",
+      "artName": "King Chinese",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60631,7 +60701,7 @@
     },
     {
       "name": "Bismarck",
-      "artName": "Bismarck",
+      "artName": "King German",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60651,7 +60721,7 @@
     },
     {
       "name": "Alexander",
-      "artName": "Alexander",
+      "artName": "King Greek",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60671,7 +60741,7 @@
     },
     {
       "name": "Caesar",
-      "artName": "Caesar",
+      "artName": "King Roman",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60691,7 +60761,7 @@
     },
     {
       "name": "Xerxes",
-      "artName": "Xerxes",
+      "artName": "King Persian",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60711,7 +60781,7 @@
     },
     {
       "name": "Hiawatha",
-      "artName": "Hiawatha",
+      "artName": "King Iroquois",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60731,7 +60801,7 @@
     },
     {
       "name": "Shaka",
-      "artName": "Shaka",
+      "artName": "King Zulu",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60751,7 +60821,7 @@
     },
     {
       "name": "Montezuma",
-      "artName": "Montezuma",
+      "artName": "King Aztec",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60771,7 +60841,7 @@
     },
     {
       "name": "Cleopatra",
-      "artName": "Cleopatra",
+      "artName": "King Egyptian",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60791,7 +60861,7 @@
     },
     {
       "name": "Elizabeth",
-      "artName": "Elizabeth",
+      "artName": "King English",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60811,7 +60881,7 @@
     },
     {
       "name": "Catherine",
-      "artName": "Catherine",
+      "artName": "King Russian",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60831,7 +60901,7 @@
     },
     {
       "name": "Abu",
-      "artName": "Abu",
+      "artName": "King Arab",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60851,7 +60921,7 @@
     },
     {
       "name": "Hannibal",
-      "artName": "Hannibal",
+      "artName": "King Carthaginian",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60871,7 +60941,7 @@
     },
     {
       "name": "Osman",
-      "artName": "Osman",
+      "artName": "King Ottoman",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60891,7 +60961,7 @@
     },
     {
       "name": "Temujin",
-      "artName": "Temujin",
+      "artName": "King Mongol",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60911,7 +60981,7 @@
     },
     {
       "name": "Gandhi",
-      "artName": "Gandhi",
+      "artName": "King Indian",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60931,7 +61001,7 @@
     },
     {
       "name": "Ragnar",
-      "artName": "Ragnar",
+      "artName": "King Viking",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60951,7 +61021,7 @@
     },
     {
       "name": "Brennus",
-      "artName": "Brennus",
+      "artName": "King Celtic",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60971,7 +61041,7 @@
     },
     {
       "name": "Tokugawa",
-      "artName": "Tokugawa",
+      "artName": "King Japanese",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -60991,7 +61061,7 @@
     },
     {
       "name": "Joan d\u0027Arc",
-      "artName": "Joan d\u0027Arc",
+      "artName": "King French",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61011,7 +61081,7 @@
     },
     {
       "name": "Wang Kon",
-      "artName": "Wang Kon",
+      "artName": "King Korean",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61031,7 +61101,7 @@
     },
     {
       "name": "Isabella",
-      "artName": "Isabella",
+      "artName": "King Spanish",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61072,9 +61142,10 @@
     },
     {
       "name": "Three-Man Chariot",
-      "artName": "Three-Man Chariot",
+      "artName": "Three Man Chariot",
       "shieldCost": 30,
       "populationCost": 0,
+      "requiredTech": "tech-5",
       "attack": 2,
       "defense": 2,
       "bombard": 0,
@@ -61093,7 +61164,7 @@
     },
     {
       "name": "Mursilis",
-      "artName": "Mursilis",
+      "artName": "King Hatti",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61113,7 +61184,7 @@
     },
     {
       "name": "Gilgamesh",
-      "artName": "Gilgamesh",
+      "artName": "King Sumeria",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61133,7 +61204,7 @@
     },
     {
       "name": "Henry",
-      "artName": "Henry",
+      "artName": "King Portugal",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61156,6 +61227,7 @@
       "artName": "Carrack",
       "shieldCost": 40,
       "populationCost": 0,
+      "requiredTech": "tech-33",
       "attack": 2,
       "defense": 2,
       "bombard": 0,
@@ -61177,6 +61249,7 @@
       "artName": "Swiss Mercenary",
       "shieldCost": 30,
       "populationCost": 0,
+      "requiredTech": "tech-23",
       "attack": 1,
       "defense": 4,
       "bombard": 0,
@@ -61195,7 +61268,7 @@
     },
     {
       "name": "William of Orange",
-      "artName": "William of Orange",
+      "artName": "King Netherlands",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61218,6 +61291,7 @@
       "artName": "Trebuchet",
       "shieldCost": 30,
       "populationCost": 0,
+      "requiredTech": "tech-24",
       "attack": 0,
       "defense": 0,
       "bombard": 6,
@@ -61237,7 +61311,7 @@
     },
     {
       "name": "Pachacuti",
-      "artName": "Pachacuti",
+      "artName": "King Incan",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61257,7 +61331,7 @@
     },
     {
       "name": "Smoke-Jaguar",
-      "artName": "Smoke-Jaguar",
+      "artName": "King Mayan",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61277,7 +61351,7 @@
     },
     {
       "name": "Theodora",
-      "artName": "Theodora",
+      "artName": "King Byzantines",
       "shieldCost": 0,
       "populationCost": 0,
       "attack": 1,
@@ -61297,7 +61371,7 @@
     },
     {
       "name": "Chasqui Scout",
-      "artName": "Chasqui Scout",
+      "artName": "Chasquis Scout",
       "shieldCost": 20,
       "populationCost": 0,
       "attack": 1,
@@ -61321,6 +61395,7 @@
       "artName": "Javelin Thrower",
       "shieldCost": 30,
       "populationCost": 0,
+      "requiredTech": "tech-6",
       "attack": 2,
       "defense": 2,
       "bombard": 0,
@@ -61342,6 +61417,7 @@
       "artName": "Dromon",
       "shieldCost": 30,
       "populationCost": 0,
+      "requiredTech": "tech-15",
       "attack": 2,
       "defense": 1,
       "bombard": 2,
@@ -61364,6 +61440,7 @@
       "artName": "Cruiser",
       "shieldCost": 160,
       "populationCost": 0,
+      "requiredTech": "tech-57",
       "attack": 15,
       "defense": 10,
       "bombard": 7,
@@ -61428,6 +61505,7 @@
       "artName": "Curragh",
       "shieldCost": 15,
       "populationCost": 0,
+      "requiredTech": "tech-3",
       "attack": 1,
       "defense": 1,
       "bombard": 0,
@@ -61449,6 +61527,7 @@
       "artName": "Paratrooper",
       "shieldCost": 90,
       "populationCost": 0,
+      "requiredTech": "tech-64",
       "attack": 4,
       "defense": 9,
       "bombard": 0,
@@ -61470,6 +61549,7 @@
       "artName": "TOW Infantry",
       "shieldCost": 120,
       "populationCost": 0,
+      "requiredTech": "tech-65",
       "attack": 12,
       "defense": 14,
       "bombard": 6,
@@ -61491,6 +61571,7 @@
       "artName": "Flak",
       "shieldCost": 70,
       "populationCost": 0,
+      "requiredTech": "tech-59",
       "attack": 1,
       "defense": 6,
       "bombard": 0,
@@ -61512,6 +61593,7 @@
       "artName": "Mobile SAM",
       "shieldCost": 100,
       "populationCost": 0,
+      "requiredTech": "tech-65",
       "attack": 1,
       "defense": 6,
       "bombard": 0,
@@ -61533,417 +61615,673 @@
     {
       "name": "Palace",
       "shieldCost": 100,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-2",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Barracks",
       "shieldCost": 40,
-      "populationCost": 0
+      "populationCost": 0,
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Granary",
       "shieldCost": 60,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-4",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Temple",
       "shieldCost": 60,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-7",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Marketplace",
       "shieldCost": 100,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-18",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Library",
       "shieldCost": 80,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-14",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Courthouse",
       "shieldCost": 80,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-13",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Walls",
       "shieldCost": 20,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-2",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Aqueduct",
       "shieldCost": 100,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-21",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Bank",
       "shieldCost": 160,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-32",
+      "requiredBuilding": "Marketplace",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Cathedral",
       "shieldCost": 160,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-22",
+      "requiredBuilding": "Temple",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "University",
       "shieldCost": 200,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-30",
+      "requiredBuilding": "Library",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Colosseum",
       "shieldCost": 120,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-21",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Factory",
       "shieldCost": 240,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-48",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Manufacturing Plant",
       "shieldCost": 320,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-80",
+      "requiredBuilding": "Factory",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Recycling Center",
       "shieldCost": 200,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-68",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Coal Plant",
       "shieldCost": 160,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-48",
+      "requiredBuilding": "Factory",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Hydro Plant",
       "shieldCost": 240,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-62",
+      "requiredBuilding": "Factory",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Nuclear Plant",
       "shieldCost": 240,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-70",
+      "requiredBuilding": "Factory",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Hospital",
       "shieldCost": 160,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-51",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Research Lab",
       "shieldCost": 200,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-67",
+      "requiredBuilding": "University",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Mass Transit System",
       "shieldCost": 200,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-73",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "SAM Missile Battery",
       "shieldCost": 80,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-65",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Coastal Fortress",
       "shieldCost": 40,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-39",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Solar Plant",
       "shieldCost": 320,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-73",
+      "requiredBuilding": "Factory",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Harbor",
       "shieldCost": 60,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-15",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Offshore Platform",
       "shieldCost": 240,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-72",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Airport",
       "shieldCost": 160,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-59",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Police Station",
       "shieldCost": 160,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-47",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Wealth",
       "shieldCost": 0,
-      "populationCost": 0
+      "populationCost": 0,
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "The Pyramids",
       "shieldCost": 400,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-2",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "The Hanging Gardens",
       "shieldCost": 300,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-20",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "The Colossus",
       "shieldCost": 200,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-1",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "The Great Lighthouse",
       "shieldCost": 300,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-15",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "The Great Library",
       "shieldCost": 400,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-14",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "The Oracle",
       "shieldCost": 300,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-10",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "The Great Wall",
       "shieldCost": 300,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-21",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Sun Tzu\u0027s Art of War",
       "shieldCost": 600,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-23",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Sistine Chapel",
       "shieldCost": 600,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-25",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Magellan\u0027s Voyage",
       "shieldCost": 400,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-37",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Copernicus\u0027 Observatory",
       "shieldCost": 400,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-33",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Shakespeare\u0027s Theater",
       "shieldCost": 450,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-40",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Leonardo\u0027s Workshop",
       "shieldCost": 600,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-27",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "JS Bach\u0027s Cathedral",
       "shieldCost": 600,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-29",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Newton\u0027s University",
       "shieldCost": 400,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-41",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Smith\u0027s Trading Company",
       "shieldCost": 600,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-36",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Universal Suffrage",
       "shieldCost": 800,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-48",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Hoover Dam",
       "shieldCost": 800,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-62",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Theory of Evolution",
       "shieldCost": 600,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-50",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "The United Nations",
       "shieldCost": 1000,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-66",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "The Manhattan Project",
       "shieldCost": 800,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-66",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Cure for Cancer",
       "shieldCost": 1000,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-77",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Longevity",
       "shieldCost": 1000,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-77",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "SETI program",
       "shieldCost": 1000,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-67",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Heroic Epic",
       "shieldCost": 200,
-      "populationCost": 0
+      "populationCost": 0,
+      "isGreatWonder": false,
+      "isSmallWonder": true
     },
     {
       "name": "Iron Works",
       "shieldCost": 300,
-      "populationCost": 0
+      "populationCost": 0,
+      "isGreatWonder": false,
+      "isSmallWonder": true
     },
     {
       "name": "Forbidden Palace",
       "shieldCost": 200,
-      "populationCost": 0
+      "populationCost": 0,
+      "isGreatWonder": false,
+      "isSmallWonder": true
     },
     {
       "name": "Military Academy",
       "shieldCost": 400,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-43",
+      "isGreatWonder": false,
+      "isSmallWonder": true
     },
     {
       "name": "The Pentagon",
       "shieldCost": 400,
-      "populationCost": 0
+      "populationCost": 0,
+      "isGreatWonder": false,
+      "isSmallWonder": true
     },
     {
       "name": "Wall Street",
       "shieldCost": 300,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredBuilding": "Stock Exchange",
+      "isGreatWonder": false,
+      "isSmallWonder": true
     },
     {
       "name": "Apollo Program",
       "shieldCost": 500,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-69",
+      "isGreatWonder": false,
+      "isSmallWonder": true
     },
     {
       "name": "Strategic Missile Defense",
       "shieldCost": 500,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-81",
+      "requiredBuilding": "SAM Missile Battery",
+      "isGreatWonder": false,
+      "isSmallWonder": true
     },
     {
       "name": "Intelligence Agency",
       "shieldCost": 400,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-52",
+      "isGreatWonder": false,
+      "isSmallWonder": true
     },
     {
       "name": "Battlefield Medicine",
       "shieldCost": 500,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredBuilding": "Hospital",
+      "isGreatWonder": false,
+      "isSmallWonder": true
     },
     {
       "name": "SS Thrusters",
       "shieldCost": 320,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-75",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "SS Engine",
       "shieldCost": 640,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-69",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "SS Docking Bay",
       "shieldCost": 160,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-69",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "SS Cockpit",
       "shieldCost": 320,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-69",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "SS Fuel Cells",
       "shieldCost": 160,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-71",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "SS Life Support System",
       "shieldCost": 320,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-71",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "SS Stasis Chamber",
       "shieldCost": 320,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-80",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "SS Storage/Supply",
       "shieldCost": 160,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-74",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "SS Planetary Party Lounge",
       "shieldCost": 160,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-76",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "SS Exterior Casing",
       "shieldCost": 640,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-74",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "The Internet",
       "shieldCost": 1000,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-72",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Civil Defense",
       "shieldCost": 120,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-62",
+      "requiredBuilding": "Barracks",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Stock Exchange",
       "shieldCost": 200,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-53",
+      "requiredBuilding": "Bank",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "Commercial Dock",
       "shieldCost": 160,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-61",
+      "requiredBuilding": "Harbor",
+      "isGreatWonder": false,
+      "isSmallWonder": false
     },
     {
       "name": "The Temple of Artemis",
       "shieldCost": 500,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-17",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "The Statue of Zeus",
       "shieldCost": 200,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-11",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "The Mausoleum of Mausollos",
       "shieldCost": 200,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-12",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Knights Templar",
       "shieldCost": 300,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-26",
+      "isGreatWonder": true,
+      "isSmallWonder": false
     },
     {
       "name": "Secret Police HQ",
       "shieldCost": 200,
-      "populationCost": 0
+      "populationCost": 0,
+      "requiredTech": "tech-52",
+      "isGreatWonder": false,
+      "isSmallWonder": true
     }
   ],
   "players": [

--- a/C7GameData/Building.cs
+++ b/C7GameData/Building.cs
@@ -1,7 +1,23 @@
+using System.Collections.Generic;
+using C7GameData.Save;
+
 namespace C7GameData {
 	public class Building : IProducible {
 		public string name { get; set; }
 		public int shieldCost { get; set; }
-		public int populationCost { get; set; } // Will always be equal to 0 in the Civ3 rule set 
+		public int populationCost { get; set; } // Will always be equal to 0 in the Civ3 rule set
+		public Tech requiredTech { get; set; }
+		public Building requiredBuilding;
+		public bool isGreatWonder;
+		public bool isSmallWonder;
+
+		public Building(SaveBuilding building, Tech requiredTech) {
+			name = building.name;
+			shieldCost = building.shieldCost;
+			populationCost = building.populationCost;
+			isGreatWonder = building.isGreatWonder;
+			isSmallWonder = building.isSmallWonder;
+			this.requiredTech = requiredTech;
+		}
 	}
 }

--- a/C7GameData/IProducible.cs
+++ b/C7GameData/IProducible.cs
@@ -7,5 +7,6 @@ namespace C7GameData {
 		string name { get; set; }
 		int shieldCost { get; set; }
 		int populationCost { get; set; }
+		Tech requiredTech { get; set; }
 	}
 }

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -42,6 +42,7 @@ namespace C7GameData {
 		/// <param name="c7Save">Destination C7 in-memory structure</param>
 		private void ImportSharedBiqData() {
 			ImportRaces();
+			ImportTechs();
 			ImportUnitPrototypes();
 			ImportBuildings();
 			ImportCiv3TerrainTypes();
@@ -53,7 +54,6 @@ namespace C7GameData {
 			save.HealRates["city"] = 2;
 			// save.ScenarioSearchPath = biq?.Game[0].ScenarioSearchFolders;
 			ImportBarbarianInfo();
-			ImportTechs();
 			ImportCitizenTypes();
 		}
 
@@ -655,7 +655,7 @@ namespace C7GameData {
 		private void ImportUnitPrototypes() {
 			PRTO[] Prto = biq.Prto ?? defaultBiq.Prto;
 			foreach (PRTO prto in Prto) {
-				UnitPrototype prototype = new UnitPrototype();
+				SaveUnitPrototype prototype = new();
 				if (prto.Type == PRTO.TYPE_SEA) {
 					prototype.categories.Add("Sea");
 				} else if (prto.Type == PRTO.TYPE_LAND) {
@@ -702,8 +702,13 @@ namespace C7GameData {
 				if (prto.GoTo) {
 					prototype.actions.Add(C7Action.UnitGoto);
 				}
+
 				//Temporary check until #329/#330 are finished
 				if (!save.UnitPrototypes.Where(p => p.name == prototype.name).Any()) {
+					if (prto.Required != -1) {
+						prototype.requiredTech = save.Techs[prto.Required].id;
+					}
+
 					save.UnitPrototypes.Add(prototype);
 				}
 			}
@@ -713,11 +718,22 @@ namespace C7GameData {
 			BLDG[] Bldg = biq.Bldg ?? defaultBiq.Bldg;
 
 			foreach (BLDG bldg in Bldg) {
-				Building building = new() {
+				SaveBuilding building = new() {
 					name=bldg.Name,
 					shieldCost=bldg.Cost * 10, // In Civ3 files, building costs are stored at 1/10th of their actual value
 					populationCost=0, // In Civ3, a building cannot have a population cost
+					isSmallWonder=bldg.SmallWonder,
+					isGreatWonder=bldg.Wonder,
 				};
+
+				if (bldg.RequiredAdvance != -1) {
+					building.requiredTech = save.Techs[bldg.RequiredAdvance].id;
+				}
+
+				if (bldg.RequiredBuilding != -1) {
+					building.requiredBuilding = Bldg[bldg.RequiredBuilding].Name;
+				}
+
 				save.Buildings.Add(building);
 			}
 		}

--- a/C7GameData/Save/SaveBuilding.cs
+++ b/C7GameData/Save/SaveBuilding.cs
@@ -1,0 +1,24 @@
+namespace C7GameData.Save {
+	public class SaveBuilding {
+		public string name;
+		public int shieldCost;
+		public int populationCost;
+		public ID requiredTech;
+		public string requiredBuilding;
+		public bool isGreatWonder;
+		public bool isSmallWonder;
+
+		public SaveBuilding() { }
+
+		public SaveBuilding(Building building) {
+			(name, shieldCost, populationCost, isGreatWonder, isSmallWonder) =
+			(building.name, building.shieldCost, building.populationCost, building.isGreatWonder, building.isSmallWonder);
+
+			if (building.requiredTech != null)
+				requiredTech = building.requiredTech.id;
+
+			if (building.requiredBuilding != null)
+				requiredBuilding = building.requiredBuilding.name;
+		}
+	}
+}

--- a/C7GameData/Save/SaveGame.cs
+++ b/C7GameData/Save/SaveGame.cs
@@ -54,10 +54,10 @@ namespace C7GameData.Save {
 				Map = new SaveMap(data.map),
 				TerrainTypes = data.terrainTypes,
 				Resources = data.Resources,
-				Buildings = data.Buildings,
+				Buildings = data.Buildings.ConvertAll(building => new SaveBuilding(building)),
 				BarbarianInfo = data.barbarianInfo,
 				Units = data.mapUnits.ConvertAll(unit => new SaveUnit(unit, data.map)),
-				UnitPrototypes = data.unitPrototypes,
+				UnitPrototypes = data.unitPrototypes.ConvertAll(proto => new SaveUnitPrototype(proto)),
 				Players = data.players.ConvertAll(player => new SavePlayer(player)),
 				Cities = data.cities.ConvertAll(city => new SaveCity(city)),
 				ExperienceLevels = data.experienceLevels,
@@ -85,78 +85,139 @@ namespace C7GameData.Save {
 			}
 		}
 
-		// TODO: GameData should store Civilizations, otherwise the round trip from
-		// SaveGame to GameData and back loses Civilization instances that are not
-		// assigned to a player.
 		public GameData ToGameData(Action<City, CitizenType> assignScenarioResidents) {
+			GameData data = InitializeGameData();
+			ConvertMapAndPlayers(data);
+			ConvertTechnologies(data);
+			ConvertBuildings(data);
+			ConvertUnits(data);
+			ConvertCities(data, assignScenarioResidents);
+			ConvertBarbarianInfo(data);
+			ConvertStrengthBonuses(data);
+			ConvertHealRates(data);
+
+			data.defaultExperienceLevelKey = DefaultExperienceLevel;
+			data.defaultExperienceLevel = data.experienceLevels.Find(el => el.key == DefaultExperienceLevel);
+
+			data.UpdateTileOwners();
+
+			return data;
+		}
+
+		private GameData InitializeGameData() {
 			// copy data without references
-			GameData data = new GameData{
+			return new GameData {
 				seed = Seed,
 				terrainTypes = TerrainTypes,
 				Resources = Resources,
-				Buildings = Buildings,
-				unitPrototypes = UnitPrototypes,
 				scenarioSearchPath = ScenarioSearchPath,
 				civilizations = Civilizations,
 				citizenTypes = CitizenTypes,
 				ids = new ID.Factory(this),
+				experienceLevels = ExperienceLevels,
 			};
+		}
+
+		private void ConvertMapAndPlayers(GameData data) {
 			// units and cities are empty
 			data.map = Map.ToGameMap(data);
 
 			// players need game map to populate tile knowledge
 			data.players = Players.ConvertAll(player => player.ToPlayer(data.map, Civilizations));
+		}
+
+		private void ConvertTechnologies(GameData data) {
+			// Fill in the list of techs and then backfill the prereqs.
+			//
+			// This is an N^2 approach, but doing a topological sort of the
+			// prereqs feels like overkill given how many techs are in a game.
+
+			foreach (SaveTech st in this.Techs) {
+				data.techs.Add(st.ToTechWithoutPrereqs());
+			}
+
+			foreach (Tech t in data.techs) {
+				t.FillInPrereqs(this.Techs, data.techs);
+			}
+		}
+
+		private void ConvertBuildings(GameData data) {
+			var techDict = data.techs.ToDictionary(t => t.id);
+
+			data.Buildings = Buildings.ConvertAll(building =>
+				new Building(
+					building,
+					building.requiredTech != null ? techDict[building.requiredTech] : null
+				)
+			);
+
+			var buildingDict = data.Buildings.ToDictionary(b => b.name);
+
+			data.Buildings = data.Buildings
+				.Zip(Buildings, (building, saveBuilding) => {
+					if (saveBuilding.requiredBuilding != null)
+						building.requiredBuilding = buildingDict[saveBuilding.requiredBuilding];
+					return building;
+				})
+				.ToList();
+		}
+
+		private void ConvertUnits(GameData data) {
+			var techDict = data.techs.ToDictionary(t => t.id);
+
+			data.unitPrototypes = UnitPrototypes.ConvertAll(prototype =>
+				new UnitPrototype(
+					prototype,
+					prototype.requiredTech != null ? techDict[prototype.requiredTech] : null
+				)
+			);
 
 			// map units need game map and players to populate location and owner
-			data.mapUnits = Units.ConvertAll(unit => unit.ToMapUnit(UnitPrototypes, ExperienceLevels, data.players, data.map));
+			data.mapUnits = Units.ConvertAll(unit =>
+				unit.ToMapUnit(data.unitPrototypes, ExperienceLevels, data.players, data.map)
+			);
+
 
 			// once unit owners are known, players can reference units
 			data.players.ForEach(player => {
-				player.units = data.mapUnits.Where(unit => unit.owner.id == player.id).ToList(); ;
+				player.units = data.mapUnits.Where(unit => unit.owner.id == player.id).ToList();
 			});
+		}
 
+		private void ConvertCities(GameData data, Action<City, CitizenType> assignScenarioResidents) {
 			// cities require game map for location and players for city owner
-			data.cities = Cities.ConvertAll(city => city.ToCity(data.map, data.players, UnitPrototypes, Civilizations, Buildings, CitizenTypes, assignScenarioResidents));
+			data.cities = Cities.ConvertAll(city =>
+				city.ToCity(data.map, data.players, data.unitPrototypes, Civilizations, data.Buildings, CitizenTypes, assignScenarioResidents)
+			);
+
+			// add references to map tiles after units and cities are defined
+			populateGameDataTileUnitsAndCities(data);
 
 			// Once cities are known, players can reference cities.
 			data.players.ForEach(player => {
-				player.cities = data.cities.Where(city => city.owner.id == player.id).ToList(); ;
+				player.cities = data.cities.Where(city => city.owner.id == player.id).ToList();
 			});
 
 			foreach (City city in data.cities) {
 				data.map.tileAt(city.location.XCoordinate, city.location.YCoordinate).cityAtTile = city;
 			}
+		}
 
-			// add references to map tiles after units and cities are defined
-			populateGameDataTileUnitsAndCities(data);
-
-			// Fill in the list of techs and then backfill the prereqs.
-			//
-			// This is an N^2 approach, but doing a topological sort of the
-			// prereqs feels like overkill given how many techs are in a game.
-			foreach (SaveTech st in this.Techs) {
-				data.techs.Add(st.ToTechWithoutPrereqs());
-			}
-			foreach (Tech t in data.techs) {
-				t.FillInPrereqs(this.Techs, data.techs);
-			}
-
-			data.experienceLevels = ExperienceLevels;
+		private void ConvertBarbarianInfo(GameData data) {
 			data.barbarianInfo = BarbarianInfo;
 
 			if (BarbarianInfo.basicBarbarianIndex != -1) {
-				data.barbarianInfo.basicBarbarian = UnitPrototypes[data.barbarianInfo.basicBarbarianIndex];
+				data.barbarianInfo.basicBarbarian = data.unitPrototypes[data.barbarianInfo.basicBarbarianIndex];
 			}
 			if (BarbarianInfo.advancedBarbarianIndex != -1) {
-				data.barbarianInfo.advancedBarbarian = UnitPrototypes[data.barbarianInfo.advancedBarbarianIndex];
+				data.barbarianInfo.advancedBarbarian = data.unitPrototypes[data.barbarianInfo.advancedBarbarianIndex];
 			}
 			if (BarbarianInfo.barbarianSeaUnitIndex != -1) {
-				data.barbarianInfo.barbarianSeaUnit = UnitPrototypes[data.barbarianInfo.barbarianSeaUnitIndex];
+				data.barbarianInfo.barbarianSeaUnit = data.unitPrototypes[data.barbarianInfo.barbarianSeaUnitIndex];
 			}
+		}
 
-			data.defaultExperienceLevelKey = DefaultExperienceLevel;
-			data.defaultExperienceLevel = data.experienceLevels.Find(el => el.key == DefaultExperienceLevel);
-
+		private void ConvertStrengthBonuses(GameData data) {
 			foreach (StrengthBonus sb in StrengthBonuses) {
 				switch (sb.description) {
 					case "Fortified":
@@ -176,15 +237,13 @@ namespace C7GameData.Save {
 						break;
 				}
 			}
+		}
 
+		private void ConvertHealRates(GameData data) {
 			data.healRateInFriendlyField = HealRates["friendly_field"];
 			data.healRateInNeutralField = HealRates["neutral_field"];
 			data.healRateInHostileField = HealRates["hostile_field"];
 			data.healRateInCity = HealRates["city"];
-
-			data.UpdateTileOwners();
-
-			return data;
 		}
 
 		public string Version = "0.0.0";
@@ -193,8 +252,8 @@ namespace C7GameData.Save {
 		public List<TerrainType> TerrainTypes = new List<TerrainType>();
 		public List<Resource> Resources = new List<Resource>();
 		public List<SaveUnit> Units = new List<SaveUnit>();
-		public List<UnitPrototype> UnitPrototypes = new List<UnitPrototype>();
-		public List<Building> Buildings = new();
+		public List<SaveUnitPrototype> UnitPrototypes = [];
+		public List<SaveBuilding> Buildings = [];
 		public List<SavePlayer> Players = new List<SavePlayer>();
 		public List<SaveCity> Cities = new List<SaveCity>();
 		public BarbarianInfo BarbarianInfo = new BarbarianInfo();

--- a/C7GameData/Save/SaveUnitPrototype.cs
+++ b/C7GameData/Save/SaveUnitPrototype.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace C7GameData.Save {
+	public class SaveUnitPrototype {
+		public string name { get; set; }
+		public string artName { get; set; }
+		public int shieldCost { get; set; }
+		public int populationCost { get; set; }
+		public ID requiredTech { get; set; }
+		public int attack { get; set; }
+		public int defense { get; set; }
+		public int bombard { get; set; }
+		public int movement { get; set; }
+		public int iconIndex { get; set; }
+
+		public HashSet<string> categories = new HashSet<string>();
+
+		public HashSet<string> actions = new HashSet<string>();
+
+		public HashSet<string> attributes = new HashSet<string>();
+
+		public SaveUnitPrototype() { }
+
+		public SaveUnitPrototype(UnitPrototype proto) {
+			(name, artName, shieldCost, populationCost,
+			attack, defense, bombard, movement, iconIndex) =
+			(proto.name, proto.artName, proto.shieldCost, proto.populationCost,
+			 proto.attack, proto.defense, proto.bombard, proto.movement, proto.iconIndex);
+
+			if (proto.requiredTech != null)
+				requiredTech = proto.requiredTech.id;
+
+			categories = new HashSet<string>(proto.categories);
+			actions = new HashSet<string>(proto.actions);
+			attributes = new HashSet<string>(proto.attributes);
+		}
+	}
+}

--- a/C7GameData/UnitPrototype.cs
+++ b/C7GameData/UnitPrototype.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 
 namespace C7GameData {
 	using System;
+	using C7GameData.Save;
 
 	/**
 	 * The prototype for a unit, which defines the characteristics of a unit.
@@ -13,6 +14,7 @@ namespace C7GameData {
 		public string artName { get; set; }
 		public int shieldCost { get; set; }
 		public int populationCost { get; set; }
+		public Tech requiredTech { get; set; }
 		public int attack { get; set; }
 		public int defense { get; set; }
 		public int bombard { get; set; }
@@ -24,6 +26,20 @@ namespace C7GameData {
 		public HashSet<string> actions = new HashSet<string>();
 
 		public HashSet<string> attributes = new HashSet<string>();
+
+		public UnitPrototype() { }
+
+		public UnitPrototype(SaveUnitPrototype proto, Tech requiredTech) {
+			(name, artName, shieldCost, populationCost, attack, defense, bombard, movement, iconIndex) =
+			(proto.name, proto.artName, proto.shieldCost, proto.populationCost,
+			 proto.attack, proto.defense, proto.bombard, proto.movement, proto.iconIndex);
+
+			this.requiredTech = requiredTech;
+
+			categories = new HashSet<string>(proto.categories);
+			actions = new HashSet<string>(proto.actions);
+			attributes = new HashSet<string>(proto.attributes);
+		}
 
 		public override string ToString() {
 			return $"{name} ({attack}/{defense}/{movement})";


### PR DESCRIPTION
This commits implement loading of several production requirements. For both buildings and units, it loads the required technology. For buildings it also loads the required building (like a Library for a University) and the wonder status.

Additionally, this commit refactors the ToGameData method of the SaveGame class, splitting it into multiple methods for better readability.

With these changes we are getting closer to creating a proper method for calculating a list of producible units and buildings, although we still need to load data on unique units and unit obsolescence.