### PR TITLE
Rewrite ExplorerAI and Return an enum from `PlayTurn`, not a bool

### DIFF
--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -45,24 +45,41 @@ namespace C7Engine {
 
 			//Do things with units.  Copy into an array first to avoid collection-was-modified exception
 			foreach (MapUnit unit in player.units.ToArray()) {
-				//For each unit, if there's already an AI task assigned, it will attempt to complete its goal.
-				//It may fail due to conditions having changed since that goal was assigned; in that case it will
-				//get a new task to try to complete.
+				// Don't waste time recalculating behaviors for fortified units.
+				// This means we'll have to unfortify all our units after
+				// interesting events like war declarations, but this seems like
+				// a good tradeoff for faster turns.
+				if (unit.isFortified) {
+					continue;
+				}
 
-				bool unitDone = false;
-				int attempts = 0;
-				int maxAttempts = 2;    //safety valve so we don't freeze the UI if SetAIForUnit returns something that fails
-				while (!unitDone) {
-					if (unit.currentAI == null || attempts > 0) {
+				// For each unit, if there's already an AI task assigned, it will attempt to complete its goal.
+				// It may fail due to conditions having changed since that goal was assigned; in that case it will
+				// get a new task to try to complete.
+				//
+				// Cap our attempts at 2 to avoid getting stuck in bad situations.
+				for (int attempt = 0; attempt < 2; ++attempt) {
+					if (unit.currentAI == null) {
 						unit.currentAI = GetAIForUnit(unit, player);
 					}
 
-					unitDone = unit.currentAI.PlayTurn(player, unit);
-					attempts++;
-					if (!unitDone && attempts >= maxAttempts) {
-						log.Warning($"Hit max AI attempts of {maxAttempts} for unit {unit} at {unit.location} without succeeding.  This indicates GetAIForUnit returned an impossible task, and should be debugged.");
+					// If the unit is still the process of doing its plan, allow
+					// it to continue next turn.
+					UnitAI.Result result = unit.currentAI.PlayTurn(player, unit);
+					if (result == UnitAI.Result.InProgress) {
 						break;
 					}
+
+					if (result == UnitAI.Result.Error) {
+						unit.currentAI = null;
+						break;
+					}
+
+					// Otherwise we need a new plan for next turn. Pick it now
+					// to avoid things like new units being preferred for
+					// exploration instead of units already far away from home
+					// for exploration.
+					unit.currentAI = GetAIForUnit(unit, player);
 				}
 
 				player.tileKnowledge.AddTilesToKnown(unit.location);
@@ -85,12 +102,23 @@ namespace C7Engine {
 				//For now tell catapults to sit tight.  It's getting really annoying watching them pointlessly bombard barb camps forever
 				return new DefenderAI(DefenderAI.MakeAiData(unit, player));
 			} else {
-				ExplorerAIData? maybeAiData = ExplorerAI.MaybeMakeAiData(unit, player);
-				if (maybeAiData != null) {
-					return new ExplorerAI(maybeAiData);
+				// As long as we don't have too many explorers yet, start a new
+				// exploring unit.
+				int numExplorers = 0;
+				foreach (MapUnit u in player.units) {
+					if (u.currentAI is ExplorerAI) {
+						++numExplorers;
+					}
 				}
 
-				//Nowhere to explore.  What to do now?
+				if (numExplorers < 10) {
+					ExplorerAIData? maybeAiData = ExplorerAI.MaybeMakeAiData(unit, player);
+					if (maybeAiData != null) {
+						return new ExplorerAI(maybeAiData);
+					}
+				}
+
+				//Nowhere to explore or too many explorers.  What to do now?
 				//Priority 1: Adequate defense of cities.
 				//Future Priority 1: Escorting Settlers
 				//Priority 2: Clearing out barbs
@@ -138,6 +166,7 @@ namespace C7Engine {
 
 			if (closestBarbDistance <= 3) {
 				CombatAIData caid = new CombatAIData();
+				caid.destination = closestBarbCamp;
 
 				PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
 				caid.path = algorithm.PathFrom(unit.location, closestBarbCamp);
@@ -203,6 +232,7 @@ namespace C7Engine {
 				return null;
 			}
 
+			// Details on how Civ3 does it: https://forums.civfanatics.com/threads/what-will-the-ai-research-next.45559/
 			return possibleTechs[(int)GameData.rng.NextInt64(possibleTechs.Count)];
 		}
 	}

--- a/C7Engine/AI/UnitAI/CombatAI.cs
+++ b/C7Engine/AI/UnitAI/CombatAI.cs
@@ -19,14 +19,16 @@ namespace C7Engine.AI.UnitAI {
 			combatAIData = d;
 		}
 
-		public bool PlayTurnImpl(Player player, MapUnit unit) {
+		public C7GameData.UnitAI.Result PlayTurnImpl(Player player, MapUnit unit) {
+			if (unit.location == combatAIData.destination) {
+				return C7GameData.UnitAI.Result.Done;
+			}
+
 			//Move along the path to the place where the unit plans to enter combat.
 			//This might initiate combat.
 			//Once there are more combat goals than run to a barbarian camp,
 			//we will need fancier algorithms
-			unit.path = combatAIData.path;
-			unit.moveAlongPath();
-			return true;
+			return this.TryToMoveAlongPath(unit, combatAIData.path, /*allowCombat=*/true);
 		}
 
 		public string SummarizePlan() {

--- a/C7Engine/AI/UnitAI/DefenderAI.cs
+++ b/C7Engine/AI/UnitAI/DefenderAI.cs
@@ -19,32 +19,17 @@ namespace C7Engine.AI.UnitAI {
 			defenderAI = d;
 		}
 
-		bool C7GameData.UnitAI.PlayTurnImpl(Player player, MapUnit unit) {
+		C7GameData.UnitAI.Result C7GameData.UnitAI.PlayTurnImpl(Player player, MapUnit unit) {
 			if (defenderAI.destination == unit.location) {
 				if (!unit.isFortified) {
 					unit.fortify();
 					log.Information("Fortifying " + unit + " at " + defenderAI.destination);
 				}
+				return C7GameData.UnitAI.Result.Done;
 			} else {
 				log.Debug("Moving defender towards " + defenderAI.destination);
-
-				Tile nextTile = defenderAI.pathToDestination.Next();
-				if (nextTile != Tile.NONE) {
-					return unit.move(unit.location.directionTo(nextTile));
-				} else {
-					//Got a crash due to trying to move to (or less likely from) Tile.NONE.
-					//However, from the logs, the destination was [15, 55], so somehow the path
-					//included Tile.NONE.  The unit was an AI (Roman) unit; due to the crash I can't get more info
-					//One possibility is it was blocked in its path the previous turn; could this happen if multiple
-					//units were on a tile it was moving to, and it defeated one, but still couldn't move?  That would
-					//likely affect its pathing.  Put a breakpoint here while debugging!
-					//This should be a higher severity Serilog error
-					log.Error("ERROR: Unit pathed via Tile.NONE");
-					return false;
-				}
+				return this.TryToMoveAlongPath(unit, defenderAI.pathToDestination, /*allowCombat=*/true);
 			}
-
-			return true;
 		}
 
 		public string SummarizePlan() {

--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -10,207 +10,132 @@ using Serilog;
 namespace C7Engine {
 	public class ExplorerAI : C7GameData.UnitAI {
 		private static ILogger log = Log.ForContext<ExplorerAI>();
-		public ExplorerAIData explorerData;
+		public ExplorerAIData data;
 
 		public ExplorerAI(ExplorerAIData d) {
-			explorerData = d;
+			data = d;
 		}
 
 		public static ExplorerAIData? MaybeMakeAiData(MapUnit unit, Player player) {
-			ExplorerAIData ai = new();
-			if (unit.unitType.categories.Contains("Sea")) {
-				ai.type = ExplorerAIData.ExplorationType.COASTLINE;
-				log.Information("Set coastline exploration AI for " + unit);
-				return ai;
+			HashSet<Tile> borderTiles = player.tileKnowledge.borderTiles;
+
+			IEnumerable<Tile> candidates = borderTiles.Where(x => (x.IsLand() && unit.IsLandUnit()) || (!x.IsLand() && !unit.IsLandUnit()));
+			ExplorerAIData? result = PickBestTileToExplore(unit, CalculateExplorationScores(player, unit, candidates));
+
+			if (result == null) {
+				return result;
 			}
 
-			if (unit.location.unitsOnTile.Exists((x) => x.unitType.categories.Contains("Sea"))) {
-				ai.type = ExplorerAIData.ExplorationType.ON_A_BOAT;
-				//TODO: Actually put the unit on the boat
-				log.Information("Set ON_A_BOAT exploration AI for " + unit);
-				return ai;
-			}
-
-			//Isn't a Settler.  If there's a city at the location, it's defended.  No boats involved.  What's our priority?
-			//If there is land to explore, we'll try to explore it.
-			//Long-term TODO: Should only send tiles on this landmass.
-			KeyValuePair<Tile, float> tileToExplore = ExplorerAI.FindTopScoringTileForExploration(player, player.tileKnowledge.AllKnownTiles().Where(t => t.IsLand()), ExplorerAIData.ExplorationType.RANDOM);
-
-			if (tileToExplore.Value <= 0) {
-				//Nowhere to explore.
-				return null;
-			}
-
-			//What type of exploration should we do?
-			int nearbyExplorers = 0;
-			foreach (MapUnit mapUnit in player.units) {
-				if (mapUnit.currentAI is ExplorerAI explorerAI) {
-					if (explorerAI.explorerData.type == ExplorerAIData.ExplorationType.NEAR_CITIES) {
-						nearbyExplorers++;
-					}
-				}
-			}
-			if (nearbyExplorers < (player.cities.Count + 1)) {
-				ai.type = ExplorerAIData.ExplorationType.NEAR_CITIES;
-			} else {
-				ai.type = ExplorerAIData.ExplorationType.RANDOM;
-			}
-			log.Information($"Set {ai.type} exploration AI for {unit}");
-			return ai;
+			log.Information($"Set AI for unit {unit.id} at {unit.location} to explore with destination of " + result.destination);
+			player.tileKnowledge.aiExplorationTargets.Add(result.destination);
+			return result;
 		}
 
-		bool UnitAI.PlayTurnImpl(Player player, MapUnit unit) {
-			if (MovingToNewExplorationArea(explorerData)) {
-				return MoveToNextTileOnPath(explorerData, unit);
-			} else {
-				bool foundNeighboringTileToExplore = ExploreNeighboringTile(player, unit, explorerData);
-				if (foundNeighboringTileToExplore) {
-					return true;
-				}
-
-				//Find the nearest tile that will allow us to continue exploring.
-				//We prefer nearest because the one that allows the most discovery might be pretty far away
-				bool foundNewPath = FindPathToNewExplorationArea(player, explorerData, unit);
-				if (foundNewPath) {
-					return MoveToNextTileOnPath(explorerData, unit);
-				}
+		UnitAI.Result UnitAI.PlayTurnImpl(Player player, MapUnit unit) {
+			if (data == null) {
+				return UnitAI.Result.Error;
 			}
-			return false;
+
+			// If we're at the destination we're done.
+			if (unit.location == data.destination) {
+				player.tileKnowledge.aiExplorationTargets.Remove(data.destination);
+				return UnitAI.Result.Done;
+			}
+
+			return this.TryToMoveAlongPath(unit, data.pathToDestination, /*allowCombat=*/false);
 		}
 
 		public string SummarizePlan() {
-			return "ExplorerAI: " + explorerData.ToString();
+			return "ExplorerAI: " + data.ToString();
 		}
 
-		private static bool MoveToNextTileOnPath(ExplorerAIData explorerData, MapUnit unit) {
-			Tile next = explorerData.path.Next();
-			foreach (KeyValuePair<TileDirection, Tile> neighbor in unit.location.neighbors) {
-				if (neighbor.Value == next) {
-					return unit.move(neighbor.Key);
+		private static int DistanceToNearestCity(Player player, Tile t) {
+			int result = int.MaxValue;
+			foreach (City c in player.cities) {
+				int distance = t.distanceTo(c.location);
+				if (distance < result) {
+					result = distance;
 				}
 			}
-			//In the future, it might no longer be possible to go to the correct neighbor, perhaps
-			//due to another civ's units having moved there.  Thus, this method can return false.
-			return false;
+			return result;
 		}
 
-		private static bool ExploreNeighboringTile(Player player, MapUnit unit, ExplorerAIData aiData) {
-			List<Tile> validNeighboringTiles = unit.unitType.categories.Contains("Sea") ? unit.location.GetCoastNeighbors() : unit.location.GetLandNeighbors();
-			if (validNeighboringTiles.Count == 0) {
-				log.Information("No valid exploration locations for unit " + unit + " at location " + unit.location);
-				return false;
+		private static int DistanceToNearestExplorationTarget(Player player, Tile t) {
+			int result = int.MaxValue;
+			foreach (Tile target in player.tileKnowledge.aiExplorationTargets) {
+				int distance = t.distanceTo(target);
+				if (distance < result) {
+					result = distance;
+				}
 			}
-			log.Verbose($"Exploring for unit {unit}");
-			KeyValuePair<Tile, float> topScoringTile = FindTopScoringTileForExploration(player, validNeighboringTiles, aiData.type);
-			Tile newLocation = topScoringTile.Key;
-
-			if (newLocation != Tile.NONE && topScoringTile.Value > 0) {
-				return unit.move(unit.location.directionTo(newLocation));
-			}
-			return false;
+			return result;
 		}
 
-		private static bool MovingToNewExplorationArea(ExplorerAIData explorerData) {
-			return explorerData.path != null && explorerData.path.PathLength() > 0;
-		}
+		private static Dictionary<Tile, float> CalculateExplorationScores(Player player, MapUnit unit, IEnumerable<Tile> possibleNewLocations) {
+			Dictionary<Tile, float> explorationScores = new Dictionary<Tile, float>();
+			foreach (Tile t in possibleNewLocations) {
+				int numUnknownNeighbors = numUnknownNeighboringTiles(player, t);
 
-		private static bool FindPathToNewExplorationArea(Player player, ExplorerAIData explorerData, MapUnit unit) {
-			Stopwatch watch = new Stopwatch();
-			watch.Start();
-			List<Tile> validExplorerTiles = new List<Tile>();
-			foreach (Tile t in player.tileKnowledge.AllKnownTiles()
-					.Where(t => unit.CanEnterTile(t, false) && t.cityAtTile == null && numUnknownNeighboringTiles(player, t) > 0)) {
-				validExplorerTiles.Add(t);
-			}
-
-			int CrowFliesDistance(Tile X, Tile Y) {
-				return X.distanceTo(unit.location) - Y.distanceTo(unit.location);
-			};
-
-			validExplorerTiles.Sort(CrowFliesDistance);
-
-			if (validExplorerTiles.Count == 0) {
-				//Nowhere to explore.
-				//TODO: Change unit AI behavior to something else e.g. defender
-				return false;
-			}
-
-			int lowestDistance = int.MaxValue;
-			TilePath chosenPath = null;
-
-			PathingAlgorithm algo = PathingAlgorithmChooser.GetAlgorithm(unit);
-			log.Debug("Explorer pathing from " + unit.location + " with " + unit.unitType);
-			foreach (Tile t in validExplorerTiles) {
-				if (t.distanceTo(unit.location) > lowestDistance) {
-					//Impossible to be shorter, skip it
+				// Don't waste time on uninteresting tiles.
+				if (numUnknownNeighbors == 0) {
 					continue;
 				}
 
-				long millis = watch.ElapsedMilliseconds;
-				TilePath path = algo.PathFrom(unit.location, t);
-				if (path.PathLength() < lowestDistance) {
-					lowestDistance = path.PathLength();
-					chosenPath = path;
+				// Don't waste time on tiles already being explored.
+				if (player.tileKnowledge.aiExplorationTargets.Contains(t)) {
+					continue;
 				}
 
-				long elapsedTimeForTile = watch.ElapsedMilliseconds - millis;
+				// Give a large score to tiles that we don't know much about.
+				int score = numUnknownNeighbors;
+				score *= numUnknownNeighbors;
 
-				if (elapsedTimeForTile >= 10) {
-					log.Warning("Pathing time for {Tile} = {Time} ms", t, elapsedTimeForTile);
+				// But penalize tiles that are far away from our cities, to 
+				// encourate semi-local exploration. Without this we won't know
+				// city sites.
+				if (player.cities.Count > 0) {
+					score -= DistanceToNearestCity(player, t);
 				}
 
-				if (lowestDistance == 1) {
-					break;
+				// Similarly with tiles that are far away from us. We use 
+				// distanceTo as a quick heuristic to avoid expensive
+				// pathfinding.
+				score -= unit.location.distanceTo(t);
+
+				// Finally, reward tiles that are far away from tiles already
+				// being explored by other explorers to encourage exploring in
+				// different directions.
+				if (player.tileKnowledge.aiExplorationTargets.Count > 0) {
+					score += DistanceToNearestExplorationTarget(player, t);
 				}
+
+				explorationScores[t] = score;
 			}
 
-			long totalPathingTime = watch.ElapsedMilliseconds;
-			if (totalPathingTime >= 100) {
-				log.Warning($"Explorer pathing took " + totalPathingTime + " milliseconds from " + unit.location + " with " + unit.unitType);
-			} else {
-				log.Debug($"Explorer pathing took " + totalPathingTime + " milliseconds");
-			}
-
-			if (chosenPath == null) {
-				//This could happen if there is e.g. a land tile that we could explore from, but on a different landmass.
-				//Later, we might recruit a boat to take us there, but for now it's a fail state.
-				return false;
-			}
-			explorerData.path = chosenPath;
-			return true;
+			return explorationScores;
 		}
 
-		public static KeyValuePair<Tile, float> FindTopScoringTileForExploration(Player player, IEnumerable<Tile> possibleNewLocations, ExplorerAIData.ExplorationType type) {
-			//Technically, this should be the *estimated* new tiles revealed.  If a mountain blocks visibility,
-			//we won't know that till we move there.
-			Dictionary<Tile, float> explorationScore = new Dictionary<Tile, float>();
-			foreach (Tile t in possibleNewLocations) {
-				int baseScore = numUnknownNeighboringTiles(player, t);
-				if (baseScore == 0) {
-					explorationScore[t] = 0;
-				} else if (type == ExplorerAIData.ExplorationType.NEAR_CITIES) {
-					if (baseScore == 0) {
-						explorationScore[t] = 0;
-					}
-					int distanceToNearestCity = int.MaxValue;
-					foreach (City c in player.cities) {
-						int distance = t.distanceTo(c.location);
-						if (distance < distanceToNearestCity) {
-							distanceToNearestCity = distance;
-						}
-					}
-
-					// Ensure we don't stray too far from the nearest city, but
-					// don't weight the distance too much or we don't do useful
-					// exploring.
-					explorationScore[t] = 100 - distanceToNearestCity + baseScore;
-					log.Verbose($"Exploration score for {t}: {explorationScore[t]}");
-				} else {
-					explorationScore[t] = baseScore;
-				}
+		private static ExplorerAIData? PickBestTileToExplore(MapUnit unit, Dictionary<Tile, float> explorationScores) {
+			if (explorationScores.Count == 0) {
+				return null;
 			}
-			IOrderedEnumerable<KeyValuePair<Tile, float>> orderedScores = explorationScore.OrderByDescending(t => t.Value);
-			return orderedScores.First();
+
+			PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
+
+			IOrderedEnumerable<KeyValuePair<Tile, float>> orderedScores = explorationScores.OrderByDescending(t => t.Value);
+			foreach (KeyValuePair<Tile, float> p in orderedScores) {
+				ExplorerAIData result = new ();
+				result.destination = p.Key;
+				result.pathToDestination = algorithm.PathFrom(unit.location, result.destination);
+
+				// If we can't reach the destination, go to the next candidate.
+				if ((result.pathToDestination?.PathLength() ?? -1) == -1) {
+					continue;
+				}
+
+				return result;
+			}
+			return null;
 		}
 
 		private static int numUnknownNeighboringTiles(Player player, Tile t) {

--- a/C7Engine/AI/UnitAI/SettlerAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerAI.cs
@@ -27,7 +27,7 @@ namespace C7Engine {
 				} else {
 					PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
 					settlerAiData.pathToDestination = algorithm.PathFrom(unit.location, settlerAiData.destination);
-					log.Information("Set AI for unit to BUILD_CITY with destination of " + settlerAiData.destination);
+					log.Information($"Set AI for unit {unit.id} of {unit.owner.civilization.name} to BUILD_CITY with destination of " + settlerAiData.destination);
 				}
 			}
 			return settlerAiData;
@@ -37,44 +37,21 @@ namespace C7Engine {
 			settlerAi = d;
 		}
 
-		bool UnitAI.PlayTurnImpl(Player player, MapUnit unit) {
-start:
+		C7GameData.UnitAI.Result UnitAI.PlayTurnImpl(Player player, MapUnit unit) {
 			switch (settlerAi.goal) {
 				case SettlerAIData.SettlerGoal.BUILD_CITY:
 					if (IsInvalidCityLocation(settlerAi.destination)) {
 						log.Information("Seeking new destination for settler " + unit.id + "headed to " + settlerAi.destination);
-						//Make sure we're using the new settler AI going forward, including this turn
-						settlerAi = MakeAiData(unit, player);
-						//Re-process since the unit's goal may have changed.
-						//TODO: In theory in the future, it might even have a non-settler AI.  Maybe we should instead return false,
-						//and have the PlayerAI re-kick the unit based on a possibly different AI class?
-						//Not too worried for settler AI types, but that's a real possibility for other types - an Explorer could
-						//very well become a Defender or Attacker if there's no exploration left, for example.
-						goto start;
+						return C7GameData.UnitAI.Result.Error;
 					}
+
 					if (unit.location == settlerAi.destination) {
 						log.Information("Building city with " + unit);
 						//TODO: This should use a message, and the message handler should cause the disbanding to happen.
 						CityInteractions.BuildCity(unit.location.XCoordinate, unit.location.YCoordinate, player.id, unit.owner.GetNextCityName());
 						unit.disband();
 					} else {
-						//If the settler has no destination, then disband rather than crash later.
-						if (settlerAi.destination == Tile.NONE) {
-							log.Information("Disbanding settler " + unit.id + " with no valid destination");
-							unit.disband();
-							return false;
-						}
-						try {
-							Tile nextTile = settlerAi.pathToDestination.Next();
-							unit.move(unit.location.directionTo(nextTile));
-						} catch (Exception ex) {
-							//This occurs when on the previous turn, a settler tries to move to the next location on its path, but cannot, due to another
-							//civilization's unit (or a barbarian unit) being on that tile.
-							//TODO: #213 - If the path cannot be completed, we should create a different path instead.
-							//But to do that, the pathing algorithm will need to be enhanced to be aware of when rival units are in the way.
-							log.Warning("#213 - Could not get next part of path for unit " + settlerAi + ", " + ex.Message);
-							return false;
-						}
+						return this.TryToMoveAlongPath(unit, settlerAi.pathToDestination, /*allowCombat=*/false);
 					}
 					break;
 				case SettlerAIData.SettlerGoal.JOIN_CITY:
@@ -88,12 +65,9 @@ start:
 						unit.disband();
 					}
 					break;
-				default:
-					log.Warning("Unknown strategy of " + settlerAi.goal + " for unit");
-					break;
 			}
 
-			return true;
+			return C7GameData.UnitAI.Result.Done;
 		}
 
 		private static bool IsInvalidCityLocation(Tile tile) {

--- a/C7Engine/AI/UnitAI/SettlerLocationAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerLocationAI.cs
@@ -23,7 +23,7 @@ namespace C7Engine {
 				return Tile.NONE;   //nowhere to settle
 			}
 
-			IOrderedEnumerable<KeyValuePair<Tile, int> > orderedScores = scores.OrderByDescending(t => t.Value);
+			IOrderedEnumerable<KeyValuePair<Tile, int>> orderedScores = scores.OrderByDescending(t => t.Value);
 			log.Debug("Top city location candidates from " + start + ":");
 			Tile returnValue = null;
 			foreach (KeyValuePair<Tile, int> kvp in orderedScores.Take(5)) {

--- a/C7Engine/AI/UnitAI/WorkerAI.cs
+++ b/C7Engine/AI/UnitAI/WorkerAI.cs
@@ -47,9 +47,9 @@ namespace C7Engine {
 			return "WorkerAI: " + data.ToString();
 		}
 
-		bool UnitAI.PlayTurnImpl(Player player, MapUnit unit) {
+		UnitAI.Result UnitAI.PlayTurnImpl(Player player, MapUnit unit) {
 			if (data == null) {
-				return false;
+				return UnitAI.Result.Error;
 			}
 
 			// If we're at the destination, do our planned move.
@@ -68,16 +68,7 @@ namespace C7Engine {
 				return PerformWorkerMove(unit, improvement);
 			}
 
-			// Finally, if we've done all the worker moves locally, continue on
-			// towards our actual goal.
-			Tile nextTile = data.pathToDestination.Next();
-			if (nextTile == Tile.NONE) {
-				log.Warning($"Worker at {unit.location} owned by {unit.owner.civilization.name} was trying to get to {data.destination} to {data.workerMove} but could not get there.");
-				return false;
-			}
-			unit.move(unit.location.directionTo(nextTile));
-
-			return true;
+			return this.TryToMoveAlongPath(unit, data.pathToDestination, /*allowCombat=*/false);
 		}
 
 		private static string? GetTileImprovement(Tile t, Player player) {
@@ -118,25 +109,34 @@ namespace C7Engine {
 			return null;
 		}
 
-		private bool PerformWorkerMove(MapUnit unit, string workerMove) {
+		private UnitAI.Result PerformWorkerMove(MapUnit unit, string workerMove) {
 			if (workerMove == C7Action.UnitBuildRoad) {
 				if (unit.canBuildRoad()) {
 					unit.PerformTerraformAction(C7Action.UnitBuildRoad);
-					return true;
+					return UnitAI.Result.InProgress;
 				}
-				return false;
+				if (unit.location.overlays.road) {
+					return UnitAI.Result.Done;
+				}
+				return UnitAI.Result.Error;
 			} else if (workerMove == C7Action.UnitBuildMine) {
 				if (unit.canBuildMine()) {
 					unit.PerformTerraformAction(C7Action.UnitBuildMine);
-					return true;
+					return UnitAI.Result.InProgress;
 				}
-				return false;
+				if (unit.location.overlays.mine) {
+					return UnitAI.Result.Done;
+				}
+				return UnitAI.Result.Error;
 			} else if (workerMove == C7Action.UnitIrrigate) {
 				if (unit.canIrrigate()) {
 					unit.PerformTerraformAction(C7Action.UnitIrrigate);
-					return true;
+					return UnitAI.Result.InProgress;
 				}
-				return false;
+				if (unit.location.overlays.irrigation) {
+					return UnitAI.Result.Done;
+				}
+				return UnitAI.Result.Error;
 			} else {
 				throw new ArgumentOutOfRangeException("Invalid worker move" + data.workerMove);
 			}

--- a/C7Engine/AI/UnitAiExtension.cs
+++ b/C7Engine/AI/UnitAiExtension.cs
@@ -1,0 +1,22 @@
+using C7GameData;
+
+namespace C7Engine {
+	// This goofy class only exists because of the arbitrary separation between
+	// C7GameData and C7Engine.
+	public static class UnitAiExtension {
+		public static UnitAI.Result TryToMoveAlongPath(this UnitAI unitAi, MapUnit unit, TilePath path, bool allowCombat) {
+			Tile nextTile = path.Next();
+			if (nextTile == Tile.NONE) {
+				return UnitAI.Result.Error;
+			}
+			if (!unit.CanEnterTile(nextTile, /*allowCombat=*/allowCombat)) {
+				return UnitAI.Result.Error;
+			}
+			bool stillAlive = unit.move(unit.location.directionTo(nextTile));
+			if (!stillAlive) {
+				return UnitAI.Result.Error;
+			}
+			return UnitAI.Result.InProgress;
+		}
+	}
+}

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -399,8 +399,6 @@ namespace C7Engine {
 				unit.location = newLoc;
 				unit.movementPoints.onUnitMove(movementCost);
 				unit.animate(MapUnit.AnimatedAction.RUN, wait);
-			} else {
-				return false;
 			}
 			return true;
 		}
@@ -592,14 +590,18 @@ namespace C7Engine {
 		}
 
 		public static void playAutomatedTurn(this MapUnit unit) {
-			bool done = !unit.currentAI.PlayTurn(unit.owner, unit);
-			if (done) {
+			UnitAI.Result result = unit.currentAI.PlayTurn(unit.owner, unit);
+			if (result == UnitAI.Result.Done) {
 				if (unit.currentAI is WorkerAI) {
 					unit.automate();
 				} else if (unit.currentAI is ExplorerAI) {
 					unit.explore();
 				}
 			}
+
+			// Do nothing after an error so control returns to the player, and
+			// nothing after an progress result, so that next turn continues the
+			// AI action.
 		}
 
 	}

--- a/C7GameData/AIData/CombatAIData.cs
+++ b/C7GameData/AIData/CombatAIData.cs
@@ -1,5 +1,6 @@
 namespace C7GameData.AIData {
 	public class CombatAIData : UnitAIData {
+		public Tile destination;
 		public TilePath path;
 	}
 }

--- a/C7GameData/AIData/ExplorerAIData.cs
+++ b/C7GameData/AIData/ExplorerAIData.cs
@@ -1,18 +1,10 @@
 namespace C7GameData.AIData {
 	public class ExplorerAIData : UnitAIData {
-		public enum ExplorationType {
-			RANDOM,
-			NEAR_CITIES,
-			COASTLINE,
-			DIRECTIONAL,
-			SCOUT_RIVAL,
-			ON_A_BOAT
-		}
-		public ExplorationType type;
-		public TilePath path;
+		public Tile destination;
+		public TilePath pathToDestination;
 
 		public override string ToString() {
-			return type + " exploration";
+			return "exploring toward " + destination;
 		}
 	}
 }

--- a/C7GameData/AIData/TileKnowledge.cs
+++ b/C7GameData/AIData/TileKnowledge.cs
@@ -2,9 +2,12 @@ using System.Collections.Generic;
 
 namespace C7GameData {
 	public class TileKnowledge {
-		HashSet<Tile> knownTiles = new HashSet<Tile>();
-		HashSet<Tile> borderTiles = new HashSet<Tile>();
-		HashSet<Tile> visibleTiles = new HashSet<Tile>();
+		HashSet<Tile> knownTiles = new();
+		public HashSet<Tile> borderTiles { get; private set; } = new();
+		HashSet<Tile> visibleTiles = new();
+
+		// The set of tiles this player currently has explorers headed towards.
+		public HashSet<Tile> aiExplorationTargets = new();
 
 		public void AddTilesToKnown(Tile unitLocation) {
 			knownTiles.Add(unitLocation);

--- a/C7GameData/UnitAI.cs
+++ b/C7GameData/UnitAI.cs
@@ -8,18 +8,24 @@ namespace C7GameData {
 	//of stuff being done.  I.e. it kinda sucks.  But that's okay.
 	//It has to start somewhere, right?
 	public interface UnitAI {
-		public bool PlayTurn(Player player, MapUnit unit) {
-			do {
-				bool wasSuccessful = PlayTurnImpl(player, unit);
-				if (!wasSuccessful) {
-					return false;
+		enum Result {
+			Done,
+			InProgress,
+			Error,
+		};
+
+		public Result PlayTurn(Player player, MapUnit unit) {
+			while (unit.movementPoints.canMove && !unit.isFortified) {
+				Result result = PlayTurnImpl(player, unit);
+				if (result == Result.Error || result == Result.Done) {
+					return result;
 				}
-			} while (unit.movementPoints.canMove && !unit.isFortified);
-			return true;
+			}
+			return Result.InProgress;
 		}
 
 		// To be implemented by each AI subclass.
-		protected abstract bool PlayTurnImpl(Player player, MapUnit unit);
+		protected abstract Result PlayTurnImpl(Player player, MapUnit unit);
 
 		// Provide a string representation of the current AI plan.
 		string SummarizePlan();


### PR DESCRIPTION
The previous return value was confusing and conflated "I'm done with my goal" and "I hit an error trying to reach my goal". This resulted in stack overflows when using the automated explore functionality on a human unit, resulted in "goto" being used in the settler ai, and some other oddities that would pop up when running in observer mode.

The new enum allows better signaling of how the AI is progressing and better error handling.

I also consolidated the logic for "move the AI unit along a path", since it was repeated in a couple of places. The annoying C7Engine/C7GameData split required that I put this in an extension class rather than being part of the UnitAI class as a protected method, like I'd prefer.

This work also revealed that the explorer ai was overly complicated and different from the other unit AIs in that it didn't fit the pattern of the AI data being a plan, and PlayTurn executing the plan. To solve that I rewrote it, and the resulting behavior is much nicer:
 - we no longer get big clumps of explorers heading for the same tile at different speeds
 - debugging what it is doing is easier
 - we have to check far fewer tiles because we take advantage of the border tiles we track

Lastly, I had the AI evaluation skip fortified units, which sped things up a bunch and stopped log spam from units repeatedly fortifying themselves as city defenders.

From https://github.com/C7-Game/Prototype/pull/590, here's what 20 turns of one unit exploring looked like prior to this PR: 
![image](https://github.com/user-attachments/assets/4c3bf23b-1cf8-446c-9f19-6cac5f7cec6c)

Now we have this: 
![image](https://github.com/user-attachments/assets/fcb2873c-5a30-4717-9b54-2325760a93b1)

which covers much more ground and finds another civ's cities. The new approach is also far more efficient with multiple explorers at play.

With building a city, getting 2 units and then exploring we used to have (20 turns):

![image](https://github.com/user-attachments/assets/896340ad-9363-444a-8780-440d2da3621f)


We now have (20 turns):

![image](https://github.com/user-attachments/assets/8b1e257b-463a-4372-8fdb-340a3638d623)
