### PR TITLE
Pathing: Ensure we don't try to path through enemies

### DIFF
--- a/C7Engine/AI/Pathing/AStarAlgorithm.cs
+++ b/C7Engine/AI/Pathing/AStarAlgorithm.cs
@@ -20,6 +20,7 @@ namespace C7Engine.Pathing {
 	// for some useful details.
 	public class AStarAlgorithm : PathingAlgorithm {
 		private readonly EdgeWalker<Tile> edgeWalker;
+		private readonly MapUnit unit;
 
 		// An estimate of the cost between two tiles, usually between a tile in
 		// the search and the destination tile. This allows targeting the search
@@ -27,9 +28,10 @@ namespace C7Engine.Pathing {
 		// the destination instead of expanding outwards in all directions.
 		private Func<Tile, Tile, double> costHeuristic;
 
-		public AStarAlgorithm(EdgeWalker<Tile> edgeWalker, Func<Tile, Tile, double> costHeuristic) {
+		public AStarAlgorithm(EdgeWalker<Tile> edgeWalker, MapUnit unit, Func<Tile, Tile, double> costHeuristic) {
 			this.edgeWalker = edgeWalker;
 			this.costHeuristic = costHeuristic;
+			this.unit = unit;
 		}
 
 		public override TilePath PathFrom(Tile start, Tile destination) {
@@ -63,6 +65,16 @@ namespace C7Engine.Pathing {
 				// Otherwise check each neighbor that we can use.
 				foreach (Edge<Tile> neighborEdge in edgeWalker.getEdges(current)) {
 					Tile neighbor = neighborEdge.current;
+
+					// Only allow a potentially attacking move for the last step,
+					// to allow pathing to attack. We don't want to try and path
+					// through opponents on the way to our destination though,
+					// as we can get stuck.
+					bool allowCombat = neighbor == destination;
+					if (!unit.CanEnterTile(neighbor, allowCombat)) {
+						continue;
+					}
+
 					double newCost = neighborEdge.distanceToCurrent + knownCosts[current];
 
 					// If we didn't know the cost to get to this neighbor, or 

--- a/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
+++ b/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
@@ -6,7 +6,7 @@ namespace C7Engine.Pathing {
 	 */
 	public class PathingAlgorithmChooser {
 		public static PathingAlgorithm GetAlgorithm(MapUnit unit) {
-			return new AStarAlgorithm(new UnitWalker(unit), (Tile from, Tile to) => {
+			return new AStarAlgorithm(new UnitWalker(unit), unit, (Tile from, Tile to) => {
 				// HACK: for land-based movement we have to deal with railroads,
 				// which have zero movement cost. If our heuristic is too strong it
 				// will result in units taking a direct path between points A and B,


### PR DESCRIPTION
Previously we acted as though we could walk through enemies and enemy cities, even if we were at peace with them. This resulted in exploring units getting stuck trying to walk past each other.
