### PR TITLE
Implement a "fast forward" mode for observer mode

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -53,6 +53,11 @@ public partial class Game : Node2D {
 	// that. This is useful so that the unit autoselector can be prevented from interfering with the player selecting fortified units.
 	public bool KeepCSUWhenFortified = false;
 
+	// When in observer mode, the number of turns to play before prompting the
+	// user to advance the turn manually. This allows for more rapid debugging
+	// without pressing the spacebar repeatedly.
+	public int turnsLeftToFastForward = 0;
+
 	[Export]
 	Control Toolbar;
 	private bool IsMovingCamera;
@@ -390,6 +395,13 @@ public partial class Game : Node2D {
 			int turnNumber = TurnHandling.GetTurnNumber();
 			Player player = controller;
 
+			// Allow fast forwarding in observer mode.
+			if (gameDataAccess.gameData.observerMode && turnsLeftToFastForward > 0) {
+				--turnsLeftToFastForward;
+				new MsgEndTurn().send();
+				return;
+			}
+
 			EmitSignal(SignalName.TurnStarted, turnNumber, player.gold, /*goldPerTurn=*/0);
 
 			Tech tech = gameDataAccess.gameData.techs.Find(x => x.id == player.currentlyResearchedTech);
@@ -577,6 +589,12 @@ public partial class Game : Node2D {
 						foreach (Player player in gameDataAccess.gameData.players) {
 							player.isHuman = false;
 						}
+						SetAnimationsEnabled(false);
+						popupOverlay.ShowPopup(
+							new TextDialog("How many turns to fast forward through?", 
+											"Turns: ", "100",
+											(string turns) => { turnsLeftToFastForward = int.Parse(turns); }), 
+								PopupOverlay.PopupCategory.Advisor);
 					} else {
 						foreach (Player player in gameDataAccess.gameData.players) {
 							if (player.id == EngineStorage.uiControllerID) {

--- a/C7/LogManager.cs
+++ b/C7/LogManager.cs
@@ -22,7 +22,7 @@ public partial class LogManager : Node {
 		// the C7Engine.AI namespace regardless of log level.
 		Log.Logger = new LoggerConfiguration()
 			// .WriteTo.GodotSink(formatter: consoleTemplate)	//Writing to console can slow the game down considerably (see #278).  Thus it is disabled by default.
-			.WriteTo.File("log.txt", buffered: true, flushToDiskInterval: TimeSpan.FromMilliseconds(250), fileSizeLimitBytes: 52428800, //50 MB
+			.WriteTo.File("log.txt", buffered: true, flushToDiskInterval: TimeSpan.FromMilliseconds(2500), fileSizeLimitBytes: 52428800, //50 MB
 						  outputTemplate: "[{Level:u3}] {Timestamp:HH:mm:ss} {SourceContext}: {Message:lj} {NewLine}{Exception}")
 
 			.Filter.ByIncludingOnly("(@l = 'Fatal' OR @l = 'Error' OR @l = 'Warning' OR @l = 'Information')")   //suggested:  OR SourceContext like 'C7Engine.AI.%' (insert the namespace you need to debug)

--- a/C7/UIElements/Popups/TextDialog.cs
+++ b/C7/UIElements/Popups/TextDialog.cs
@@ -1,0 +1,84 @@
+using Godot;
+using System;
+
+public partial class TextDialog : Popup {
+	LineEdit textEditBox = new LineEdit();
+	private string header;
+	private string prompt;
+	private string defaultText;
+	Action<string> handleText;
+
+
+	public TextDialog(string header, string prompt, string defaultText, Action<string> handleText) {
+		this.defaultText = defaultText;
+		this.prompt = prompt;
+		this.header = header;
+		this.handleText = handleText;
+
+		textEditBox.Theme = ThemeFactory.DefaultTheme;
+		textEditBox.CaretBlink = true;
+		alignment = BoxContainer.AlignmentMode.End;
+		margins = new Margins(right: -10); // 10px margin from the right
+	}
+
+	public override void _Ready() {
+		base._Ready();
+
+		AddTexture(530, 260);
+		AddBackground(530, 150, 110);
+		AddHeader(header, 120);
+
+		HBoxContainer labelAndTextBox = new HBoxContainer();
+		labelAndTextBox.Alignment = BoxContainer.AlignmentMode.Begin;
+		labelAndTextBox.SizeFlagsHorizontal = SizeFlags.ExpandFill;
+		labelAndTextBox.SizeFlagsStretchRatio = 1;
+		labelAndTextBox.AnchorLeft = 0.0f;
+		labelAndTextBox.AnchorRight = 0.85f;
+		labelAndTextBox.SetPosition(new Vector2(30, 170));
+
+		Label promptLabel = new Label();
+		promptLabel.Text = prompt;
+		labelAndTextBox.AddChild(promptLabel);
+
+		textEditBox.SizeFlagsHorizontal = SizeFlags.ExpandFill;
+		textEditBox.SizeFlagsStretchRatio = 1;
+		textEditBox.Text = defaultText;
+		labelAndTextBox.AddChild(textEditBox);
+
+		this.AddChild(labelAndTextBox);
+
+		textEditBox.SelectAll();
+		textEditBox.GrabFocus();
+
+		textEditBox.TextSubmitted += HandleTextInput;
+
+		//Cancel/confirm buttons.  Note the X button is thinner than the O button.
+		ImageTexture circleTexture= Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 1, 1, 19, 19);
+		ImageTexture xTexture = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 21, 1, 15, 19);
+		ImageTexture circleHover = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 37, 1, 19, 19);
+		ImageTexture xHover = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 57, 1, 15, 19);
+		ImageTexture circlePressed = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 73, 1, 19, 19);
+		ImageTexture xPressed = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 93, 1, 15, 19);
+		TextureButton confirmButton = new TextureButton();
+		confirmButton.TextureNormal = circleTexture;
+		confirmButton.TextureHover = circleHover;
+		confirmButton.TexturePressed = circlePressed;
+		confirmButton.SetPosition(new Vector2(475, 213));
+		AddChild(confirmButton);
+		TextureButton cancelButton = new TextureButton();
+		cancelButton.TextureNormal = xTexture;
+		cancelButton.TextureHover = xHover;
+		cancelButton.TexturePressed = xPressed;
+		cancelButton.SetPosition(new Vector2(500, 213));
+		AddChild(cancelButton);
+
+		confirmButton.Pressed += () => { HandleTextInput(textEditBox.Text); };
+		cancelButton.Pressed += GetParent<PopupOverlay>().OnHidePopup;
+	}
+
+	private void HandleTextInput(string text) {
+		GetViewport().SetInputAsHandled();
+		GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
+		handleText(text);
+	}
+}


### PR DESCRIPTION
This makes testing things easier, as we can quickly run through the first N turns of the game without having to repeatedly press the space bar.

To make this faster, I reduced the frequency at which we flush the logs to disk.