### PR TITLE
Stop the AI from repeatedly attempting to walk across oceans

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -591,9 +591,9 @@ public partial class Game : Node2D {
 						}
 						SetAnimationsEnabled(false);
 						popupOverlay.ShowPopup(
-							new TextDialog("How many turns to fast forward through?", 
+							new TextDialog("How many turns to fast forward through?",
 											"Turns: ", "100",
-											(string turns) => { turnsLeftToFastForward = int.Parse(turns); }), 
+											(string turns) => { turnsLeftToFastForward = int.Parse(turns); }),
 								PopupOverlay.PopupCategory.Advisor);
 					} else {
 						foreach (Player player in gameDataAccess.gameData.players) {

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -15,6 +15,7 @@
         "id": "tile-1",
         "x": 0,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26,6 +27,7 @@
         "id": "tile-2",
         "x": 2,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37,6 +39,7 @@
         "id": "tile-3",
         "x": 4,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48,6 +51,7 @@
         "id": "tile-4",
         "x": 6,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -59,6 +63,7 @@
         "id": "tile-5",
         "x": 8,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -70,6 +75,7 @@
         "id": "tile-6",
         "x": 10,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -81,6 +87,7 @@
         "id": "tile-7",
         "x": 12,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -92,6 +99,7 @@
         "id": "tile-8",
         "x": 14,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -103,6 +111,7 @@
         "id": "tile-9",
         "x": 16,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -114,6 +123,7 @@
         "id": "tile-10",
         "x": 18,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -125,6 +135,7 @@
         "id": "tile-11",
         "x": 20,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -136,6 +147,7 @@
         "id": "tile-12",
         "x": 22,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -147,6 +159,7 @@
         "id": "tile-13",
         "x": 24,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -158,6 +171,7 @@
         "id": "tile-14",
         "x": 26,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -169,6 +183,7 @@
         "id": "tile-15",
         "x": 28,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -180,6 +195,7 @@
         "id": "tile-16",
         "x": 30,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -191,6 +207,7 @@
         "id": "tile-17",
         "x": 32,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -202,6 +219,7 @@
         "id": "tile-18",
         "x": 34,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -213,6 +231,7 @@
         "id": "tile-19",
         "x": 36,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -224,6 +243,7 @@
         "id": "tile-20",
         "x": 38,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -235,6 +255,7 @@
         "id": "tile-21",
         "x": 40,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -246,6 +267,7 @@
         "id": "tile-22",
         "x": 42,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -257,6 +279,7 @@
         "id": "tile-23",
         "x": 44,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -268,6 +291,7 @@
         "id": "tile-24",
         "x": 46,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -279,6 +303,7 @@
         "id": "tile-25",
         "x": 48,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -290,6 +315,7 @@
         "id": "tile-26",
         "x": 50,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -301,6 +327,7 @@
         "id": "tile-27",
         "x": 52,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -312,6 +339,7 @@
         "id": "tile-28",
         "x": 54,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -323,6 +351,7 @@
         "id": "tile-29",
         "x": 56,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -334,6 +363,7 @@
         "id": "tile-30",
         "x": 58,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -345,6 +375,7 @@
         "id": "tile-31",
         "x": 60,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -356,6 +387,7 @@
         "id": "tile-32",
         "x": 62,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -367,6 +399,7 @@
         "id": "tile-33",
         "x": 64,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -378,6 +411,7 @@
         "id": "tile-34",
         "x": 66,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -389,6 +423,7 @@
         "id": "tile-35",
         "x": 68,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -400,6 +435,7 @@
         "id": "tile-36",
         "x": 70,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -411,6 +447,7 @@
         "id": "tile-37",
         "x": 72,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -422,6 +459,7 @@
         "id": "tile-38",
         "x": 74,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -433,6 +471,7 @@
         "id": "tile-39",
         "x": 76,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -444,6 +483,7 @@
         "id": "tile-40",
         "x": 78,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -455,6 +495,7 @@
         "id": "tile-41",
         "x": 80,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -466,6 +507,7 @@
         "id": "tile-42",
         "x": 82,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -477,6 +519,7 @@
         "id": "tile-43",
         "x": 84,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -488,6 +531,7 @@
         "id": "tile-44",
         "x": 86,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -499,6 +543,7 @@
         "id": "tile-45",
         "x": 88,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -510,6 +555,7 @@
         "id": "tile-46",
         "x": 90,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -521,6 +567,7 @@
         "id": "tile-47",
         "x": 92,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -532,6 +579,7 @@
         "id": "tile-48",
         "x": 94,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -543,6 +591,7 @@
         "id": "tile-49",
         "x": 96,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -554,6 +603,7 @@
         "id": "tile-50",
         "x": 98,
         "y": 0,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -565,6 +615,7 @@
         "id": "tile-51",
         "x": 1,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -576,6 +627,7 @@
         "id": "tile-52",
         "x": 3,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -587,6 +639,7 @@
         "id": "tile-53",
         "x": 5,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -598,6 +651,7 @@
         "id": "tile-54",
         "x": 7,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -609,6 +663,7 @@
         "id": "tile-55",
         "x": 9,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -620,6 +675,7 @@
         "id": "tile-56",
         "x": 11,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -631,6 +687,7 @@
         "id": "tile-57",
         "x": 13,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -642,6 +699,7 @@
         "id": "tile-58",
         "x": 15,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -653,6 +711,7 @@
         "id": "tile-59",
         "x": 17,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -664,6 +723,7 @@
         "id": "tile-60",
         "x": 19,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -675,6 +735,7 @@
         "id": "tile-61",
         "x": 21,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -686,6 +747,7 @@
         "id": "tile-62",
         "x": 23,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -697,6 +759,7 @@
         "id": "tile-63",
         "x": 25,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -708,6 +771,7 @@
         "id": "tile-64",
         "x": 27,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -719,6 +783,7 @@
         "id": "tile-65",
         "x": 29,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -730,6 +795,7 @@
         "id": "tile-66",
         "x": 31,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -741,6 +807,7 @@
         "id": "tile-67",
         "x": 33,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -752,6 +819,7 @@
         "id": "tile-68",
         "x": 35,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -763,6 +831,7 @@
         "id": "tile-69",
         "x": 37,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -774,6 +843,7 @@
         "id": "tile-70",
         "x": 39,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -785,6 +855,7 @@
         "id": "tile-71",
         "x": 41,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -796,6 +867,7 @@
         "id": "tile-72",
         "x": 43,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -807,6 +879,7 @@
         "id": "tile-73",
         "x": 45,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -818,6 +891,7 @@
         "id": "tile-74",
         "x": 47,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -829,6 +903,7 @@
         "id": "tile-75",
         "x": 49,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -840,6 +915,7 @@
         "id": "tile-76",
         "x": 51,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -851,6 +927,7 @@
         "id": "tile-77",
         "x": 53,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -862,6 +939,7 @@
         "id": "tile-78",
         "x": 55,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -873,6 +951,7 @@
         "id": "tile-79",
         "x": 57,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -884,6 +963,7 @@
         "id": "tile-80",
         "x": 59,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -895,6 +975,7 @@
         "id": "tile-81",
         "x": 61,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -906,6 +987,7 @@
         "id": "tile-82",
         "x": 63,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -917,6 +999,7 @@
         "id": "tile-83",
         "x": 65,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -928,6 +1011,7 @@
         "id": "tile-84",
         "x": 67,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -939,6 +1023,7 @@
         "id": "tile-85",
         "x": 69,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -950,6 +1035,7 @@
         "id": "tile-86",
         "x": 71,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -961,6 +1047,7 @@
         "id": "tile-87",
         "x": 73,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -972,6 +1059,7 @@
         "id": "tile-88",
         "x": 75,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -983,6 +1071,7 @@
         "id": "tile-89",
         "x": 77,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -994,6 +1083,7 @@
         "id": "tile-90",
         "x": 79,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1005,6 +1095,7 @@
         "id": "tile-91",
         "x": 81,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1016,6 +1107,7 @@
         "id": "tile-92",
         "x": 83,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1027,6 +1119,7 @@
         "id": "tile-93",
         "x": 85,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1038,6 +1131,7 @@
         "id": "tile-94",
         "x": 87,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1049,6 +1143,7 @@
         "id": "tile-95",
         "x": 89,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1060,6 +1155,7 @@
         "id": "tile-96",
         "x": 91,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1071,6 +1167,7 @@
         "id": "tile-97",
         "x": 93,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1082,6 +1179,7 @@
         "id": "tile-98",
         "x": 95,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1093,6 +1191,7 @@
         "id": "tile-99",
         "x": 97,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1104,6 +1203,7 @@
         "id": "tile-100",
         "x": 99,
         "y": 1,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1115,6 +1215,7 @@
         "id": "tile-101",
         "x": 0,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1126,6 +1227,7 @@
         "id": "tile-102",
         "x": 2,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1137,6 +1239,7 @@
         "id": "tile-103",
         "x": 4,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1148,6 +1251,7 @@
         "id": "tile-104",
         "x": 6,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1159,6 +1263,7 @@
         "id": "tile-105",
         "x": 8,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1170,6 +1275,7 @@
         "id": "tile-106",
         "x": 10,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1181,6 +1287,7 @@
         "id": "tile-107",
         "x": 12,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1192,6 +1299,7 @@
         "id": "tile-108",
         "x": 14,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1203,6 +1311,7 @@
         "id": "tile-109",
         "x": 16,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1214,6 +1323,7 @@
         "id": "tile-110",
         "x": 18,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1225,6 +1335,7 @@
         "id": "tile-111",
         "x": 20,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1236,6 +1347,7 @@
         "id": "tile-112",
         "x": 22,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1247,6 +1359,7 @@
         "id": "tile-113",
         "x": 24,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1258,6 +1371,7 @@
         "id": "tile-114",
         "x": 26,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1269,6 +1383,7 @@
         "id": "tile-115",
         "x": 28,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1280,6 +1395,7 @@
         "id": "tile-116",
         "x": 30,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1291,6 +1407,7 @@
         "id": "tile-117",
         "x": 32,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1302,6 +1419,7 @@
         "id": "tile-118",
         "x": 34,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1313,6 +1431,7 @@
         "id": "tile-119",
         "x": 36,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1324,6 +1443,7 @@
         "id": "tile-120",
         "x": 38,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1335,6 +1455,7 @@
         "id": "tile-121",
         "x": 40,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1346,6 +1467,7 @@
         "id": "tile-122",
         "x": 42,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1357,6 +1479,7 @@
         "id": "tile-123",
         "x": 44,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1368,6 +1491,7 @@
         "id": "tile-124",
         "x": 46,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1379,6 +1503,7 @@
         "id": "tile-125",
         "x": 48,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1390,6 +1515,7 @@
         "id": "tile-126",
         "x": 50,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1401,6 +1527,7 @@
         "id": "tile-127",
         "x": 52,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1412,6 +1539,7 @@
         "id": "tile-128",
         "x": 54,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1423,6 +1551,7 @@
         "id": "tile-129",
         "x": 56,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1434,6 +1563,7 @@
         "id": "tile-130",
         "x": 58,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1445,6 +1575,7 @@
         "id": "tile-131",
         "x": 60,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1456,6 +1587,7 @@
         "id": "tile-132",
         "x": 62,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1467,6 +1599,7 @@
         "id": "tile-133",
         "x": 64,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1478,6 +1611,7 @@
         "id": "tile-134",
         "x": 66,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1489,6 +1623,7 @@
         "id": "tile-135",
         "x": 68,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1500,6 +1635,7 @@
         "id": "tile-136",
         "x": 70,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1511,6 +1647,7 @@
         "id": "tile-137",
         "x": 72,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1522,6 +1659,7 @@
         "id": "tile-138",
         "x": 74,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1533,6 +1671,7 @@
         "id": "tile-139",
         "x": 76,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1544,6 +1683,7 @@
         "id": "tile-140",
         "x": 78,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1555,6 +1695,7 @@
         "id": "tile-141",
         "x": 80,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1566,6 +1707,7 @@
         "id": "tile-142",
         "x": 82,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1577,6 +1719,7 @@
         "id": "tile-143",
         "x": 84,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1588,6 +1731,7 @@
         "id": "tile-144",
         "x": 86,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1599,6 +1743,7 @@
         "id": "tile-145",
         "x": 88,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1610,6 +1755,7 @@
         "id": "tile-146",
         "x": 90,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1621,6 +1767,7 @@
         "id": "tile-147",
         "x": 92,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1632,6 +1779,7 @@
         "id": "tile-148",
         "x": 94,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1643,6 +1791,7 @@
         "id": "tile-149",
         "x": 96,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1654,6 +1803,7 @@
         "id": "tile-150",
         "x": 98,
         "y": 2,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1665,6 +1815,7 @@
         "id": "tile-151",
         "x": 1,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1676,6 +1827,7 @@
         "id": "tile-152",
         "x": 3,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1687,6 +1839,7 @@
         "id": "tile-153",
         "x": 5,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1698,6 +1851,7 @@
         "id": "tile-154",
         "x": 7,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1709,6 +1863,7 @@
         "id": "tile-155",
         "x": 9,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1720,6 +1875,7 @@
         "id": "tile-156",
         "x": 11,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1731,6 +1887,7 @@
         "id": "tile-157",
         "x": 13,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1742,6 +1899,7 @@
         "id": "tile-158",
         "x": 15,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1753,6 +1911,7 @@
         "id": "tile-159",
         "x": 17,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1764,6 +1923,7 @@
         "id": "tile-160",
         "x": 19,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1775,6 +1935,7 @@
         "id": "tile-161",
         "x": 21,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1786,6 +1947,7 @@
         "id": "tile-162",
         "x": 23,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1797,6 +1959,7 @@
         "id": "tile-163",
         "x": 25,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1808,6 +1971,7 @@
         "id": "tile-164",
         "x": 27,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1819,6 +1983,7 @@
         "id": "tile-165",
         "x": 29,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1830,6 +1995,7 @@
         "id": "tile-166",
         "x": 31,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1841,6 +2007,7 @@
         "id": "tile-167",
         "x": 33,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1852,6 +2019,7 @@
         "id": "tile-168",
         "x": 35,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1863,6 +2031,7 @@
         "id": "tile-169",
         "x": 37,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1874,6 +2043,7 @@
         "id": "tile-170",
         "x": 39,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1885,6 +2055,7 @@
         "id": "tile-171",
         "x": 41,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1896,6 +2067,7 @@
         "id": "tile-172",
         "x": 43,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1907,6 +2079,7 @@
         "id": "tile-173",
         "x": 45,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1918,6 +2091,7 @@
         "id": "tile-174",
         "x": 47,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1929,6 +2103,7 @@
         "id": "tile-175",
         "x": 49,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1940,6 +2115,7 @@
         "id": "tile-176",
         "x": 51,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1951,6 +2127,7 @@
         "id": "tile-177",
         "x": 53,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1962,6 +2139,7 @@
         "id": "tile-178",
         "x": 55,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1973,6 +2151,7 @@
         "id": "tile-179",
         "x": 57,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1984,6 +2163,7 @@
         "id": "tile-180",
         "x": 59,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -1995,6 +2175,7 @@
         "id": "tile-181",
         "x": 61,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2006,6 +2187,7 @@
         "id": "tile-182",
         "x": 63,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2017,6 +2199,7 @@
         "id": "tile-183",
         "x": 65,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2028,6 +2211,7 @@
         "id": "tile-184",
         "x": 67,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2039,6 +2223,7 @@
         "id": "tile-185",
         "x": 69,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2050,6 +2235,7 @@
         "id": "tile-186",
         "x": 71,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2061,6 +2247,7 @@
         "id": "tile-187",
         "x": 73,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2072,6 +2259,7 @@
         "id": "tile-188",
         "x": 75,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2083,6 +2271,7 @@
         "id": "tile-189",
         "x": 77,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2094,6 +2283,7 @@
         "id": "tile-190",
         "x": 79,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2105,6 +2295,7 @@
         "id": "tile-191",
         "x": 81,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2116,6 +2307,7 @@
         "id": "tile-192",
         "x": 83,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2127,6 +2319,7 @@
         "id": "tile-193",
         "x": 85,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2138,6 +2331,7 @@
         "id": "tile-194",
         "x": 87,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2149,6 +2343,7 @@
         "id": "tile-195",
         "x": 89,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2160,6 +2355,7 @@
         "id": "tile-196",
         "x": 91,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2171,6 +2367,7 @@
         "id": "tile-197",
         "x": 93,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2182,6 +2379,7 @@
         "id": "tile-198",
         "x": 95,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2193,6 +2391,7 @@
         "id": "tile-199",
         "x": 97,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2204,6 +2403,7 @@
         "id": "tile-200",
         "x": 99,
         "y": 3,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2215,6 +2415,7 @@
         "id": "tile-201",
         "x": 0,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2226,6 +2427,7 @@
         "id": "tile-202",
         "x": 2,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2237,6 +2439,7 @@
         "id": "tile-203",
         "x": 4,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2248,6 +2451,7 @@
         "id": "tile-204",
         "x": 6,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2259,6 +2463,7 @@
         "id": "tile-205",
         "x": 8,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2270,6 +2475,7 @@
         "id": "tile-206",
         "x": 10,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2281,6 +2487,7 @@
         "id": "tile-207",
         "x": 12,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2292,6 +2499,7 @@
         "id": "tile-208",
         "x": 14,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2303,6 +2511,7 @@
         "id": "tile-209",
         "x": 16,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2314,6 +2523,7 @@
         "id": "tile-210",
         "x": 18,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2325,6 +2535,7 @@
         "id": "tile-211",
         "x": 20,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2336,6 +2547,7 @@
         "id": "tile-212",
         "x": 22,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2347,6 +2559,7 @@
         "id": "tile-213",
         "x": 24,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2358,6 +2571,7 @@
         "id": "tile-214",
         "x": 26,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2369,6 +2583,7 @@
         "id": "tile-215",
         "x": 28,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2380,6 +2595,7 @@
         "id": "tile-216",
         "x": 30,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2391,6 +2607,7 @@
         "id": "tile-217",
         "x": 32,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2402,6 +2619,7 @@
         "id": "tile-218",
         "x": 34,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2413,6 +2631,7 @@
         "id": "tile-219",
         "x": 36,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2424,6 +2643,7 @@
         "id": "tile-220",
         "x": 38,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2435,6 +2655,7 @@
         "id": "tile-221",
         "x": 40,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2446,6 +2667,7 @@
         "id": "tile-222",
         "x": 42,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2457,6 +2679,7 @@
         "id": "tile-223",
         "x": 44,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2468,6 +2691,7 @@
         "id": "tile-224",
         "x": 46,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2479,6 +2703,7 @@
         "id": "tile-225",
         "x": 48,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2490,6 +2715,7 @@
         "id": "tile-226",
         "x": 50,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2501,6 +2727,7 @@
         "id": "tile-227",
         "x": 52,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2512,6 +2739,7 @@
         "id": "tile-228",
         "x": 54,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2523,6 +2751,7 @@
         "id": "tile-229",
         "x": 56,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2534,6 +2763,7 @@
         "id": "tile-230",
         "x": 58,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2545,6 +2775,7 @@
         "id": "tile-231",
         "x": 60,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2556,6 +2787,7 @@
         "id": "tile-232",
         "x": 62,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2567,6 +2799,7 @@
         "id": "tile-233",
         "x": 64,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2578,6 +2811,7 @@
         "id": "tile-234",
         "x": 66,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2589,6 +2823,7 @@
         "id": "tile-235",
         "x": 68,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2600,6 +2835,7 @@
         "id": "tile-236",
         "x": 70,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2611,6 +2847,7 @@
         "id": "tile-237",
         "x": 72,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2622,6 +2859,7 @@
         "id": "tile-238",
         "x": 74,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2633,6 +2871,7 @@
         "id": "tile-239",
         "x": 76,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2644,6 +2883,7 @@
         "id": "tile-240",
         "x": 78,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2655,6 +2895,7 @@
         "id": "tile-241",
         "x": 80,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2666,6 +2907,7 @@
         "id": "tile-242",
         "x": 82,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2677,6 +2919,7 @@
         "id": "tile-243",
         "x": 84,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2688,6 +2931,7 @@
         "id": "tile-244",
         "x": 86,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2699,6 +2943,7 @@
         "id": "tile-245",
         "x": 88,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2710,6 +2955,7 @@
         "id": "tile-246",
         "x": 90,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2721,6 +2967,7 @@
         "id": "tile-247",
         "x": 92,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2732,6 +2979,7 @@
         "id": "tile-248",
         "x": 94,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2743,6 +2991,7 @@
         "id": "tile-249",
         "x": 96,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2754,6 +3003,7 @@
         "id": "tile-250",
         "x": 98,
         "y": 4,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2765,6 +3015,7 @@
         "id": "tile-251",
         "x": 1,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2776,6 +3027,7 @@
         "id": "tile-252",
         "x": 3,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2787,6 +3039,7 @@
         "id": "tile-253",
         "x": 5,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2798,6 +3051,7 @@
         "id": "tile-254",
         "x": 7,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2809,6 +3063,7 @@
         "id": "tile-255",
         "x": 9,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2820,6 +3075,7 @@
         "id": "tile-256",
         "x": 11,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2831,6 +3087,7 @@
         "id": "tile-257",
         "x": 13,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2842,6 +3099,7 @@
         "id": "tile-258",
         "x": 15,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2853,6 +3111,7 @@
         "id": "tile-259",
         "x": 17,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2864,6 +3123,7 @@
         "id": "tile-260",
         "x": 19,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2875,6 +3135,7 @@
         "id": "tile-261",
         "x": 21,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2886,6 +3147,7 @@
         "id": "tile-262",
         "x": 23,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2897,6 +3159,7 @@
         "id": "tile-263",
         "x": 25,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2908,6 +3171,7 @@
         "id": "tile-264",
         "x": 27,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2919,6 +3183,7 @@
         "id": "tile-265",
         "x": 29,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2930,6 +3195,7 @@
         "id": "tile-266",
         "x": 31,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -2941,6 +3207,7 @@
         "id": "tile-267",
         "x": 33,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2952,6 +3219,7 @@
         "id": "tile-268",
         "x": 35,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2963,6 +3231,7 @@
         "id": "tile-269",
         "x": 37,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2974,6 +3243,7 @@
         "id": "tile-270",
         "x": 39,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2985,6 +3255,7 @@
         "id": "tile-271",
         "x": 41,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -2996,6 +3267,7 @@
         "id": "tile-272",
         "x": 43,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3007,6 +3279,7 @@
         "id": "tile-273",
         "x": 45,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3018,6 +3291,7 @@
         "id": "tile-274",
         "x": 47,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3029,6 +3303,7 @@
         "id": "tile-275",
         "x": 49,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3040,6 +3315,7 @@
         "id": "tile-276",
         "x": 51,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3051,6 +3327,7 @@
         "id": "tile-277",
         "x": 53,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3062,6 +3339,7 @@
         "id": "tile-278",
         "x": 55,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3073,6 +3351,7 @@
         "id": "tile-279",
         "x": 57,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3084,6 +3363,7 @@
         "id": "tile-280",
         "x": 59,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3095,6 +3375,7 @@
         "id": "tile-281",
         "x": 61,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3106,6 +3387,7 @@
         "id": "tile-282",
         "x": 63,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3117,6 +3399,7 @@
         "id": "tile-283",
         "x": 65,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3128,6 +3411,7 @@
         "id": "tile-284",
         "x": 67,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3139,6 +3423,7 @@
         "id": "tile-285",
         "x": 69,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3150,6 +3435,7 @@
         "id": "tile-286",
         "x": 71,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3161,6 +3447,7 @@
         "id": "tile-287",
         "x": 73,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3172,6 +3459,7 @@
         "id": "tile-288",
         "x": 75,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3183,6 +3471,7 @@
         "id": "tile-289",
         "x": 77,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3194,6 +3483,7 @@
         "id": "tile-290",
         "x": 79,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3205,6 +3495,7 @@
         "id": "tile-291",
         "x": 81,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3216,6 +3507,7 @@
         "id": "tile-292",
         "x": 83,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3227,6 +3519,7 @@
         "id": "tile-293",
         "x": 85,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3238,6 +3531,7 @@
         "id": "tile-294",
         "x": 87,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3249,6 +3543,7 @@
         "id": "tile-295",
         "x": 89,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3260,6 +3555,7 @@
         "id": "tile-296",
         "x": 91,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3271,6 +3567,7 @@
         "id": "tile-297",
         "x": 93,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3282,6 +3579,7 @@
         "id": "tile-298",
         "x": 95,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3293,6 +3591,7 @@
         "id": "tile-299",
         "x": 97,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3304,6 +3603,7 @@
         "id": "tile-300",
         "x": 99,
         "y": 5,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3315,6 +3615,7 @@
         "id": "tile-301",
         "x": 0,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3326,6 +3627,7 @@
         "id": "tile-302",
         "x": 2,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3337,6 +3639,7 @@
         "id": "tile-303",
         "x": 4,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3348,6 +3651,7 @@
         "id": "tile-304",
         "x": 6,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3359,6 +3663,7 @@
         "id": "tile-305",
         "x": 8,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3370,6 +3675,7 @@
         "id": "tile-306",
         "x": 10,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3381,6 +3687,7 @@
         "id": "tile-307",
         "x": 12,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3392,6 +3699,7 @@
         "id": "tile-308",
         "x": 14,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3403,6 +3711,7 @@
         "id": "tile-309",
         "x": 16,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3414,6 +3723,7 @@
         "id": "tile-310",
         "x": 18,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3425,6 +3735,7 @@
         "id": "tile-311",
         "x": 20,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3436,6 +3747,7 @@
         "id": "tile-312",
         "x": 22,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3447,6 +3759,7 @@
         "id": "tile-313",
         "x": 24,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3458,6 +3771,7 @@
         "id": "tile-314",
         "x": 26,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3469,6 +3783,7 @@
         "id": "tile-315",
         "x": 28,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3480,6 +3795,7 @@
         "id": "tile-316",
         "x": 30,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -3491,6 +3807,7 @@
         "id": "tile-317",
         "x": 32,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -3502,6 +3819,7 @@
         "id": "tile-318",
         "x": 34,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3513,6 +3831,7 @@
         "id": "tile-319",
         "x": 36,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3524,6 +3843,7 @@
         "id": "tile-320",
         "x": 38,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3535,6 +3855,7 @@
         "id": "tile-321",
         "x": 40,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3546,6 +3867,7 @@
         "id": "tile-322",
         "x": 42,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -3557,6 +3879,7 @@
         "id": "tile-323",
         "x": 44,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -3568,6 +3891,7 @@
         "id": "tile-324",
         "x": 46,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3579,6 +3903,7 @@
         "id": "tile-325",
         "x": 48,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3590,6 +3915,7 @@
         "id": "tile-326",
         "x": 50,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3601,6 +3927,7 @@
         "id": "tile-327",
         "x": 52,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3612,6 +3939,7 @@
         "id": "tile-328",
         "x": 54,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3623,6 +3951,7 @@
         "id": "tile-329",
         "x": 56,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3634,6 +3963,7 @@
         "id": "tile-330",
         "x": 58,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3645,6 +3975,7 @@
         "id": "tile-331",
         "x": 60,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3656,6 +3987,7 @@
         "id": "tile-332",
         "x": 62,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3667,6 +3999,7 @@
         "id": "tile-333",
         "x": 64,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3678,6 +4011,7 @@
         "id": "tile-334",
         "x": 66,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3689,6 +4023,7 @@
         "id": "tile-335",
         "x": 68,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3700,6 +4035,7 @@
         "id": "tile-336",
         "x": 70,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3711,6 +4047,7 @@
         "id": "tile-337",
         "x": 72,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3722,6 +4059,7 @@
         "id": "tile-338",
         "x": 74,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3733,6 +4071,7 @@
         "id": "tile-339",
         "x": 76,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3744,6 +4083,7 @@
         "id": "tile-340",
         "x": 78,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3755,6 +4095,7 @@
         "id": "tile-341",
         "x": 80,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3766,6 +4107,7 @@
         "id": "tile-342",
         "x": 82,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3777,6 +4119,7 @@
         "id": "tile-343",
         "x": 84,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3788,6 +4131,7 @@
         "id": "tile-344",
         "x": 86,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3799,6 +4143,7 @@
         "id": "tile-345",
         "x": 88,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3810,6 +4155,7 @@
         "id": "tile-346",
         "x": 90,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3821,6 +4167,7 @@
         "id": "tile-347",
         "x": 92,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3832,6 +4179,7 @@
         "id": "tile-348",
         "x": 94,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3843,6 +4191,7 @@
         "id": "tile-349",
         "x": 96,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3854,6 +4203,7 @@
         "id": "tile-350",
         "x": 98,
         "y": 6,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3865,6 +4215,7 @@
         "id": "tile-351",
         "x": 1,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3876,6 +4227,7 @@
         "id": "tile-352",
         "x": 3,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3887,6 +4239,7 @@
         "id": "tile-353",
         "x": 5,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3898,6 +4251,7 @@
         "id": "tile-354",
         "x": 7,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3909,6 +4263,7 @@
         "id": "tile-355",
         "x": 9,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3920,6 +4275,7 @@
         "id": "tile-356",
         "x": 11,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3931,6 +4287,7 @@
         "id": "tile-357",
         "x": 13,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3942,6 +4299,7 @@
         "id": "tile-358",
         "x": 15,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3953,6 +4311,7 @@
         "id": "tile-359",
         "x": 17,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3964,6 +4323,7 @@
         "id": "tile-360",
         "x": 19,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3975,6 +4335,7 @@
         "id": "tile-361",
         "x": 21,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3986,6 +4347,7 @@
         "id": "tile-362",
         "x": 23,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -3997,6 +4359,7 @@
         "id": "tile-363",
         "x": 25,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4008,6 +4371,7 @@
         "id": "tile-364",
         "x": 27,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4019,6 +4383,7 @@
         "id": "tile-365",
         "x": 29,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -4030,6 +4395,7 @@
         "id": "tile-366",
         "x": 31,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -4041,6 +4407,7 @@
         "id": "tile-367",
         "x": 33,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -4052,6 +4419,7 @@
         "id": "tile-368",
         "x": 35,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4063,6 +4431,7 @@
         "id": "tile-369",
         "x": 37,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4074,6 +4443,7 @@
         "id": "tile-370",
         "x": 39,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -4085,6 +4455,7 @@
         "id": "tile-371",
         "x": 41,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -4096,6 +4467,7 @@
         "id": "tile-372",
         "x": 43,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -4107,6 +4479,7 @@
         "id": "tile-373",
         "x": 45,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -4118,6 +4491,7 @@
         "id": "tile-374",
         "x": 47,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4129,6 +4503,7 @@
         "id": "tile-375",
         "x": 49,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4140,6 +4515,7 @@
         "id": "tile-376",
         "x": 51,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4151,6 +4527,7 @@
         "id": "tile-377",
         "x": 53,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4162,6 +4539,7 @@
         "id": "tile-378",
         "x": 55,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4173,6 +4551,7 @@
         "id": "tile-379",
         "x": 57,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4184,6 +4563,7 @@
         "id": "tile-380",
         "x": 59,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4195,6 +4575,7 @@
         "id": "tile-381",
         "x": 61,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4206,6 +4587,7 @@
         "id": "tile-382",
         "x": 63,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4217,6 +4599,7 @@
         "id": "tile-383",
         "x": 65,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4228,6 +4611,7 @@
         "id": "tile-384",
         "x": 67,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4239,6 +4623,7 @@
         "id": "tile-385",
         "x": 69,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4250,6 +4635,7 @@
         "id": "tile-386",
         "x": 71,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4261,6 +4647,7 @@
         "id": "tile-387",
         "x": 73,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4272,6 +4659,7 @@
         "id": "tile-388",
         "x": 75,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4283,6 +4671,7 @@
         "id": "tile-389",
         "x": 77,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4294,6 +4683,7 @@
         "id": "tile-390",
         "x": 79,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4305,6 +4695,7 @@
         "id": "tile-391",
         "x": 81,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4316,6 +4707,7 @@
         "id": "tile-392",
         "x": 83,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4327,6 +4719,7 @@
         "id": "tile-393",
         "x": 85,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4338,6 +4731,7 @@
         "id": "tile-394",
         "x": 87,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4349,6 +4743,7 @@
         "id": "tile-395",
         "x": 89,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4360,6 +4755,7 @@
         "id": "tile-396",
         "x": 91,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4371,6 +4767,7 @@
         "id": "tile-397",
         "x": 93,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4382,6 +4779,7 @@
         "id": "tile-398",
         "x": 95,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4393,6 +4791,7 @@
         "id": "tile-399",
         "x": 97,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4404,6 +4803,7 @@
         "id": "tile-400",
         "x": 99,
         "y": 7,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4415,6 +4815,7 @@
         "id": "tile-401",
         "x": 0,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4426,6 +4827,7 @@
         "id": "tile-402",
         "x": 2,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4437,6 +4839,7 @@
         "id": "tile-403",
         "x": 4,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4448,6 +4851,7 @@
         "id": "tile-404",
         "x": 6,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4459,6 +4863,7 @@
         "id": "tile-405",
         "x": 8,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4470,6 +4875,7 @@
         "id": "tile-406",
         "x": 10,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4481,6 +4887,7 @@
         "id": "tile-407",
         "x": 12,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4492,6 +4899,7 @@
         "id": "tile-408",
         "x": 14,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4503,6 +4911,7 @@
         "id": "tile-409",
         "x": 16,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4514,6 +4923,7 @@
         "id": "tile-410",
         "x": 18,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4525,6 +4935,7 @@
         "id": "tile-411",
         "x": 20,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4536,6 +4947,7 @@
         "id": "tile-412",
         "x": 22,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4547,6 +4959,7 @@
         "id": "tile-413",
         "x": 24,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4558,6 +4971,7 @@
         "id": "tile-414",
         "x": 26,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4569,6 +4983,7 @@
         "id": "tile-415",
         "x": 28,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -4580,6 +4995,7 @@
         "id": "tile-416",
         "x": 30,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -4591,6 +5007,7 @@
         "id": "tile-417",
         "x": 32,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -4602,6 +5019,7 @@
         "id": "tile-418",
         "x": 34,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -4613,6 +5031,7 @@
         "id": "tile-419",
         "x": 36,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4624,6 +5043,7 @@
         "id": "tile-420",
         "x": 38,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -4635,6 +5055,7 @@
         "id": "tile-421",
         "x": 40,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -4646,6 +5067,7 @@
         "id": "tile-422",
         "x": 42,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -4657,6 +5079,7 @@
         "id": "tile-423",
         "x": 44,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -4668,6 +5091,7 @@
         "id": "tile-424",
         "x": 46,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -4679,6 +5103,7 @@
         "id": "tile-425",
         "x": 48,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -4690,6 +5115,7 @@
         "id": "tile-426",
         "x": 50,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4701,6 +5127,7 @@
         "id": "tile-427",
         "x": 52,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -4712,6 +5139,7 @@
         "id": "tile-428",
         "x": 54,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4723,6 +5151,7 @@
         "id": "tile-429",
         "x": 56,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4734,6 +5163,7 @@
         "id": "tile-430",
         "x": 58,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -4745,6 +5175,7 @@
         "id": "tile-431",
         "x": 60,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4756,6 +5187,7 @@
         "id": "tile-432",
         "x": 62,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4767,6 +5199,7 @@
         "id": "tile-433",
         "x": 64,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4778,6 +5211,7 @@
         "id": "tile-434",
         "x": 66,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4789,6 +5223,7 @@
         "id": "tile-435",
         "x": 68,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4800,6 +5235,7 @@
         "id": "tile-436",
         "x": 70,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4811,6 +5247,7 @@
         "id": "tile-437",
         "x": 72,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4822,6 +5259,7 @@
         "id": "tile-438",
         "x": 74,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4833,6 +5271,7 @@
         "id": "tile-439",
         "x": 76,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4844,6 +5283,7 @@
         "id": "tile-440",
         "x": 78,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4855,6 +5295,7 @@
         "id": "tile-441",
         "x": 80,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4866,6 +5307,7 @@
         "id": "tile-442",
         "x": 82,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4877,6 +5319,7 @@
         "id": "tile-443",
         "x": 84,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4888,6 +5331,7 @@
         "id": "tile-444",
         "x": 86,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4899,6 +5343,7 @@
         "id": "tile-445",
         "x": 88,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4910,6 +5355,7 @@
         "id": "tile-446",
         "x": 90,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4921,6 +5367,7 @@
         "id": "tile-447",
         "x": 92,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4932,6 +5379,7 @@
         "id": "tile-448",
         "x": 94,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4943,6 +5391,7 @@
         "id": "tile-449",
         "x": 96,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4954,6 +5403,7 @@
         "id": "tile-450",
         "x": 98,
         "y": 8,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4965,6 +5415,7 @@
         "id": "tile-451",
         "x": 1,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4976,6 +5427,7 @@
         "id": "tile-452",
         "x": 3,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4987,6 +5439,7 @@
         "id": "tile-453",
         "x": 5,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -4998,6 +5451,7 @@
         "id": "tile-454",
         "x": 7,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5009,6 +5463,7 @@
         "id": "tile-455",
         "x": 9,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5020,6 +5475,7 @@
         "id": "tile-456",
         "x": 11,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5031,6 +5487,7 @@
         "id": "tile-457",
         "x": 13,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5042,6 +5499,7 @@
         "id": "tile-458",
         "x": 15,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5053,6 +5511,7 @@
         "id": "tile-459",
         "x": 17,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5064,6 +5523,7 @@
         "id": "tile-460",
         "x": 19,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5075,6 +5535,7 @@
         "id": "tile-461",
         "x": 21,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5086,6 +5547,7 @@
         "id": "tile-462",
         "x": 23,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5097,6 +5559,7 @@
         "id": "tile-463",
         "x": 25,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5108,6 +5571,7 @@
         "id": "tile-464",
         "x": 27,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -5119,6 +5583,7 @@
         "id": "tile-465",
         "x": 29,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -5130,6 +5595,7 @@
         "id": "tile-466",
         "x": 31,
         "y": 9,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -5144,6 +5610,7 @@
         "id": "tile-467",
         "x": 33,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -5155,6 +5622,7 @@
         "id": "tile-468",
         "x": 35,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -5166,6 +5634,7 @@
         "id": "tile-469",
         "x": 37,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -5177,6 +5646,7 @@
         "id": "tile-470",
         "x": 39,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -5188,6 +5658,7 @@
         "id": "tile-471",
         "x": 41,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -5199,6 +5670,7 @@
         "id": "tile-472",
         "x": 43,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -5210,6 +5682,7 @@
         "id": "tile-473",
         "x": 45,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -5221,6 +5694,7 @@
         "id": "tile-474",
         "x": 47,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -5232,6 +5706,7 @@
         "id": "tile-475",
         "x": 49,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -5243,6 +5718,7 @@
         "id": "tile-476",
         "x": 51,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -5254,6 +5730,7 @@
         "id": "tile-477",
         "x": 53,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -5265,6 +5742,7 @@
         "id": "tile-478",
         "x": 55,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5276,6 +5754,7 @@
         "id": "tile-479",
         "x": 57,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5287,6 +5766,7 @@
         "id": "tile-480",
         "x": 59,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5298,6 +5778,7 @@
         "id": "tile-481",
         "x": 61,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5309,6 +5790,7 @@
         "id": "tile-482",
         "x": 63,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5320,6 +5802,7 @@
         "id": "tile-483",
         "x": 65,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5331,6 +5814,7 @@
         "id": "tile-484",
         "x": 67,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5342,6 +5826,7 @@
         "id": "tile-485",
         "x": 69,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5353,6 +5838,7 @@
         "id": "tile-486",
         "x": 71,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5364,6 +5850,7 @@
         "id": "tile-487",
         "x": 73,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5375,6 +5862,7 @@
         "id": "tile-488",
         "x": 75,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5386,6 +5874,7 @@
         "id": "tile-489",
         "x": 77,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5397,6 +5886,7 @@
         "id": "tile-490",
         "x": 79,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5408,6 +5898,7 @@
         "id": "tile-491",
         "x": 81,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5419,6 +5910,7 @@
         "id": "tile-492",
         "x": 83,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5430,6 +5922,7 @@
         "id": "tile-493",
         "x": 85,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5441,6 +5934,7 @@
         "id": "tile-494",
         "x": 87,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5452,6 +5946,7 @@
         "id": "tile-495",
         "x": 89,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5463,6 +5958,7 @@
         "id": "tile-496",
         "x": 91,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5474,6 +5970,7 @@
         "id": "tile-497",
         "x": 93,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5485,6 +5982,7 @@
         "id": "tile-498",
         "x": 95,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5496,6 +5994,7 @@
         "id": "tile-499",
         "x": 97,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5507,6 +6006,7 @@
         "id": "tile-500",
         "x": 99,
         "y": 9,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5518,6 +6018,7 @@
         "id": "tile-501",
         "x": 0,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5529,6 +6030,7 @@
         "id": "tile-502",
         "x": 2,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5540,6 +6042,7 @@
         "id": "tile-503",
         "x": 4,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5551,6 +6054,7 @@
         "id": "tile-504",
         "x": 6,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5562,6 +6066,7 @@
         "id": "tile-505",
         "x": 8,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5573,6 +6078,7 @@
         "id": "tile-506",
         "x": 10,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5584,6 +6090,7 @@
         "id": "tile-507",
         "x": 12,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5595,6 +6102,7 @@
         "id": "tile-508",
         "x": 14,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5606,6 +6114,7 @@
         "id": "tile-509",
         "x": 16,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5617,6 +6126,7 @@
         "id": "tile-510",
         "x": 18,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5628,6 +6138,7 @@
         "id": "tile-511",
         "x": 20,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5639,6 +6150,7 @@
         "id": "tile-512",
         "x": 22,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5650,6 +6162,7 @@
         "id": "tile-513",
         "x": 24,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5661,6 +6174,7 @@
         "id": "tile-514",
         "x": 26,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5672,6 +6186,7 @@
         "id": "tile-515",
         "x": 28,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -5683,6 +6198,7 @@
         "id": "tile-516",
         "x": 30,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -5694,6 +6210,7 @@
         "id": "tile-517",
         "x": 32,
         "y": 10,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "resource": "Game",
@@ -5709,6 +6226,7 @@
         "id": "tile-518",
         "x": 34,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -5720,6 +6238,7 @@
         "id": "tile-519",
         "x": 36,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -5731,6 +6250,7 @@
         "id": "tile-520",
         "x": 38,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -5742,6 +6262,7 @@
         "id": "tile-521",
         "x": 40,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -5753,6 +6274,7 @@
         "id": "tile-522",
         "x": 42,
         "y": 10,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -5767,6 +6289,7 @@
         "id": "tile-523",
         "x": 44,
         "y": 10,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "resource": "Game",
@@ -5782,6 +6305,7 @@
         "id": "tile-524",
         "x": 46,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -5793,6 +6317,7 @@
         "id": "tile-525",
         "x": 48,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -5804,6 +6329,7 @@
         "id": "tile-526",
         "x": 50,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -5815,6 +6341,7 @@
         "id": "tile-527",
         "x": 52,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -5826,6 +6353,7 @@
         "id": "tile-528",
         "x": 54,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -5837,6 +6365,7 @@
         "id": "tile-529",
         "x": 56,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -5848,6 +6377,7 @@
         "id": "tile-530",
         "x": 58,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5859,6 +6389,7 @@
         "id": "tile-531",
         "x": 60,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5870,6 +6401,7 @@
         "id": "tile-532",
         "x": 62,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5881,6 +6413,7 @@
         "id": "tile-533",
         "x": 64,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5892,6 +6425,7 @@
         "id": "tile-534",
         "x": 66,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5903,6 +6437,7 @@
         "id": "tile-535",
         "x": 68,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5914,6 +6449,7 @@
         "id": "tile-536",
         "x": 70,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5925,6 +6461,7 @@
         "id": "tile-537",
         "x": 72,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5936,6 +6473,7 @@
         "id": "tile-538",
         "x": 74,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5947,6 +6485,7 @@
         "id": "tile-539",
         "x": 76,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -5958,6 +6497,7 @@
         "id": "tile-540",
         "x": 78,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5969,6 +6509,7 @@
         "id": "tile-541",
         "x": 80,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5980,6 +6521,7 @@
         "id": "tile-542",
         "x": 82,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -5991,6 +6533,7 @@
         "id": "tile-543",
         "x": 84,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6002,6 +6545,7 @@
         "id": "tile-544",
         "x": 86,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6013,6 +6557,7 @@
         "id": "tile-545",
         "x": 88,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6024,6 +6569,7 @@
         "id": "tile-546",
         "x": 90,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6035,6 +6581,7 @@
         "id": "tile-547",
         "x": 92,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6046,6 +6593,7 @@
         "id": "tile-548",
         "x": 94,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6057,6 +6605,7 @@
         "id": "tile-549",
         "x": 96,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6068,6 +6617,7 @@
         "id": "tile-550",
         "x": 98,
         "y": 10,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6079,6 +6629,7 @@
         "id": "tile-551",
         "x": 1,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6090,6 +6641,7 @@
         "id": "tile-552",
         "x": 3,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6101,6 +6653,7 @@
         "id": "tile-553",
         "x": 5,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6112,6 +6665,7 @@
         "id": "tile-554",
         "x": 7,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6123,6 +6677,7 @@
         "id": "tile-555",
         "x": 9,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6134,6 +6689,7 @@
         "id": "tile-556",
         "x": 11,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6145,6 +6701,7 @@
         "id": "tile-557",
         "x": 13,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6156,6 +6713,7 @@
         "id": "tile-558",
         "x": 15,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6167,6 +6725,7 @@
         "id": "tile-559",
         "x": 17,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6178,6 +6737,7 @@
         "id": "tile-560",
         "x": 19,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -6189,6 +6749,7 @@
         "id": "tile-561",
         "x": 21,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6200,6 +6761,7 @@
         "id": "tile-562",
         "x": 23,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6211,6 +6773,7 @@
         "id": "tile-563",
         "x": 25,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6222,6 +6785,7 @@
         "id": "tile-564",
         "x": 27,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -6233,6 +6797,7 @@
         "id": "tile-565",
         "x": 29,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -6244,6 +6809,7 @@
         "id": "tile-566",
         "x": 31,
         "y": 11,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -6258,6 +6824,7 @@
         "id": "tile-567",
         "x": 33,
         "y": 11,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -6272,6 +6839,7 @@
         "id": "tile-568",
         "x": 35,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -6283,6 +6851,7 @@
         "id": "tile-569",
         "x": 37,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -6294,6 +6863,7 @@
         "id": "tile-570",
         "x": 39,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -6305,6 +6875,7 @@
         "id": "tile-571",
         "x": 41,
         "y": 11,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -6319,6 +6890,7 @@
         "id": "tile-572",
         "x": 43,
         "y": 11,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -6333,6 +6905,7 @@
         "id": "tile-573",
         "x": 45,
         "y": 11,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -6347,6 +6920,7 @@
         "id": "tile-574",
         "x": 47,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -6358,6 +6932,7 @@
         "id": "tile-575",
         "x": 49,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -6369,6 +6944,7 @@
         "id": "tile-576",
         "x": 51,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -6380,6 +6956,7 @@
         "id": "tile-577",
         "x": 53,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -6391,6 +6968,7 @@
         "id": "tile-578",
         "x": 55,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -6402,6 +6980,7 @@
         "id": "tile-579",
         "x": 57,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6413,6 +6992,7 @@
         "id": "tile-580",
         "x": 59,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6424,6 +7004,7 @@
         "id": "tile-581",
         "x": 61,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6435,6 +7016,7 @@
         "id": "tile-582",
         "x": 63,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6446,6 +7028,7 @@
         "id": "tile-583",
         "x": 65,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6457,6 +7040,7 @@
         "id": "tile-584",
         "x": 67,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6468,6 +7052,7 @@
         "id": "tile-585",
         "x": 69,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6479,6 +7064,7 @@
         "id": "tile-586",
         "x": 71,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6490,6 +7076,7 @@
         "id": "tile-587",
         "x": 73,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6501,6 +7088,7 @@
         "id": "tile-588",
         "x": 75,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -6512,6 +7100,7 @@
         "id": "tile-589",
         "x": 77,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -6523,6 +7112,7 @@
         "id": "tile-590",
         "x": 79,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6534,6 +7124,7 @@
         "id": "tile-591",
         "x": 81,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6545,6 +7136,7 @@
         "id": "tile-592",
         "x": 83,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6556,6 +7148,7 @@
         "id": "tile-593",
         "x": 85,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -6567,6 +7160,7 @@
         "id": "tile-594",
         "x": 87,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6578,6 +7172,7 @@
         "id": "tile-595",
         "x": 89,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6589,6 +7184,7 @@
         "id": "tile-596",
         "x": 91,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6600,6 +7196,7 @@
         "id": "tile-597",
         "x": 93,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6611,6 +7208,7 @@
         "id": "tile-598",
         "x": 95,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6622,6 +7220,7 @@
         "id": "tile-599",
         "x": 97,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6633,6 +7232,7 @@
         "id": "tile-600",
         "x": 99,
         "y": 11,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6644,6 +7244,7 @@
         "id": "tile-601",
         "x": 0,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6655,6 +7256,7 @@
         "id": "tile-602",
         "x": 2,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6666,6 +7268,7 @@
         "id": "tile-603",
         "x": 4,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6677,6 +7280,7 @@
         "id": "tile-604",
         "x": 6,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6688,6 +7292,7 @@
         "id": "tile-605",
         "x": 8,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6699,6 +7304,7 @@
         "id": "tile-606",
         "x": 10,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6710,6 +7316,7 @@
         "id": "tile-607",
         "x": 12,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6721,6 +7328,7 @@
         "id": "tile-608",
         "x": 14,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6732,6 +7340,7 @@
         "id": "tile-609",
         "x": 16,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6743,6 +7352,7 @@
         "id": "tile-610",
         "x": 18,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -6754,6 +7364,7 @@
         "id": "tile-611",
         "x": 20,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -6765,6 +7376,7 @@
         "id": "tile-612",
         "x": 22,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6776,6 +7388,7 @@
         "id": "tile-613",
         "x": 24,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -6787,6 +7400,7 @@
         "id": "tile-614",
         "x": 26,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -6798,6 +7412,7 @@
         "id": "tile-615",
         "x": 28,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -6809,6 +7424,7 @@
         "id": "tile-616",
         "x": 30,
         "y": 12,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -6823,6 +7439,7 @@
         "id": "tile-617",
         "x": 32,
         "y": 12,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -6837,6 +7454,7 @@
         "id": "tile-618",
         "x": 34,
         "y": 12,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -6851,6 +7469,7 @@
         "id": "tile-619",
         "x": 36,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -6862,6 +7481,7 @@
         "id": "tile-620",
         "x": 38,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -6873,6 +7493,7 @@
         "id": "tile-621",
         "x": 40,
         "y": 12,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Coal",
@@ -6888,6 +7509,7 @@
         "id": "tile-622",
         "x": 42,
         "y": 12,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -6902,6 +7524,7 @@
         "id": "tile-623",
         "x": 44,
         "y": 12,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -6916,6 +7539,7 @@
         "id": "tile-624",
         "x": 46,
         "y": 12,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -6930,6 +7554,7 @@
         "id": "tile-625",
         "x": 48,
         "y": 12,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -6944,6 +7569,7 @@
         "id": "tile-626",
         "x": 50,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -6955,6 +7581,7 @@
         "id": "tile-627",
         "x": 52,
         "y": 12,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -6969,6 +7596,7 @@
         "id": "tile-628",
         "x": 54,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -6980,6 +7608,7 @@
         "id": "tile-629",
         "x": 56,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -6991,6 +7620,7 @@
         "id": "tile-630",
         "x": 58,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7002,6 +7632,7 @@
         "id": "tile-631",
         "x": 60,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7013,6 +7644,7 @@
         "id": "tile-632",
         "x": 62,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7024,6 +7656,7 @@
         "id": "tile-633",
         "x": 64,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7035,6 +7668,7 @@
         "id": "tile-634",
         "x": 66,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7046,6 +7680,7 @@
         "id": "tile-635",
         "x": 68,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7057,6 +7692,7 @@
         "id": "tile-636",
         "x": 70,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7068,6 +7704,7 @@
         "id": "tile-637",
         "x": 72,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7079,6 +7716,7 @@
         "id": "tile-638",
         "x": 74,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -7090,6 +7728,7 @@
         "id": "tile-639",
         "x": 76,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -7101,6 +7740,7 @@
         "id": "tile-640",
         "x": 78,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -7112,6 +7752,7 @@
         "id": "tile-641",
         "x": 80,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7123,6 +7764,7 @@
         "id": "tile-642",
         "x": 82,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7134,6 +7776,7 @@
         "id": "tile-643",
         "x": 84,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7145,6 +7788,7 @@
         "id": "tile-644",
         "x": 86,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7156,6 +7800,7 @@
         "id": "tile-645",
         "x": 88,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7167,6 +7812,7 @@
         "id": "tile-646",
         "x": 90,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7178,6 +7824,7 @@
         "id": "tile-647",
         "x": 92,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7189,6 +7836,7 @@
         "id": "tile-648",
         "x": 94,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7200,6 +7848,7 @@
         "id": "tile-649",
         "x": 96,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7211,6 +7860,7 @@
         "id": "tile-650",
         "x": 98,
         "y": 12,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7222,6 +7872,7 @@
         "id": "tile-651",
         "x": 1,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7233,6 +7884,7 @@
         "id": "tile-652",
         "x": 3,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7244,6 +7896,7 @@
         "id": "tile-653",
         "x": 5,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7255,6 +7908,7 @@
         "id": "tile-654",
         "x": 7,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7266,6 +7920,7 @@
         "id": "tile-655",
         "x": 9,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7277,6 +7932,7 @@
         "id": "tile-656",
         "x": 11,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7288,6 +7944,7 @@
         "id": "tile-657",
         "x": 13,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7299,6 +7956,7 @@
         "id": "tile-658",
         "x": 15,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7310,6 +7968,7 @@
         "id": "tile-659",
         "x": 17,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -7321,6 +7980,7 @@
         "id": "tile-660",
         "x": 19,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -7332,6 +7992,7 @@
         "id": "tile-661",
         "x": 21,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -7343,6 +8004,7 @@
         "id": "tile-662",
         "x": 23,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7354,6 +8016,7 @@
         "id": "tile-663",
         "x": 25,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7365,6 +8028,7 @@
         "id": "tile-664",
         "x": 27,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -7376,6 +8040,7 @@
         "id": "tile-665",
         "x": 29,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -7387,6 +8052,7 @@
         "id": "tile-666",
         "x": 31,
         "y": 13,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -7401,6 +8067,7 @@
         "id": "tile-667",
         "x": 33,
         "y": 13,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -7415,6 +8082,7 @@
         "id": "tile-668",
         "x": 35,
         "y": 13,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -7429,6 +8097,7 @@
         "id": "tile-669",
         "x": 37,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -7440,6 +8109,7 @@
         "id": "tile-670",
         "x": 39,
         "y": 13,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -7455,6 +8125,7 @@
         "id": "tile-671",
         "x": 41,
         "y": 13,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -7469,6 +8140,7 @@
         "id": "tile-672",
         "x": 43,
         "y": 13,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -7483,6 +8155,7 @@
         "id": "tile-673",
         "x": 45,
         "y": 13,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -7497,6 +8170,7 @@
         "id": "tile-674",
         "x": 47,
         "y": 13,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -7511,6 +8185,7 @@
         "id": "tile-675",
         "x": 49,
         "y": 13,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -7526,6 +8201,7 @@
         "id": "tile-676",
         "x": 51,
         "y": 13,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -7540,6 +8216,7 @@
         "id": "tile-677",
         "x": 53,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -7551,6 +8228,7 @@
         "id": "tile-678",
         "x": 55,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -7562,6 +8240,7 @@
         "id": "tile-679",
         "x": 57,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7573,6 +8252,7 @@
         "id": "tile-680",
         "x": 59,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7584,6 +8264,7 @@
         "id": "tile-681",
         "x": 61,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7595,6 +8276,7 @@
         "id": "tile-682",
         "x": 63,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7606,6 +8288,7 @@
         "id": "tile-683",
         "x": 65,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7617,6 +8300,7 @@
         "id": "tile-684",
         "x": 67,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7628,6 +8312,7 @@
         "id": "tile-685",
         "x": 69,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7639,6 +8324,7 @@
         "id": "tile-686",
         "x": 71,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7650,6 +8336,7 @@
         "id": "tile-687",
         "x": 73,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -7661,6 +8348,7 @@
         "id": "tile-688",
         "x": 75,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -7672,6 +8360,7 @@
         "id": "tile-689",
         "x": 77,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -7683,6 +8372,7 @@
         "id": "tile-690",
         "x": 79,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -7694,6 +8384,7 @@
         "id": "tile-691",
         "x": 81,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7705,6 +8396,7 @@
         "id": "tile-692",
         "x": 83,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7716,6 +8408,7 @@
         "id": "tile-693",
         "x": 85,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -7727,6 +8420,7 @@
         "id": "tile-694",
         "x": 87,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -7738,6 +8432,7 @@
         "id": "tile-695",
         "x": 89,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7749,6 +8444,7 @@
         "id": "tile-696",
         "x": 91,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7760,6 +8456,7 @@
         "id": "tile-697",
         "x": 93,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7771,6 +8468,7 @@
         "id": "tile-698",
         "x": 95,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7782,6 +8480,7 @@
         "id": "tile-699",
         "x": 97,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7793,6 +8492,7 @@
         "id": "tile-700",
         "x": 99,
         "y": 13,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7804,6 +8504,7 @@
         "id": "tile-701",
         "x": 0,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7815,6 +8516,7 @@
         "id": "tile-702",
         "x": 2,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7826,6 +8528,7 @@
         "id": "tile-703",
         "x": 4,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7837,6 +8540,7 @@
         "id": "tile-704",
         "x": 6,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7848,6 +8552,7 @@
         "id": "tile-705",
         "x": 8,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7859,6 +8564,7 @@
         "id": "tile-706",
         "x": 10,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7870,6 +8576,7 @@
         "id": "tile-707",
         "x": 12,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7881,6 +8588,7 @@
         "id": "tile-708",
         "x": 14,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7892,6 +8600,7 @@
         "id": "tile-709",
         "x": 16,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -7903,6 +8612,7 @@
         "id": "tile-710",
         "x": 18,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -7914,6 +8624,7 @@
         "id": "tile-711",
         "x": 20,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -7925,6 +8636,7 @@
         "id": "tile-712",
         "x": 22,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -7937,6 +8649,7 @@
         "id": "tile-713",
         "x": 24,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -7948,6 +8661,7 @@
         "id": "tile-714",
         "x": 26,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -7959,6 +8673,7 @@
         "id": "tile-715",
         "x": 28,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -7970,6 +8685,7 @@
         "id": "tile-716",
         "x": 30,
         "y": 14,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -7984,6 +8700,7 @@
         "id": "tile-717",
         "x": 32,
         "y": 14,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -7998,6 +8715,7 @@
         "id": "tile-718",
         "x": 34,
         "y": 14,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -8012,6 +8730,7 @@
         "id": "tile-719",
         "x": 36,
         "y": 14,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -8026,6 +8745,7 @@
         "id": "tile-720",
         "x": 38,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -8037,6 +8757,7 @@
         "id": "tile-721",
         "x": 40,
         "y": 14,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -8051,6 +8772,7 @@
         "id": "tile-722",
         "x": 42,
         "y": 14,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -8065,6 +8787,7 @@
         "id": "tile-723",
         "x": 44,
         "y": 14,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "resource": "Aluminum",
@@ -8080,6 +8803,7 @@
         "id": "tile-724",
         "x": 46,
         "y": 14,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -8094,6 +8818,7 @@
         "id": "tile-725",
         "x": 48,
         "y": 14,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -8108,6 +8833,7 @@
         "id": "tile-726",
         "x": 50,
         "y": 14,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -8122,6 +8848,7 @@
         "id": "tile-727",
         "x": 52,
         "y": 14,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "resource": "Oil",
@@ -8137,6 +8864,7 @@
         "id": "tile-728",
         "x": 54,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -8148,6 +8876,7 @@
         "id": "tile-729",
         "x": 56,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -8159,6 +8888,7 @@
         "id": "tile-730",
         "x": 58,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8170,6 +8900,7 @@
         "id": "tile-731",
         "x": 60,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8181,6 +8912,7 @@
         "id": "tile-732",
         "x": 62,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8192,6 +8924,7 @@
         "id": "tile-733",
         "x": 64,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8203,6 +8936,7 @@
         "id": "tile-734",
         "x": 66,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8214,6 +8948,7 @@
         "id": "tile-735",
         "x": 68,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8225,6 +8960,7 @@
         "id": "tile-736",
         "x": 70,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8236,6 +8972,7 @@
         "id": "tile-737",
         "x": 72,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -8247,6 +8984,7 @@
         "id": "tile-738",
         "x": 74,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -8258,6 +8996,7 @@
         "id": "tile-739",
         "x": 76,
         "y": 14,
+        "continent": 2,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -8272,6 +9011,7 @@
         "id": "tile-740",
         "x": 78,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -8283,6 +9023,7 @@
         "id": "tile-741",
         "x": 80,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -8294,6 +9035,7 @@
         "id": "tile-742",
         "x": 82,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8305,6 +9047,7 @@
         "id": "tile-743",
         "x": 84,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8316,6 +9059,7 @@
         "id": "tile-744",
         "x": 86,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -8327,6 +9071,7 @@
         "id": "tile-745",
         "x": 88,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -8338,6 +9083,7 @@
         "id": "tile-746",
         "x": 90,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8349,6 +9095,7 @@
         "id": "tile-747",
         "x": 92,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8360,6 +9107,7 @@
         "id": "tile-748",
         "x": 94,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8371,6 +9119,7 @@
         "id": "tile-749",
         "x": 96,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8382,6 +9131,7 @@
         "id": "tile-750",
         "x": 98,
         "y": 14,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8393,6 +9143,7 @@
         "id": "tile-751",
         "x": 1,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8404,6 +9155,7 @@
         "id": "tile-752",
         "x": 3,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8415,6 +9167,7 @@
         "id": "tile-753",
         "x": 5,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8426,6 +9179,7 @@
         "id": "tile-754",
         "x": 7,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8437,6 +9191,7 @@
         "id": "tile-755",
         "x": 9,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8448,6 +9203,7 @@
         "id": "tile-756",
         "x": 11,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8459,6 +9215,7 @@
         "id": "tile-757",
         "x": 13,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8470,6 +9227,7 @@
         "id": "tile-758",
         "x": 15,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -8481,6 +9239,7 @@
         "id": "tile-759",
         "x": 17,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -8493,6 +9252,7 @@
         "id": "tile-760",
         "x": 19,
         "y": 15,
+        "continent": 3,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -8507,6 +9267,7 @@
         "id": "tile-761",
         "x": 21,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -8518,6 +9279,7 @@
         "id": "tile-762",
         "x": 23,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -8529,6 +9291,7 @@
         "id": "tile-763",
         "x": 25,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8540,6 +9303,7 @@
         "id": "tile-764",
         "x": 27,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -8551,6 +9315,7 @@
         "id": "tile-765",
         "x": 29,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -8562,6 +9327,7 @@
         "id": "tile-766",
         "x": 31,
         "y": 15,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -8576,6 +9342,7 @@
         "id": "tile-767",
         "x": 33,
         "y": 15,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -8590,6 +9357,7 @@
         "id": "tile-768",
         "x": 35,
         "y": 15,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -8604,6 +9372,7 @@
         "id": "tile-769",
         "x": 37,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -8615,6 +9384,7 @@
         "id": "tile-770",
         "x": 39,
         "y": 15,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -8629,6 +9399,7 @@
         "id": "tile-771",
         "x": 41,
         "y": 15,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -8640,6 +9411,7 @@
         "id": "tile-772",
         "x": 43,
         "y": 15,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -8655,6 +9427,7 @@
         "id": "tile-773",
         "x": 45,
         "y": 15,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -8669,6 +9442,7 @@
         "id": "tile-774",
         "x": 47,
         "y": 15,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -8683,6 +9457,7 @@
         "id": "tile-775",
         "x": 49,
         "y": 15,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -8697,6 +9472,7 @@
         "id": "tile-776",
         "x": 51,
         "y": 15,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -8711,6 +9487,7 @@
         "id": "tile-777",
         "x": 53,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -8722,6 +9499,7 @@
         "id": "tile-778",
         "x": 55,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -8733,6 +9511,7 @@
         "id": "tile-779",
         "x": 57,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8744,6 +9523,7 @@
         "id": "tile-780",
         "x": 59,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8755,6 +9535,7 @@
         "id": "tile-781",
         "x": 61,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8766,6 +9547,7 @@
         "id": "tile-782",
         "x": 63,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8777,6 +9559,7 @@
         "id": "tile-783",
         "x": 65,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8788,6 +9571,7 @@
         "id": "tile-784",
         "x": 67,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8799,6 +9583,7 @@
         "id": "tile-785",
         "x": 69,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8810,6 +9595,7 @@
         "id": "tile-786",
         "x": 71,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -8821,6 +9607,7 @@
         "id": "tile-787",
         "x": 73,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -8832,6 +9619,7 @@
         "id": "tile-788",
         "x": 75,
         "y": 15,
+        "continent": 2,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -8846,6 +9634,7 @@
         "id": "tile-789",
         "x": 77,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -8857,6 +9646,7 @@
         "id": "tile-790",
         "x": 79,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -8868,6 +9658,7 @@
         "id": "tile-791",
         "x": 81,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8879,6 +9670,7 @@
         "id": "tile-792",
         "x": 83,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8890,6 +9682,7 @@
         "id": "tile-793",
         "x": 85,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -8901,6 +9694,7 @@
         "id": "tile-794",
         "x": 87,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -8912,6 +9706,7 @@
         "id": "tile-795",
         "x": 89,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -8923,6 +9718,7 @@
         "id": "tile-796",
         "x": 91,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8934,6 +9730,7 @@
         "id": "tile-797",
         "x": 93,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8945,6 +9742,7 @@
         "id": "tile-798",
         "x": 95,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8956,6 +9754,7 @@
         "id": "tile-799",
         "x": 97,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8967,6 +9766,7 @@
         "id": "tile-800",
         "x": 99,
         "y": 15,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8978,6 +9778,7 @@
         "id": "tile-801",
         "x": 0,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -8989,6 +9790,7 @@
         "id": "tile-802",
         "x": 2,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9000,6 +9802,7 @@
         "id": "tile-803",
         "x": 4,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9011,6 +9814,7 @@
         "id": "tile-804",
         "x": 6,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9022,6 +9826,7 @@
         "id": "tile-805",
         "x": 8,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9033,6 +9838,7 @@
         "id": "tile-806",
         "x": 10,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9044,6 +9850,7 @@
         "id": "tile-807",
         "x": 12,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9055,6 +9862,7 @@
         "id": "tile-808",
         "x": 14,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9066,6 +9874,7 @@
         "id": "tile-809",
         "x": 16,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -9077,6 +9886,7 @@
         "id": "tile-810",
         "x": 18,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -9088,6 +9898,7 @@
         "id": "tile-811",
         "x": 20,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -9099,6 +9910,7 @@
         "id": "tile-812",
         "x": 22,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -9110,6 +9922,7 @@
         "id": "tile-813",
         "x": 24,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9121,6 +9934,7 @@
         "id": "tile-814",
         "x": 26,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9132,6 +9946,7 @@
         "id": "tile-815",
         "x": 28,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -9143,6 +9958,7 @@
         "id": "tile-816",
         "x": 30,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -9154,6 +9970,7 @@
         "id": "tile-817",
         "x": 32,
         "y": 16,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -9168,6 +9985,7 @@
         "id": "tile-818",
         "x": 34,
         "y": 16,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -9182,6 +10000,7 @@
         "id": "tile-819",
         "x": 36,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -9193,6 +10012,7 @@
         "id": "tile-820",
         "x": 38,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -9204,6 +10024,7 @@
         "id": "tile-821",
         "x": 40,
         "y": 16,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -9215,6 +10036,7 @@
         "id": "tile-822",
         "x": 42,
         "y": 16,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -9229,6 +10051,7 @@
         "id": "tile-823",
         "x": 44,
         "y": 16,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -9244,6 +10067,7 @@
         "id": "tile-824",
         "x": 46,
         "y": 16,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -9258,6 +10082,7 @@
         "id": "tile-825",
         "x": 48,
         "y": 16,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -9272,6 +10097,7 @@
         "id": "tile-826",
         "x": 50,
         "y": 16,
+        "continent": 1,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -9286,6 +10112,7 @@
         "id": "tile-827",
         "x": 52,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -9297,6 +10124,7 @@
         "id": "tile-828",
         "x": 54,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -9308,6 +10136,7 @@
         "id": "tile-829",
         "x": 56,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9319,6 +10148,7 @@
         "id": "tile-830",
         "x": 58,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9330,6 +10160,7 @@
         "id": "tile-831",
         "x": 60,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9341,6 +10172,7 @@
         "id": "tile-832",
         "x": 62,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9352,6 +10184,7 @@
         "id": "tile-833",
         "x": 64,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9363,6 +10196,7 @@
         "id": "tile-834",
         "x": 66,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9374,6 +10208,7 @@
         "id": "tile-835",
         "x": 68,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9385,6 +10220,7 @@
         "id": "tile-836",
         "x": 70,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -9396,6 +10232,7 @@
         "id": "tile-837",
         "x": 72,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -9407,6 +10244,7 @@
         "id": "tile-838",
         "x": 74,
         "y": 16,
+        "continent": 2,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest"
       },
@@ -9418,6 +10256,7 @@
         "id": "tile-839",
         "x": 76,
         "y": 16,
+        "continent": 2,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "resource": "Oil",
@@ -9433,6 +10272,7 @@
         "id": "tile-840",
         "x": 78,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -9444,6 +10284,7 @@
         "id": "tile-841",
         "x": 80,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -9455,6 +10296,7 @@
         "id": "tile-842",
         "x": 82,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9466,6 +10308,7 @@
         "id": "tile-843",
         "x": 84,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9477,6 +10320,7 @@
         "id": "tile-844",
         "x": 86,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -9488,6 +10332,7 @@
         "id": "tile-845",
         "x": 88,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -9499,6 +10344,7 @@
         "id": "tile-846",
         "x": 90,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9510,6 +10356,7 @@
         "id": "tile-847",
         "x": 92,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9521,6 +10368,7 @@
         "id": "tile-848",
         "x": 94,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9532,6 +10380,7 @@
         "id": "tile-849",
         "x": 96,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9543,6 +10392,7 @@
         "id": "tile-850",
         "x": 98,
         "y": 16,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9554,6 +10404,7 @@
         "id": "tile-851",
         "x": 1,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9565,6 +10416,7 @@
         "id": "tile-852",
         "x": 3,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9576,6 +10428,7 @@
         "id": "tile-853",
         "x": 5,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9587,6 +10440,7 @@
         "id": "tile-854",
         "x": 7,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9598,6 +10452,7 @@
         "id": "tile-855",
         "x": 9,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9609,6 +10464,7 @@
         "id": "tile-856",
         "x": 11,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9620,6 +10476,7 @@
         "id": "tile-857",
         "x": 13,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9631,6 +10488,7 @@
         "id": "tile-858",
         "x": 15,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -9642,6 +10500,7 @@
         "id": "tile-859",
         "x": 17,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -9653,6 +10512,7 @@
         "id": "tile-860",
         "x": 19,
         "y": 17,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "resource": "Uranium",
@@ -9668,6 +10528,7 @@
         "id": "tile-861",
         "x": 21,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -9679,6 +10540,7 @@
         "id": "tile-862",
         "x": 23,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -9690,6 +10552,7 @@
         "id": "tile-863",
         "x": 25,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9701,6 +10564,7 @@
         "id": "tile-864",
         "x": 27,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -9712,6 +10576,7 @@
         "id": "tile-865",
         "x": 29,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -9723,6 +10588,7 @@
         "id": "tile-866",
         "x": 31,
         "y": 17,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -9737,6 +10603,7 @@
         "id": "tile-867",
         "x": 33,
         "y": 17,
+        "continent": 0,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -9751,6 +10618,7 @@
         "id": "tile-868",
         "x": 35,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -9762,6 +10630,7 @@
         "id": "tile-869",
         "x": 37,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -9773,6 +10642,7 @@
         "id": "tile-870",
         "x": 39,
         "y": 17,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -9787,6 +10657,7 @@
         "id": "tile-871",
         "x": 41,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -9798,6 +10669,7 @@
         "id": "tile-872",
         "x": 43,
         "y": 17,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -9812,6 +10684,7 @@
         "id": "tile-873",
         "x": 45,
         "y": 17,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "resource": "Game"
@@ -9824,6 +10697,7 @@
         "id": "tile-874",
         "x": 47,
         "y": 17,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -9838,6 +10712,7 @@
         "id": "tile-875",
         "x": 49,
         "y": 17,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -9852,6 +10727,7 @@
         "id": "tile-876",
         "x": 51,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -9863,6 +10739,7 @@
         "id": "tile-877",
         "x": 53,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -9874,6 +10751,7 @@
         "id": "tile-878",
         "x": 55,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9885,6 +10763,7 @@
         "id": "tile-879",
         "x": 57,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9896,6 +10775,7 @@
         "id": "tile-880",
         "x": 59,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9907,6 +10787,7 @@
         "id": "tile-881",
         "x": 61,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9918,6 +10799,7 @@
         "id": "tile-882",
         "x": 63,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9929,6 +10811,7 @@
         "id": "tile-883",
         "x": 65,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9940,6 +10823,7 @@
         "id": "tile-884",
         "x": 67,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -9951,6 +10835,7 @@
         "id": "tile-885",
         "x": 69,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -9962,6 +10847,7 @@
         "id": "tile-886",
         "x": 71,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -9973,6 +10859,7 @@
         "id": "tile-887",
         "x": 73,
         "y": 17,
+        "continent": 2,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra"
       },
@@ -9984,6 +10871,7 @@
         "id": "tile-888",
         "x": 75,
         "y": 17,
+        "continent": 2,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest"
       },
@@ -9995,6 +10883,7 @@
         "id": "tile-889",
         "x": 77,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10006,6 +10895,7 @@
         "id": "tile-890",
         "x": 79,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -10017,6 +10907,7 @@
         "id": "tile-891",
         "x": 81,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10028,6 +10919,7 @@
         "id": "tile-892",
         "x": 83,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10039,6 +10931,7 @@
         "id": "tile-893",
         "x": 85,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -10050,6 +10943,7 @@
         "id": "tile-894",
         "x": 87,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10061,6 +10955,7 @@
         "id": "tile-895",
         "x": 89,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -10072,6 +10967,7 @@
         "id": "tile-896",
         "x": 91,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10083,6 +10979,7 @@
         "id": "tile-897",
         "x": 93,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10094,6 +10991,7 @@
         "id": "tile-898",
         "x": 95,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10105,6 +11003,7 @@
         "id": "tile-899",
         "x": 97,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10116,6 +11015,7 @@
         "id": "tile-900",
         "x": 99,
         "y": 17,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10127,6 +11027,7 @@
         "id": "tile-901",
         "x": 0,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10138,6 +11039,7 @@
         "id": "tile-902",
         "x": 2,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10149,6 +11051,7 @@
         "id": "tile-903",
         "x": 4,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10160,6 +11063,7 @@
         "id": "tile-904",
         "x": 6,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10171,6 +11075,7 @@
         "id": "tile-905",
         "x": 8,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10182,6 +11087,7 @@
         "id": "tile-906",
         "x": 10,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10193,6 +11099,7 @@
         "id": "tile-907",
         "x": 12,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10204,6 +11111,7 @@
         "id": "tile-908",
         "x": 14,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -10215,6 +11123,7 @@
         "id": "tile-909",
         "x": 16,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10226,6 +11135,7 @@
         "id": "tile-910",
         "x": 18,
         "y": 18,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -10240,6 +11150,7 @@
         "id": "tile-911",
         "x": 20,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10251,6 +11162,7 @@
         "id": "tile-912",
         "x": 22,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -10262,6 +11174,7 @@
         "id": "tile-913",
         "x": 24,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10273,6 +11186,7 @@
         "id": "tile-914",
         "x": 26,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10284,6 +11198,7 @@
         "id": "tile-915",
         "x": 28,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -10295,6 +11210,7 @@
         "id": "tile-916",
         "x": 30,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10306,6 +11222,7 @@
         "id": "tile-917",
         "x": 32,
         "y": 18,
+        "continent": 0,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -10317,6 +11234,7 @@
         "id": "tile-918",
         "x": 34,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10328,6 +11246,7 @@
         "id": "tile-919",
         "x": 36,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -10339,6 +11258,7 @@
         "id": "tile-920",
         "x": 38,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10350,6 +11270,7 @@
         "id": "tile-921",
         "x": 40,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10361,6 +11282,7 @@
         "id": "tile-922",
         "x": 42,
         "y": 18,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -10372,6 +11294,7 @@
         "id": "tile-923",
         "x": 44,
         "y": 18,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -10387,6 +11310,7 @@
         "id": "tile-924",
         "x": 46,
         "y": 18,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -10401,6 +11325,7 @@
         "id": "tile-925",
         "x": 48,
         "y": 18,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -10415,6 +11340,7 @@
         "id": "tile-926",
         "x": 50,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10426,6 +11352,7 @@
         "id": "tile-927",
         "x": 52,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -10437,6 +11364,7 @@
         "id": "tile-928",
         "x": 54,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10448,6 +11376,7 @@
         "id": "tile-929",
         "x": 56,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10459,6 +11388,7 @@
         "id": "tile-930",
         "x": 58,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10470,6 +11400,7 @@
         "id": "tile-931",
         "x": 60,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10481,6 +11412,7 @@
         "id": "tile-932",
         "x": 62,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10492,6 +11424,7 @@
         "id": "tile-933",
         "x": 64,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10503,6 +11436,7 @@
         "id": "tile-934",
         "x": 66,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10514,6 +11448,7 @@
         "id": "tile-935",
         "x": 68,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10525,6 +11460,7 @@
         "id": "tile-936",
         "x": 70,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -10536,6 +11472,7 @@
         "id": "tile-937",
         "x": 72,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10547,6 +11484,7 @@
         "id": "tile-938",
         "x": 74,
         "y": 18,
+        "continent": 2,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -10561,6 +11499,7 @@
         "id": "tile-939",
         "x": 76,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10572,6 +11511,7 @@
         "id": "tile-940",
         "x": 78,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -10583,6 +11523,7 @@
         "id": "tile-941",
         "x": 80,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10594,6 +11535,7 @@
         "id": "tile-942",
         "x": 82,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10605,6 +11547,7 @@
         "id": "tile-943",
         "x": 84,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -10616,6 +11559,7 @@
         "id": "tile-944",
         "x": 86,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10627,6 +11571,7 @@
         "id": "tile-945",
         "x": 88,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10638,6 +11583,7 @@
         "id": "tile-946",
         "x": 90,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -10649,6 +11595,7 @@
         "id": "tile-947",
         "x": 92,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10660,6 +11607,7 @@
         "id": "tile-948",
         "x": 94,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10671,6 +11619,7 @@
         "id": "tile-949",
         "x": 96,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10682,6 +11631,7 @@
         "id": "tile-950",
         "x": 98,
         "y": 18,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10693,6 +11643,7 @@
         "id": "tile-951",
         "x": 1,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10704,6 +11655,7 @@
         "id": "tile-952",
         "x": 3,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10715,6 +11667,7 @@
         "id": "tile-953",
         "x": 5,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10726,6 +11679,7 @@
         "id": "tile-954",
         "x": 7,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10737,6 +11691,7 @@
         "id": "tile-955",
         "x": 9,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10748,6 +11703,7 @@
         "id": "tile-956",
         "x": 11,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10759,6 +11715,7 @@
         "id": "tile-957",
         "x": 13,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10770,6 +11727,7 @@
         "id": "tile-958",
         "x": 15,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -10781,6 +11739,7 @@
         "id": "tile-959",
         "x": 17,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10792,6 +11751,7 @@
         "id": "tile-960",
         "x": 19,
         "y": 19,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -10806,6 +11766,7 @@
         "id": "tile-961",
         "x": 21,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10817,6 +11778,7 @@
         "id": "tile-962",
         "x": 23,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -10828,6 +11790,7 @@
         "id": "tile-963",
         "x": 25,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -10839,6 +11802,7 @@
         "id": "tile-964",
         "x": 27,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -10850,6 +11814,7 @@
         "id": "tile-965",
         "x": 29,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10861,6 +11826,7 @@
         "id": "tile-966",
         "x": 31,
         "y": 19,
+        "continent": 0,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -10875,6 +11841,7 @@
         "id": "tile-967",
         "x": 33,
         "y": 19,
+        "continent": 0,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -10886,6 +11853,7 @@
         "id": "tile-968",
         "x": 35,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10897,6 +11865,7 @@
         "id": "tile-969",
         "x": 37,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -10908,6 +11877,7 @@
         "id": "tile-970",
         "x": 39,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10919,6 +11889,7 @@
         "id": "tile-971",
         "x": 41,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10930,6 +11901,7 @@
         "id": "tile-972",
         "x": 43,
         "y": 19,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -10944,6 +11916,7 @@
         "id": "tile-973",
         "x": 45,
         "y": 19,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -10958,6 +11931,7 @@
         "id": "tile-974",
         "x": 47,
         "y": 19,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -10972,6 +11946,7 @@
         "id": "tile-975",
         "x": 49,
         "y": 19,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -10986,6 +11961,7 @@
         "id": "tile-976",
         "x": 51,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -10997,6 +11973,7 @@
         "id": "tile-977",
         "x": 53,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11008,6 +11985,7 @@
         "id": "tile-978",
         "x": 55,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11019,6 +11997,7 @@
         "id": "tile-979",
         "x": 57,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11030,6 +12009,7 @@
         "id": "tile-980",
         "x": 59,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11041,6 +12021,7 @@
         "id": "tile-981",
         "x": 61,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11052,6 +12033,7 @@
         "id": "tile-982",
         "x": 63,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11063,6 +12045,7 @@
         "id": "tile-983",
         "x": 65,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11074,6 +12057,7 @@
         "id": "tile-984",
         "x": 67,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11085,6 +12069,7 @@
         "id": "tile-985",
         "x": 69,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11096,6 +12081,7 @@
         "id": "tile-986",
         "x": 71,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11107,6 +12093,7 @@
         "id": "tile-987",
         "x": 73,
         "y": 19,
+        "continent": 2,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Cattle"
@@ -11119,6 +12106,7 @@
         "id": "tile-988",
         "x": 75,
         "y": 19,
+        "continent": 2,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -11130,6 +12118,7 @@
         "id": "tile-989",
         "x": 77,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11141,6 +12130,7 @@
         "id": "tile-990",
         "x": 79,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11152,6 +12142,7 @@
         "id": "tile-991",
         "x": 81,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11163,6 +12154,7 @@
         "id": "tile-992",
         "x": 83,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11174,6 +12166,7 @@
         "id": "tile-993",
         "x": 85,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11185,6 +12178,7 @@
         "id": "tile-994",
         "x": 87,
         "y": 19,
+        "continent": 4,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -11199,6 +12193,7 @@
         "id": "tile-995",
         "x": 89,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11210,6 +12205,7 @@
         "id": "tile-996",
         "x": 91,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11221,6 +12217,7 @@
         "id": "tile-997",
         "x": 93,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11232,6 +12229,7 @@
         "id": "tile-998",
         "x": 95,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11243,6 +12241,7 @@
         "id": "tile-999",
         "x": 97,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11254,6 +12253,7 @@
         "id": "tile-1000",
         "x": 99,
         "y": 19,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11265,6 +12265,7 @@
         "id": "tile-1001",
         "x": 0,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11276,6 +12277,7 @@
         "id": "tile-1002",
         "x": 2,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11287,6 +12289,7 @@
         "id": "tile-1003",
         "x": 4,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11298,6 +12301,7 @@
         "id": "tile-1004",
         "x": 6,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11309,6 +12313,7 @@
         "id": "tile-1005",
         "x": 8,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11320,6 +12325,7 @@
         "id": "tile-1006",
         "x": 10,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11331,6 +12337,7 @@
         "id": "tile-1007",
         "x": 12,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11342,6 +12349,7 @@
         "id": "tile-1008",
         "x": 14,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11353,6 +12361,7 @@
         "id": "tile-1009",
         "x": 16,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11364,6 +12373,7 @@
         "id": "tile-1010",
         "x": 18,
         "y": 20,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -11378,6 +12388,7 @@
         "id": "tile-1011",
         "x": 20,
         "y": 20,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -11392,6 +12403,7 @@
         "id": "tile-1012",
         "x": 22,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11403,6 +12415,7 @@
         "id": "tile-1013",
         "x": 24,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11414,6 +12427,7 @@
         "id": "tile-1014",
         "x": 26,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11425,6 +12439,7 @@
         "id": "tile-1015",
         "x": 28,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11436,6 +12451,7 @@
         "id": "tile-1016",
         "x": 30,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11447,6 +12463,7 @@
         "id": "tile-1017",
         "x": 32,
         "y": 20,
+        "continent": 0,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -11462,6 +12479,7 @@
         "id": "tile-1018",
         "x": 34,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11473,6 +12491,7 @@
         "id": "tile-1019",
         "x": 36,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11484,6 +12503,7 @@
         "id": "tile-1020",
         "x": 38,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11495,6 +12515,7 @@
         "id": "tile-1021",
         "x": 40,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11506,6 +12527,7 @@
         "id": "tile-1022",
         "x": 42,
         "y": 20,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -11517,6 +12539,7 @@
         "id": "tile-1023",
         "x": 44,
         "y": 20,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -11531,6 +12554,7 @@
         "id": "tile-1024",
         "x": 46,
         "y": 20,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Gold",
@@ -11546,6 +12570,7 @@
         "id": "tile-1025",
         "x": 48,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11557,6 +12582,7 @@
         "id": "tile-1026",
         "x": 50,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11568,6 +12594,7 @@
         "id": "tile-1027",
         "x": 52,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11579,6 +12606,7 @@
         "id": "tile-1028",
         "x": 54,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11590,6 +12618,7 @@
         "id": "tile-1029",
         "x": 56,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11601,6 +12630,7 @@
         "id": "tile-1030",
         "x": 58,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11612,6 +12642,7 @@
         "id": "tile-1031",
         "x": 60,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11623,6 +12654,7 @@
         "id": "tile-1032",
         "x": 62,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11634,6 +12666,7 @@
         "id": "tile-1033",
         "x": 64,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11645,6 +12678,7 @@
         "id": "tile-1034",
         "x": 66,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11656,6 +12690,7 @@
         "id": "tile-1035",
         "x": 68,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11667,6 +12702,7 @@
         "id": "tile-1036",
         "x": 70,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11678,6 +12714,7 @@
         "id": "tile-1037",
         "x": 72,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11689,6 +12726,7 @@
         "id": "tile-1038",
         "x": 74,
         "y": 20,
+        "continent": 2,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -11703,6 +12741,7 @@
         "id": "tile-1039",
         "x": 76,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11714,6 +12753,7 @@
         "id": "tile-1040",
         "x": 78,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11725,6 +12765,7 @@
         "id": "tile-1041",
         "x": 80,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11736,6 +12777,7 @@
         "id": "tile-1042",
         "x": 82,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11747,6 +12789,7 @@
         "id": "tile-1043",
         "x": 84,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11758,6 +12801,7 @@
         "id": "tile-1044",
         "x": 86,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11769,6 +12813,7 @@
         "id": "tile-1045",
         "x": 88,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11780,6 +12825,7 @@
         "id": "tile-1046",
         "x": 90,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11791,6 +12837,7 @@
         "id": "tile-1047",
         "x": 92,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11802,6 +12849,7 @@
         "id": "tile-1048",
         "x": 94,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11813,6 +12861,7 @@
         "id": "tile-1049",
         "x": 96,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11824,6 +12873,7 @@
         "id": "tile-1050",
         "x": 98,
         "y": 20,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11835,6 +12885,7 @@
         "id": "tile-1051",
         "x": 1,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11846,6 +12897,7 @@
         "id": "tile-1052",
         "x": 3,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11857,6 +12909,7 @@
         "id": "tile-1053",
         "x": 5,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11868,6 +12921,7 @@
         "id": "tile-1054",
         "x": 7,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11879,6 +12933,7 @@
         "id": "tile-1055",
         "x": 9,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11890,6 +12945,7 @@
         "id": "tile-1056",
         "x": 11,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11901,6 +12957,7 @@
         "id": "tile-1057",
         "x": 13,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -11912,6 +12969,7 @@
         "id": "tile-1058",
         "x": 15,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11923,6 +12981,7 @@
         "id": "tile-1059",
         "x": 17,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11934,6 +12993,7 @@
         "id": "tile-1060",
         "x": 19,
         "y": 21,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -11948,6 +13008,7 @@
         "id": "tile-1061",
         "x": 21,
         "y": 21,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -11962,6 +13023,7 @@
         "id": "tile-1062",
         "x": 23,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -11973,6 +13035,7 @@
         "id": "tile-1063",
         "x": 25,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11984,6 +13047,7 @@
         "id": "tile-1064",
         "x": 27,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -11995,6 +13059,7 @@
         "id": "tile-1065",
         "x": 29,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12006,6 +13071,7 @@
         "id": "tile-1066",
         "x": 31,
         "y": 21,
+        "continent": 0,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -12017,6 +13083,7 @@
         "id": "tile-1067",
         "x": 33,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12028,6 +13095,7 @@
         "id": "tile-1068",
         "x": 35,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12039,6 +13107,7 @@
         "id": "tile-1069",
         "x": 37,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12050,6 +13119,7 @@
         "id": "tile-1070",
         "x": 39,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12061,6 +13131,7 @@
         "id": "tile-1071",
         "x": 41,
         "y": 21,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -12072,6 +13143,7 @@
         "id": "tile-1072",
         "x": 43,
         "y": 21,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -12087,6 +13159,7 @@
         "id": "tile-1073",
         "x": 45,
         "y": 21,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -12101,6 +13174,7 @@
         "id": "tile-1074",
         "x": 47,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12112,6 +13186,7 @@
         "id": "tile-1075",
         "x": 49,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12123,6 +13198,7 @@
         "id": "tile-1076",
         "x": 51,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12134,6 +13210,7 @@
         "id": "tile-1077",
         "x": 53,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12145,6 +13222,7 @@
         "id": "tile-1078",
         "x": 55,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12156,6 +13234,7 @@
         "id": "tile-1079",
         "x": 57,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12167,6 +13246,7 @@
         "id": "tile-1080",
         "x": 59,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12178,6 +13258,7 @@
         "id": "tile-1081",
         "x": 61,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12189,6 +13270,7 @@
         "id": "tile-1082",
         "x": 63,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12200,6 +13282,7 @@
         "id": "tile-1083",
         "x": 65,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12211,6 +13294,7 @@
         "id": "tile-1084",
         "x": 67,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12222,6 +13306,7 @@
         "id": "tile-1085",
         "x": 69,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12233,6 +13318,7 @@
         "id": "tile-1086",
         "x": 71,
         "y": 21,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -12247,6 +13333,7 @@
         "id": "tile-1087",
         "x": 73,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12258,6 +13345,7 @@
         "id": "tile-1088",
         "x": 75,
         "y": 21,
+        "continent": 2,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -12272,6 +13360,7 @@
         "id": "tile-1089",
         "x": 77,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12283,6 +13372,7 @@
         "id": "tile-1090",
         "x": 79,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12294,6 +13384,7 @@
         "id": "tile-1091",
         "x": 81,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12305,6 +13396,7 @@
         "id": "tile-1092",
         "x": 83,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12316,6 +13408,7 @@
         "id": "tile-1093",
         "x": 85,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12327,6 +13420,7 @@
         "id": "tile-1094",
         "x": 87,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12338,6 +13432,7 @@
         "id": "tile-1095",
         "x": 89,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12349,6 +13444,7 @@
         "id": "tile-1096",
         "x": 91,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12360,6 +13456,7 @@
         "id": "tile-1097",
         "x": 93,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12371,6 +13468,7 @@
         "id": "tile-1098",
         "x": 95,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12382,6 +13480,7 @@
         "id": "tile-1099",
         "x": 97,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12393,6 +13492,7 @@
         "id": "tile-1100",
         "x": 99,
         "y": 21,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12404,6 +13504,7 @@
         "id": "tile-1101",
         "x": 0,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12415,6 +13516,7 @@
         "id": "tile-1102",
         "x": 2,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12426,6 +13528,7 @@
         "id": "tile-1103",
         "x": 4,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12437,6 +13540,7 @@
         "id": "tile-1104",
         "x": 6,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12448,6 +13552,7 @@
         "id": "tile-1105",
         "x": 8,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12459,6 +13564,7 @@
         "id": "tile-1106",
         "x": 10,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12470,6 +13576,7 @@
         "id": "tile-1107",
         "x": 12,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12481,6 +13588,7 @@
         "id": "tile-1108",
         "x": 14,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12492,6 +13600,7 @@
         "id": "tile-1109",
         "x": 16,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12503,6 +13612,7 @@
         "id": "tile-1110",
         "x": 18,
         "y": 22,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -12518,6 +13628,7 @@
         "id": "tile-1111",
         "x": 20,
         "y": 22,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Tobacco"
@@ -12530,6 +13641,7 @@
         "id": "tile-1112",
         "x": 22,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12541,6 +13653,7 @@
         "id": "tile-1113",
         "x": 24,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12552,6 +13665,7 @@
         "id": "tile-1114",
         "x": 26,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12563,6 +13677,7 @@
         "id": "tile-1115",
         "x": 28,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12574,6 +13689,7 @@
         "id": "tile-1116",
         "x": 30,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12585,6 +13701,7 @@
         "id": "tile-1117",
         "x": 32,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12596,6 +13713,7 @@
         "id": "tile-1118",
         "x": 34,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12607,6 +13725,7 @@
         "id": "tile-1119",
         "x": 36,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12618,6 +13737,7 @@
         "id": "tile-1120",
         "x": 38,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12629,6 +13749,7 @@
         "id": "tile-1121",
         "x": 40,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12640,6 +13761,7 @@
         "id": "tile-1122",
         "x": 42,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12651,6 +13773,7 @@
         "id": "tile-1123",
         "x": 44,
         "y": 22,
+        "continent": 1,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -12665,6 +13788,7 @@
         "id": "tile-1124",
         "x": 46,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12676,6 +13800,7 @@
         "id": "tile-1125",
         "x": 48,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12687,6 +13812,7 @@
         "id": "tile-1126",
         "x": 50,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12698,6 +13824,7 @@
         "id": "tile-1127",
         "x": 52,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12709,6 +13836,7 @@
         "id": "tile-1128",
         "x": 54,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12720,6 +13848,7 @@
         "id": "tile-1129",
         "x": 56,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12731,6 +13860,7 @@
         "id": "tile-1130",
         "x": 58,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12742,6 +13872,7 @@
         "id": "tile-1131",
         "x": 60,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12753,6 +13884,7 @@
         "id": "tile-1132",
         "x": 62,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12764,6 +13896,7 @@
         "id": "tile-1133",
         "x": 64,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12775,6 +13908,7 @@
         "id": "tile-1134",
         "x": 66,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12786,6 +13920,7 @@
         "id": "tile-1135",
         "x": 68,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12797,6 +13932,7 @@
         "id": "tile-1136",
         "x": 70,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12808,6 +13944,7 @@
         "id": "tile-1137",
         "x": 72,
         "y": 22,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -12819,6 +13956,7 @@
         "id": "tile-1138",
         "x": 74,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12830,6 +13968,7 @@
         "id": "tile-1139",
         "x": 76,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12841,6 +13980,7 @@
         "id": "tile-1140",
         "x": 78,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12852,6 +13992,7 @@
         "id": "tile-1141",
         "x": 80,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12863,6 +14004,7 @@
         "id": "tile-1142",
         "x": 82,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12874,6 +14016,7 @@
         "id": "tile-1143",
         "x": 84,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12885,6 +14028,7 @@
         "id": "tile-1144",
         "x": 86,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12896,6 +14040,7 @@
         "id": "tile-1145",
         "x": 88,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -12907,6 +14052,7 @@
         "id": "tile-1146",
         "x": 90,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -12918,6 +14064,7 @@
         "id": "tile-1147",
         "x": 92,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12929,6 +14076,7 @@
         "id": "tile-1148",
         "x": 94,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12940,6 +14088,7 @@
         "id": "tile-1149",
         "x": 96,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12951,6 +14100,7 @@
         "id": "tile-1150",
         "x": 98,
         "y": 22,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12962,6 +14112,7 @@
         "id": "tile-1151",
         "x": 1,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12973,6 +14124,7 @@
         "id": "tile-1152",
         "x": 3,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12984,6 +14136,7 @@
         "id": "tile-1153",
         "x": 5,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -12995,6 +14148,7 @@
         "id": "tile-1154",
         "x": 7,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13006,6 +14160,7 @@
         "id": "tile-1155",
         "x": 9,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13017,6 +14172,7 @@
         "id": "tile-1156",
         "x": 11,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13028,6 +14184,7 @@
         "id": "tile-1157",
         "x": 13,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13039,6 +14196,7 @@
         "id": "tile-1158",
         "x": 15,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13050,6 +14208,7 @@
         "id": "tile-1159",
         "x": 17,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13061,6 +14220,7 @@
         "id": "tile-1160",
         "x": 19,
         "y": 23,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -13075,6 +14235,7 @@
         "id": "tile-1161",
         "x": 21,
         "y": 23,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -13089,6 +14250,7 @@
         "id": "tile-1162",
         "x": 23,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13100,6 +14262,7 @@
         "id": "tile-1163",
         "x": 25,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13111,6 +14274,7 @@
         "id": "tile-1164",
         "x": 27,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13122,6 +14286,7 @@
         "id": "tile-1165",
         "x": 29,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -13134,6 +14299,7 @@
         "id": "tile-1166",
         "x": 31,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13145,6 +14311,7 @@
         "id": "tile-1167",
         "x": 33,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -13157,6 +14324,7 @@
         "id": "tile-1168",
         "x": 35,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13168,6 +14336,7 @@
         "id": "tile-1169",
         "x": 37,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13179,6 +14348,7 @@
         "id": "tile-1170",
         "x": 39,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13190,6 +14360,7 @@
         "id": "tile-1171",
         "x": 41,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13201,6 +14372,7 @@
         "id": "tile-1172",
         "x": 43,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13212,6 +14384,7 @@
         "id": "tile-1173",
         "x": 45,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13223,6 +14396,7 @@
         "id": "tile-1174",
         "x": 47,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13234,6 +14408,7 @@
         "id": "tile-1175",
         "x": 49,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13245,6 +14420,7 @@
         "id": "tile-1176",
         "x": 51,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13256,6 +14432,7 @@
         "id": "tile-1177",
         "x": 53,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13267,6 +14444,7 @@
         "id": "tile-1178",
         "x": 55,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13278,6 +14456,7 @@
         "id": "tile-1179",
         "x": 57,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13289,6 +14468,7 @@
         "id": "tile-1180",
         "x": 59,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13300,6 +14480,7 @@
         "id": "tile-1181",
         "x": 61,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13311,6 +14492,7 @@
         "id": "tile-1182",
         "x": 63,
         "y": 23,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -13327,6 +14509,7 @@
         "id": "tile-1183",
         "x": 65,
         "y": 23,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -13341,6 +14524,7 @@
         "id": "tile-1184",
         "x": 67,
         "y": 23,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Tobacco",
@@ -13356,6 +14540,7 @@
         "id": "tile-1185",
         "x": 69,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13367,6 +14552,7 @@
         "id": "tile-1186",
         "x": 71,
         "y": 23,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -13378,6 +14564,7 @@
         "id": "tile-1187",
         "x": 73,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13389,6 +14576,7 @@
         "id": "tile-1188",
         "x": 75,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13400,6 +14588,7 @@
         "id": "tile-1189",
         "x": 77,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13411,6 +14600,7 @@
         "id": "tile-1190",
         "x": 79,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13422,6 +14612,7 @@
         "id": "tile-1191",
         "x": 81,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13433,6 +14624,7 @@
         "id": "tile-1192",
         "x": 83,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13444,6 +14636,7 @@
         "id": "tile-1193",
         "x": 85,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13455,6 +14648,7 @@
         "id": "tile-1194",
         "x": 87,
         "y": 23,
+        "continent": 6,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -13469,6 +14663,7 @@
         "id": "tile-1195",
         "x": 89,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13480,6 +14675,7 @@
         "id": "tile-1196",
         "x": 91,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13491,6 +14687,7 @@
         "id": "tile-1197",
         "x": 93,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13502,6 +14699,7 @@
         "id": "tile-1198",
         "x": 95,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13513,6 +14711,7 @@
         "id": "tile-1199",
         "x": 97,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13524,6 +14723,7 @@
         "id": "tile-1200",
         "x": 99,
         "y": 23,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13535,6 +14735,7 @@
         "id": "tile-1201",
         "x": 0,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13546,6 +14747,7 @@
         "id": "tile-1202",
         "x": 2,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13557,6 +14759,7 @@
         "id": "tile-1203",
         "x": 4,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13568,6 +14771,7 @@
         "id": "tile-1204",
         "x": 6,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13579,6 +14783,7 @@
         "id": "tile-1205",
         "x": 8,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13590,6 +14795,7 @@
         "id": "tile-1206",
         "x": 10,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13601,6 +14807,7 @@
         "id": "tile-1207",
         "x": 12,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13612,6 +14819,7 @@
         "id": "tile-1208",
         "x": 14,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13623,6 +14831,7 @@
         "id": "tile-1209",
         "x": 16,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13634,6 +14843,7 @@
         "id": "tile-1210",
         "x": 18,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13645,6 +14855,7 @@
         "id": "tile-1211",
         "x": 20,
         "y": 24,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -13659,6 +14870,7 @@
         "id": "tile-1212",
         "x": 22,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13670,6 +14882,7 @@
         "id": "tile-1213",
         "x": 24,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13681,6 +14894,7 @@
         "id": "tile-1214",
         "x": 26,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13692,6 +14906,7 @@
         "id": "tile-1215",
         "x": 28,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13703,6 +14918,7 @@
         "id": "tile-1216",
         "x": 30,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13714,6 +14930,7 @@
         "id": "tile-1217",
         "x": 32,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13725,6 +14942,7 @@
         "id": "tile-1218",
         "x": 34,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13736,6 +14954,7 @@
         "id": "tile-1219",
         "x": 36,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13747,6 +14966,7 @@
         "id": "tile-1220",
         "x": 38,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13758,6 +14978,7 @@
         "id": "tile-1221",
         "x": 40,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13769,6 +14990,7 @@
         "id": "tile-1222",
         "x": 42,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13780,6 +15002,7 @@
         "id": "tile-1223",
         "x": 44,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13791,6 +15014,7 @@
         "id": "tile-1224",
         "x": 46,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13802,6 +15026,7 @@
         "id": "tile-1225",
         "x": 48,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13813,6 +15038,7 @@
         "id": "tile-1226",
         "x": 50,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13824,6 +15050,7 @@
         "id": "tile-1227",
         "x": 52,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -13835,6 +15062,7 @@
         "id": "tile-1228",
         "x": 54,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13846,6 +15074,7 @@
         "id": "tile-1229",
         "x": 56,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13857,6 +15086,7 @@
         "id": "tile-1230",
         "x": 58,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13868,6 +15098,7 @@
         "id": "tile-1231",
         "x": 60,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13879,6 +15110,7 @@
         "id": "tile-1232",
         "x": 62,
         "y": 24,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -13895,6 +15127,7 @@
         "id": "tile-1233",
         "x": 64,
         "y": 24,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Gold",
@@ -13913,6 +15146,7 @@
         "id": "tile-1234",
         "x": 66,
         "y": 24,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -13928,6 +15162,7 @@
         "id": "tile-1235",
         "x": 68,
         "y": 24,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -13942,6 +15177,7 @@
         "id": "tile-1236",
         "x": 70,
         "y": 24,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -13956,6 +15192,7 @@
         "id": "tile-1237",
         "x": 72,
         "y": 24,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -13970,6 +15207,7 @@
         "id": "tile-1238",
         "x": 74,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -13981,6 +15219,7 @@
         "id": "tile-1239",
         "x": 76,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -13992,6 +15231,7 @@
         "id": "tile-1240",
         "x": 78,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14003,6 +15243,7 @@
         "id": "tile-1241",
         "x": 80,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14014,6 +15255,7 @@
         "id": "tile-1242",
         "x": 82,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14025,6 +15267,7 @@
         "id": "tile-1243",
         "x": 84,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14036,6 +15279,7 @@
         "id": "tile-1244",
         "x": 86,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -14047,6 +15291,7 @@
         "id": "tile-1245",
         "x": 88,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -14058,6 +15303,7 @@
         "id": "tile-1246",
         "x": 90,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14069,6 +15315,7 @@
         "id": "tile-1247",
         "x": 92,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14080,6 +15327,7 @@
         "id": "tile-1248",
         "x": 94,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14091,6 +15339,7 @@
         "id": "tile-1249",
         "x": 96,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14102,6 +15351,7 @@
         "id": "tile-1250",
         "x": 98,
         "y": 24,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14113,6 +15363,7 @@
         "id": "tile-1251",
         "x": 1,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14124,6 +15375,7 @@
         "id": "tile-1252",
         "x": 3,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14135,6 +15387,7 @@
         "id": "tile-1253",
         "x": 5,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14146,6 +15399,7 @@
         "id": "tile-1254",
         "x": 7,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14157,6 +15411,7 @@
         "id": "tile-1255",
         "x": 9,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14168,6 +15423,7 @@
         "id": "tile-1256",
         "x": 11,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14179,6 +15435,7 @@
         "id": "tile-1257",
         "x": 13,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14190,6 +15447,7 @@
         "id": "tile-1258",
         "x": 15,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14201,6 +15459,7 @@
         "id": "tile-1259",
         "x": 17,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -14212,6 +15471,7 @@
         "id": "tile-1260",
         "x": 19,
         "y": 25,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -14223,6 +15483,7 @@
         "id": "tile-1261",
         "x": 21,
         "y": 25,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -14234,6 +15495,7 @@
         "id": "tile-1262",
         "x": 23,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -14245,6 +15507,7 @@
         "id": "tile-1263",
         "x": 25,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14256,6 +15519,7 @@
         "id": "tile-1264",
         "x": 27,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14267,6 +15531,7 @@
         "id": "tile-1265",
         "x": 29,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14278,6 +15543,7 @@
         "id": "tile-1266",
         "x": 31,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14289,6 +15555,7 @@
         "id": "tile-1267",
         "x": 33,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14300,6 +15567,7 @@
         "id": "tile-1268",
         "x": 35,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14311,6 +15579,7 @@
         "id": "tile-1269",
         "x": 37,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14322,6 +15591,7 @@
         "id": "tile-1270",
         "x": 39,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14333,6 +15603,7 @@
         "id": "tile-1271",
         "x": 41,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14344,6 +15615,7 @@
         "id": "tile-1272",
         "x": 43,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14355,6 +15627,7 @@
         "id": "tile-1273",
         "x": 45,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14366,6 +15639,7 @@
         "id": "tile-1274",
         "x": 47,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14377,6 +15651,7 @@
         "id": "tile-1275",
         "x": 49,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14388,6 +15663,7 @@
         "id": "tile-1276",
         "x": 51,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14399,6 +15675,7 @@
         "id": "tile-1277",
         "x": 53,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14410,6 +15687,7 @@
         "id": "tile-1278",
         "x": 55,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -14421,6 +15699,7 @@
         "id": "tile-1279",
         "x": 57,
         "y": 25,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -14435,6 +15714,7 @@
         "id": "tile-1280",
         "x": 59,
         "y": 25,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -14449,6 +15729,7 @@
         "id": "tile-1281",
         "x": 61,
         "y": 25,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -14464,6 +15745,7 @@
         "id": "tile-1282",
         "x": 63,
         "y": 25,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -14481,6 +15763,7 @@
         "id": "tile-1283",
         "x": 65,
         "y": 25,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -14497,6 +15780,7 @@
         "id": "tile-1284",
         "x": 67,
         "y": 25,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -14511,6 +15795,7 @@
         "id": "tile-1285",
         "x": 69,
         "y": 25,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -14525,6 +15810,7 @@
         "id": "tile-1286",
         "x": 71,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -14536,6 +15822,7 @@
         "id": "tile-1287",
         "x": 73,
         "y": 25,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -14550,6 +15837,7 @@
         "id": "tile-1288",
         "x": 75,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -14561,6 +15849,7 @@
         "id": "tile-1289",
         "x": 77,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14572,6 +15861,7 @@
         "id": "tile-1290",
         "x": 79,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14583,6 +15873,7 @@
         "id": "tile-1291",
         "x": 81,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14594,6 +15885,7 @@
         "id": "tile-1292",
         "x": 83,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14605,6 +15897,7 @@
         "id": "tile-1293",
         "x": 85,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -14617,6 +15910,7 @@
         "id": "tile-1294",
         "x": 87,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -14628,6 +15922,7 @@
         "id": "tile-1295",
         "x": 89,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14639,6 +15934,7 @@
         "id": "tile-1296",
         "x": 91,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14650,6 +15946,7 @@
         "id": "tile-1297",
         "x": 93,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14661,6 +15958,7 @@
         "id": "tile-1298",
         "x": 95,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14672,6 +15970,7 @@
         "id": "tile-1299",
         "x": 97,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14683,6 +15982,7 @@
         "id": "tile-1300",
         "x": 99,
         "y": 25,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14694,6 +15994,7 @@
         "id": "tile-1301",
         "x": 0,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14705,6 +16006,7 @@
         "id": "tile-1302",
         "x": 2,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14716,6 +16018,7 @@
         "id": "tile-1303",
         "x": 4,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14727,6 +16030,7 @@
         "id": "tile-1304",
         "x": 6,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14738,6 +16042,7 @@
         "id": "tile-1305",
         "x": 8,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14749,6 +16054,7 @@
         "id": "tile-1306",
         "x": 10,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14760,6 +16066,7 @@
         "id": "tile-1307",
         "x": 12,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14771,6 +16078,7 @@
         "id": "tile-1308",
         "x": 14,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14782,6 +16090,7 @@
         "id": "tile-1309",
         "x": 16,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14793,6 +16102,7 @@
         "id": "tile-1310",
         "x": 18,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -14804,6 +16114,7 @@
         "id": "tile-1311",
         "x": 20,
         "y": 26,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -14818,6 +16129,7 @@
         "id": "tile-1312",
         "x": 22,
         "y": 26,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -14832,6 +16144,7 @@
         "id": "tile-1313",
         "x": 24,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -14843,6 +16156,7 @@
         "id": "tile-1314",
         "x": 26,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14854,6 +16168,7 @@
         "id": "tile-1315",
         "x": 28,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14865,6 +16180,7 @@
         "id": "tile-1316",
         "x": 30,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14876,6 +16192,7 @@
         "id": "tile-1317",
         "x": 32,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14887,6 +16204,7 @@
         "id": "tile-1318",
         "x": 34,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14898,6 +16216,7 @@
         "id": "tile-1319",
         "x": 36,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14909,6 +16228,7 @@
         "id": "tile-1320",
         "x": 38,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14920,6 +16240,7 @@
         "id": "tile-1321",
         "x": 40,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14931,6 +16252,7 @@
         "id": "tile-1322",
         "x": 42,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14942,6 +16264,7 @@
         "id": "tile-1323",
         "x": 44,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14953,6 +16276,7 @@
         "id": "tile-1324",
         "x": 46,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14964,6 +16288,7 @@
         "id": "tile-1325",
         "x": 48,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14975,6 +16300,7 @@
         "id": "tile-1326",
         "x": 50,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -14986,6 +16312,7 @@
         "id": "tile-1327",
         "x": 52,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -14997,6 +16324,7 @@
         "id": "tile-1328",
         "x": 54,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -15008,6 +16336,7 @@
         "id": "tile-1329",
         "x": 56,
         "y": 26,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -15019,6 +16348,7 @@
         "id": "tile-1330",
         "x": 58,
         "y": 26,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -15033,6 +16363,7 @@
         "id": "tile-1331",
         "x": 60,
         "y": 26,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Aluminum"
@@ -15045,6 +16376,7 @@
         "id": "tile-1332",
         "x": 62,
         "y": 26,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -15059,6 +16391,7 @@
         "id": "tile-1333",
         "x": 64,
         "y": 26,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -15077,6 +16410,7 @@
         "id": "tile-1334",
         "x": 66,
         "y": 26,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -15091,6 +16425,7 @@
         "id": "tile-1335",
         "x": 68,
         "y": 26,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Wheat"
@@ -15103,6 +16438,7 @@
         "id": "tile-1336",
         "x": 70,
         "y": 26,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -15118,6 +16454,7 @@
         "id": "tile-1337",
         "x": 72,
         "y": 26,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -15132,6 +16469,7 @@
         "id": "tile-1338",
         "x": 74,
         "y": 26,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -15148,6 +16486,7 @@
         "id": "tile-1339",
         "x": 76,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -15159,6 +16498,7 @@
         "id": "tile-1340",
         "x": 78,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -15170,6 +16510,7 @@
         "id": "tile-1341",
         "x": 80,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15181,6 +16522,7 @@
         "id": "tile-1342",
         "x": 82,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -15192,6 +16534,7 @@
         "id": "tile-1343",
         "x": 84,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -15203,6 +16546,7 @@
         "id": "tile-1344",
         "x": 86,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -15214,6 +16558,7 @@
         "id": "tile-1345",
         "x": 88,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -15225,6 +16570,7 @@
         "id": "tile-1346",
         "x": 90,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -15236,6 +16582,7 @@
         "id": "tile-1347",
         "x": 92,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15247,6 +16594,7 @@
         "id": "tile-1348",
         "x": 94,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15258,6 +16606,7 @@
         "id": "tile-1349",
         "x": 96,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15269,6 +16618,7 @@
         "id": "tile-1350",
         "x": 98,
         "y": 26,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15280,6 +16630,7 @@
         "id": "tile-1351",
         "x": 1,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15291,6 +16642,7 @@
         "id": "tile-1352",
         "x": 3,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15302,6 +16654,7 @@
         "id": "tile-1353",
         "x": 5,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15313,6 +16666,7 @@
         "id": "tile-1354",
         "x": 7,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15324,6 +16678,7 @@
         "id": "tile-1355",
         "x": 9,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15335,6 +16690,7 @@
         "id": "tile-1356",
         "x": 11,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15346,6 +16702,7 @@
         "id": "tile-1357",
         "x": 13,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15357,6 +16714,7 @@
         "id": "tile-1358",
         "x": 15,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -15368,6 +16726,7 @@
         "id": "tile-1359",
         "x": 17,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -15379,6 +16738,7 @@
         "id": "tile-1360",
         "x": 19,
         "y": 27,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Tobacco"
@@ -15391,6 +16751,7 @@
         "id": "tile-1361",
         "x": 21,
         "y": 27,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -15405,6 +16766,7 @@
         "id": "tile-1362",
         "x": 23,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -15416,6 +16778,7 @@
         "id": "tile-1363",
         "x": 25,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -15427,6 +16790,7 @@
         "id": "tile-1364",
         "x": 27,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15438,6 +16802,7 @@
         "id": "tile-1365",
         "x": 29,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -15449,6 +16814,7 @@
         "id": "tile-1366",
         "x": 31,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -15460,6 +16826,7 @@
         "id": "tile-1367",
         "x": 33,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15471,6 +16838,7 @@
         "id": "tile-1368",
         "x": 35,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15482,6 +16850,7 @@
         "id": "tile-1369",
         "x": 37,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15493,6 +16862,7 @@
         "id": "tile-1370",
         "x": 39,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15504,6 +16874,7 @@
         "id": "tile-1371",
         "x": 41,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15515,6 +16886,7 @@
         "id": "tile-1372",
         "x": 43,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15526,6 +16898,7 @@
         "id": "tile-1373",
         "x": 45,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15537,6 +16910,7 @@
         "id": "tile-1374",
         "x": 47,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15548,6 +16922,7 @@
         "id": "tile-1375",
         "x": 49,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15559,6 +16934,7 @@
         "id": "tile-1376",
         "x": 51,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15570,6 +16946,7 @@
         "id": "tile-1377",
         "x": 53,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -15581,6 +16958,7 @@
         "id": "tile-1378",
         "x": 55,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -15592,6 +16970,7 @@
         "id": "tile-1379",
         "x": 57,
         "y": 27,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -15606,6 +16985,7 @@
         "id": "tile-1380",
         "x": 59,
         "y": 27,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -15617,6 +16997,7 @@
         "id": "tile-1381",
         "x": 61,
         "y": 27,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -15631,6 +17012,7 @@
         "id": "tile-1382",
         "x": 63,
         "y": 27,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -15646,6 +17028,7 @@
         "id": "tile-1383",
         "x": 65,
         "y": 27,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -15663,6 +17046,7 @@
         "id": "tile-1384",
         "x": 67,
         "y": 27,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -15677,6 +17061,7 @@
         "id": "tile-1385",
         "x": 69,
         "y": 27,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -15688,6 +17073,7 @@
         "id": "tile-1386",
         "x": 71,
         "y": 27,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -15702,6 +17088,7 @@
         "id": "tile-1387",
         "x": 73,
         "y": 27,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -15719,6 +17106,7 @@
         "id": "tile-1388",
         "x": 75,
         "y": 27,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Wheat",
@@ -15735,6 +17123,7 @@
         "id": "tile-1389",
         "x": 77,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -15746,6 +17135,7 @@
         "id": "tile-1390",
         "x": 79,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -15757,6 +17147,7 @@
         "id": "tile-1391",
         "x": 81,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -15768,6 +17159,7 @@
         "id": "tile-1392",
         "x": 83,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -15779,6 +17171,7 @@
         "id": "tile-1393",
         "x": 85,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -15790,6 +17183,7 @@
         "id": "tile-1394",
         "x": 87,
         "y": 27,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -15801,6 +17195,7 @@
         "id": "tile-1395",
         "x": 89,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -15812,6 +17207,7 @@
         "id": "tile-1396",
         "x": 91,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -15823,6 +17219,7 @@
         "id": "tile-1397",
         "x": 93,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15834,6 +17231,7 @@
         "id": "tile-1398",
         "x": 95,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15845,6 +17243,7 @@
         "id": "tile-1399",
         "x": 97,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15856,6 +17255,7 @@
         "id": "tile-1400",
         "x": 99,
         "y": 27,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15867,6 +17267,7 @@
         "id": "tile-1401",
         "x": 0,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15878,6 +17279,7 @@
         "id": "tile-1402",
         "x": 2,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15889,6 +17291,7 @@
         "id": "tile-1403",
         "x": 4,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15900,6 +17303,7 @@
         "id": "tile-1404",
         "x": 6,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15911,6 +17315,7 @@
         "id": "tile-1405",
         "x": 8,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15922,6 +17327,7 @@
         "id": "tile-1406",
         "x": 10,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15933,6 +17339,7 @@
         "id": "tile-1407",
         "x": 12,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15944,6 +17351,7 @@
         "id": "tile-1408",
         "x": 14,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -15955,6 +17363,7 @@
         "id": "tile-1409",
         "x": 16,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -15966,6 +17375,7 @@
         "id": "tile-1410",
         "x": 18,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -15977,6 +17387,7 @@
         "id": "tile-1411",
         "x": 20,
         "y": 28,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -15988,6 +17399,7 @@
         "id": "tile-1412",
         "x": 22,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -15999,6 +17411,7 @@
         "id": "tile-1413",
         "x": 24,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16010,6 +17423,7 @@
         "id": "tile-1414",
         "x": 26,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16021,6 +17435,7 @@
         "id": "tile-1415",
         "x": 28,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16032,6 +17447,7 @@
         "id": "tile-1416",
         "x": 30,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16043,6 +17459,7 @@
         "id": "tile-1417",
         "x": 32,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16054,6 +17471,7 @@
         "id": "tile-1418",
         "x": 34,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16065,6 +17483,7 @@
         "id": "tile-1419",
         "x": 36,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16076,6 +17495,7 @@
         "id": "tile-1420",
         "x": 38,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16087,6 +17507,7 @@
         "id": "tile-1421",
         "x": 40,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16098,6 +17519,7 @@
         "id": "tile-1422",
         "x": 42,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16109,6 +17531,7 @@
         "id": "tile-1423",
         "x": 44,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16120,6 +17543,7 @@
         "id": "tile-1424",
         "x": 46,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16131,6 +17555,7 @@
         "id": "tile-1425",
         "x": 48,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16142,6 +17567,7 @@
         "id": "tile-1426",
         "x": 50,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16153,6 +17579,7 @@
         "id": "tile-1427",
         "x": 52,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16164,6 +17591,7 @@
         "id": "tile-1428",
         "x": 54,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -16175,6 +17603,7 @@
         "id": "tile-1429",
         "x": 56,
         "y": 28,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -16189,6 +17618,7 @@
         "id": "tile-1430",
         "x": 58,
         "y": 28,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -16203,6 +17633,7 @@
         "id": "tile-1431",
         "x": 60,
         "y": 28,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -16217,6 +17648,7 @@
         "id": "tile-1432",
         "x": 62,
         "y": 28,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Incense",
@@ -16232,6 +17664,7 @@
         "id": "tile-1433",
         "x": 64,
         "y": 28,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -16248,6 +17681,7 @@
         "id": "tile-1434",
         "x": 66,
         "y": 28,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -16262,6 +17696,7 @@
         "id": "tile-1435",
         "x": 68,
         "y": 28,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -16276,6 +17711,7 @@
         "id": "tile-1436",
         "x": 70,
         "y": 28,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -16291,6 +17727,7 @@
         "id": "tile-1437",
         "x": 72,
         "y": 28,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -16307,6 +17744,7 @@
         "id": "tile-1438",
         "x": 74,
         "y": 28,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -16323,6 +17761,7 @@
         "id": "tile-1439",
         "x": 76,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -16334,6 +17773,7 @@
         "id": "tile-1440",
         "x": 78,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16345,6 +17785,7 @@
         "id": "tile-1441",
         "x": 80,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16356,6 +17797,7 @@
         "id": "tile-1442",
         "x": 82,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16367,6 +17809,7 @@
         "id": "tile-1443",
         "x": 84,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -16378,6 +17821,7 @@
         "id": "tile-1444",
         "x": 86,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -16389,6 +17833,7 @@
         "id": "tile-1445",
         "x": 88,
         "y": 28,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -16400,6 +17845,7 @@
         "id": "tile-1446",
         "x": 90,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -16411,6 +17857,7 @@
         "id": "tile-1447",
         "x": 92,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16422,6 +17869,7 @@
         "id": "tile-1448",
         "x": 94,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16433,6 +17881,7 @@
         "id": "tile-1449",
         "x": 96,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16444,6 +17893,7 @@
         "id": "tile-1450",
         "x": 98,
         "y": 28,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16455,6 +17905,7 @@
         "id": "tile-1451",
         "x": 1,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16466,6 +17917,7 @@
         "id": "tile-1452",
         "x": 3,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16477,6 +17929,7 @@
         "id": "tile-1453",
         "x": 5,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16488,6 +17941,7 @@
         "id": "tile-1454",
         "x": 7,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16499,6 +17953,7 @@
         "id": "tile-1455",
         "x": 9,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16510,6 +17965,7 @@
         "id": "tile-1456",
         "x": 11,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16521,6 +17977,7 @@
         "id": "tile-1457",
         "x": 13,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16532,6 +17989,7 @@
         "id": "tile-1458",
         "x": 15,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16543,6 +18001,7 @@
         "id": "tile-1459",
         "x": 17,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16554,6 +18013,7 @@
         "id": "tile-1460",
         "x": 19,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -16565,6 +18025,7 @@
         "id": "tile-1461",
         "x": 21,
         "y": 29,
+        "continent": 3,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -16576,6 +18037,7 @@
         "id": "tile-1462",
         "x": 23,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -16587,6 +18049,7 @@
         "id": "tile-1463",
         "x": 25,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16598,6 +18061,7 @@
         "id": "tile-1464",
         "x": 27,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16609,6 +18073,7 @@
         "id": "tile-1465",
         "x": 29,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16620,6 +18085,7 @@
         "id": "tile-1466",
         "x": 31,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16631,6 +18097,7 @@
         "id": "tile-1467",
         "x": 33,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16642,6 +18109,7 @@
         "id": "tile-1468",
         "x": 35,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16653,6 +18121,7 @@
         "id": "tile-1469",
         "x": 37,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16664,6 +18133,7 @@
         "id": "tile-1470",
         "x": 39,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16675,6 +18145,7 @@
         "id": "tile-1471",
         "x": 41,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16686,6 +18157,7 @@
         "id": "tile-1472",
         "x": 43,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16697,6 +18169,7 @@
         "id": "tile-1473",
         "x": 45,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16708,6 +18181,7 @@
         "id": "tile-1474",
         "x": 47,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16719,6 +18193,7 @@
         "id": "tile-1475",
         "x": 49,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -16730,6 +18205,7 @@
         "id": "tile-1476",
         "x": 51,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16741,6 +18217,7 @@
         "id": "tile-1477",
         "x": 53,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -16752,6 +18229,7 @@
         "id": "tile-1478",
         "x": 55,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -16763,6 +18241,7 @@
         "id": "tile-1479",
         "x": 57,
         "y": 29,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -16777,6 +18256,7 @@
         "id": "tile-1480",
         "x": 59,
         "y": 29,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -16791,6 +18271,7 @@
         "id": "tile-1481",
         "x": 61,
         "y": 29,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -16802,6 +18283,7 @@
         "id": "tile-1482",
         "x": 63,
         "y": 29,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -16816,6 +18298,7 @@
         "id": "tile-1483",
         "x": 65,
         "y": 29,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -16832,6 +18315,7 @@
         "id": "tile-1484",
         "x": 67,
         "y": 29,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -16843,6 +18327,7 @@
         "id": "tile-1485",
         "x": 69,
         "y": 29,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -16858,6 +18343,7 @@
         "id": "tile-1486",
         "x": 71,
         "y": 29,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "resource": "Wheat",
@@ -16877,6 +18363,7 @@
         "id": "tile-1487",
         "x": 73,
         "y": 29,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -16893,6 +18380,7 @@
         "id": "tile-1488",
         "x": 75,
         "y": 29,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -16904,6 +18392,7 @@
         "id": "tile-1489",
         "x": 77,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -16915,6 +18404,7 @@
         "id": "tile-1490",
         "x": 79,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16926,6 +18416,7 @@
         "id": "tile-1491",
         "x": 81,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16937,6 +18428,7 @@
         "id": "tile-1492",
         "x": 83,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -16948,6 +18440,7 @@
         "id": "tile-1493",
         "x": 85,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -16959,6 +18452,7 @@
         "id": "tile-1494",
         "x": 87,
         "y": 29,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Gold"
@@ -16971,6 +18465,7 @@
         "id": "tile-1495",
         "x": 89,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -16982,6 +18477,7 @@
         "id": "tile-1496",
         "x": 91,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -16993,6 +18489,7 @@
         "id": "tile-1497",
         "x": 93,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17004,6 +18501,7 @@
         "id": "tile-1498",
         "x": 95,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17015,6 +18513,7 @@
         "id": "tile-1499",
         "x": 97,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17026,6 +18525,7 @@
         "id": "tile-1500",
         "x": 99,
         "y": 29,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17037,6 +18537,7 @@
         "id": "tile-1501",
         "x": 0,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17048,6 +18549,7 @@
         "id": "tile-1502",
         "x": 2,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17059,6 +18561,7 @@
         "id": "tile-1503",
         "x": 4,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17070,6 +18573,7 @@
         "id": "tile-1504",
         "x": 6,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17081,6 +18585,7 @@
         "id": "tile-1505",
         "x": 8,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17092,6 +18597,7 @@
         "id": "tile-1506",
         "x": 10,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17103,6 +18609,7 @@
         "id": "tile-1507",
         "x": 12,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17114,6 +18621,7 @@
         "id": "tile-1508",
         "x": 14,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17125,6 +18633,7 @@
         "id": "tile-1509",
         "x": 16,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -17136,6 +18645,7 @@
         "id": "tile-1510",
         "x": 18,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -17147,6 +18657,7 @@
         "id": "tile-1511",
         "x": 20,
         "y": 30,
+        "continent": 3,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -17161,6 +18672,7 @@
         "id": "tile-1512",
         "x": 22,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -17172,6 +18684,7 @@
         "id": "tile-1513",
         "x": 24,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -17183,6 +18696,7 @@
         "id": "tile-1514",
         "x": 26,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17194,6 +18708,7 @@
         "id": "tile-1515",
         "x": 28,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -17205,6 +18720,7 @@
         "id": "tile-1516",
         "x": 30,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -17216,6 +18732,7 @@
         "id": "tile-1517",
         "x": 32,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17227,6 +18744,7 @@
         "id": "tile-1518",
         "x": 34,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17238,6 +18756,7 @@
         "id": "tile-1519",
         "x": 36,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17249,6 +18768,7 @@
         "id": "tile-1520",
         "x": 38,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17260,6 +18780,7 @@
         "id": "tile-1521",
         "x": 40,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17271,6 +18792,7 @@
         "id": "tile-1522",
         "x": 42,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17282,6 +18804,7 @@
         "id": "tile-1523",
         "x": 44,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17293,6 +18816,7 @@
         "id": "tile-1524",
         "x": 46,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17304,6 +18828,7 @@
         "id": "tile-1525",
         "x": 48,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17315,6 +18840,7 @@
         "id": "tile-1526",
         "x": 50,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -17326,6 +18852,7 @@
         "id": "tile-1527",
         "x": 52,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -17337,6 +18864,7 @@
         "id": "tile-1528",
         "x": 54,
         "y": 30,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -17348,6 +18876,7 @@
         "id": "tile-1529",
         "x": 56,
         "y": 30,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -17362,6 +18891,7 @@
         "id": "tile-1530",
         "x": 58,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -17373,6 +18903,7 @@
         "id": "tile-1531",
         "x": 60,
         "y": 30,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -17387,6 +18918,7 @@
         "id": "tile-1532",
         "x": 62,
         "y": 30,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -17398,6 +18930,7 @@
         "id": "tile-1533",
         "x": 64,
         "y": 30,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -17415,6 +18948,7 @@
         "id": "tile-1534",
         "x": 66,
         "y": 30,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -17430,6 +18964,7 @@
         "id": "tile-1535",
         "x": 68,
         "y": 30,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "resource": "Oasis"
@@ -17442,6 +18977,7 @@
         "id": "tile-1536",
         "x": 70,
         "y": 30,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -17457,6 +18993,7 @@
         "id": "tile-1537",
         "x": 72,
         "y": 30,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -17472,6 +19009,7 @@
         "id": "tile-1538",
         "x": 74,
         "y": 30,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -17486,6 +19024,7 @@
         "id": "tile-1539",
         "x": 76,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -17497,6 +19036,7 @@
         "id": "tile-1540",
         "x": 78,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -17508,6 +19048,7 @@
         "id": "tile-1541",
         "x": 80,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -17519,6 +19060,7 @@
         "id": "tile-1542",
         "x": 82,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -17530,6 +19072,7 @@
         "id": "tile-1543",
         "x": 84,
         "y": 30,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -17541,6 +19084,7 @@
         "id": "tile-1544",
         "x": 86,
         "y": 30,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -17555,6 +19099,7 @@
         "id": "tile-1545",
         "x": 88,
         "y": 30,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -17569,6 +19114,7 @@
         "id": "tile-1546",
         "x": 90,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -17580,6 +19126,7 @@
         "id": "tile-1547",
         "x": 92,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -17591,6 +19138,7 @@
         "id": "tile-1548",
         "x": 94,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17602,6 +19150,7 @@
         "id": "tile-1549",
         "x": 96,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17613,6 +19162,7 @@
         "id": "tile-1550",
         "x": 98,
         "y": 30,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17624,6 +19174,7 @@
         "id": "tile-1551",
         "x": 1,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17635,6 +19186,7 @@
         "id": "tile-1552",
         "x": 3,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17646,6 +19198,7 @@
         "id": "tile-1553",
         "x": 5,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17657,6 +19210,7 @@
         "id": "tile-1554",
         "x": 7,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17668,6 +19222,7 @@
         "id": "tile-1555",
         "x": 9,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17679,6 +19234,7 @@
         "id": "tile-1556",
         "x": 11,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17690,6 +19246,7 @@
         "id": "tile-1557",
         "x": 13,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17701,6 +19258,7 @@
         "id": "tile-1558",
         "x": 15,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17712,6 +19270,7 @@
         "id": "tile-1559",
         "x": 17,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -17723,6 +19282,7 @@
         "id": "tile-1560",
         "x": 19,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -17734,6 +19294,7 @@
         "id": "tile-1561",
         "x": 21,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -17745,6 +19306,7 @@
         "id": "tile-1562",
         "x": 23,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -17756,6 +19318,7 @@
         "id": "tile-1563",
         "x": 25,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17767,6 +19330,7 @@
         "id": "tile-1564",
         "x": 27,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -17778,6 +19342,7 @@
         "id": "tile-1565",
         "x": 29,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -17789,6 +19354,7 @@
         "id": "tile-1566",
         "x": 31,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -17800,6 +19366,7 @@
         "id": "tile-1567",
         "x": 33,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17811,6 +19378,7 @@
         "id": "tile-1568",
         "x": 35,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17822,6 +19390,7 @@
         "id": "tile-1569",
         "x": 37,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17833,6 +19402,7 @@
         "id": "tile-1570",
         "x": 39,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17844,6 +19414,7 @@
         "id": "tile-1571",
         "x": 41,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17855,6 +19426,7 @@
         "id": "tile-1572",
         "x": 43,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17866,6 +19438,7 @@
         "id": "tile-1573",
         "x": 45,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -17877,6 +19450,7 @@
         "id": "tile-1574",
         "x": 47,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -17888,6 +19462,7 @@
         "id": "tile-1575",
         "x": 49,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -17899,6 +19474,7 @@
         "id": "tile-1576",
         "x": 51,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -17910,6 +19486,7 @@
         "id": "tile-1577",
         "x": 53,
         "y": 31,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -17921,6 +19498,7 @@
         "id": "tile-1578",
         "x": 55,
         "y": 31,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -17932,6 +19510,7 @@
         "id": "tile-1579",
         "x": 57,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -17943,6 +19522,7 @@
         "id": "tile-1580",
         "x": 59,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -17954,6 +19534,7 @@
         "id": "tile-1581",
         "x": 61,
         "y": 31,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -17968,6 +19549,7 @@
         "id": "tile-1582",
         "x": 63,
         "y": 31,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -17982,6 +19564,7 @@
         "id": "tile-1583",
         "x": 65,
         "y": 31,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -17996,6 +19579,7 @@
         "id": "tile-1584",
         "x": 67,
         "y": 31,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -18010,6 +19594,7 @@
         "id": "tile-1585",
         "x": 69,
         "y": 31,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -18021,6 +19606,7 @@
         "id": "tile-1586",
         "x": 71,
         "y": 31,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -18035,6 +19621,7 @@
         "id": "tile-1587",
         "x": 73,
         "y": 31,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -18046,6 +19633,7 @@
         "id": "tile-1588",
         "x": 75,
         "y": 31,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -18060,6 +19648,7 @@
         "id": "tile-1589",
         "x": 77,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18071,6 +19660,7 @@
         "id": "tile-1590",
         "x": 79,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -18082,6 +19672,7 @@
         "id": "tile-1591",
         "x": 81,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18093,6 +19684,7 @@
         "id": "tile-1592",
         "x": 83,
         "y": 31,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -18108,6 +19700,7 @@
         "id": "tile-1593",
         "x": 85,
         "y": 31,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -18119,6 +19712,7 @@
         "id": "tile-1594",
         "x": 87,
         "y": 31,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -18133,6 +19727,7 @@
         "id": "tile-1595",
         "x": 89,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18144,6 +19739,7 @@
         "id": "tile-1596",
         "x": 91,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18155,6 +19751,7 @@
         "id": "tile-1597",
         "x": 93,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -18166,6 +19763,7 @@
         "id": "tile-1598",
         "x": 95,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18177,6 +19775,7 @@
         "id": "tile-1599",
         "x": 97,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18188,6 +19787,7 @@
         "id": "tile-1600",
         "x": 99,
         "y": 31,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18199,6 +19799,7 @@
         "id": "tile-1601",
         "x": 0,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18210,6 +19811,7 @@
         "id": "tile-1602",
         "x": 2,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18221,6 +19823,7 @@
         "id": "tile-1603",
         "x": 4,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18232,6 +19835,7 @@
         "id": "tile-1604",
         "x": 6,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18243,6 +19847,7 @@
         "id": "tile-1605",
         "x": 8,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18254,6 +19859,7 @@
         "id": "tile-1606",
         "x": 10,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18265,6 +19871,7 @@
         "id": "tile-1607",
         "x": 12,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18276,6 +19883,7 @@
         "id": "tile-1608",
         "x": 14,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18287,6 +19895,7 @@
         "id": "tile-1609",
         "x": 16,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -18298,6 +19907,7 @@
         "id": "tile-1610",
         "x": 18,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18309,6 +19919,7 @@
         "id": "tile-1611",
         "x": 20,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18320,6 +19931,7 @@
         "id": "tile-1612",
         "x": 22,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18331,6 +19943,7 @@
         "id": "tile-1613",
         "x": 24,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -18342,6 +19955,7 @@
         "id": "tile-1614",
         "x": 26,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -18353,6 +19967,7 @@
         "id": "tile-1615",
         "x": 28,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18364,6 +19979,7 @@
         "id": "tile-1616",
         "x": 30,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -18375,6 +19991,7 @@
         "id": "tile-1617",
         "x": 32,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18386,6 +20003,7 @@
         "id": "tile-1618",
         "x": 34,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18397,6 +20015,7 @@
         "id": "tile-1619",
         "x": 36,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18408,6 +20027,7 @@
         "id": "tile-1620",
         "x": 38,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18419,6 +20039,7 @@
         "id": "tile-1621",
         "x": 40,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18430,6 +20051,7 @@
         "id": "tile-1622",
         "x": 42,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18441,6 +20063,7 @@
         "id": "tile-1623",
         "x": 44,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18452,6 +20075,7 @@
         "id": "tile-1624",
         "x": 46,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18463,6 +20087,7 @@
         "id": "tile-1625",
         "x": 48,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -18474,6 +20099,7 @@
         "id": "tile-1626",
         "x": 50,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -18485,6 +20111,7 @@
         "id": "tile-1627",
         "x": 52,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18496,6 +20123,7 @@
         "id": "tile-1628",
         "x": 54,
         "y": 32,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -18507,6 +20135,7 @@
         "id": "tile-1629",
         "x": 56,
         "y": 32,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -18521,6 +20150,7 @@
         "id": "tile-1630",
         "x": 58,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18532,6 +20162,7 @@
         "id": "tile-1631",
         "x": 60,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18543,6 +20174,7 @@
         "id": "tile-1632",
         "x": 62,
         "y": 32,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -18554,6 +20186,7 @@
         "id": "tile-1633",
         "x": 64,
         "y": 32,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "resource": "Saltpeter"
@@ -18566,6 +20199,7 @@
         "id": "tile-1634",
         "x": 66,
         "y": 32,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -18577,6 +20211,7 @@
         "id": "tile-1635",
         "x": 68,
         "y": 32,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -18593,6 +20228,7 @@
         "id": "tile-1636",
         "x": 70,
         "y": 32,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -18604,6 +20240,7 @@
         "id": "tile-1637",
         "x": 72,
         "y": 32,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -18615,6 +20252,7 @@
         "id": "tile-1638",
         "x": 74,
         "y": 32,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -18626,6 +20264,7 @@
         "id": "tile-1639",
         "x": 76,
         "y": 32,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "resource": "Gems"
@@ -18638,6 +20277,7 @@
         "id": "tile-1640",
         "x": 78,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18649,6 +20289,7 @@
         "id": "tile-1641",
         "x": 80,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18660,6 +20301,7 @@
         "id": "tile-1642",
         "x": 82,
         "y": 32,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -18671,6 +20313,7 @@
         "id": "tile-1643",
         "x": 84,
         "y": 32,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -18682,6 +20325,7 @@
         "id": "tile-1644",
         "x": 86,
         "y": 32,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "resource": "Iron",
@@ -18697,6 +20341,7 @@
         "id": "tile-1645",
         "x": 88,
         "y": 32,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -18708,6 +20353,7 @@
         "id": "tile-1646",
         "x": 90,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18719,6 +20365,7 @@
         "id": "tile-1647",
         "x": 92,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18730,6 +20377,7 @@
         "id": "tile-1648",
         "x": 94,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -18741,6 +20389,7 @@
         "id": "tile-1649",
         "x": 96,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18752,6 +20401,7 @@
         "id": "tile-1650",
         "x": 98,
         "y": 32,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18763,6 +20413,7 @@
         "id": "tile-1651",
         "x": 1,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18774,6 +20425,7 @@
         "id": "tile-1652",
         "x": 3,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18785,6 +20437,7 @@
         "id": "tile-1653",
         "x": 5,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18796,6 +20449,7 @@
         "id": "tile-1654",
         "x": 7,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18807,6 +20461,7 @@
         "id": "tile-1655",
         "x": 9,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18818,6 +20473,7 @@
         "id": "tile-1656",
         "x": 11,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18829,6 +20485,7 @@
         "id": "tile-1657",
         "x": 13,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18840,6 +20497,7 @@
         "id": "tile-1658",
         "x": 15,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -18851,6 +20509,7 @@
         "id": "tile-1659",
         "x": 17,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18862,6 +20521,7 @@
         "id": "tile-1660",
         "x": 19,
         "y": 33,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -18873,6 +20533,7 @@
         "id": "tile-1661",
         "x": 21,
         "y": 33,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -18887,6 +20548,7 @@
         "id": "tile-1662",
         "x": 23,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18898,6 +20560,7 @@
         "id": "tile-1663",
         "x": 25,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -18909,6 +20572,7 @@
         "id": "tile-1664",
         "x": 27,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18920,6 +20584,7 @@
         "id": "tile-1665",
         "x": 29,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -18931,6 +20596,7 @@
         "id": "tile-1666",
         "x": 31,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -18942,6 +20608,7 @@
         "id": "tile-1667",
         "x": 33,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18953,6 +20620,7 @@
         "id": "tile-1668",
         "x": 35,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18964,6 +20632,7 @@
         "id": "tile-1669",
         "x": 37,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18975,6 +20644,7 @@
         "id": "tile-1670",
         "x": 39,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18986,6 +20656,7 @@
         "id": "tile-1671",
         "x": 41,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -18997,6 +20668,7 @@
         "id": "tile-1672",
         "x": 43,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19008,6 +20680,7 @@
         "id": "tile-1673",
         "x": 45,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19019,6 +20692,7 @@
         "id": "tile-1674",
         "x": 47,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19030,6 +20704,7 @@
         "id": "tile-1675",
         "x": 49,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -19041,6 +20716,7 @@
         "id": "tile-1676",
         "x": 51,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -19052,6 +20728,7 @@
         "id": "tile-1677",
         "x": 53,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -19063,6 +20740,7 @@
         "id": "tile-1678",
         "x": 55,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -19074,6 +20752,7 @@
         "id": "tile-1679",
         "x": 57,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -19086,6 +20765,7 @@
         "id": "tile-1680",
         "x": 59,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -19097,6 +20777,7 @@
         "id": "tile-1681",
         "x": 61,
         "y": 33,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -19111,6 +20792,7 @@
         "id": "tile-1682",
         "x": 63,
         "y": 33,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -19125,6 +20807,7 @@
         "id": "tile-1683",
         "x": 65,
         "y": 33,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -19136,6 +20819,7 @@
         "id": "tile-1684",
         "x": 67,
         "y": 33,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -19151,6 +20835,7 @@
         "id": "tile-1685",
         "x": 69,
         "y": 33,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -19167,6 +20852,7 @@
         "id": "tile-1686",
         "x": 71,
         "y": 33,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -19178,6 +20864,7 @@
         "id": "tile-1687",
         "x": 73,
         "y": 33,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "resource": "Sugar"
@@ -19190,6 +20877,7 @@
         "id": "tile-1688",
         "x": 75,
         "y": 33,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -19204,6 +20892,7 @@
         "id": "tile-1689",
         "x": 77,
         "y": 33,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -19215,6 +20904,7 @@
         "id": "tile-1690",
         "x": 79,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -19226,6 +20916,7 @@
         "id": "tile-1691",
         "x": 81,
         "y": 33,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -19240,6 +20931,7 @@
         "id": "tile-1692",
         "x": 83,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -19251,6 +20943,7 @@
         "id": "tile-1693",
         "x": 85,
         "y": 33,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -19266,6 +20959,7 @@
         "id": "tile-1694",
         "x": 87,
         "y": 33,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -19280,6 +20974,7 @@
         "id": "tile-1695",
         "x": 89,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -19291,6 +20986,7 @@
         "id": "tile-1696",
         "x": 91,
         "y": 33,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -19302,6 +20998,7 @@
         "id": "tile-1697",
         "x": 93,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -19313,6 +21010,7 @@
         "id": "tile-1698",
         "x": 95,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -19324,6 +21022,7 @@
         "id": "tile-1699",
         "x": 97,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19335,6 +21034,7 @@
         "id": "tile-1700",
         "x": 99,
         "y": 33,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19346,6 +21046,7 @@
         "id": "tile-1701",
         "x": 0,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19357,6 +21058,7 @@
         "id": "tile-1702",
         "x": 2,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19368,6 +21070,7 @@
         "id": "tile-1703",
         "x": 4,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19379,6 +21082,7 @@
         "id": "tile-1704",
         "x": 6,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19390,6 +21094,7 @@
         "id": "tile-1705",
         "x": 8,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19401,6 +21106,7 @@
         "id": "tile-1706",
         "x": 10,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19412,6 +21118,7 @@
         "id": "tile-1707",
         "x": 12,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19423,6 +21130,7 @@
         "id": "tile-1708",
         "x": 14,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -19434,6 +21142,7 @@
         "id": "tile-1709",
         "x": 16,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -19446,6 +21155,7 @@
         "id": "tile-1710",
         "x": 18,
         "y": 34,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "resource": "Oasis",
@@ -19461,6 +21171,7 @@
         "id": "tile-1711",
         "x": 20,
         "y": 34,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -19475,6 +21186,7 @@
         "id": "tile-1712",
         "x": 22,
         "y": 34,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "resource": "Oasis"
@@ -19487,6 +21199,7 @@
         "id": "tile-1713",
         "x": 24,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -19498,6 +21211,7 @@
         "id": "tile-1714",
         "x": 26,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -19509,6 +21223,7 @@
         "id": "tile-1715",
         "x": 28,
         "y": 34,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -19520,6 +21235,7 @@
         "id": "tile-1716",
         "x": 30,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -19531,6 +21247,7 @@
         "id": "tile-1717",
         "x": 32,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -19542,6 +21259,7 @@
         "id": "tile-1718",
         "x": 34,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19553,6 +21271,7 @@
         "id": "tile-1719",
         "x": 36,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19564,6 +21283,7 @@
         "id": "tile-1720",
         "x": 38,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19575,6 +21295,7 @@
         "id": "tile-1721",
         "x": 40,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19586,6 +21307,7 @@
         "id": "tile-1722",
         "x": 42,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19597,6 +21319,7 @@
         "id": "tile-1723",
         "x": 44,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19608,6 +21331,7 @@
         "id": "tile-1724",
         "x": 46,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19619,6 +21343,7 @@
         "id": "tile-1725",
         "x": 48,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19630,6 +21355,7 @@
         "id": "tile-1726",
         "x": 50,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -19641,6 +21367,7 @@
         "id": "tile-1727",
         "x": 52,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -19652,6 +21379,7 @@
         "id": "tile-1728",
         "x": 54,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -19663,6 +21391,7 @@
         "id": "tile-1729",
         "x": 56,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -19674,6 +21403,7 @@
         "id": "tile-1730",
         "x": 58,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -19685,6 +21415,7 @@
         "id": "tile-1731",
         "x": 60,
         "y": 34,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -19699,6 +21430,7 @@
         "id": "tile-1732",
         "x": 62,
         "y": 34,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "resource": "Horses"
@@ -19711,6 +21443,7 @@
         "id": "tile-1733",
         "x": 64,
         "y": 34,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -19725,6 +21458,7 @@
         "id": "tile-1734",
         "x": 66,
         "y": 34,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -19739,6 +21473,7 @@
         "id": "tile-1735",
         "x": 68,
         "y": 34,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -19757,6 +21492,7 @@
         "id": "tile-1736",
         "x": 70,
         "y": 34,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -19771,6 +21507,7 @@
         "id": "tile-1737",
         "x": 72,
         "y": 34,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -19782,6 +21519,7 @@
         "id": "tile-1738",
         "x": 74,
         "y": 34,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -19793,6 +21531,7 @@
         "id": "tile-1739",
         "x": 76,
         "y": 34,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -19804,6 +21543,7 @@
         "id": "tile-1740",
         "x": 78,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -19815,6 +21555,7 @@
         "id": "tile-1741",
         "x": 80,
         "y": 34,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -19826,6 +21567,7 @@
         "id": "tile-1742",
         "x": 82,
         "y": 34,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -19840,6 +21582,7 @@
         "id": "tile-1743",
         "x": 84,
         "y": 34,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Sugar"
@@ -19852,6 +21595,7 @@
         "id": "tile-1744",
         "x": 86,
         "y": 34,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -19863,6 +21607,7 @@
         "id": "tile-1745",
         "x": 88,
         "y": 34,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -19874,6 +21619,7 @@
         "id": "tile-1746",
         "x": 90,
         "y": 34,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "resource": "Oasis"
@@ -19886,6 +21632,7 @@
         "id": "tile-1747",
         "x": 92,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -19897,6 +21644,7 @@
         "id": "tile-1748",
         "x": 94,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -19908,6 +21656,7 @@
         "id": "tile-1749",
         "x": 96,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19919,6 +21668,7 @@
         "id": "tile-1750",
         "x": 98,
         "y": 34,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19930,6 +21680,7 @@
         "id": "tile-1751",
         "x": 1,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19941,6 +21692,7 @@
         "id": "tile-1752",
         "x": 3,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19952,6 +21704,7 @@
         "id": "tile-1753",
         "x": 5,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19963,6 +21716,7 @@
         "id": "tile-1754",
         "x": 7,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19974,6 +21728,7 @@
         "id": "tile-1755",
         "x": 9,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19985,6 +21740,7 @@
         "id": "tile-1756",
         "x": 11,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -19996,6 +21752,7 @@
         "id": "tile-1757",
         "x": 13,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -20007,6 +21764,7 @@
         "id": "tile-1758",
         "x": 15,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -20018,6 +21776,7 @@
         "id": "tile-1759",
         "x": 17,
         "y": 35,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -20029,6 +21788,7 @@
         "id": "tile-1760",
         "x": 19,
         "y": 35,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -20040,6 +21800,7 @@
         "id": "tile-1761",
         "x": 21,
         "y": 35,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -20054,6 +21815,7 @@
         "id": "tile-1762",
         "x": 23,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -20065,6 +21827,7 @@
         "id": "tile-1763",
         "x": 25,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -20076,6 +21839,7 @@
         "id": "tile-1764",
         "x": 27,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -20087,6 +21851,7 @@
         "id": "tile-1765",
         "x": 29,
         "y": 35,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Cattle"
@@ -20099,6 +21864,7 @@
         "id": "tile-1766",
         "x": 31,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -20110,6 +21876,7 @@
         "id": "tile-1767",
         "x": 33,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -20121,6 +21888,7 @@
         "id": "tile-1768",
         "x": 35,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20132,6 +21900,7 @@
         "id": "tile-1769",
         "x": 37,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20143,6 +21912,7 @@
         "id": "tile-1770",
         "x": 39,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20154,6 +21924,7 @@
         "id": "tile-1771",
         "x": 41,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20165,6 +21936,7 @@
         "id": "tile-1772",
         "x": 43,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20176,6 +21948,7 @@
         "id": "tile-1773",
         "x": 45,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20187,6 +21960,7 @@
         "id": "tile-1774",
         "x": 47,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20198,6 +21972,7 @@
         "id": "tile-1775",
         "x": 49,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -20209,6 +21984,7 @@
         "id": "tile-1776",
         "x": 51,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -20220,6 +21996,7 @@
         "id": "tile-1777",
         "x": 53,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -20231,6 +22008,7 @@
         "id": "tile-1778",
         "x": 55,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -20242,6 +22020,7 @@
         "id": "tile-1779",
         "x": 57,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -20253,6 +22032,7 @@
         "id": "tile-1780",
         "x": 59,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -20264,6 +22044,7 @@
         "id": "tile-1781",
         "x": 61,
         "y": 35,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -20275,6 +22056,7 @@
         "id": "tile-1782",
         "x": 63,
         "y": 35,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -20286,6 +22068,7 @@
         "id": "tile-1783",
         "x": 65,
         "y": 35,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -20300,6 +22083,7 @@
         "id": "tile-1784",
         "x": 67,
         "y": 35,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -20316,6 +22100,7 @@
         "id": "tile-1785",
         "x": 69,
         "y": 35,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -20331,6 +22116,7 @@
         "id": "tile-1786",
         "x": 71,
         "y": 35,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -20342,6 +22128,7 @@
         "id": "tile-1787",
         "x": 73,
         "y": 35,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -20356,6 +22143,7 @@
         "id": "tile-1788",
         "x": 75,
         "y": 35,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -20367,6 +22155,7 @@
         "id": "tile-1789",
         "x": 77,
         "y": 35,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -20382,6 +22171,7 @@
         "id": "tile-1790",
         "x": 79,
         "y": 35,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -20396,6 +22186,7 @@
         "id": "tile-1791",
         "x": 81,
         "y": 35,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "resource": "Gems",
@@ -20411,6 +22202,7 @@
         "id": "tile-1792",
         "x": 83,
         "y": 35,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -20425,6 +22217,7 @@
         "id": "tile-1793",
         "x": 85,
         "y": 35,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -20439,6 +22232,7 @@
         "id": "tile-1794",
         "x": 87,
         "y": 35,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -20450,6 +22244,7 @@
         "id": "tile-1795",
         "x": 89,
         "y": 35,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -20461,6 +22256,7 @@
         "id": "tile-1796",
         "x": 91,
         "y": 35,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -20472,6 +22268,7 @@
         "id": "tile-1797",
         "x": 93,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -20483,6 +22280,7 @@
         "id": "tile-1798",
         "x": 95,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -20494,6 +22292,7 @@
         "id": "tile-1799",
         "x": 97,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20505,6 +22304,7 @@
         "id": "tile-1800",
         "x": 99,
         "y": 35,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20516,6 +22316,7 @@
         "id": "tile-1801",
         "x": 0,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20527,6 +22328,7 @@
         "id": "tile-1802",
         "x": 2,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20538,6 +22340,7 @@
         "id": "tile-1803",
         "x": 4,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20549,6 +22352,7 @@
         "id": "tile-1804",
         "x": 6,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20560,6 +22364,7 @@
         "id": "tile-1805",
         "x": 8,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20571,6 +22376,7 @@
         "id": "tile-1806",
         "x": 10,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20582,6 +22388,7 @@
         "id": "tile-1807",
         "x": 12,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -20593,6 +22400,7 @@
         "id": "tile-1808",
         "x": 14,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -20604,6 +22412,7 @@
         "id": "tile-1809",
         "x": 16,
         "y": 36,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -20615,6 +22424,7 @@
         "id": "tile-1810",
         "x": 18,
         "y": 36,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -20626,6 +22436,7 @@
         "id": "tile-1811",
         "x": 20,
         "y": 36,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "resource": "Oasis",
@@ -20641,6 +22452,7 @@
         "id": "tile-1812",
         "x": 22,
         "y": 36,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -20655,6 +22467,7 @@
         "id": "tile-1813",
         "x": 24,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -20666,6 +22479,7 @@
         "id": "tile-1814",
         "x": 26,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -20677,6 +22491,7 @@
         "id": "tile-1815",
         "x": 28,
         "y": 36,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -20688,6 +22503,7 @@
         "id": "tile-1816",
         "x": 30,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -20699,6 +22515,7 @@
         "id": "tile-1817",
         "x": 32,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -20710,6 +22527,7 @@
         "id": "tile-1818",
         "x": 34,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -20721,6 +22539,7 @@
         "id": "tile-1819",
         "x": 36,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20732,6 +22551,7 @@
         "id": "tile-1820",
         "x": 38,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20743,6 +22563,7 @@
         "id": "tile-1821",
         "x": 40,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20754,6 +22575,7 @@
         "id": "tile-1822",
         "x": 42,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20765,6 +22587,7 @@
         "id": "tile-1823",
         "x": 44,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20776,6 +22599,7 @@
         "id": "tile-1824",
         "x": 46,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20787,6 +22611,7 @@
         "id": "tile-1825",
         "x": 48,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20798,6 +22623,7 @@
         "id": "tile-1826",
         "x": 50,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -20809,6 +22635,7 @@
         "id": "tile-1827",
         "x": 52,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -20820,6 +22647,7 @@
         "id": "tile-1828",
         "x": 54,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -20831,6 +22659,7 @@
         "id": "tile-1829",
         "x": 56,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -20842,6 +22671,7 @@
         "id": "tile-1830",
         "x": 58,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -20853,6 +22683,7 @@
         "id": "tile-1831",
         "x": 60,
         "y": 36,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -20864,6 +22695,7 @@
         "id": "tile-1832",
         "x": 62,
         "y": 36,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -20875,6 +22707,7 @@
         "id": "tile-1833",
         "x": 64,
         "y": 36,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "resource": "Gems"
@@ -20887,6 +22720,7 @@
         "id": "tile-1834",
         "x": 66,
         "y": 36,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -20903,6 +22737,7 @@
         "id": "tile-1835",
         "x": 68,
         "y": 36,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -20920,6 +22755,7 @@
         "id": "tile-1836",
         "x": 70,
         "y": 36,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -20931,6 +22767,7 @@
         "id": "tile-1837",
         "x": 72,
         "y": 36,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -20945,6 +22782,7 @@
         "id": "tile-1838",
         "x": 74,
         "y": 36,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -20956,6 +22794,7 @@
         "id": "tile-1839",
         "x": 76,
         "y": 36,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -20972,6 +22811,7 @@
         "id": "tile-1840",
         "x": 78,
         "y": 36,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -20987,6 +22827,7 @@
         "id": "tile-1841",
         "x": 80,
         "y": 36,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -21002,6 +22843,7 @@
         "id": "tile-1842",
         "x": 82,
         "y": 36,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -21016,6 +22858,7 @@
         "id": "tile-1843",
         "x": 84,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -21027,6 +22870,7 @@
         "id": "tile-1844",
         "x": 86,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -21038,6 +22882,7 @@
         "id": "tile-1845",
         "x": 88,
         "y": 36,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -21049,6 +22894,7 @@
         "id": "tile-1846",
         "x": 90,
         "y": 36,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -21060,6 +22906,7 @@
         "id": "tile-1847",
         "x": 92,
         "y": 36,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -21071,6 +22918,7 @@
         "id": "tile-1848",
         "x": 94,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -21082,6 +22930,7 @@
         "id": "tile-1849",
         "x": 96,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -21093,6 +22942,7 @@
         "id": "tile-1850",
         "x": 98,
         "y": 36,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21104,6 +22954,7 @@
         "id": "tile-1851",
         "x": 1,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21115,6 +22966,7 @@
         "id": "tile-1852",
         "x": 3,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21126,6 +22978,7 @@
         "id": "tile-1853",
         "x": 5,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21137,6 +22990,7 @@
         "id": "tile-1854",
         "x": 7,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21148,6 +23002,7 @@
         "id": "tile-1855",
         "x": 9,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21159,6 +23014,7 @@
         "id": "tile-1856",
         "x": 11,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21170,6 +23026,7 @@
         "id": "tile-1857",
         "x": 13,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -21181,6 +23038,7 @@
         "id": "tile-1858",
         "x": 15,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -21192,6 +23050,7 @@
         "id": "tile-1859",
         "x": 17,
         "y": 37,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -21203,6 +23062,7 @@
         "id": "tile-1860",
         "x": 19,
         "y": 37,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "resource": "Oasis"
@@ -21215,6 +23075,7 @@
         "id": "tile-1861",
         "x": 21,
         "y": 37,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -21226,6 +23087,7 @@
         "id": "tile-1862",
         "x": 23,
         "y": 37,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -21237,6 +23099,7 @@
         "id": "tile-1863",
         "x": 25,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -21248,6 +23111,7 @@
         "id": "tile-1864",
         "x": 27,
         "y": 37,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "resource": "Uranium"
@@ -21260,6 +23124,7 @@
         "id": "tile-1865",
         "x": 29,
         "y": 37,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -21271,6 +23136,7 @@
         "id": "tile-1866",
         "x": 31,
         "y": 37,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -21282,6 +23148,7 @@
         "id": "tile-1867",
         "x": 33,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -21293,6 +23160,7 @@
         "id": "tile-1868",
         "x": 35,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -21304,6 +23172,7 @@
         "id": "tile-1869",
         "x": 37,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21315,6 +23184,7 @@
         "id": "tile-1870",
         "x": 39,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21326,6 +23196,7 @@
         "id": "tile-1871",
         "x": 41,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21337,6 +23208,7 @@
         "id": "tile-1872",
         "x": 43,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21348,6 +23220,7 @@
         "id": "tile-1873",
         "x": 45,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21359,6 +23232,7 @@
         "id": "tile-1874",
         "x": 47,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21370,6 +23244,7 @@
         "id": "tile-1875",
         "x": 49,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21381,6 +23256,7 @@
         "id": "tile-1876",
         "x": 51,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21392,6 +23268,7 @@
         "id": "tile-1877",
         "x": 53,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21403,6 +23280,7 @@
         "id": "tile-1878",
         "x": 55,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21414,6 +23292,7 @@
         "id": "tile-1879",
         "x": 57,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -21425,6 +23304,7 @@
         "id": "tile-1880",
         "x": 59,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -21436,6 +23316,7 @@
         "id": "tile-1881",
         "x": 61,
         "y": 37,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -21447,6 +23328,7 @@
         "id": "tile-1882",
         "x": 63,
         "y": 37,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -21458,6 +23340,7 @@
         "id": "tile-1883",
         "x": 65,
         "y": 37,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "resource": "Gems",
@@ -21474,6 +23357,7 @@
         "id": "tile-1884",
         "x": 67,
         "y": 37,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -21490,6 +23374,7 @@
         "id": "tile-1885",
         "x": 69,
         "y": 37,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -21501,6 +23386,7 @@
         "id": "tile-1886",
         "x": 71,
         "y": 37,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "resource": "Game"
@@ -21513,6 +23399,7 @@
         "id": "tile-1887",
         "x": 73,
         "y": 37,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "resource": "Game"
@@ -21525,6 +23412,7 @@
         "id": "tile-1888",
         "x": 75,
         "y": 37,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -21540,6 +23428,7 @@
         "id": "tile-1889",
         "x": 77,
         "y": 37,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -21557,6 +23446,7 @@
         "id": "tile-1890",
         "x": 79,
         "y": 37,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -21571,6 +23461,7 @@
         "id": "tile-1891",
         "x": 81,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -21582,6 +23473,7 @@
         "id": "tile-1892",
         "x": 83,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -21593,6 +23485,7 @@
         "id": "tile-1893",
         "x": 85,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -21604,6 +23497,7 @@
         "id": "tile-1894",
         "x": 87,
         "y": 37,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -21618,6 +23512,7 @@
         "id": "tile-1895",
         "x": 89,
         "y": 37,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Tobacco"
@@ -21630,6 +23525,7 @@
         "id": "tile-1896",
         "x": 91,
         "y": 37,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -21641,6 +23537,7 @@
         "id": "tile-1897",
         "x": 93,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -21652,6 +23549,7 @@
         "id": "tile-1898",
         "x": 95,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -21663,6 +23561,7 @@
         "id": "tile-1899",
         "x": 97,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21674,6 +23573,7 @@
         "id": "tile-1900",
         "x": 99,
         "y": 37,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21685,6 +23585,7 @@
         "id": "tile-1901",
         "x": 0,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21696,6 +23597,7 @@
         "id": "tile-1902",
         "x": 2,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21707,6 +23609,7 @@
         "id": "tile-1903",
         "x": 4,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21718,6 +23621,7 @@
         "id": "tile-1904",
         "x": 6,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21729,6 +23633,7 @@
         "id": "tile-1905",
         "x": 8,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21740,6 +23645,7 @@
         "id": "tile-1906",
         "x": 10,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21751,6 +23657,7 @@
         "id": "tile-1907",
         "x": 12,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -21763,6 +23670,7 @@
         "id": "tile-1908",
         "x": 14,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -21774,6 +23682,7 @@
         "id": "tile-1909",
         "x": 16,
         "y": 38,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -21785,6 +23694,7 @@
         "id": "tile-1910",
         "x": 18,
         "y": 38,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "resource": "Oasis"
@@ -21797,6 +23707,7 @@
         "id": "tile-1911",
         "x": 20,
         "y": 38,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -21808,6 +23719,7 @@
         "id": "tile-1912",
         "x": 22,
         "y": 38,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -21819,6 +23731,7 @@
         "id": "tile-1913",
         "x": 24,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -21830,6 +23743,7 @@
         "id": "tile-1914",
         "x": 26,
         "y": 38,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -21841,6 +23755,7 @@
         "id": "tile-1915",
         "x": 28,
         "y": 38,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -21852,6 +23767,7 @@
         "id": "tile-1916",
         "x": 30,
         "y": 38,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -21863,6 +23779,7 @@
         "id": "tile-1917",
         "x": 32,
         "y": 38,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -21874,6 +23791,7 @@
         "id": "tile-1918",
         "x": 34,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -21885,6 +23803,7 @@
         "id": "tile-1919",
         "x": 36,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -21896,6 +23815,7 @@
         "id": "tile-1920",
         "x": 38,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21907,6 +23827,7 @@
         "id": "tile-1921",
         "x": 40,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21918,6 +23839,7 @@
         "id": "tile-1922",
         "x": 42,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21929,6 +23851,7 @@
         "id": "tile-1923",
         "x": 44,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21940,6 +23863,7 @@
         "id": "tile-1924",
         "x": 46,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21951,6 +23875,7 @@
         "id": "tile-1925",
         "x": 48,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21962,6 +23887,7 @@
         "id": "tile-1926",
         "x": 50,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21973,6 +23899,7 @@
         "id": "tile-1927",
         "x": 52,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21984,6 +23911,7 @@
         "id": "tile-1928",
         "x": 54,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -21995,6 +23923,7 @@
         "id": "tile-1929",
         "x": 56,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -22006,6 +23935,7 @@
         "id": "tile-1930",
         "x": 58,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -22018,6 +23948,7 @@
         "id": "tile-1931",
         "x": 60,
         "y": 38,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -22029,6 +23960,7 @@
         "id": "tile-1932",
         "x": 62,
         "y": 38,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Aluminum"
@@ -22041,6 +23973,7 @@
         "id": "tile-1933",
         "x": 64,
         "y": 38,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -22055,6 +23988,7 @@
         "id": "tile-1934",
         "x": 66,
         "y": 38,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -22072,6 +24006,7 @@
         "id": "tile-1935",
         "x": 68,
         "y": 38,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -22083,6 +24018,7 @@
         "id": "tile-1936",
         "x": 70,
         "y": 38,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -22094,6 +24030,7 @@
         "id": "tile-1937",
         "x": 72,
         "y": 38,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -22105,6 +24042,7 @@
         "id": "tile-1938",
         "x": 74,
         "y": 38,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -22116,6 +24054,7 @@
         "id": "tile-1939",
         "x": 76,
         "y": 38,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -22132,6 +24071,7 @@
         "id": "tile-1940",
         "x": 78,
         "y": 38,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -22149,6 +24089,7 @@
         "id": "tile-1941",
         "x": 80,
         "y": 38,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -22160,6 +24101,7 @@
         "id": "tile-1942",
         "x": 82,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -22171,6 +24113,7 @@
         "id": "tile-1943",
         "x": 84,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -22182,6 +24125,7 @@
         "id": "tile-1944",
         "x": 86,
         "y": 38,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -22193,6 +24137,7 @@
         "id": "tile-1945",
         "x": 88,
         "y": 38,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -22204,6 +24149,7 @@
         "id": "tile-1946",
         "x": 90,
         "y": 38,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -22218,6 +24164,7 @@
         "id": "tile-1947",
         "x": 92,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -22229,6 +24176,7 @@
         "id": "tile-1948",
         "x": 94,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -22240,6 +24188,7 @@
         "id": "tile-1949",
         "x": 96,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22251,6 +24200,7 @@
         "id": "tile-1950",
         "x": 98,
         "y": 38,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22262,6 +24212,7 @@
         "id": "tile-1951",
         "x": 1,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22273,6 +24224,7 @@
         "id": "tile-1952",
         "x": 3,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22284,6 +24236,7 @@
         "id": "tile-1953",
         "x": 5,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22295,6 +24248,7 @@
         "id": "tile-1954",
         "x": 7,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22306,6 +24260,7 @@
         "id": "tile-1955",
         "x": 9,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -22317,6 +24272,7 @@
         "id": "tile-1956",
         "x": 11,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -22328,6 +24284,7 @@
         "id": "tile-1957",
         "x": 13,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -22339,6 +24296,7 @@
         "id": "tile-1958",
         "x": 15,
         "y": 39,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -22350,6 +24308,7 @@
         "id": "tile-1959",
         "x": 17,
         "y": 39,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -22361,6 +24320,7 @@
         "id": "tile-1960",
         "x": 19,
         "y": 39,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -22372,6 +24332,7 @@
         "id": "tile-1961",
         "x": 21,
         "y": 39,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -22383,6 +24344,7 @@
         "id": "tile-1962",
         "x": 23,
         "y": 39,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -22394,6 +24356,7 @@
         "id": "tile-1963",
         "x": 25,
         "y": 39,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -22408,6 +24371,7 @@
         "id": "tile-1964",
         "x": 27,
         "y": 39,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -22422,6 +24386,7 @@
         "id": "tile-1965",
         "x": 29,
         "y": 39,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -22433,6 +24398,7 @@
         "id": "tile-1966",
         "x": 31,
         "y": 39,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -22444,6 +24410,7 @@
         "id": "tile-1967",
         "x": 33,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -22455,6 +24422,7 @@
         "id": "tile-1968",
         "x": 35,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -22466,6 +24434,7 @@
         "id": "tile-1969",
         "x": 37,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22477,6 +24446,7 @@
         "id": "tile-1970",
         "x": 39,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22488,6 +24458,7 @@
         "id": "tile-1971",
         "x": 41,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22499,6 +24470,7 @@
         "id": "tile-1972",
         "x": 43,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22510,6 +24482,7 @@
         "id": "tile-1973",
         "x": 45,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22521,6 +24494,7 @@
         "id": "tile-1974",
         "x": 47,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22532,6 +24506,7 @@
         "id": "tile-1975",
         "x": 49,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22543,6 +24518,7 @@
         "id": "tile-1976",
         "x": 51,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22554,6 +24530,7 @@
         "id": "tile-1977",
         "x": 53,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22565,6 +24542,7 @@
         "id": "tile-1978",
         "x": 55,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -22576,6 +24554,7 @@
         "id": "tile-1979",
         "x": 57,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -22587,6 +24566,7 @@
         "id": "tile-1980",
         "x": 59,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -22599,6 +24579,7 @@
         "id": "tile-1981",
         "x": 61,
         "y": 39,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -22610,6 +24591,7 @@
         "id": "tile-1982",
         "x": 63,
         "y": 39,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -22621,6 +24603,7 @@
         "id": "tile-1983",
         "x": 65,
         "y": 39,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -22638,6 +24621,7 @@
         "id": "tile-1984",
         "x": 67,
         "y": 39,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Gold",
@@ -22653,6 +24637,7 @@
         "id": "tile-1985",
         "x": 69,
         "y": 39,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -22667,6 +24652,7 @@
         "id": "tile-1986",
         "x": 71,
         "y": 39,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -22678,6 +24664,7 @@
         "id": "tile-1987",
         "x": 73,
         "y": 39,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -22692,6 +24679,7 @@
         "id": "tile-1988",
         "x": 75,
         "y": 39,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Horses"
@@ -22704,6 +24692,7 @@
         "id": "tile-1989",
         "x": 77,
         "y": 39,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -22720,6 +24709,7 @@
         "id": "tile-1990",
         "x": 79,
         "y": 39,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "resource": "Coal",
@@ -22736,6 +24726,7 @@
         "id": "tile-1991",
         "x": 81,
         "y": 39,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -22747,6 +24738,7 @@
         "id": "tile-1992",
         "x": 83,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -22758,6 +24750,7 @@
         "id": "tile-1993",
         "x": 85,
         "y": 39,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -22772,6 +24765,7 @@
         "id": "tile-1994",
         "x": 87,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -22783,6 +24777,7 @@
         "id": "tile-1995",
         "x": 89,
         "y": 39,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -22794,6 +24789,7 @@
         "id": "tile-1996",
         "x": 91,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -22805,6 +24801,7 @@
         "id": "tile-1997",
         "x": 93,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -22816,6 +24813,7 @@
         "id": "tile-1998",
         "x": 95,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22827,6 +24825,7 @@
         "id": "tile-1999",
         "x": 97,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22838,6 +24837,7 @@
         "id": "tile-2000",
         "x": 99,
         "y": 39,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22849,6 +24849,7 @@
         "id": "tile-2001",
         "x": 0,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22860,6 +24861,7 @@
         "id": "tile-2002",
         "x": 2,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22871,6 +24873,7 @@
         "id": "tile-2003",
         "x": 4,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22882,6 +24885,7 @@
         "id": "tile-2004",
         "x": 6,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -22893,6 +24897,7 @@
         "id": "tile-2005",
         "x": 8,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -22904,6 +24909,7 @@
         "id": "tile-2006",
         "x": 10,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -22915,6 +24921,7 @@
         "id": "tile-2007",
         "x": 12,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -22926,6 +24933,7 @@
         "id": "tile-2008",
         "x": 14,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -22937,6 +24945,7 @@
         "id": "tile-2009",
         "x": 16,
         "y": 40,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -22948,6 +24957,7 @@
         "id": "tile-2010",
         "x": 18,
         "y": 40,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -22959,6 +24969,7 @@
         "id": "tile-2011",
         "x": 20,
         "y": 40,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -22970,6 +24981,7 @@
         "id": "tile-2012",
         "x": 22,
         "y": 40,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -22981,6 +24993,7 @@
         "id": "tile-2013",
         "x": 24,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -22992,6 +25005,7 @@
         "id": "tile-2014",
         "x": 26,
         "y": 40,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -23003,6 +25017,7 @@
         "id": "tile-2015",
         "x": 28,
         "y": 40,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -23017,6 +25032,7 @@
         "id": "tile-2016",
         "x": 30,
         "y": 40,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -23028,6 +25044,7 @@
         "id": "tile-2017",
         "x": 32,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -23039,6 +25056,7 @@
         "id": "tile-2018",
         "x": 34,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -23050,6 +25068,7 @@
         "id": "tile-2019",
         "x": 36,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23061,6 +25080,7 @@
         "id": "tile-2020",
         "x": 38,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23072,6 +25092,7 @@
         "id": "tile-2021",
         "x": 40,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23083,6 +25104,7 @@
         "id": "tile-2022",
         "x": 42,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23094,6 +25116,7 @@
         "id": "tile-2023",
         "x": 44,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23105,6 +25128,7 @@
         "id": "tile-2024",
         "x": 46,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23116,6 +25140,7 @@
         "id": "tile-2025",
         "x": 48,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23127,6 +25152,7 @@
         "id": "tile-2026",
         "x": 50,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23138,6 +25164,7 @@
         "id": "tile-2027",
         "x": 52,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23149,6 +25176,7 @@
         "id": "tile-2028",
         "x": 54,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -23160,6 +25188,7 @@
         "id": "tile-2029",
         "x": 56,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -23171,6 +25200,7 @@
         "id": "tile-2030",
         "x": 58,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -23183,6 +25213,7 @@
         "id": "tile-2031",
         "x": 60,
         "y": 40,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -23194,6 +25225,7 @@
         "id": "tile-2032",
         "x": 62,
         "y": 40,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -23205,6 +25237,7 @@
         "id": "tile-2033",
         "x": 64,
         "y": 40,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -23222,6 +25255,7 @@
         "id": "tile-2034",
         "x": 66,
         "y": 40,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -23237,6 +25271,7 @@
         "id": "tile-2035",
         "x": 68,
         "y": 40,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -23248,6 +25283,7 @@
         "id": "tile-2036",
         "x": 70,
         "y": 40,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -23262,6 +25298,7 @@
         "id": "tile-2037",
         "x": 72,
         "y": 40,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -23273,6 +25310,7 @@
         "id": "tile-2038",
         "x": 74,
         "y": 40,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -23284,6 +25322,7 @@
         "id": "tile-2039",
         "x": 76,
         "y": 40,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -23298,6 +25337,7 @@
         "id": "tile-2040",
         "x": 78,
         "y": 40,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -23316,6 +25356,7 @@
         "id": "tile-2041",
         "x": 80,
         "y": 40,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -23330,6 +25371,7 @@
         "id": "tile-2042",
         "x": 82,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -23342,6 +25384,7 @@
         "id": "tile-2043",
         "x": 84,
         "y": 40,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "volcano"
       },
@@ -23353,6 +25396,7 @@
         "id": "tile-2044",
         "x": 86,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -23364,6 +25408,7 @@
         "id": "tile-2045",
         "x": 88,
         "y": 40,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -23375,6 +25420,7 @@
         "id": "tile-2046",
         "x": 90,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -23386,6 +25432,7 @@
         "id": "tile-2047",
         "x": 92,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -23397,6 +25444,7 @@
         "id": "tile-2048",
         "x": 94,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23408,6 +25456,7 @@
         "id": "tile-2049",
         "x": 96,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23419,6 +25468,7 @@
         "id": "tile-2050",
         "x": 98,
         "y": 40,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23430,6 +25480,7 @@
         "id": "tile-2051",
         "x": 1,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23441,6 +25492,7 @@
         "id": "tile-2052",
         "x": 3,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23452,6 +25504,7 @@
         "id": "tile-2053",
         "x": 5,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23463,6 +25516,7 @@
         "id": "tile-2054",
         "x": 7,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -23474,6 +25528,7 @@
         "id": "tile-2055",
         "x": 9,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -23485,6 +25540,7 @@
         "id": "tile-2056",
         "x": 11,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -23496,6 +25552,7 @@
         "id": "tile-2057",
         "x": 13,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -23507,6 +25564,7 @@
         "id": "tile-2058",
         "x": 15,
         "y": 41,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "resource": "Sugar"
@@ -23519,6 +25577,7 @@
         "id": "tile-2059",
         "x": 17,
         "y": 41,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -23530,6 +25589,7 @@
         "id": "tile-2060",
         "x": 19,
         "y": 41,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "resource": "Sugar"
@@ -23542,6 +25602,7 @@
         "id": "tile-2061",
         "x": 21,
         "y": 41,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -23553,6 +25614,7 @@
         "id": "tile-2062",
         "x": 23,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -23564,6 +25626,7 @@
         "id": "tile-2063",
         "x": 25,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -23575,6 +25638,7 @@
         "id": "tile-2064",
         "x": 27,
         "y": 41,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -23586,6 +25650,7 @@
         "id": "tile-2065",
         "x": 29,
         "y": 41,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -23600,6 +25665,7 @@
         "id": "tile-2066",
         "x": 31,
         "y": 41,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Wheat"
@@ -23612,6 +25678,7 @@
         "id": "tile-2067",
         "x": 33,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -23623,6 +25690,7 @@
         "id": "tile-2068",
         "x": 35,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -23634,6 +25702,7 @@
         "id": "tile-2069",
         "x": 37,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23645,6 +25714,7 @@
         "id": "tile-2070",
         "x": 39,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23656,6 +25726,7 @@
         "id": "tile-2071",
         "x": 41,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23667,6 +25738,7 @@
         "id": "tile-2072",
         "x": 43,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23678,6 +25750,7 @@
         "id": "tile-2073",
         "x": 45,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23689,6 +25762,7 @@
         "id": "tile-2074",
         "x": 47,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23700,6 +25774,7 @@
         "id": "tile-2075",
         "x": 49,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23711,6 +25786,7 @@
         "id": "tile-2076",
         "x": 51,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23722,6 +25798,7 @@
         "id": "tile-2077",
         "x": 53,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -23733,6 +25810,7 @@
         "id": "tile-2078",
         "x": 55,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -23745,6 +25823,7 @@
         "id": "tile-2079",
         "x": 57,
         "y": 41,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -23761,6 +25840,7 @@
         "id": "tile-2080",
         "x": 59,
         "y": 41,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "resource": "Gold"
@@ -23773,6 +25853,7 @@
         "id": "tile-2081",
         "x": 61,
         "y": 41,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -23784,6 +25865,7 @@
         "id": "tile-2082",
         "x": 63,
         "y": 41,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -23799,6 +25881,7 @@
         "id": "tile-2083",
         "x": 65,
         "y": 41,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Iron",
@@ -23816,6 +25899,7 @@
         "id": "tile-2084",
         "x": 67,
         "y": 41,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -23830,6 +25914,7 @@
         "id": "tile-2085",
         "x": 69,
         "y": 41,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -23841,6 +25926,7 @@
         "id": "tile-2086",
         "x": 71,
         "y": 41,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -23855,6 +25941,7 @@
         "id": "tile-2087",
         "x": 73,
         "y": 41,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -23866,6 +25953,7 @@
         "id": "tile-2088",
         "x": 75,
         "y": 41,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -23877,6 +25965,7 @@
         "id": "tile-2089",
         "x": 77,
         "y": 41,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "resource": "Spices",
@@ -23893,6 +25982,7 @@
         "id": "tile-2090",
         "x": 79,
         "y": 41,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -23909,6 +25999,7 @@
         "id": "tile-2091",
         "x": 81,
         "y": 41,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -23920,6 +26011,7 @@
         "id": "tile-2092",
         "x": 83,
         "y": 41,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -23931,6 +26023,7 @@
         "id": "tile-2093",
         "x": 85,
         "y": 41,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -23945,6 +26038,7 @@
         "id": "tile-2094",
         "x": 87,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -23956,6 +26050,7 @@
         "id": "tile-2095",
         "x": 89,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -23967,6 +26062,7 @@
         "id": "tile-2096",
         "x": 91,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -23978,6 +26074,7 @@
         "id": "tile-2097",
         "x": 93,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -23989,6 +26086,7 @@
         "id": "tile-2098",
         "x": 95,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24000,6 +26098,7 @@
         "id": "tile-2099",
         "x": 97,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24011,6 +26110,7 @@
         "id": "tile-2100",
         "x": 99,
         "y": 41,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24022,6 +26122,7 @@
         "id": "tile-2101",
         "x": 0,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24033,6 +26134,7 @@
         "id": "tile-2102",
         "x": 2,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24044,6 +26146,7 @@
         "id": "tile-2103",
         "x": 4,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24055,6 +26158,7 @@
         "id": "tile-2104",
         "x": 6,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -24066,6 +26170,7 @@
         "id": "tile-2105",
         "x": 8,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -24077,6 +26182,7 @@
         "id": "tile-2106",
         "x": 10,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -24088,6 +26194,7 @@
         "id": "tile-2107",
         "x": 12,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -24099,6 +26206,7 @@
         "id": "tile-2108",
         "x": 14,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -24110,6 +26218,7 @@
         "id": "tile-2109",
         "x": 16,
         "y": 42,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -24121,6 +26230,7 @@
         "id": "tile-2110",
         "x": 18,
         "y": 42,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "resource": "Sugar"
@@ -24133,6 +26243,7 @@
         "id": "tile-2111",
         "x": 20,
         "y": 42,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -24147,6 +26258,7 @@
         "id": "tile-2112",
         "x": 22,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -24158,6 +26270,7 @@
         "id": "tile-2113",
         "x": 24,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -24169,6 +26282,7 @@
         "id": "tile-2114",
         "x": 26,
         "y": 42,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -24180,6 +26294,7 @@
         "id": "tile-2115",
         "x": 28,
         "y": 42,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -24194,6 +26309,7 @@
         "id": "tile-2116",
         "x": 30,
         "y": 42,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -24205,6 +26321,7 @@
         "id": "tile-2117",
         "x": 32,
         "y": 42,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -24216,6 +26333,7 @@
         "id": "tile-2118",
         "x": 34,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -24227,6 +26345,7 @@
         "id": "tile-2119",
         "x": 36,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -24238,6 +26357,7 @@
         "id": "tile-2120",
         "x": 38,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24249,6 +26369,7 @@
         "id": "tile-2121",
         "x": 40,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24260,6 +26381,7 @@
         "id": "tile-2122",
         "x": 42,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24271,6 +26393,7 @@
         "id": "tile-2123",
         "x": 44,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24282,6 +26405,7 @@
         "id": "tile-2124",
         "x": 46,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24293,6 +26417,7 @@
         "id": "tile-2125",
         "x": 48,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24304,6 +26429,7 @@
         "id": "tile-2126",
         "x": 50,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24315,6 +26441,7 @@
         "id": "tile-2127",
         "x": 52,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -24326,6 +26453,7 @@
         "id": "tile-2128",
         "x": 54,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -24337,6 +26465,7 @@
         "id": "tile-2129",
         "x": 56,
         "y": 42,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -24352,6 +26481,7 @@
         "id": "tile-2130",
         "x": 58,
         "y": 42,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -24369,6 +26499,7 @@
         "id": "tile-2131",
         "x": 60,
         "y": 42,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -24380,6 +26511,7 @@
         "id": "tile-2132",
         "x": 62,
         "y": 42,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -24394,6 +26526,7 @@
         "id": "tile-2133",
         "x": 64,
         "y": 42,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -24411,6 +26544,7 @@
         "id": "tile-2134",
         "x": 66,
         "y": 42,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -24425,6 +26559,7 @@
         "id": "tile-2135",
         "x": 68,
         "y": 42,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -24436,6 +26571,7 @@
         "id": "tile-2136",
         "x": 70,
         "y": 42,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -24450,6 +26586,7 @@
         "id": "tile-2137",
         "x": 72,
         "y": 42,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -24461,6 +26598,7 @@
         "id": "tile-2138",
         "x": 74,
         "y": 42,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -24472,6 +26610,7 @@
         "id": "tile-2139",
         "x": 76,
         "y": 42,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -24486,6 +26625,7 @@
         "id": "tile-2140",
         "x": 78,
         "y": 42,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -24503,6 +26643,7 @@
         "id": "tile-2141",
         "x": 80,
         "y": 42,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -24514,6 +26655,7 @@
         "id": "tile-2142",
         "x": 82,
         "y": 42,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -24525,6 +26667,7 @@
         "id": "tile-2143",
         "x": 84,
         "y": 42,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -24536,6 +26679,7 @@
         "id": "tile-2144",
         "x": 86,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -24547,6 +26691,7 @@
         "id": "tile-2145",
         "x": 88,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -24558,6 +26703,7 @@
         "id": "tile-2146",
         "x": 90,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -24569,6 +26715,7 @@
         "id": "tile-2147",
         "x": 92,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24580,6 +26727,7 @@
         "id": "tile-2148",
         "x": 94,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24591,6 +26739,7 @@
         "id": "tile-2149",
         "x": 96,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24602,6 +26751,7 @@
         "id": "tile-2150",
         "x": 98,
         "y": 42,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24613,6 +26763,7 @@
         "id": "tile-2151",
         "x": 1,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24624,6 +26775,7 @@
         "id": "tile-2152",
         "x": 3,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24635,6 +26787,7 @@
         "id": "tile-2153",
         "x": 5,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -24646,6 +26799,7 @@
         "id": "tile-2154",
         "x": 7,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -24657,6 +26811,7 @@
         "id": "tile-2155",
         "x": 9,
         "y": 43,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -24671,6 +26826,7 @@
         "id": "tile-2156",
         "x": 11,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -24682,6 +26838,7 @@
         "id": "tile-2157",
         "x": 13,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -24693,6 +26850,7 @@
         "id": "tile-2158",
         "x": 15,
         "y": 43,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -24704,6 +26862,7 @@
         "id": "tile-2159",
         "x": 17,
         "y": 43,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -24715,6 +26874,7 @@
         "id": "tile-2160",
         "x": 19,
         "y": 43,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -24726,6 +26886,7 @@
         "id": "tile-2161",
         "x": 21,
         "y": 43,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -24740,6 +26901,7 @@
         "id": "tile-2162",
         "x": 23,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -24751,6 +26913,7 @@
         "id": "tile-2163",
         "x": 25,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -24762,6 +26925,7 @@
         "id": "tile-2164",
         "x": 27,
         "y": 43,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -24773,6 +26937,7 @@
         "id": "tile-2165",
         "x": 29,
         "y": 43,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -24784,6 +26949,7 @@
         "id": "tile-2166",
         "x": 31,
         "y": 43,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -24798,6 +26964,7 @@
         "id": "tile-2167",
         "x": 33,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -24809,6 +26976,7 @@
         "id": "tile-2168",
         "x": 35,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -24820,6 +26988,7 @@
         "id": "tile-2169",
         "x": 37,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24831,6 +27000,7 @@
         "id": "tile-2170",
         "x": 39,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24842,6 +27012,7 @@
         "id": "tile-2171",
         "x": 41,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24853,6 +27024,7 @@
         "id": "tile-2172",
         "x": 43,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24864,6 +27036,7 @@
         "id": "tile-2173",
         "x": 45,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24875,6 +27048,7 @@
         "id": "tile-2174",
         "x": 47,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24886,6 +27060,7 @@
         "id": "tile-2175",
         "x": 49,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -24897,6 +27072,7 @@
         "id": "tile-2176",
         "x": 51,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -24908,6 +27084,7 @@
         "id": "tile-2177",
         "x": 53,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -24919,6 +27096,7 @@
         "id": "tile-2178",
         "x": 55,
         "y": 43,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -24933,6 +27111,7 @@
         "id": "tile-2179",
         "x": 57,
         "y": 43,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -24949,6 +27128,7 @@
         "id": "tile-2180",
         "x": 59,
         "y": 43,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -24964,6 +27144,7 @@
         "id": "tile-2181",
         "x": 61,
         "y": 43,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -24975,6 +27156,7 @@
         "id": "tile-2182",
         "x": 63,
         "y": 43,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -24993,6 +27175,7 @@
         "id": "tile-2183",
         "x": 65,
         "y": 43,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -25007,6 +27190,7 @@
         "id": "tile-2184",
         "x": 67,
         "y": 43,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -25018,6 +27202,7 @@
         "id": "tile-2185",
         "x": 69,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25029,6 +27214,7 @@
         "id": "tile-2186",
         "x": 71,
         "y": 43,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -25043,6 +27229,7 @@
         "id": "tile-2187",
         "x": 73,
         "y": 43,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -25054,6 +27241,7 @@
         "id": "tile-2188",
         "x": 75,
         "y": 43,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -25065,6 +27253,7 @@
         "id": "tile-2189",
         "x": 77,
         "y": 43,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -25082,6 +27271,7 @@
         "id": "tile-2190",
         "x": 79,
         "y": 43,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -25096,6 +27286,7 @@
         "id": "tile-2191",
         "x": 81,
         "y": 43,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -25110,6 +27301,7 @@
         "id": "tile-2192",
         "x": 83,
         "y": 43,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "volcano"
       },
@@ -25121,6 +27313,7 @@
         "id": "tile-2193",
         "x": 85,
         "y": 43,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -25135,6 +27328,7 @@
         "id": "tile-2194",
         "x": 87,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25146,6 +27340,7 @@
         "id": "tile-2195",
         "x": 89,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -25157,6 +27352,7 @@
         "id": "tile-2196",
         "x": 91,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25168,6 +27364,7 @@
         "id": "tile-2197",
         "x": 93,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25179,6 +27376,7 @@
         "id": "tile-2198",
         "x": 95,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25190,6 +27388,7 @@
         "id": "tile-2199",
         "x": 97,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25201,6 +27400,7 @@
         "id": "tile-2200",
         "x": 99,
         "y": 43,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25212,6 +27412,7 @@
         "id": "tile-2201",
         "x": 0,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25223,6 +27424,7 @@
         "id": "tile-2202",
         "x": 2,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25234,6 +27436,7 @@
         "id": "tile-2203",
         "x": 4,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -25245,6 +27448,7 @@
         "id": "tile-2204",
         "x": 6,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25256,6 +27460,7 @@
         "id": "tile-2205",
         "x": 8,
         "y": 44,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -25271,6 +27476,7 @@
         "id": "tile-2206",
         "x": 10,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25282,6 +27488,7 @@
         "id": "tile-2207",
         "x": 12,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25293,6 +27500,7 @@
         "id": "tile-2208",
         "x": 14,
         "y": 44,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -25304,6 +27512,7 @@
         "id": "tile-2209",
         "x": 16,
         "y": 44,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "resource": "Horses"
@@ -25316,6 +27525,7 @@
         "id": "tile-2210",
         "x": 18,
         "y": 44,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -25327,6 +27537,7 @@
         "id": "tile-2211",
         "x": 20,
         "y": 44,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Wines"
@@ -25339,6 +27550,7 @@
         "id": "tile-2212",
         "x": 22,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25350,6 +27562,7 @@
         "id": "tile-2213",
         "x": 24,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -25361,6 +27574,7 @@
         "id": "tile-2214",
         "x": 26,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25372,6 +27586,7 @@
         "id": "tile-2215",
         "x": 28,
         "y": 44,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "resource": "Game"
@@ -25384,6 +27599,7 @@
         "id": "tile-2216",
         "x": 30,
         "y": 44,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -25395,6 +27611,7 @@
         "id": "tile-2217",
         "x": 32,
         "y": 44,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -25406,6 +27623,7 @@
         "id": "tile-2218",
         "x": 34,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25417,6 +27635,7 @@
         "id": "tile-2219",
         "x": 36,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -25428,6 +27647,7 @@
         "id": "tile-2220",
         "x": 38,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25439,6 +27659,7 @@
         "id": "tile-2221",
         "x": 40,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25450,6 +27671,7 @@
         "id": "tile-2222",
         "x": 42,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25461,6 +27683,7 @@
         "id": "tile-2223",
         "x": 44,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25472,6 +27695,7 @@
         "id": "tile-2224",
         "x": 46,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25483,6 +27707,7 @@
         "id": "tile-2225",
         "x": 48,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25494,6 +27719,7 @@
         "id": "tile-2226",
         "x": 50,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -25505,6 +27731,7 @@
         "id": "tile-2227",
         "x": 52,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25516,6 +27743,7 @@
         "id": "tile-2228",
         "x": 54,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25527,6 +27755,7 @@
         "id": "tile-2229",
         "x": 56,
         "y": 44,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "resource": "Spices"
@@ -25539,6 +27768,7 @@
         "id": "tile-2230",
         "x": 58,
         "y": 44,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -25556,6 +27786,7 @@
         "id": "tile-2231",
         "x": 60,
         "y": 44,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Saltpeter",
@@ -25571,6 +27802,7 @@
         "id": "tile-2232",
         "x": 62,
         "y": 44,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -25588,6 +27820,7 @@
         "id": "tile-2233",
         "x": 64,
         "y": 44,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -25604,6 +27837,7 @@
         "id": "tile-2234",
         "x": 66,
         "y": 44,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -25618,6 +27852,7 @@
         "id": "tile-2235",
         "x": 68,
         "y": 44,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -25629,6 +27864,7 @@
         "id": "tile-2236",
         "x": 70,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25640,6 +27876,7 @@
         "id": "tile-2237",
         "x": 72,
         "y": 44,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Iron"
@@ -25652,6 +27889,7 @@
         "id": "tile-2238",
         "x": 74,
         "y": 44,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -25663,6 +27901,7 @@
         "id": "tile-2239",
         "x": 76,
         "y": 44,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -25679,6 +27918,7 @@
         "id": "tile-2240",
         "x": 78,
         "y": 44,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -25695,6 +27935,7 @@
         "id": "tile-2241",
         "x": 80,
         "y": 44,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -25706,6 +27947,7 @@
         "id": "tile-2242",
         "x": 82,
         "y": 44,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -25720,6 +27962,7 @@
         "id": "tile-2243",
         "x": 84,
         "y": 44,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -25731,6 +27974,7 @@
         "id": "tile-2244",
         "x": 86,
         "y": 44,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -25745,6 +27989,7 @@
         "id": "tile-2245",
         "x": 88,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25756,6 +28001,7 @@
         "id": "tile-2246",
         "x": 90,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -25767,6 +28013,7 @@
         "id": "tile-2247",
         "x": 92,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25778,6 +28025,7 @@
         "id": "tile-2248",
         "x": 94,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25789,6 +28037,7 @@
         "id": "tile-2249",
         "x": 96,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25800,6 +28049,7 @@
         "id": "tile-2250",
         "x": 98,
         "y": 44,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25811,6 +28061,7 @@
         "id": "tile-2251",
         "x": 1,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -25822,6 +28073,7 @@
         "id": "tile-2252",
         "x": 3,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -25833,6 +28085,7 @@
         "id": "tile-2253",
         "x": 5,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25844,6 +28097,7 @@
         "id": "tile-2254",
         "x": 7,
         "y": 45,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Gold",
@@ -25860,6 +28114,7 @@
         "id": "tile-2255",
         "x": 9,
         "y": 45,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -25876,6 +28131,7 @@
         "id": "tile-2256",
         "x": 11,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25887,6 +28143,7 @@
         "id": "tile-2257",
         "x": 13,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25898,6 +28155,7 @@
         "id": "tile-2258",
         "x": 15,
         "y": 45,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -25912,6 +28170,7 @@
         "id": "tile-2259",
         "x": 17,
         "y": 45,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -25923,6 +28182,7 @@
         "id": "tile-2260",
         "x": 19,
         "y": 45,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -25937,6 +28197,7 @@
         "id": "tile-2261",
         "x": 21,
         "y": 45,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Wines"
@@ -25949,6 +28210,7 @@
         "id": "tile-2262",
         "x": 23,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25960,6 +28222,7 @@
         "id": "tile-2263",
         "x": 25,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -25971,6 +28234,7 @@
         "id": "tile-2264",
         "x": 27,
         "y": 45,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -25982,6 +28246,7 @@
         "id": "tile-2265",
         "x": 29,
         "y": 45,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -25993,6 +28258,7 @@
         "id": "tile-2266",
         "x": 31,
         "y": 45,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -26007,6 +28273,7 @@
         "id": "tile-2267",
         "x": 33,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -26018,6 +28285,7 @@
         "id": "tile-2268",
         "x": 35,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -26029,6 +28297,7 @@
         "id": "tile-2269",
         "x": 37,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26040,6 +28309,7 @@
         "id": "tile-2270",
         "x": 39,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26051,6 +28321,7 @@
         "id": "tile-2271",
         "x": 41,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26062,6 +28333,7 @@
         "id": "tile-2272",
         "x": 43,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26073,6 +28345,7 @@
         "id": "tile-2273",
         "x": 45,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26084,6 +28357,7 @@
         "id": "tile-2274",
         "x": 47,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26095,6 +28369,7 @@
         "id": "tile-2275",
         "x": 49,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -26106,6 +28381,7 @@
         "id": "tile-2276",
         "x": 51,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -26118,6 +28394,7 @@
         "id": "tile-2277",
         "x": 53,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -26129,6 +28406,7 @@
         "id": "tile-2278",
         "x": 55,
         "y": 45,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -26140,6 +28418,7 @@
         "id": "tile-2279",
         "x": 57,
         "y": 45,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -26155,6 +28434,7 @@
         "id": "tile-2280",
         "x": 59,
         "y": 45,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -26172,6 +28452,7 @@
         "id": "tile-2281",
         "x": 61,
         "y": 45,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -26188,6 +28469,7 @@
         "id": "tile-2282",
         "x": 63,
         "y": 45,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -26205,6 +28487,7 @@
         "id": "tile-2283",
         "x": 65,
         "y": 45,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -26216,6 +28499,7 @@
         "id": "tile-2284",
         "x": 67,
         "y": 45,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "resource": "Tropical Fruit"
@@ -26228,6 +28512,7 @@
         "id": "tile-2285",
         "x": 69,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -26239,6 +28524,7 @@
         "id": "tile-2286",
         "x": 71,
         "y": 45,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -26250,6 +28536,7 @@
         "id": "tile-2287",
         "x": 73,
         "y": 45,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -26264,6 +28551,7 @@
         "id": "tile-2288",
         "x": 75,
         "y": 45,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -26280,6 +28568,7 @@
         "id": "tile-2289",
         "x": 77,
         "y": 45,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -26296,6 +28585,7 @@
         "id": "tile-2290",
         "x": 79,
         "y": 45,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -26307,6 +28597,7 @@
         "id": "tile-2291",
         "x": 81,
         "y": 45,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Gold"
@@ -26319,6 +28610,7 @@
         "id": "tile-2292",
         "x": 83,
         "y": 45,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -26333,6 +28625,7 @@
         "id": "tile-2293",
         "x": 85,
         "y": 45,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Horses"
@@ -26345,6 +28638,7 @@
         "id": "tile-2294",
         "x": 87,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -26356,6 +28650,7 @@
         "id": "tile-2295",
         "x": 89,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -26367,6 +28662,7 @@
         "id": "tile-2296",
         "x": 91,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26378,6 +28674,7 @@
         "id": "tile-2297",
         "x": 93,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26389,6 +28686,7 @@
         "id": "tile-2298",
         "x": 95,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26400,6 +28698,7 @@
         "id": "tile-2299",
         "x": 97,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26411,6 +28710,7 @@
         "id": "tile-2300",
         "x": 99,
         "y": 45,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26422,6 +28722,7 @@
         "id": "tile-2301",
         "x": 0,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26433,6 +28734,7 @@
         "id": "tile-2302",
         "x": 2,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -26444,6 +28746,7 @@
         "id": "tile-2303",
         "x": 4,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -26455,6 +28758,7 @@
         "id": "tile-2304",
         "x": 6,
         "y": 46,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -26466,6 +28770,7 @@
         "id": "tile-2305",
         "x": 8,
         "y": 46,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -26482,6 +28787,7 @@
         "id": "tile-2306",
         "x": 10,
         "y": 46,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -26498,6 +28804,7 @@
         "id": "tile-2307",
         "x": 12,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -26509,6 +28816,7 @@
         "id": "tile-2308",
         "x": 14,
         "y": 46,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -26523,6 +28831,7 @@
         "id": "tile-2309",
         "x": 16,
         "y": 46,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -26534,6 +28843,7 @@
         "id": "tile-2310",
         "x": 18,
         "y": 46,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -26548,6 +28858,7 @@
         "id": "tile-2311",
         "x": 20,
         "y": 46,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Wines"
@@ -26560,6 +28871,7 @@
         "id": "tile-2312",
         "x": 22,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -26571,6 +28883,7 @@
         "id": "tile-2313",
         "x": 24,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -26582,6 +28895,7 @@
         "id": "tile-2314",
         "x": 26,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -26594,6 +28908,7 @@
         "id": "tile-2315",
         "x": 28,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -26605,6 +28920,7 @@
         "id": "tile-2316",
         "x": 30,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -26616,6 +28932,7 @@
         "id": "tile-2317",
         "x": 32,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -26627,6 +28944,7 @@
         "id": "tile-2318",
         "x": 34,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -26638,6 +28956,7 @@
         "id": "tile-2319",
         "x": 36,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26649,6 +28968,7 @@
         "id": "tile-2320",
         "x": 38,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26660,6 +28980,7 @@
         "id": "tile-2321",
         "x": 40,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26671,6 +28992,7 @@
         "id": "tile-2322",
         "x": 42,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26682,6 +29004,7 @@
         "id": "tile-2323",
         "x": 44,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26693,6 +29016,7 @@
         "id": "tile-2324",
         "x": 46,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26704,6 +29028,7 @@
         "id": "tile-2325",
         "x": 48,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -26715,6 +29040,7 @@
         "id": "tile-2326",
         "x": 50,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -26726,6 +29052,7 @@
         "id": "tile-2327",
         "x": 52,
         "y": 46,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -26737,6 +29064,7 @@
         "id": "tile-2328",
         "x": 54,
         "y": 46,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -26748,6 +29076,7 @@
         "id": "tile-2329",
         "x": 56,
         "y": 46,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -26762,6 +29091,7 @@
         "id": "tile-2330",
         "x": 58,
         "y": 46,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -26777,6 +29107,7 @@
         "id": "tile-2331",
         "x": 60,
         "y": 46,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -26796,6 +29127,7 @@
         "id": "tile-2332",
         "x": 62,
         "y": 46,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "resource": "Gold",
@@ -26813,6 +29145,7 @@
         "id": "tile-2333",
         "x": 64,
         "y": 46,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -26827,6 +29160,7 @@
         "id": "tile-2334",
         "x": 66,
         "y": 46,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -26838,6 +29172,7 @@
         "id": "tile-2335",
         "x": 68,
         "y": 46,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -26849,6 +29184,7 @@
         "id": "tile-2336",
         "x": 70,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -26860,6 +29196,7 @@
         "id": "tile-2337",
         "x": 72,
         "y": 46,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -26874,6 +29211,7 @@
         "id": "tile-2338",
         "x": 74,
         "y": 46,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -26890,6 +29228,7 @@
         "id": "tile-2339",
         "x": 76,
         "y": 46,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Cattle",
@@ -26907,6 +29246,7 @@
         "id": "tile-2340",
         "x": 78,
         "y": 46,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -26918,6 +29258,7 @@
         "id": "tile-2341",
         "x": 80,
         "y": 46,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -26932,6 +29273,7 @@
         "id": "tile-2342",
         "x": 82,
         "y": 46,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -26946,6 +29288,7 @@
         "id": "tile-2343",
         "x": 84,
         "y": 46,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -26960,6 +29303,7 @@
         "id": "tile-2344",
         "x": 86,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -26971,6 +29315,7 @@
         "id": "tile-2345",
         "x": 88,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -26983,6 +29328,7 @@
         "id": "tile-2346",
         "x": 90,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -26994,6 +29340,7 @@
         "id": "tile-2347",
         "x": 92,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27005,6 +29352,7 @@
         "id": "tile-2348",
         "x": 94,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27016,6 +29364,7 @@
         "id": "tile-2349",
         "x": 96,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27027,6 +29376,7 @@
         "id": "tile-2350",
         "x": 98,
         "y": 46,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27038,6 +29388,7 @@
         "id": "tile-2351",
         "x": 1,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27049,6 +29400,7 @@
         "id": "tile-2352",
         "x": 3,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -27060,6 +29412,7 @@
         "id": "tile-2353",
         "x": 5,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -27071,6 +29424,7 @@
         "id": "tile-2354",
         "x": 7,
         "y": 47,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -27082,6 +29436,7 @@
         "id": "tile-2355",
         "x": 9,
         "y": 47,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -27098,6 +29453,7 @@
         "id": "tile-2356",
         "x": 11,
         "y": 47,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -27113,6 +29469,7 @@
         "id": "tile-2357",
         "x": 13,
         "y": 47,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -27124,6 +29481,7 @@
         "id": "tile-2358",
         "x": 15,
         "y": 47,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -27135,6 +29493,7 @@
         "id": "tile-2359",
         "x": 17,
         "y": 47,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -27146,6 +29505,7 @@
         "id": "tile-2360",
         "x": 19,
         "y": 47,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -27160,6 +29520,7 @@
         "id": "tile-2361",
         "x": 21,
         "y": 47,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -27171,6 +29532,7 @@
         "id": "tile-2362",
         "x": 23,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -27182,6 +29544,7 @@
         "id": "tile-2363",
         "x": 25,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -27193,6 +29556,7 @@
         "id": "tile-2364",
         "x": 27,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -27204,6 +29568,7 @@
         "id": "tile-2365",
         "x": 29,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -27215,6 +29580,7 @@
         "id": "tile-2366",
         "x": 31,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -27226,6 +29592,7 @@
         "id": "tile-2367",
         "x": 33,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -27237,6 +29604,7 @@
         "id": "tile-2368",
         "x": 35,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27248,6 +29616,7 @@
         "id": "tile-2369",
         "x": 37,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27259,6 +29628,7 @@
         "id": "tile-2370",
         "x": 39,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27270,6 +29640,7 @@
         "id": "tile-2371",
         "x": 41,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27281,6 +29652,7 @@
         "id": "tile-2372",
         "x": 43,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27292,6 +29664,7 @@
         "id": "tile-2373",
         "x": 45,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27303,6 +29676,7 @@
         "id": "tile-2374",
         "x": 47,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -27314,6 +29688,7 @@
         "id": "tile-2375",
         "x": 49,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -27325,6 +29700,7 @@
         "id": "tile-2376",
         "x": 51,
         "y": 47,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Iron"
@@ -27337,6 +29713,7 @@
         "id": "tile-2377",
         "x": 53,
         "y": 47,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -27348,6 +29725,7 @@
         "id": "tile-2378",
         "x": 55,
         "y": 47,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -27359,6 +29737,7 @@
         "id": "tile-2379",
         "x": 57,
         "y": 47,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -27370,6 +29749,7 @@
         "id": "tile-2380",
         "x": 59,
         "y": 47,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -27385,6 +29765,7 @@
         "id": "tile-2381",
         "x": 61,
         "y": 47,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -27400,6 +29781,7 @@
         "id": "tile-2382",
         "x": 63,
         "y": 47,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -27411,6 +29793,7 @@
         "id": "tile-2383",
         "x": 65,
         "y": 47,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -27422,6 +29805,7 @@
         "id": "tile-2384",
         "x": 67,
         "y": 47,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -27433,6 +29817,7 @@
         "id": "tile-2385",
         "x": 69,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -27444,6 +29829,7 @@
         "id": "tile-2386",
         "x": 71,
         "y": 47,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -27458,6 +29844,7 @@
         "id": "tile-2387",
         "x": 73,
         "y": 47,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -27472,6 +29859,7 @@
         "id": "tile-2388",
         "x": 75,
         "y": 47,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -27490,6 +29878,7 @@
         "id": "tile-2389",
         "x": 77,
         "y": 47,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -27501,6 +29890,7 @@
         "id": "tile-2390",
         "x": 79,
         "y": 47,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -27515,6 +29905,7 @@
         "id": "tile-2391",
         "x": 81,
         "y": 47,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -27530,6 +29921,7 @@
         "id": "tile-2392",
         "x": 83,
         "y": 47,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -27545,6 +29937,7 @@
         "id": "tile-2393",
         "x": 85,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -27556,6 +29949,7 @@
         "id": "tile-2394",
         "x": 87,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -27567,6 +29961,7 @@
         "id": "tile-2395",
         "x": 89,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27578,6 +29973,7 @@
         "id": "tile-2396",
         "x": 91,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27589,6 +29985,7 @@
         "id": "tile-2397",
         "x": 93,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27600,6 +29997,7 @@
         "id": "tile-2398",
         "x": 95,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27611,6 +30009,7 @@
         "id": "tile-2399",
         "x": 97,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27622,6 +30021,7 @@
         "id": "tile-2400",
         "x": 99,
         "y": 47,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27633,6 +30033,7 @@
         "id": "tile-2401",
         "x": 0,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27644,6 +30045,7 @@
         "id": "tile-2402",
         "x": 2,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -27655,6 +30057,7 @@
         "id": "tile-2403",
         "x": 4,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -27666,6 +30069,7 @@
         "id": "tile-2404",
         "x": 6,
         "y": 48,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -27677,6 +30081,7 @@
         "id": "tile-2405",
         "x": 8,
         "y": 48,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Cattle"
@@ -27689,6 +30094,7 @@
         "id": "tile-2406",
         "x": 10,
         "y": 48,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -27706,6 +30112,7 @@
         "id": "tile-2407",
         "x": 12,
         "y": 48,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -27720,6 +30127,7 @@
         "id": "tile-2408",
         "x": 14,
         "y": 48,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -27731,6 +30139,7 @@
         "id": "tile-2409",
         "x": 16,
         "y": 48,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -27742,6 +30151,7 @@
         "id": "tile-2410",
         "x": 18,
         "y": 48,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -27753,6 +30163,7 @@
         "id": "tile-2411",
         "x": 20,
         "y": 48,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -27764,6 +30175,7 @@
         "id": "tile-2412",
         "x": 22,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -27775,6 +30187,7 @@
         "id": "tile-2413",
         "x": 24,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -27786,6 +30199,7 @@
         "id": "tile-2414",
         "x": 26,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -27797,6 +30211,7 @@
         "id": "tile-2415",
         "x": 28,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -27808,6 +30223,7 @@
         "id": "tile-2416",
         "x": 30,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -27819,6 +30235,7 @@
         "id": "tile-2417",
         "x": 32,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -27830,6 +30247,7 @@
         "id": "tile-2418",
         "x": 34,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27841,6 +30259,7 @@
         "id": "tile-2419",
         "x": 36,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27852,6 +30271,7 @@
         "id": "tile-2420",
         "x": 38,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27863,6 +30283,7 @@
         "id": "tile-2421",
         "x": 40,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27874,6 +30295,7 @@
         "id": "tile-2422",
         "x": 42,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27885,6 +30307,7 @@
         "id": "tile-2423",
         "x": 44,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27896,6 +30319,7 @@
         "id": "tile-2424",
         "x": 46,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -27907,6 +30331,7 @@
         "id": "tile-2425",
         "x": 48,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -27918,6 +30343,7 @@
         "id": "tile-2426",
         "x": 50,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -27929,6 +30355,7 @@
         "id": "tile-2427",
         "x": 52,
         "y": 48,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -27940,6 +30367,7 @@
         "id": "tile-2428",
         "x": 54,
         "y": 48,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -27951,6 +30379,7 @@
         "id": "tile-2429",
         "x": 56,
         "y": 48,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "resource": "Coal"
@@ -27963,6 +30392,7 @@
         "id": "tile-2430",
         "x": 58,
         "y": 48,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -27977,6 +30407,7 @@
         "id": "tile-2431",
         "x": 60,
         "y": 48,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "resource": "Tropical Fruit",
@@ -27992,6 +30423,7 @@
         "id": "tile-2432",
         "x": 62,
         "y": 48,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -28003,6 +30435,7 @@
         "id": "tile-2433",
         "x": 64,
         "y": 48,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -28018,6 +30451,7 @@
         "id": "tile-2434",
         "x": 66,
         "y": 48,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -28032,6 +30466,7 @@
         "id": "tile-2435",
         "x": 68,
         "y": 48,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -28046,6 +30481,7 @@
         "id": "tile-2436",
         "x": 70,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -28057,6 +30493,7 @@
         "id": "tile-2437",
         "x": 72,
         "y": 48,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -28068,6 +30505,7 @@
         "id": "tile-2438",
         "x": 74,
         "y": 48,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -28083,6 +30521,7 @@
         "id": "tile-2439",
         "x": 76,
         "y": 48,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -28099,6 +30538,7 @@
         "id": "tile-2440",
         "x": 78,
         "y": 48,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -28114,6 +30554,7 @@
         "id": "tile-2441",
         "x": 80,
         "y": 48,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -28131,6 +30572,7 @@
         "id": "tile-2442",
         "x": 82,
         "y": 48,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -28149,6 +30591,7 @@
         "id": "tile-2443",
         "x": 84,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -28160,6 +30603,7 @@
         "id": "tile-2444",
         "x": 86,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -28171,6 +30615,7 @@
         "id": "tile-2445",
         "x": 88,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28182,6 +30627,7 @@
         "id": "tile-2446",
         "x": 90,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28193,6 +30639,7 @@
         "id": "tile-2447",
         "x": 92,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28204,6 +30651,7 @@
         "id": "tile-2448",
         "x": 94,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28215,6 +30663,7 @@
         "id": "tile-2449",
         "x": 96,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28226,6 +30675,7 @@
         "id": "tile-2450",
         "x": 98,
         "y": 48,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28237,6 +30687,7 @@
         "id": "tile-2451",
         "x": 1,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -28248,6 +30699,7 @@
         "id": "tile-2452",
         "x": 3,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -28259,6 +30711,7 @@
         "id": "tile-2453",
         "x": 5,
         "y": 49,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -28270,6 +30723,7 @@
         "id": "tile-2454",
         "x": 7,
         "y": 49,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -28281,6 +30735,7 @@
         "id": "tile-2455",
         "x": 9,
         "y": 49,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -28295,6 +30750,7 @@
         "id": "tile-2456",
         "x": 11,
         "y": 49,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -28311,6 +30767,7 @@
         "id": "tile-2457",
         "x": 13,
         "y": 49,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -28322,6 +30779,7 @@
         "id": "tile-2458",
         "x": 15,
         "y": 49,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -28333,6 +30791,7 @@
         "id": "tile-2459",
         "x": 17,
         "y": 49,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -28347,6 +30806,7 @@
         "id": "tile-2460",
         "x": 19,
         "y": 49,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -28358,6 +30818,7 @@
         "id": "tile-2461",
         "x": 21,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -28369,6 +30830,7 @@
         "id": "tile-2462",
         "x": 23,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -28380,6 +30842,7 @@
         "id": "tile-2463",
         "x": 25,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -28391,6 +30854,7 @@
         "id": "tile-2464",
         "x": 27,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -28402,6 +30866,7 @@
         "id": "tile-2465",
         "x": 29,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -28413,6 +30878,7 @@
         "id": "tile-2466",
         "x": 31,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -28424,6 +30890,7 @@
         "id": "tile-2467",
         "x": 33,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28435,6 +30902,7 @@
         "id": "tile-2468",
         "x": 35,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28446,6 +30914,7 @@
         "id": "tile-2469",
         "x": 37,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28457,6 +30926,7 @@
         "id": "tile-2470",
         "x": 39,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28468,6 +30938,7 @@
         "id": "tile-2471",
         "x": 41,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28479,6 +30950,7 @@
         "id": "tile-2472",
         "x": 43,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28490,6 +30962,7 @@
         "id": "tile-2473",
         "x": 45,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28501,6 +30974,7 @@
         "id": "tile-2474",
         "x": 47,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -28512,6 +30986,7 @@
         "id": "tile-2475",
         "x": 49,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -28523,6 +30998,7 @@
         "id": "tile-2476",
         "x": 51,
         "y": 49,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -28534,6 +31010,7 @@
         "id": "tile-2477",
         "x": 53,
         "y": 49,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -28545,6 +31022,7 @@
         "id": "tile-2478",
         "x": 55,
         "y": 49,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -28556,6 +31034,7 @@
         "id": "tile-2479",
         "x": 57,
         "y": 49,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -28570,6 +31049,7 @@
         "id": "tile-2480",
         "x": 59,
         "y": 49,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -28581,6 +31061,7 @@
         "id": "tile-2481",
         "x": 61,
         "y": 49,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -28592,6 +31073,7 @@
         "id": "tile-2482",
         "x": 63,
         "y": 49,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -28608,6 +31090,7 @@
         "id": "tile-2483",
         "x": 65,
         "y": 49,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -28624,6 +31107,7 @@
         "id": "tile-2484",
         "x": 67,
         "y": 49,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -28635,6 +31119,7 @@
         "id": "tile-2485",
         "x": 69,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -28646,6 +31131,7 @@
         "id": "tile-2486",
         "x": 71,
         "y": 49,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "resource": "Oil"
@@ -28658,6 +31144,7 @@
         "id": "tile-2487",
         "x": 73,
         "y": 49,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -28669,6 +31156,7 @@
         "id": "tile-2488",
         "x": 75,
         "y": 49,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "resource": "Uranium",
@@ -28686,6 +31174,7 @@
         "id": "tile-2489",
         "x": 77,
         "y": 49,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -28705,6 +31194,7 @@
         "id": "tile-2490",
         "x": 79,
         "y": 49,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -28722,6 +31212,7 @@
         "id": "tile-2491",
         "x": 81,
         "y": 49,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Cattle",
@@ -28738,6 +31229,7 @@
         "id": "tile-2492",
         "x": 83,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -28749,6 +31241,7 @@
         "id": "tile-2493",
         "x": 85,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -28760,6 +31253,7 @@
         "id": "tile-2494",
         "x": 87,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28771,6 +31265,7 @@
         "id": "tile-2495",
         "x": 89,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28782,6 +31277,7 @@
         "id": "tile-2496",
         "x": 91,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28793,6 +31289,7 @@
         "id": "tile-2497",
         "x": 93,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28804,6 +31301,7 @@
         "id": "tile-2498",
         "x": 95,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28815,6 +31313,7 @@
         "id": "tile-2499",
         "x": 97,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28826,6 +31325,7 @@
         "id": "tile-2500",
         "x": 99,
         "y": 49,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28837,6 +31337,7 @@
         "id": "tile-2501",
         "x": 0,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -28848,6 +31349,7 @@
         "id": "tile-2502",
         "x": 2,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -28859,6 +31361,7 @@
         "id": "tile-2503",
         "x": 4,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -28870,6 +31373,7 @@
         "id": "tile-2504",
         "x": 6,
         "y": 50,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "resource": "Furs"
@@ -28882,6 +31386,7 @@
         "id": "tile-2505",
         "x": 8,
         "y": 50,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -28896,6 +31401,7 @@
         "id": "tile-2506",
         "x": 10,
         "y": 50,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -28914,6 +31420,7 @@
         "id": "tile-2507",
         "x": 12,
         "y": 50,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -28929,6 +31436,7 @@
         "id": "tile-2508",
         "x": 14,
         "y": 50,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -28940,6 +31448,7 @@
         "id": "tile-2509",
         "x": 16,
         "y": 50,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -28956,6 +31465,7 @@
         "id": "tile-2510",
         "x": 18,
         "y": 50,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -28967,6 +31477,7 @@
         "id": "tile-2511",
         "x": 20,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -28978,6 +31489,7 @@
         "id": "tile-2512",
         "x": 22,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -28989,6 +31501,7 @@
         "id": "tile-2513",
         "x": 24,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -29000,6 +31513,7 @@
         "id": "tile-2514",
         "x": 26,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -29011,6 +31525,7 @@
         "id": "tile-2515",
         "x": 28,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -29022,6 +31537,7 @@
         "id": "tile-2516",
         "x": 30,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29033,6 +31549,7 @@
         "id": "tile-2517",
         "x": 32,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29044,6 +31561,7 @@
         "id": "tile-2518",
         "x": 34,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29055,6 +31573,7 @@
         "id": "tile-2519",
         "x": 36,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29066,6 +31585,7 @@
         "id": "tile-2520",
         "x": 38,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29077,6 +31597,7 @@
         "id": "tile-2521",
         "x": 40,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29088,6 +31609,7 @@
         "id": "tile-2522",
         "x": 42,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29099,6 +31621,7 @@
         "id": "tile-2523",
         "x": 44,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29110,6 +31633,7 @@
         "id": "tile-2524",
         "x": 46,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -29121,6 +31645,7 @@
         "id": "tile-2525",
         "x": 48,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -29132,6 +31657,7 @@
         "id": "tile-2526",
         "x": 50,
         "y": 50,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -29146,6 +31672,7 @@
         "id": "tile-2527",
         "x": 52,
         "y": 50,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -29157,6 +31684,7 @@
         "id": "tile-2528",
         "x": 54,
         "y": 50,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -29168,6 +31696,7 @@
         "id": "tile-2529",
         "x": 56,
         "y": 50,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -29182,6 +31711,7 @@
         "id": "tile-2530",
         "x": 58,
         "y": 50,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -29193,6 +31723,7 @@
         "id": "tile-2531",
         "x": 60,
         "y": 50,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "resource": "Tropical Fruit",
@@ -29208,6 +31739,7 @@
         "id": "tile-2532",
         "x": 62,
         "y": 50,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -29224,6 +31756,7 @@
         "id": "tile-2533",
         "x": 64,
         "y": 50,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -29240,6 +31773,7 @@
         "id": "tile-2534",
         "x": 66,
         "y": 50,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -29251,6 +31785,7 @@
         "id": "tile-2535",
         "x": 68,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -29262,6 +31797,7 @@
         "id": "tile-2536",
         "x": 70,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -29273,6 +31809,7 @@
         "id": "tile-2537",
         "x": 72,
         "y": 50,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -29284,6 +31821,7 @@
         "id": "tile-2538",
         "x": 74,
         "y": 50,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -29298,6 +31836,7 @@
         "id": "tile-2539",
         "x": 76,
         "y": 50,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -29316,6 +31855,7 @@
         "id": "tile-2540",
         "x": 78,
         "y": 50,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -29332,6 +31872,7 @@
         "id": "tile-2541",
         "x": 80,
         "y": 50,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -29346,6 +31887,7 @@
         "id": "tile-2542",
         "x": 82,
         "y": 50,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -29360,6 +31902,7 @@
         "id": "tile-2543",
         "x": 84,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -29371,6 +31914,7 @@
         "id": "tile-2544",
         "x": 86,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -29382,6 +31926,7 @@
         "id": "tile-2545",
         "x": 88,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29393,6 +31938,7 @@
         "id": "tile-2546",
         "x": 90,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29404,6 +31950,7 @@
         "id": "tile-2547",
         "x": 92,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29415,6 +31962,7 @@
         "id": "tile-2548",
         "x": 94,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29426,6 +31974,7 @@
         "id": "tile-2549",
         "x": 96,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29437,6 +31986,7 @@
         "id": "tile-2550",
         "x": 98,
         "y": 50,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29448,6 +31998,7 @@
         "id": "tile-2551",
         "x": 1,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -29459,6 +32010,7 @@
         "id": "tile-2552",
         "x": 3,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -29470,6 +32022,7 @@
         "id": "tile-2553",
         "x": 5,
         "y": 51,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -29481,6 +32034,7 @@
         "id": "tile-2554",
         "x": 7,
         "y": 51,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -29492,6 +32046,7 @@
         "id": "tile-2555",
         "x": 9,
         "y": 51,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -29508,6 +32063,7 @@
         "id": "tile-2556",
         "x": 11,
         "y": 51,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -29523,6 +32079,7 @@
         "id": "tile-2557",
         "x": 13,
         "y": 51,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -29534,6 +32091,7 @@
         "id": "tile-2558",
         "x": 15,
         "y": 51,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -29550,6 +32108,7 @@
         "id": "tile-2559",
         "x": 17,
         "y": 51,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -29567,6 +32126,7 @@
         "id": "tile-2560",
         "x": 19,
         "y": 51,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -29581,6 +32141,7 @@
         "id": "tile-2561",
         "x": 21,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -29592,6 +32153,7 @@
         "id": "tile-2562",
         "x": 23,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -29603,6 +32165,7 @@
         "id": "tile-2563",
         "x": 25,
         "y": 51,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -29614,6 +32177,7 @@
         "id": "tile-2564",
         "x": 27,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -29625,6 +32189,7 @@
         "id": "tile-2565",
         "x": 29,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -29636,6 +32201,7 @@
         "id": "tile-2566",
         "x": 31,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29647,6 +32213,7 @@
         "id": "tile-2567",
         "x": 33,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29658,6 +32225,7 @@
         "id": "tile-2568",
         "x": 35,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29669,6 +32237,7 @@
         "id": "tile-2569",
         "x": 37,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29680,6 +32249,7 @@
         "id": "tile-2570",
         "x": 39,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29691,6 +32261,7 @@
         "id": "tile-2571",
         "x": 41,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29702,6 +32273,7 @@
         "id": "tile-2572",
         "x": 43,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29713,6 +32285,7 @@
         "id": "tile-2573",
         "x": 45,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29724,6 +32297,7 @@
         "id": "tile-2574",
         "x": 47,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -29735,6 +32309,7 @@
         "id": "tile-2575",
         "x": 49,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -29746,6 +32321,7 @@
         "id": "tile-2576",
         "x": 51,
         "y": 51,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -29757,6 +32333,7 @@
         "id": "tile-2577",
         "x": 53,
         "y": 51,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -29768,6 +32345,7 @@
         "id": "tile-2578",
         "x": 55,
         "y": 51,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -29779,6 +32357,7 @@
         "id": "tile-2579",
         "x": 57,
         "y": 51,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -29790,6 +32369,7 @@
         "id": "tile-2580",
         "x": 59,
         "y": 51,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -29806,6 +32386,7 @@
         "id": "tile-2581",
         "x": 61,
         "y": 51,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -29823,6 +32404,7 @@
         "id": "tile-2582",
         "x": 63,
         "y": 51,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -29839,6 +32421,7 @@
         "id": "tile-2583",
         "x": 65,
         "y": 51,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -29853,6 +32436,7 @@
         "id": "tile-2584",
         "x": 67,
         "y": 51,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -29864,6 +32448,7 @@
         "id": "tile-2585",
         "x": 69,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -29875,6 +32460,7 @@
         "id": "tile-2586",
         "x": 71,
         "y": 51,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -29886,6 +32472,7 @@
         "id": "tile-2587",
         "x": 73,
         "y": 51,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -29900,6 +32487,7 @@
         "id": "tile-2588",
         "x": 75,
         "y": 51,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -29916,6 +32504,7 @@
         "id": "tile-2589",
         "x": 77,
         "y": 51,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Wheat",
@@ -29933,6 +32522,7 @@
         "id": "tile-2590",
         "x": 79,
         "y": 51,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -29944,6 +32534,7 @@
         "id": "tile-2591",
         "x": 81,
         "y": 51,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -29955,6 +32546,7 @@
         "id": "tile-2592",
         "x": 83,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -29966,6 +32558,7 @@
         "id": "tile-2593",
         "x": 85,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -29977,6 +32570,7 @@
         "id": "tile-2594",
         "x": 87,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29988,6 +32582,7 @@
         "id": "tile-2595",
         "x": 89,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -29999,6 +32594,7 @@
         "id": "tile-2596",
         "x": 91,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30010,6 +32606,7 @@
         "id": "tile-2597",
         "x": 93,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30021,6 +32618,7 @@
         "id": "tile-2598",
         "x": 95,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30032,6 +32630,7 @@
         "id": "tile-2599",
         "x": 97,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30043,6 +32642,7 @@
         "id": "tile-2600",
         "x": 99,
         "y": 51,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30054,6 +32654,7 @@
         "id": "tile-2601",
         "x": 0,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30065,6 +32666,7 @@
         "id": "tile-2602",
         "x": 2,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -30076,6 +32678,7 @@
         "id": "tile-2603",
         "x": 4,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -30087,6 +32690,7 @@
         "id": "tile-2604",
         "x": 6,
         "y": 52,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -30098,6 +32702,7 @@
         "id": "tile-2605",
         "x": 8,
         "y": 52,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -30114,6 +32719,7 @@
         "id": "tile-2606",
         "x": 10,
         "y": 52,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -30131,6 +32737,7 @@
         "id": "tile-2607",
         "x": 12,
         "y": 52,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -30142,6 +32749,7 @@
         "id": "tile-2608",
         "x": 14,
         "y": 52,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -30156,6 +32764,7 @@
         "id": "tile-2609",
         "x": 16,
         "y": 52,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -30173,6 +32782,7 @@
         "id": "tile-2610",
         "x": 18,
         "y": 52,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "resource": "Tropical Fruit",
@@ -30191,6 +32801,7 @@
         "id": "tile-2611",
         "x": 20,
         "y": 52,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -30207,6 +32818,7 @@
         "id": "tile-2612",
         "x": 22,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -30218,6 +32830,7 @@
         "id": "tile-2613",
         "x": 24,
         "y": 52,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -30232,6 +32845,7 @@
         "id": "tile-2614",
         "x": 26,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -30243,6 +32857,7 @@
         "id": "tile-2615",
         "x": 28,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -30255,6 +32870,7 @@
         "id": "tile-2616",
         "x": 30,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30266,6 +32882,7 @@
         "id": "tile-2617",
         "x": 32,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30277,6 +32894,7 @@
         "id": "tile-2618",
         "x": 34,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30288,6 +32906,7 @@
         "id": "tile-2619",
         "x": 36,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30299,6 +32918,7 @@
         "id": "tile-2620",
         "x": 38,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30310,6 +32930,7 @@
         "id": "tile-2621",
         "x": 40,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30321,6 +32942,7 @@
         "id": "tile-2622",
         "x": 42,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30332,6 +32954,7 @@
         "id": "tile-2623",
         "x": 44,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30343,6 +32966,7 @@
         "id": "tile-2624",
         "x": 46,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30354,6 +32978,7 @@
         "id": "tile-2625",
         "x": 48,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -30365,6 +32990,7 @@
         "id": "tile-2626",
         "x": 50,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -30376,6 +33002,7 @@
         "id": "tile-2627",
         "x": 52,
         "y": 52,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -30387,6 +33014,7 @@
         "id": "tile-2628",
         "x": 54,
         "y": 52,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -30398,6 +33026,7 @@
         "id": "tile-2629",
         "x": 56,
         "y": 52,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -30412,6 +33041,7 @@
         "id": "tile-2630",
         "x": 58,
         "y": 52,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -30428,6 +33058,7 @@
         "id": "tile-2631",
         "x": 60,
         "y": 52,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "resource": "Tropical Fruit",
@@ -30446,6 +33077,7 @@
         "id": "tile-2632",
         "x": 62,
         "y": 52,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -30462,6 +33094,7 @@
         "id": "tile-2633",
         "x": 64,
         "y": 52,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -30476,6 +33109,7 @@
         "id": "tile-2634",
         "x": 66,
         "y": 52,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -30487,6 +33121,7 @@
         "id": "tile-2635",
         "x": 68,
         "y": 52,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -30498,6 +33133,7 @@
         "id": "tile-2636",
         "x": 70,
         "y": 52,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -30509,6 +33145,7 @@
         "id": "tile-2637",
         "x": 72,
         "y": 52,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "resource": "Rubber"
@@ -30521,6 +33158,7 @@
         "id": "tile-2638",
         "x": 74,
         "y": 52,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -30537,6 +33175,7 @@
         "id": "tile-2639",
         "x": 76,
         "y": 52,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -30553,6 +33192,7 @@
         "id": "tile-2640",
         "x": 78,
         "y": 52,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -30567,6 +33207,7 @@
         "id": "tile-2641",
         "x": 80,
         "y": 52,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -30581,6 +33222,7 @@
         "id": "tile-2642",
         "x": 82,
         "y": 52,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -30595,6 +33237,7 @@
         "id": "tile-2643",
         "x": 84,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -30606,6 +33249,7 @@
         "id": "tile-2644",
         "x": 86,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -30617,6 +33261,7 @@
         "id": "tile-2645",
         "x": 88,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30628,6 +33273,7 @@
         "id": "tile-2646",
         "x": 90,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30639,6 +33285,7 @@
         "id": "tile-2647",
         "x": 92,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30650,6 +33297,7 @@
         "id": "tile-2648",
         "x": 94,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30661,6 +33309,7 @@
         "id": "tile-2649",
         "x": 96,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30672,6 +33321,7 @@
         "id": "tile-2650",
         "x": 98,
         "y": 52,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30683,6 +33333,7 @@
         "id": "tile-2651",
         "x": 1,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -30694,6 +33345,7 @@
         "id": "tile-2652",
         "x": 3,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -30705,6 +33357,7 @@
         "id": "tile-2653",
         "x": 5,
         "y": 53,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "resource": "Iron"
@@ -30717,6 +33370,7 @@
         "id": "tile-2654",
         "x": 7,
         "y": 53,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -30733,6 +33387,7 @@
         "id": "tile-2655",
         "x": 9,
         "y": 53,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -30749,6 +33404,7 @@
         "id": "tile-2656",
         "x": 11,
         "y": 53,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -30760,6 +33416,7 @@
         "id": "tile-2657",
         "x": 13,
         "y": 53,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -30776,6 +33433,7 @@
         "id": "tile-2658",
         "x": 15,
         "y": 53,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -30793,6 +33451,7 @@
         "id": "tile-2659",
         "x": 17,
         "y": 53,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -30812,6 +33471,7 @@
         "id": "tile-2660",
         "x": 19,
         "y": 53,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -30830,6 +33490,7 @@
         "id": "tile-2661",
         "x": 21,
         "y": 53,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -30845,6 +33506,7 @@
         "id": "tile-2662",
         "x": 23,
         "y": 53,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -30856,6 +33518,7 @@
         "id": "tile-2663",
         "x": 25,
         "y": 53,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "resource": "Coal"
@@ -30868,6 +33531,7 @@
         "id": "tile-2664",
         "x": 27,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -30879,6 +33543,7 @@
         "id": "tile-2665",
         "x": 29,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -30890,6 +33555,7 @@
         "id": "tile-2666",
         "x": 31,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30901,6 +33567,7 @@
         "id": "tile-2667",
         "x": 33,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30912,6 +33579,7 @@
         "id": "tile-2668",
         "x": 35,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30923,6 +33591,7 @@
         "id": "tile-2669",
         "x": 37,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30934,6 +33603,7 @@
         "id": "tile-2670",
         "x": 39,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30945,6 +33615,7 @@
         "id": "tile-2671",
         "x": 41,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30956,6 +33627,7 @@
         "id": "tile-2672",
         "x": 43,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30967,6 +33639,7 @@
         "id": "tile-2673",
         "x": 45,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -30978,6 +33651,7 @@
         "id": "tile-2674",
         "x": 47,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -30989,6 +33663,7 @@
         "id": "tile-2675",
         "x": 49,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -31000,6 +33675,7 @@
         "id": "tile-2676",
         "x": 51,
         "y": 53,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -31011,6 +33687,7 @@
         "id": "tile-2677",
         "x": 53,
         "y": 53,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -31025,6 +33702,7 @@
         "id": "tile-2678",
         "x": 55,
         "y": 53,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -31040,6 +33718,7 @@
         "id": "tile-2679",
         "x": 57,
         "y": 53,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "resource": "Rubber",
@@ -31057,6 +33736,7 @@
         "id": "tile-2680",
         "x": 59,
         "y": 53,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -31074,6 +33754,7 @@
         "id": "tile-2681",
         "x": 61,
         "y": 53,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -31088,6 +33769,7 @@
         "id": "tile-2682",
         "x": 63,
         "y": 53,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -31102,6 +33784,7 @@
         "id": "tile-2683",
         "x": 65,
         "y": 53,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -31113,6 +33796,7 @@
         "id": "tile-2684",
         "x": 67,
         "y": 53,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -31127,6 +33811,7 @@
         "id": "tile-2685",
         "x": 69,
         "y": 53,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -31138,6 +33823,7 @@
         "id": "tile-2686",
         "x": 71,
         "y": 53,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -31152,6 +33838,7 @@
         "id": "tile-2687",
         "x": 73,
         "y": 53,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -31166,6 +33853,7 @@
         "id": "tile-2688",
         "x": 75,
         "y": 53,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "resource": "Spices",
@@ -31182,6 +33870,7 @@
         "id": "tile-2689",
         "x": 77,
         "y": 53,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -31193,6 +33882,7 @@
         "id": "tile-2690",
         "x": 79,
         "y": 53,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -31204,6 +33894,7 @@
         "id": "tile-2691",
         "x": 81,
         "y": 53,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -31215,6 +33906,7 @@
         "id": "tile-2692",
         "x": 83,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -31226,6 +33918,7 @@
         "id": "tile-2693",
         "x": 85,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -31237,6 +33930,7 @@
         "id": "tile-2694",
         "x": 87,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31248,6 +33942,7 @@
         "id": "tile-2695",
         "x": 89,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31259,6 +33954,7 @@
         "id": "tile-2696",
         "x": 91,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31270,6 +33966,7 @@
         "id": "tile-2697",
         "x": 93,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31281,6 +33978,7 @@
         "id": "tile-2698",
         "x": 95,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31292,6 +33990,7 @@
         "id": "tile-2699",
         "x": 97,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31303,6 +34002,7 @@
         "id": "tile-2700",
         "x": 99,
         "y": 53,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31314,6 +34014,7 @@
         "id": "tile-2701",
         "x": 0,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -31325,6 +34026,7 @@
         "id": "tile-2702",
         "x": 2,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -31336,6 +34038,7 @@
         "id": "tile-2703",
         "x": 4,
         "y": 54,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -31347,6 +34050,7 @@
         "id": "tile-2704",
         "x": 6,
         "y": 54,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -31363,6 +34067,7 @@
         "id": "tile-2705",
         "x": 8,
         "y": 54,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -31379,6 +34084,7 @@
         "id": "tile-2706",
         "x": 10,
         "y": 54,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Wheat"
@@ -31391,6 +34097,7 @@
         "id": "tile-2707",
         "x": 12,
         "y": 54,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -31407,6 +34114,7 @@
         "id": "tile-2708",
         "x": 14,
         "y": 54,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -31425,6 +34133,7 @@
         "id": "tile-2709",
         "x": 16,
         "y": 54,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -31441,6 +34150,7 @@
         "id": "tile-2710",
         "x": 18,
         "y": 54,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -31456,6 +34166,7 @@
         "id": "tile-2711",
         "x": 20,
         "y": 54,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -31472,6 +34183,7 @@
         "id": "tile-2712",
         "x": 22,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -31484,6 +34196,7 @@
         "id": "tile-2713",
         "x": 24,
         "y": 54,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -31495,6 +34208,7 @@
         "id": "tile-2714",
         "x": 26,
         "y": 54,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -31509,6 +34223,7 @@
         "id": "tile-2715",
         "x": 28,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -31520,6 +34235,7 @@
         "id": "tile-2716",
         "x": 30,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -31531,6 +34247,7 @@
         "id": "tile-2717",
         "x": 32,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31542,6 +34259,7 @@
         "id": "tile-2718",
         "x": 34,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31553,6 +34271,7 @@
         "id": "tile-2719",
         "x": 36,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31564,6 +34283,7 @@
         "id": "tile-2720",
         "x": 38,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31575,6 +34295,7 @@
         "id": "tile-2721",
         "x": 40,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31586,6 +34307,7 @@
         "id": "tile-2722",
         "x": 42,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31597,6 +34319,7 @@
         "id": "tile-2723",
         "x": 44,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31608,6 +34331,7 @@
         "id": "tile-2724",
         "x": 46,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31619,6 +34343,7 @@
         "id": "tile-2725",
         "x": 48,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -31630,6 +34355,7 @@
         "id": "tile-2726",
         "x": 50,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -31641,6 +34367,7 @@
         "id": "tile-2727",
         "x": 52,
         "y": 54,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -31652,6 +34379,7 @@
         "id": "tile-2728",
         "x": 54,
         "y": 54,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "resource": "Tropical Fruit",
@@ -31668,6 +34396,7 @@
         "id": "tile-2729",
         "x": 56,
         "y": 54,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -31685,6 +34414,7 @@
         "id": "tile-2730",
         "x": 58,
         "y": 54,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -31702,6 +34432,7 @@
         "id": "tile-2731",
         "x": 60,
         "y": 54,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -31713,6 +34444,7 @@
         "id": "tile-2732",
         "x": 62,
         "y": 54,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -31727,6 +34459,7 @@
         "id": "tile-2733",
         "x": 64,
         "y": 54,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -31738,6 +34471,7 @@
         "id": "tile-2734",
         "x": 66,
         "y": 54,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "resource": "Oil"
@@ -31750,6 +34484,7 @@
         "id": "tile-2735",
         "x": 68,
         "y": 54,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -31761,6 +34496,7 @@
         "id": "tile-2736",
         "x": 70,
         "y": 54,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -31775,6 +34511,7 @@
         "id": "tile-2737",
         "x": 72,
         "y": 54,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -31786,6 +34523,7 @@
         "id": "tile-2738",
         "x": 74,
         "y": 54,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -31797,6 +34535,7 @@
         "id": "tile-2739",
         "x": 76,
         "y": 54,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -31808,6 +34547,7 @@
         "id": "tile-2740",
         "x": 78,
         "y": 54,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -31822,6 +34562,7 @@
         "id": "tile-2741",
         "x": 80,
         "y": 54,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -31833,6 +34574,7 @@
         "id": "tile-2742",
         "x": 82,
         "y": 54,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Iron"
@@ -31845,6 +34587,7 @@
         "id": "tile-2743",
         "x": 84,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -31856,6 +34599,7 @@
         "id": "tile-2744",
         "x": 86,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -31867,6 +34611,7 @@
         "id": "tile-2745",
         "x": 88,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31878,6 +34623,7 @@
         "id": "tile-2746",
         "x": 90,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31889,6 +34635,7 @@
         "id": "tile-2747",
         "x": 92,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31900,6 +34647,7 @@
         "id": "tile-2748",
         "x": 94,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31911,6 +34659,7 @@
         "id": "tile-2749",
         "x": 96,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31922,6 +34671,7 @@
         "id": "tile-2750",
         "x": 98,
         "y": 54,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -31933,6 +34683,7 @@
         "id": "tile-2751",
         "x": 1,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -31944,6 +34695,7 @@
         "id": "tile-2752",
         "x": 3,
         "y": 55,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -31958,6 +34710,7 @@
         "id": "tile-2753",
         "x": 5,
         "y": 55,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -31974,6 +34727,7 @@
         "id": "tile-2754",
         "x": 7,
         "y": 55,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -31991,6 +34745,7 @@
         "id": "tile-2755",
         "x": 9,
         "y": 55,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Wheat"
@@ -32003,6 +34758,7 @@
         "id": "tile-2756",
         "x": 11,
         "y": 55,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -32014,6 +34770,7 @@
         "id": "tile-2757",
         "x": 13,
         "y": 55,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -32029,6 +34786,7 @@
         "id": "tile-2758",
         "x": 15,
         "y": 55,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -32043,6 +34801,7 @@
         "id": "tile-2759",
         "x": 17,
         "y": 55,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -32057,6 +34816,7 @@
         "id": "tile-2760",
         "x": 19,
         "y": 55,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -32068,6 +34828,7 @@
         "id": "tile-2761",
         "x": 21,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -32079,6 +34840,7 @@
         "id": "tile-2762",
         "x": 23,
         "y": 55,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -32093,6 +34855,7 @@
         "id": "tile-2763",
         "x": 25,
         "y": 55,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -32104,6 +34867,7 @@
         "id": "tile-2764",
         "x": 27,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -32115,6 +34879,7 @@
         "id": "tile-2765",
         "x": 29,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -32126,6 +34891,7 @@
         "id": "tile-2766",
         "x": 31,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32137,6 +34903,7 @@
         "id": "tile-2767",
         "x": 33,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32148,6 +34915,7 @@
         "id": "tile-2768",
         "x": 35,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32159,6 +34927,7 @@
         "id": "tile-2769",
         "x": 37,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32170,6 +34939,7 @@
         "id": "tile-2770",
         "x": 39,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32181,6 +34951,7 @@
         "id": "tile-2771",
         "x": 41,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32192,6 +34963,7 @@
         "id": "tile-2772",
         "x": 43,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32203,6 +34975,7 @@
         "id": "tile-2773",
         "x": 45,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32214,6 +34987,7 @@
         "id": "tile-2774",
         "x": 47,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32225,6 +34999,7 @@
         "id": "tile-2775",
         "x": 49,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -32236,6 +35011,7 @@
         "id": "tile-2776",
         "x": 51,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -32247,6 +35023,7 @@
         "id": "tile-2777",
         "x": 53,
         "y": 55,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -32263,6 +35040,7 @@
         "id": "tile-2778",
         "x": 55,
         "y": 55,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -32280,6 +35058,7 @@
         "id": "tile-2779",
         "x": 57,
         "y": 55,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -32296,6 +35075,7 @@
         "id": "tile-2780",
         "x": 59,
         "y": 55,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -32310,6 +35090,7 @@
         "id": "tile-2781",
         "x": 61,
         "y": 55,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -32325,6 +35106,7 @@
         "id": "tile-2782",
         "x": 63,
         "y": 55,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "resource": "Coal"
@@ -32337,6 +35119,7 @@
         "id": "tile-2783",
         "x": 65,
         "y": 55,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -32348,6 +35131,7 @@
         "id": "tile-2784",
         "x": 67,
         "y": 55,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -32359,6 +35143,7 @@
         "id": "tile-2785",
         "x": 69,
         "y": 55,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -32370,6 +35155,7 @@
         "id": "tile-2786",
         "x": 71,
         "y": 55,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -32381,6 +35167,7 @@
         "id": "tile-2787",
         "x": 73,
         "y": 55,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -32392,6 +35179,7 @@
         "id": "tile-2788",
         "x": 75,
         "y": 55,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -32406,6 +35194,7 @@
         "id": "tile-2789",
         "x": 77,
         "y": 55,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -32417,6 +35206,7 @@
         "id": "tile-2790",
         "x": 79,
         "y": 55,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -32428,6 +35218,7 @@
         "id": "tile-2791",
         "x": 81,
         "y": 55,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -32442,6 +35233,7 @@
         "id": "tile-2792",
         "x": 83,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -32453,6 +35245,7 @@
         "id": "tile-2793",
         "x": 85,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -32464,6 +35257,7 @@
         "id": "tile-2794",
         "x": 87,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32475,6 +35269,7 @@
         "id": "tile-2795",
         "x": 89,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32486,6 +35281,7 @@
         "id": "tile-2796",
         "x": 91,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32497,6 +35293,7 @@
         "id": "tile-2797",
         "x": 93,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32508,6 +35305,7 @@
         "id": "tile-2798",
         "x": 95,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32519,6 +35317,7 @@
         "id": "tile-2799",
         "x": 97,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32530,6 +35329,7 @@
         "id": "tile-2800",
         "x": 99,
         "y": 55,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -32541,6 +35341,7 @@
         "id": "tile-2801",
         "x": 0,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -32552,6 +35353,7 @@
         "id": "tile-2802",
         "x": 2,
         "y": 56,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -32563,6 +35365,7 @@
         "id": "tile-2803",
         "x": 4,
         "y": 56,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -32579,6 +35382,7 @@
         "id": "tile-2804",
         "x": 6,
         "y": 56,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "resource": "Rubber",
@@ -32596,6 +35400,7 @@
         "id": "tile-2805",
         "x": 8,
         "y": 56,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -32607,6 +35412,7 @@
         "id": "tile-2806",
         "x": 10,
         "y": 56,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -32618,6 +35424,7 @@
         "id": "tile-2807",
         "x": 12,
         "y": 56,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -32629,6 +35436,7 @@
         "id": "tile-2808",
         "x": 14,
         "y": 56,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Horses"
@@ -32641,6 +35449,7 @@
         "id": "tile-2809",
         "x": 16,
         "y": 56,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -32652,6 +35461,7 @@
         "id": "tile-2810",
         "x": 18,
         "y": 56,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -32663,6 +35473,7 @@
         "id": "tile-2811",
         "x": 20,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -32674,6 +35485,7 @@
         "id": "tile-2812",
         "x": 22,
         "y": 56,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -32685,6 +35497,7 @@
         "id": "tile-2813",
         "x": 24,
         "y": 56,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -32696,6 +35509,7 @@
         "id": "tile-2814",
         "x": 26,
         "y": 56,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -32707,6 +35521,7 @@
         "id": "tile-2815",
         "x": 28,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -32718,6 +35533,7 @@
         "id": "tile-2816",
         "x": 30,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -32729,6 +35545,7 @@
         "id": "tile-2817",
         "x": 32,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32740,6 +35557,7 @@
         "id": "tile-2818",
         "x": 34,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32751,6 +35569,7 @@
         "id": "tile-2819",
         "x": 36,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32762,6 +35581,7 @@
         "id": "tile-2820",
         "x": 38,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32773,6 +35593,7 @@
         "id": "tile-2821",
         "x": 40,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32784,6 +35605,7 @@
         "id": "tile-2822",
         "x": 42,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32795,6 +35617,7 @@
         "id": "tile-2823",
         "x": 44,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32806,6 +35629,7 @@
         "id": "tile-2824",
         "x": 46,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -32817,6 +35641,7 @@
         "id": "tile-2825",
         "x": 48,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -32828,6 +35653,7 @@
         "id": "tile-2826",
         "x": 50,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -32839,6 +35665,7 @@
         "id": "tile-2827",
         "x": 52,
         "y": 56,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -32854,6 +35681,7 @@
         "id": "tile-2828",
         "x": 54,
         "y": 56,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -32871,6 +35699,7 @@
         "id": "tile-2829",
         "x": 56,
         "y": 56,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "resource": "Dyes",
@@ -32886,6 +35715,7 @@
         "id": "tile-2830",
         "x": 58,
         "y": 56,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "resource": "Dyes"
@@ -32898,6 +35728,7 @@
         "id": "tile-2831",
         "x": 60,
         "y": 56,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -32913,6 +35744,7 @@
         "id": "tile-2832",
         "x": 62,
         "y": 56,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -32928,6 +35760,7 @@
         "id": "tile-2833",
         "x": 64,
         "y": 56,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -32939,6 +35772,7 @@
         "id": "tile-2834",
         "x": 66,
         "y": 56,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -32950,6 +35784,7 @@
         "id": "tile-2835",
         "x": 68,
         "y": 56,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "resource": "Game"
@@ -32962,6 +35797,7 @@
         "id": "tile-2836",
         "x": 70,
         "y": 56,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -32976,6 +35812,7 @@
         "id": "tile-2837",
         "x": 72,
         "y": 56,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -32987,6 +35824,7 @@
         "id": "tile-2838",
         "x": 74,
         "y": 56,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -33001,6 +35839,7 @@
         "id": "tile-2839",
         "x": 76,
         "y": 56,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -33012,6 +35851,7 @@
         "id": "tile-2840",
         "x": 78,
         "y": 56,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -33026,6 +35866,7 @@
         "id": "tile-2841",
         "x": 80,
         "y": 56,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -33037,6 +35878,7 @@
         "id": "tile-2842",
         "x": 82,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -33048,6 +35890,7 @@
         "id": "tile-2843",
         "x": 84,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -33059,6 +35902,7 @@
         "id": "tile-2844",
         "x": 86,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33070,6 +35914,7 @@
         "id": "tile-2845",
         "x": 88,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33081,6 +35926,7 @@
         "id": "tile-2846",
         "x": 90,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33092,6 +35938,7 @@
         "id": "tile-2847",
         "x": 92,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33103,6 +35950,7 @@
         "id": "tile-2848",
         "x": 94,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33114,6 +35962,7 @@
         "id": "tile-2849",
         "x": 96,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33125,6 +35974,7 @@
         "id": "tile-2850",
         "x": 98,
         "y": 56,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -33136,6 +35986,7 @@
         "id": "tile-2851",
         "x": 1,
         "y": 57,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -33147,6 +35998,7 @@
         "id": "tile-2852",
         "x": 3,
         "y": 57,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -33162,6 +36014,7 @@
         "id": "tile-2853",
         "x": 5,
         "y": 57,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -33179,6 +36032,7 @@
         "id": "tile-2854",
         "x": 7,
         "y": 57,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -33190,6 +36044,7 @@
         "id": "tile-2855",
         "x": 9,
         "y": 57,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -33204,6 +36059,7 @@
         "id": "tile-2856",
         "x": 11,
         "y": 57,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -33215,6 +36071,7 @@
         "id": "tile-2857",
         "x": 13,
         "y": 57,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -33226,6 +36083,7 @@
         "id": "tile-2858",
         "x": 15,
         "y": 57,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -33240,6 +36098,7 @@
         "id": "tile-2859",
         "x": 17,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -33251,6 +36110,7 @@
         "id": "tile-2860",
         "x": 19,
         "y": 57,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "resource": "Ivory"
@@ -33263,6 +36123,7 @@
         "id": "tile-2861",
         "x": 21,
         "y": 57,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "resource": "Ivory"
@@ -33275,6 +36136,7 @@
         "id": "tile-2862",
         "x": 23,
         "y": 57,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -33286,6 +36148,7 @@
         "id": "tile-2863",
         "x": 25,
         "y": 57,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -33297,6 +36160,7 @@
         "id": "tile-2864",
         "x": 27,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -33308,6 +36172,7 @@
         "id": "tile-2865",
         "x": 29,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -33319,6 +36184,7 @@
         "id": "tile-2866",
         "x": 31,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33330,6 +36196,7 @@
         "id": "tile-2867",
         "x": 33,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33341,6 +36208,7 @@
         "id": "tile-2868",
         "x": 35,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33352,6 +36220,7 @@
         "id": "tile-2869",
         "x": 37,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33363,6 +36232,7 @@
         "id": "tile-2870",
         "x": 39,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33374,6 +36244,7 @@
         "id": "tile-2871",
         "x": 41,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33385,6 +36256,7 @@
         "id": "tile-2872",
         "x": 43,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33396,6 +36268,7 @@
         "id": "tile-2873",
         "x": 45,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33407,6 +36280,7 @@
         "id": "tile-2874",
         "x": 47,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33418,6 +36292,7 @@
         "id": "tile-2875",
         "x": 49,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -33429,6 +36304,7 @@
         "id": "tile-2876",
         "x": 51,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -33440,6 +36316,7 @@
         "id": "tile-2877",
         "x": 53,
         "y": 57,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -33456,6 +36333,7 @@
         "id": "tile-2878",
         "x": 55,
         "y": 57,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -33467,6 +36345,7 @@
         "id": "tile-2879",
         "x": 57,
         "y": 57,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "resource": "Dyes"
@@ -33479,6 +36358,7 @@
         "id": "tile-2880",
         "x": 59,
         "y": 57,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -33495,6 +36375,7 @@
         "id": "tile-2881",
         "x": 61,
         "y": 57,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -33512,6 +36393,7 @@
         "id": "tile-2882",
         "x": 63,
         "y": 57,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -33523,6 +36405,7 @@
         "id": "tile-2883",
         "x": 65,
         "y": 57,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -33534,6 +36417,7 @@
         "id": "tile-2884",
         "x": 67,
         "y": 57,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -33545,6 +36429,7 @@
         "id": "tile-2885",
         "x": 69,
         "y": 57,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -33559,6 +36444,7 @@
         "id": "tile-2886",
         "x": 71,
         "y": 57,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -33570,6 +36456,7 @@
         "id": "tile-2887",
         "x": 73,
         "y": 57,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -33584,6 +36471,7 @@
         "id": "tile-2888",
         "x": 75,
         "y": 57,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -33595,6 +36483,7 @@
         "id": "tile-2889",
         "x": 77,
         "y": 57,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "features": [
@@ -33609,6 +36498,7 @@
         "id": "tile-2890",
         "x": 79,
         "y": 57,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -33620,6 +36510,7 @@
         "id": "tile-2891",
         "x": 81,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -33631,6 +36522,7 @@
         "id": "tile-2892",
         "x": 83,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -33642,6 +36534,7 @@
         "id": "tile-2893",
         "x": 85,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33653,6 +36546,7 @@
         "id": "tile-2894",
         "x": 87,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33664,6 +36558,7 @@
         "id": "tile-2895",
         "x": 89,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33675,6 +36570,7 @@
         "id": "tile-2896",
         "x": 91,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33686,6 +36582,7 @@
         "id": "tile-2897",
         "x": 93,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33697,6 +36594,7 @@
         "id": "tile-2898",
         "x": 95,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33708,6 +36606,7 @@
         "id": "tile-2899",
         "x": 97,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -33719,6 +36618,7 @@
         "id": "tile-2900",
         "x": 99,
         "y": 57,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -33730,6 +36630,7 @@
         "id": "tile-2901",
         "x": 0,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -33741,6 +36642,7 @@
         "id": "tile-2902",
         "x": 2,
         "y": 58,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -33752,6 +36654,7 @@
         "id": "tile-2903",
         "x": 4,
         "y": 58,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -33768,6 +36671,7 @@
         "id": "tile-2904",
         "x": 6,
         "y": 58,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -33779,6 +36683,7 @@
         "id": "tile-2905",
         "x": 8,
         "y": 58,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -33796,6 +36701,7 @@
         "id": "tile-2906",
         "x": 10,
         "y": 58,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -33810,6 +36716,7 @@
         "id": "tile-2907",
         "x": 12,
         "y": 58,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "resource": "Game"
@@ -33822,6 +36729,7 @@
         "id": "tile-2908",
         "x": 14,
         "y": 58,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -33833,6 +36741,7 @@
         "id": "tile-2909",
         "x": 16,
         "y": 58,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "resource": "Game"
@@ -33845,6 +36754,7 @@
         "id": "tile-2910",
         "x": 18,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -33856,6 +36766,7 @@
         "id": "tile-2911",
         "x": 20,
         "y": 58,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "resource": "Ivory"
@@ -33868,6 +36779,7 @@
         "id": "tile-2912",
         "x": 22,
         "y": 58,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -33879,6 +36791,7 @@
         "id": "tile-2913",
         "x": 24,
         "y": 58,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -33890,6 +36803,7 @@
         "id": "tile-2914",
         "x": 26,
         "y": 58,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -33901,6 +36815,7 @@
         "id": "tile-2915",
         "x": 28,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -33912,6 +36827,7 @@
         "id": "tile-2916",
         "x": 30,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -33923,6 +36839,7 @@
         "id": "tile-2917",
         "x": 32,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33934,6 +36851,7 @@
         "id": "tile-2918",
         "x": 34,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33945,6 +36863,7 @@
         "id": "tile-2919",
         "x": 36,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33956,6 +36875,7 @@
         "id": "tile-2920",
         "x": 38,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33967,6 +36887,7 @@
         "id": "tile-2921",
         "x": 40,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33978,6 +36899,7 @@
         "id": "tile-2922",
         "x": 42,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -33989,6 +36911,7 @@
         "id": "tile-2923",
         "x": 44,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34000,6 +36923,7 @@
         "id": "tile-2924",
         "x": 46,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34011,6 +36935,7 @@
         "id": "tile-2925",
         "x": 48,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34022,6 +36947,7 @@
         "id": "tile-2926",
         "x": 50,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -34034,6 +36960,7 @@
         "id": "tile-2927",
         "x": 52,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -34045,6 +36972,7 @@
         "id": "tile-2928",
         "x": 54,
         "y": 58,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -34059,6 +36987,7 @@
         "id": "tile-2929",
         "x": 56,
         "y": 58,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -34070,6 +36999,7 @@
         "id": "tile-2930",
         "x": 58,
         "y": 58,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -34086,6 +37016,7 @@
         "id": "tile-2931",
         "x": 60,
         "y": 58,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -34103,6 +37034,7 @@
         "id": "tile-2932",
         "x": 62,
         "y": 58,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -34117,6 +37049,7 @@
         "id": "tile-2933",
         "x": 64,
         "y": 58,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -34131,6 +37064,7 @@
         "id": "tile-2934",
         "x": 66,
         "y": 58,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -34142,6 +37076,7 @@
         "id": "tile-2935",
         "x": 68,
         "y": 58,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -34153,6 +37088,7 @@
         "id": "tile-2936",
         "x": 70,
         "y": 58,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -34164,6 +37100,7 @@
         "id": "tile-2937",
         "x": 72,
         "y": 58,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -34175,6 +37112,7 @@
         "id": "tile-2938",
         "x": 74,
         "y": 58,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh",
         "resource": "Oil"
@@ -34187,6 +37125,7 @@
         "id": "tile-2939",
         "x": 76,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -34198,6 +37137,7 @@
         "id": "tile-2940",
         "x": 78,
         "y": 58,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -34209,6 +37149,7 @@
         "id": "tile-2941",
         "x": 80,
         "y": 58,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -34223,6 +37164,7 @@
         "id": "tile-2942",
         "x": 82,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -34234,6 +37176,7 @@
         "id": "tile-2943",
         "x": 84,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -34245,6 +37188,7 @@
         "id": "tile-2944",
         "x": 86,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34256,6 +37200,7 @@
         "id": "tile-2945",
         "x": 88,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34267,6 +37212,7 @@
         "id": "tile-2946",
         "x": 90,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34278,6 +37224,7 @@
         "id": "tile-2947",
         "x": 92,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34289,6 +37236,7 @@
         "id": "tile-2948",
         "x": 94,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34300,6 +37248,7 @@
         "id": "tile-2949",
         "x": 96,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34311,6 +37260,7 @@
         "id": "tile-2950",
         "x": 98,
         "y": 58,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -34322,6 +37272,7 @@
         "id": "tile-2951",
         "x": 1,
         "y": 59,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "resource": "Iron",
@@ -34337,6 +37288,7 @@
         "id": "tile-2952",
         "x": 3,
         "y": 59,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -34348,6 +37300,7 @@
         "id": "tile-2953",
         "x": 5,
         "y": 59,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -34359,6 +37312,7 @@
         "id": "tile-2954",
         "x": 7,
         "y": 59,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -34375,6 +37329,7 @@
         "id": "tile-2955",
         "x": 9,
         "y": 59,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -34391,6 +37346,7 @@
         "id": "tile-2956",
         "x": 11,
         "y": 59,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -34402,6 +37358,7 @@
         "id": "tile-2957",
         "x": 13,
         "y": 59,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -34413,6 +37370,7 @@
         "id": "tile-2958",
         "x": 15,
         "y": 59,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -34427,6 +37385,7 @@
         "id": "tile-2959",
         "x": 17,
         "y": 59,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -34438,6 +37397,7 @@
         "id": "tile-2960",
         "x": 19,
         "y": 59,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "resource": "Ivory"
@@ -34450,6 +37410,7 @@
         "id": "tile-2961",
         "x": 21,
         "y": 59,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -34461,6 +37422,7 @@
         "id": "tile-2962",
         "x": 23,
         "y": 59,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -34475,6 +37437,7 @@
         "id": "tile-2963",
         "x": 25,
         "y": 59,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -34489,6 +37452,7 @@
         "id": "tile-2964",
         "x": 27,
         "y": 59,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -34500,6 +37464,7 @@
         "id": "tile-2965",
         "x": 29,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -34511,6 +37476,7 @@
         "id": "tile-2966",
         "x": 31,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -34522,6 +37488,7 @@
         "id": "tile-2967",
         "x": 33,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -34533,6 +37500,7 @@
         "id": "tile-2968",
         "x": 35,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34544,6 +37512,7 @@
         "id": "tile-2969",
         "x": 37,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34555,6 +37524,7 @@
         "id": "tile-2970",
         "x": 39,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34566,6 +37536,7 @@
         "id": "tile-2971",
         "x": 41,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34577,6 +37548,7 @@
         "id": "tile-2972",
         "x": 43,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34588,6 +37560,7 @@
         "id": "tile-2973",
         "x": 45,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34599,6 +37572,7 @@
         "id": "tile-2974",
         "x": 47,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34610,6 +37584,7 @@
         "id": "tile-2975",
         "x": 49,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34621,6 +37596,7 @@
         "id": "tile-2976",
         "x": 51,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -34632,6 +37608,7 @@
         "id": "tile-2977",
         "x": 53,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -34643,6 +37620,7 @@
         "id": "tile-2978",
         "x": 55,
         "y": 59,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -34654,6 +37632,7 @@
         "id": "tile-2979",
         "x": 57,
         "y": 59,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -34668,6 +37647,7 @@
         "id": "tile-2980",
         "x": 59,
         "y": 59,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -34685,6 +37665,7 @@
         "id": "tile-2981",
         "x": 61,
         "y": 59,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -34696,6 +37677,7 @@
         "id": "tile-2982",
         "x": 63,
         "y": 59,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -34707,6 +37689,7 @@
         "id": "tile-2983",
         "x": 65,
         "y": 59,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -34718,6 +37701,7 @@
         "id": "tile-2984",
         "x": 67,
         "y": 59,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -34729,6 +37713,7 @@
         "id": "tile-2985",
         "x": 69,
         "y": 59,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -34740,6 +37725,7 @@
         "id": "tile-2986",
         "x": 71,
         "y": 59,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Incense"
@@ -34752,6 +37738,7 @@
         "id": "tile-2987",
         "x": 73,
         "y": 59,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -34763,6 +37750,7 @@
         "id": "tile-2988",
         "x": 75,
         "y": 59,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "marsh"
       },
@@ -34774,6 +37762,7 @@
         "id": "tile-2989",
         "x": 77,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -34785,6 +37774,7 @@
         "id": "tile-2990",
         "x": 79,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -34796,6 +37786,7 @@
         "id": "tile-2991",
         "x": 81,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -34807,6 +37798,7 @@
         "id": "tile-2992",
         "x": 83,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -34818,6 +37810,7 @@
         "id": "tile-2993",
         "x": 85,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34829,6 +37822,7 @@
         "id": "tile-2994",
         "x": 87,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34840,6 +37834,7 @@
         "id": "tile-2995",
         "x": 89,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34851,6 +37846,7 @@
         "id": "tile-2996",
         "x": 91,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34862,6 +37858,7 @@
         "id": "tile-2997",
         "x": 93,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34873,6 +37870,7 @@
         "id": "tile-2998",
         "x": 95,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -34884,6 +37882,7 @@
         "id": "tile-2999",
         "x": 97,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -34895,6 +37894,7 @@
         "id": "tile-3000",
         "x": 99,
         "y": 59,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -34906,6 +37906,7 @@
         "id": "tile-3001",
         "x": 0,
         "y": 60,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -34920,6 +37921,7 @@
         "id": "tile-3002",
         "x": 2,
         "y": 60,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -34935,6 +37937,7 @@
         "id": "tile-3003",
         "x": 4,
         "y": 60,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "resource": "Oasis"
@@ -34947,6 +37950,7 @@
         "id": "tile-3004",
         "x": 6,
         "y": 60,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -34962,6 +37966,7 @@
         "id": "tile-3005",
         "x": 8,
         "y": 60,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "resource": "Uranium",
@@ -34979,6 +37984,7 @@
         "id": "tile-3006",
         "x": 10,
         "y": 60,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -34990,6 +37996,7 @@
         "id": "tile-3007",
         "x": 12,
         "y": 60,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -35001,6 +38008,7 @@
         "id": "tile-3008",
         "x": 14,
         "y": 60,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -35015,6 +38023,7 @@
         "id": "tile-3009",
         "x": 16,
         "y": 60,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -35029,6 +38038,7 @@
         "id": "tile-3010",
         "x": 18,
         "y": 60,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -35040,6 +38050,7 @@
         "id": "tile-3011",
         "x": 20,
         "y": 60,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -35051,6 +38062,7 @@
         "id": "tile-3012",
         "x": 22,
         "y": 60,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -35062,6 +38074,7 @@
         "id": "tile-3013",
         "x": 24,
         "y": 60,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -35076,6 +38089,7 @@
         "id": "tile-3014",
         "x": 26,
         "y": 60,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle",
         "features": [
@@ -35090,6 +38104,7 @@
         "id": "tile-3015",
         "x": 28,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -35101,6 +38116,7 @@
         "id": "tile-3016",
         "x": 30,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -35112,6 +38128,7 @@
         "id": "tile-3017",
         "x": 32,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -35123,6 +38140,7 @@
         "id": "tile-3018",
         "x": 34,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -35134,6 +38152,7 @@
         "id": "tile-3019",
         "x": 36,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -35145,6 +38164,7 @@
         "id": "tile-3020",
         "x": 38,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35156,6 +38176,7 @@
         "id": "tile-3021",
         "x": 40,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35167,6 +38188,7 @@
         "id": "tile-3022",
         "x": 42,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35178,6 +38200,7 @@
         "id": "tile-3023",
         "x": 44,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35189,6 +38212,7 @@
         "id": "tile-3024",
         "x": 46,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35200,6 +38224,7 @@
         "id": "tile-3025",
         "x": 48,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35211,6 +38236,7 @@
         "id": "tile-3026",
         "x": 50,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -35222,6 +38248,7 @@
         "id": "tile-3027",
         "x": 52,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -35233,6 +38260,7 @@
         "id": "tile-3028",
         "x": 54,
         "y": 60,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -35244,6 +38272,7 @@
         "id": "tile-3029",
         "x": 56,
         "y": 60,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -35255,6 +38284,7 @@
         "id": "tile-3030",
         "x": 58,
         "y": 60,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "resource": "Wheat",
@@ -35273,6 +38303,7 @@
         "id": "tile-3031",
         "x": 60,
         "y": 60,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -35287,6 +38318,7 @@
         "id": "tile-3032",
         "x": 62,
         "y": 60,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -35301,6 +38333,7 @@
         "id": "tile-3033",
         "x": 64,
         "y": 60,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -35312,6 +38345,7 @@
         "id": "tile-3034",
         "x": 66,
         "y": 60,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -35327,6 +38361,7 @@
         "id": "tile-3035",
         "x": 68,
         "y": 60,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -35341,6 +38376,7 @@
         "id": "tile-3036",
         "x": 70,
         "y": 60,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -35355,6 +38391,7 @@
         "id": "tile-3037",
         "x": 72,
         "y": 60,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -35366,6 +38403,7 @@
         "id": "tile-3038",
         "x": 74,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -35377,6 +38415,7 @@
         "id": "tile-3039",
         "x": 76,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -35388,6 +38427,7 @@
         "id": "tile-3040",
         "x": 78,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -35399,6 +38439,7 @@
         "id": "tile-3041",
         "x": 80,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -35410,6 +38451,7 @@
         "id": "tile-3042",
         "x": 82,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -35421,6 +38463,7 @@
         "id": "tile-3043",
         "x": 84,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35432,6 +38475,7 @@
         "id": "tile-3044",
         "x": 86,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35443,6 +38487,7 @@
         "id": "tile-3045",
         "x": 88,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35454,6 +38499,7 @@
         "id": "tile-3046",
         "x": 90,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35465,6 +38511,7 @@
         "id": "tile-3047",
         "x": 92,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35476,6 +38523,7 @@
         "id": "tile-3048",
         "x": 94,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35487,6 +38535,7 @@
         "id": "tile-3049",
         "x": 96,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -35498,6 +38547,7 @@
         "id": "tile-3050",
         "x": 98,
         "y": 60,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -35509,6 +38559,7 @@
         "id": "tile-3051",
         "x": 1,
         "y": 61,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -35523,6 +38574,7 @@
         "id": "tile-3052",
         "x": 3,
         "y": 61,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -35537,6 +38589,7 @@
         "id": "tile-3053",
         "x": 5,
         "y": 61,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -35551,6 +38604,7 @@
         "id": "tile-3054",
         "x": 7,
         "y": 61,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -35568,6 +38622,7 @@
         "id": "tile-3055",
         "x": 9,
         "y": 61,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -35579,6 +38634,7 @@
         "id": "tile-3056",
         "x": 11,
         "y": 61,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "features": [
@@ -35593,6 +38649,7 @@
         "id": "tile-3057",
         "x": 13,
         "y": 61,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "resource": "Sugar",
@@ -35608,6 +38665,7 @@
         "id": "tile-3058",
         "x": 15,
         "y": 61,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -35622,6 +38680,7 @@
         "id": "tile-3059",
         "x": 17,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -35633,6 +38692,7 @@
         "id": "tile-3060",
         "x": 19,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -35644,6 +38704,7 @@
         "id": "tile-3061",
         "x": 21,
         "y": 61,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -35655,6 +38716,7 @@
         "id": "tile-3062",
         "x": 23,
         "y": 61,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -35666,6 +38728,7 @@
         "id": "tile-3063",
         "x": 25,
         "y": 61,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "jungle"
       },
@@ -35677,6 +38740,7 @@
         "id": "tile-3064",
         "x": 27,
         "y": 61,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Aluminum"
@@ -35689,6 +38753,7 @@
         "id": "tile-3065",
         "x": 29,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -35700,6 +38765,7 @@
         "id": "tile-3066",
         "x": 31,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -35711,6 +38777,7 @@
         "id": "tile-3067",
         "x": 33,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -35722,6 +38789,7 @@
         "id": "tile-3068",
         "x": 35,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -35733,6 +38801,7 @@
         "id": "tile-3069",
         "x": 37,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -35744,6 +38813,7 @@
         "id": "tile-3070",
         "x": 39,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -35755,6 +38825,7 @@
         "id": "tile-3071",
         "x": 41,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35766,6 +38837,7 @@
         "id": "tile-3072",
         "x": 43,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35777,6 +38849,7 @@
         "id": "tile-3073",
         "x": 45,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35788,6 +38861,7 @@
         "id": "tile-3074",
         "x": 47,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35799,6 +38873,7 @@
         "id": "tile-3075",
         "x": 49,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -35810,6 +38885,7 @@
         "id": "tile-3076",
         "x": 51,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -35821,6 +38897,7 @@
         "id": "tile-3077",
         "x": 53,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -35832,6 +38909,7 @@
         "id": "tile-3078",
         "x": 55,
         "y": 61,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -35843,6 +38921,7 @@
         "id": "tile-3079",
         "x": 57,
         "y": 61,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -35859,6 +38938,7 @@
         "id": "tile-3080",
         "x": 59,
         "y": 61,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -35874,6 +38954,7 @@
         "id": "tile-3081",
         "x": 61,
         "y": 61,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -35885,6 +38966,7 @@
         "id": "tile-3082",
         "x": 63,
         "y": 61,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -35896,6 +38978,7 @@
         "id": "tile-3083",
         "x": 65,
         "y": 61,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -35912,6 +38995,7 @@
         "id": "tile-3084",
         "x": 67,
         "y": 61,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -35929,6 +39013,7 @@
         "id": "tile-3085",
         "x": 69,
         "y": 61,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -35944,6 +39029,7 @@
         "id": "tile-3086",
         "x": 71,
         "y": 61,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "resource": "Incense"
@@ -35956,6 +39042,7 @@
         "id": "tile-3087",
         "x": 73,
         "y": 61,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -35967,6 +39054,7 @@
         "id": "tile-3088",
         "x": 75,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -35978,6 +39066,7 @@
         "id": "tile-3089",
         "x": 77,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -35990,6 +39079,7 @@
         "id": "tile-3090",
         "x": 79,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -36001,6 +39091,7 @@
         "id": "tile-3091",
         "x": 81,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -36012,6 +39103,7 @@
         "id": "tile-3092",
         "x": 83,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36023,6 +39115,7 @@
         "id": "tile-3093",
         "x": 85,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36034,6 +39127,7 @@
         "id": "tile-3094",
         "x": 87,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36045,6 +39139,7 @@
         "id": "tile-3095",
         "x": 89,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36056,6 +39151,7 @@
         "id": "tile-3096",
         "x": 91,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36067,6 +39163,7 @@
         "id": "tile-3097",
         "x": 93,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36078,6 +39175,7 @@
         "id": "tile-3098",
         "x": 95,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36089,6 +39187,7 @@
         "id": "tile-3099",
         "x": 97,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -36100,6 +39199,7 @@
         "id": "tile-3100",
         "x": 99,
         "y": 61,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36111,6 +39211,7 @@
         "id": "tile-3101",
         "x": 0,
         "y": 62,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -36125,6 +39226,7 @@
         "id": "tile-3102",
         "x": 2,
         "y": 62,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -36139,6 +39241,7 @@
         "id": "tile-3103",
         "x": 4,
         "y": 62,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -36153,6 +39256,7 @@
         "id": "tile-3104",
         "x": 6,
         "y": 62,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -36169,6 +39273,7 @@
         "id": "tile-3105",
         "x": 8,
         "y": 62,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "features": [
@@ -36183,6 +39288,7 @@
         "id": "tile-3106",
         "x": 10,
         "y": 62,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "resource": "Cattle"
@@ -36195,6 +39301,7 @@
         "id": "tile-3107",
         "x": 12,
         "y": 62,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -36206,6 +39313,7 @@
         "id": "tile-3108",
         "x": 14,
         "y": 62,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -36217,6 +39325,7 @@
         "id": "tile-3109",
         "x": 16,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36228,6 +39337,7 @@
         "id": "tile-3110",
         "x": 18,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36239,6 +39349,7 @@
         "id": "tile-3111",
         "x": 20,
         "y": 62,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -36253,6 +39364,7 @@
         "id": "tile-3112",
         "x": 22,
         "y": 62,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -36264,6 +39376,7 @@
         "id": "tile-3113",
         "x": 24,
         "y": 62,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -36275,6 +39388,7 @@
         "id": "tile-3114",
         "x": 26,
         "y": 62,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -36286,6 +39400,7 @@
         "id": "tile-3115",
         "x": 28,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36297,6 +39412,7 @@
         "id": "tile-3116",
         "x": 30,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36308,6 +39424,7 @@
         "id": "tile-3117",
         "x": 32,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36319,6 +39436,7 @@
         "id": "tile-3118",
         "x": 34,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36330,6 +39448,7 @@
         "id": "tile-3119",
         "x": 36,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36341,6 +39460,7 @@
         "id": "tile-3120",
         "x": 38,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -36352,6 +39472,7 @@
         "id": "tile-3121",
         "x": 40,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -36363,6 +39484,7 @@
         "id": "tile-3122",
         "x": 42,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -36374,6 +39496,7 @@
         "id": "tile-3123",
         "x": 44,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36385,6 +39508,7 @@
         "id": "tile-3124",
         "x": 46,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36396,6 +39520,7 @@
         "id": "tile-3125",
         "x": 48,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36407,6 +39532,7 @@
         "id": "tile-3126",
         "x": 50,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -36418,6 +39544,7 @@
         "id": "tile-3127",
         "x": 52,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36429,6 +39556,7 @@
         "id": "tile-3128",
         "x": 54,
         "y": 62,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -36440,6 +39568,7 @@
         "id": "tile-3129",
         "x": 56,
         "y": 62,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "resource": "Wheat",
@@ -36457,6 +39586,7 @@
         "id": "tile-3130",
         "x": 58,
         "y": 62,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -36473,6 +39603,7 @@
         "id": "tile-3131",
         "x": 60,
         "y": 62,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -36484,6 +39615,7 @@
         "id": "tile-3132",
         "x": 62,
         "y": 62,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -36498,6 +39630,7 @@
         "id": "tile-3133",
         "x": 64,
         "y": 62,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -36509,6 +39642,7 @@
         "id": "tile-3134",
         "x": 66,
         "y": 62,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -36524,6 +39658,7 @@
         "id": "tile-3135",
         "x": 68,
         "y": 62,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -36541,6 +39676,7 @@
         "id": "tile-3136",
         "x": 70,
         "y": 62,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -36557,6 +39693,7 @@
         "id": "tile-3137",
         "x": 72,
         "y": 62,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -36568,6 +39705,7 @@
         "id": "tile-3138",
         "x": 74,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36579,6 +39717,7 @@
         "id": "tile-3139",
         "x": 76,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -36590,6 +39729,7 @@
         "id": "tile-3140",
         "x": 78,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -36601,6 +39741,7 @@
         "id": "tile-3141",
         "x": 80,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -36612,6 +39753,7 @@
         "id": "tile-3142",
         "x": 82,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36623,6 +39765,7 @@
         "id": "tile-3143",
         "x": 84,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36634,6 +39777,7 @@
         "id": "tile-3144",
         "x": 86,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36645,6 +39789,7 @@
         "id": "tile-3145",
         "x": 88,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36656,6 +39801,7 @@
         "id": "tile-3146",
         "x": 90,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36667,6 +39813,7 @@
         "id": "tile-3147",
         "x": 92,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36678,6 +39825,7 @@
         "id": "tile-3148",
         "x": 94,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36689,6 +39837,7 @@
         "id": "tile-3149",
         "x": 96,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -36700,6 +39849,7 @@
         "id": "tile-3150",
         "x": 98,
         "y": 62,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36711,6 +39861,7 @@
         "id": "tile-3151",
         "x": 1,
         "y": 63,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -36722,6 +39873,7 @@
         "id": "tile-3152",
         "x": 3,
         "y": 63,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -36736,6 +39888,7 @@
         "id": "tile-3153",
         "x": 5,
         "y": 63,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -36750,6 +39903,7 @@
         "id": "tile-3154",
         "x": 7,
         "y": 63,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "features": [
@@ -36766,6 +39920,7 @@
         "id": "tile-3155",
         "x": 9,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36777,6 +39932,7 @@
         "id": "tile-3156",
         "x": 11,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36788,6 +39944,7 @@
         "id": "tile-3157",
         "x": 13,
         "y": 63,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -36802,6 +39959,7 @@
         "id": "tile-3158",
         "x": 15,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36813,6 +39971,7 @@
         "id": "tile-3159",
         "x": 17,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36824,6 +39983,7 @@
         "id": "tile-3160",
         "x": 19,
         "y": 63,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "resource": "Game"
@@ -36836,6 +39996,7 @@
         "id": "tile-3161",
         "x": 21,
         "y": 63,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -36850,6 +40011,7 @@
         "id": "tile-3162",
         "x": 23,
         "y": 63,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -36861,6 +40023,7 @@
         "id": "tile-3163",
         "x": 25,
         "y": 63,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -36872,6 +40035,7 @@
         "id": "tile-3164",
         "x": 27,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36883,6 +40047,7 @@
         "id": "tile-3165",
         "x": 29,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36894,6 +40059,7 @@
         "id": "tile-3166",
         "x": 31,
         "y": 63,
+        "continent": 8,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "resource": "Game"
@@ -36906,6 +40072,7 @@
         "id": "tile-3167",
         "x": 33,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36917,6 +40084,7 @@
         "id": "tile-3168",
         "x": 35,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36928,6 +40096,7 @@
         "id": "tile-3169",
         "x": 37,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36939,6 +40108,7 @@
         "id": "tile-3170",
         "x": 39,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -36950,6 +40120,7 @@
         "id": "tile-3171",
         "x": 41,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -36961,6 +40132,7 @@
         "id": "tile-3172",
         "x": 43,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -36973,6 +40145,7 @@
         "id": "tile-3173",
         "x": 45,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36984,6 +40157,7 @@
         "id": "tile-3174",
         "x": 47,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -36995,6 +40169,7 @@
         "id": "tile-3175",
         "x": 49,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37006,6 +40181,7 @@
         "id": "tile-3176",
         "x": 51,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -37017,6 +40193,7 @@
         "id": "tile-3177",
         "x": 53,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37028,6 +40205,7 @@
         "id": "tile-3178",
         "x": 55,
         "y": 63,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -37043,6 +40221,7 @@
         "id": "tile-3179",
         "x": 57,
         "y": 63,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -37059,6 +40238,7 @@
         "id": "tile-3180",
         "x": 59,
         "y": 63,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -37070,6 +40250,7 @@
         "id": "tile-3181",
         "x": 61,
         "y": 63,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -37081,6 +40262,7 @@
         "id": "tile-3182",
         "x": 63,
         "y": 63,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -37092,6 +40274,7 @@
         "id": "tile-3183",
         "x": 65,
         "y": 63,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -37103,6 +40286,7 @@
         "id": "tile-3184",
         "x": 67,
         "y": 63,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Aluminum",
@@ -37118,6 +40302,7 @@
         "id": "tile-3185",
         "x": 69,
         "y": 63,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -37134,6 +40319,7 @@
         "id": "tile-3186",
         "x": 71,
         "y": 63,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -37150,6 +40336,7 @@
         "id": "tile-3187",
         "x": 73,
         "y": 63,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -37161,6 +40348,7 @@
         "id": "tile-3188",
         "x": 75,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37172,6 +40360,7 @@
         "id": "tile-3189",
         "x": 77,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -37183,6 +40372,7 @@
         "id": "tile-3190",
         "x": 79,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -37194,6 +40384,7 @@
         "id": "tile-3191",
         "x": 81,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -37205,6 +40396,7 @@
         "id": "tile-3192",
         "x": 83,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37216,6 +40408,7 @@
         "id": "tile-3193",
         "x": 85,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37227,6 +40420,7 @@
         "id": "tile-3194",
         "x": 87,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37238,6 +40432,7 @@
         "id": "tile-3195",
         "x": 89,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37249,6 +40444,7 @@
         "id": "tile-3196",
         "x": 91,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37260,6 +40456,7 @@
         "id": "tile-3197",
         "x": 93,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37271,6 +40468,7 @@
         "id": "tile-3198",
         "x": 95,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37282,6 +40480,7 @@
         "id": "tile-3199",
         "x": 97,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -37293,6 +40492,7 @@
         "id": "tile-3200",
         "x": 99,
         "y": 63,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37304,6 +40504,7 @@
         "id": "tile-3201",
         "x": 0,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37315,6 +40516,7 @@
         "id": "tile-3202",
         "x": 2,
         "y": 64,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -37329,6 +40531,7 @@
         "id": "tile-3203",
         "x": 4,
         "y": 64,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -37343,6 +40546,7 @@
         "id": "tile-3204",
         "x": 6,
         "y": 64,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -37360,6 +40564,7 @@
         "id": "tile-3205",
         "x": 8,
         "y": 64,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "resource": "Furs",
@@ -37375,6 +40580,7 @@
         "id": "tile-3206",
         "x": 10,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37386,6 +40592,7 @@
         "id": "tile-3207",
         "x": 12,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37397,6 +40604,7 @@
         "id": "tile-3208",
         "x": 14,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37408,6 +40616,7 @@
         "id": "tile-3209",
         "x": 16,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37419,6 +40628,7 @@
         "id": "tile-3210",
         "x": 18,
         "y": 64,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -37430,6 +40640,7 @@
         "id": "tile-3211",
         "x": 20,
         "y": 64,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -37444,6 +40655,7 @@
         "id": "tile-3212",
         "x": 22,
         "y": 64,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -37455,6 +40667,7 @@
         "id": "tile-3213",
         "x": 24,
         "y": 64,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -37466,6 +40679,7 @@
         "id": "tile-3214",
         "x": 26,
         "y": 64,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -37477,6 +40691,7 @@
         "id": "tile-3215",
         "x": 28,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37488,6 +40703,7 @@
         "id": "tile-3216",
         "x": 30,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37499,6 +40715,7 @@
         "id": "tile-3217",
         "x": 32,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37510,6 +40727,7 @@
         "id": "tile-3218",
         "x": 34,
         "y": 64,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "features": [
@@ -37524,6 +40742,7 @@
         "id": "tile-3219",
         "x": 36,
         "y": 64,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Saltpeter",
@@ -37540,6 +40759,7 @@
         "id": "tile-3220",
         "x": 38,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37551,6 +40771,7 @@
         "id": "tile-3221",
         "x": 40,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37562,6 +40783,7 @@
         "id": "tile-3222",
         "x": 42,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37573,6 +40795,7 @@
         "id": "tile-3223",
         "x": 44,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -37584,6 +40807,7 @@
         "id": "tile-3224",
         "x": 46,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37595,6 +40819,7 @@
         "id": "tile-3225",
         "x": 48,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37606,6 +40831,7 @@
         "id": "tile-3226",
         "x": 50,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37617,6 +40843,7 @@
         "id": "tile-3227",
         "x": 52,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -37628,6 +40855,7 @@
         "id": "tile-3228",
         "x": 54,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37639,6 +40867,7 @@
         "id": "tile-3229",
         "x": 56,
         "y": 64,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -37654,6 +40883,7 @@
         "id": "tile-3230",
         "x": 58,
         "y": 64,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -37665,6 +40895,7 @@
         "id": "tile-3231",
         "x": 60,
         "y": 64,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -37676,6 +40907,7 @@
         "id": "tile-3232",
         "x": 62,
         "y": 64,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -37687,6 +40919,7 @@
         "id": "tile-3233",
         "x": 64,
         "y": 64,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -37698,6 +40931,7 @@
         "id": "tile-3234",
         "x": 66,
         "y": 64,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -37709,6 +40943,7 @@
         "id": "tile-3235",
         "x": 68,
         "y": 64,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -37720,6 +40955,7 @@
         "id": "tile-3236",
         "x": 70,
         "y": 64,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -37736,6 +40972,7 @@
         "id": "tile-3237",
         "x": 72,
         "y": 64,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -37753,6 +40990,7 @@
         "id": "tile-3238",
         "x": 74,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37764,6 +41002,7 @@
         "id": "tile-3239",
         "x": 76,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -37775,6 +41014,7 @@
         "id": "tile-3240",
         "x": 78,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -37786,6 +41026,7 @@
         "id": "tile-3241",
         "x": 80,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -37797,6 +41038,7 @@
         "id": "tile-3242",
         "x": 82,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37808,6 +41050,7 @@
         "id": "tile-3243",
         "x": 84,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37819,6 +41062,7 @@
         "id": "tile-3244",
         "x": 86,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37830,6 +41074,7 @@
         "id": "tile-3245",
         "x": 88,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37841,6 +41086,7 @@
         "id": "tile-3246",
         "x": 90,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37852,6 +41098,7 @@
         "id": "tile-3247",
         "x": 92,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37863,6 +41110,7 @@
         "id": "tile-3248",
         "x": 94,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37874,6 +41122,7 @@
         "id": "tile-3249",
         "x": 96,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -37885,6 +41134,7 @@
         "id": "tile-3250",
         "x": 98,
         "y": 64,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -37896,6 +41146,7 @@
         "id": "tile-3251",
         "x": 1,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37907,6 +41158,7 @@
         "id": "tile-3252",
         "x": 3,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37918,6 +41170,7 @@
         "id": "tile-3253",
         "x": 5,
         "y": 65,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -37934,6 +41187,7 @@
         "id": "tile-3254",
         "x": 7,
         "y": 65,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -37950,6 +41204,7 @@
         "id": "tile-3255",
         "x": 9,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37961,6 +41216,7 @@
         "id": "tile-3256",
         "x": 11,
         "y": 65,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "resource": "Wheat",
@@ -37976,6 +41232,7 @@
         "id": "tile-3257",
         "x": 13,
         "y": 65,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -37987,6 +41244,7 @@
         "id": "tile-3258",
         "x": 15,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -37998,6 +41256,7 @@
         "id": "tile-3259",
         "x": 17,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38009,6 +41268,7 @@
         "id": "tile-3260",
         "x": 19,
         "y": 65,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -38020,6 +41280,7 @@
         "id": "tile-3261",
         "x": 21,
         "y": 65,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -38034,6 +41295,7 @@
         "id": "tile-3262",
         "x": 23,
         "y": 65,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -38045,6 +41307,7 @@
         "id": "tile-3263",
         "x": 25,
         "y": 65,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -38056,6 +41319,7 @@
         "id": "tile-3264",
         "x": 27,
         "y": 65,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -38067,6 +41331,7 @@
         "id": "tile-3265",
         "x": 29,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38078,6 +41343,7 @@
         "id": "tile-3266",
         "x": 31,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38089,6 +41355,7 @@
         "id": "tile-3267",
         "x": 33,
         "y": 65,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -38100,6 +41367,7 @@
         "id": "tile-3268",
         "x": 35,
         "y": 65,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -38114,6 +41382,7 @@
         "id": "tile-3269",
         "x": 37,
         "y": 65,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -38130,6 +41399,7 @@
         "id": "tile-3270",
         "x": 39,
         "y": 65,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "resource": "Sugar"
@@ -38142,6 +41412,7 @@
         "id": "tile-3271",
         "x": 41,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38153,6 +41424,7 @@
         "id": "tile-3272",
         "x": 43,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38164,6 +41436,7 @@
         "id": "tile-3273",
         "x": 45,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -38175,6 +41448,7 @@
         "id": "tile-3274",
         "x": 47,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -38186,6 +41460,7 @@
         "id": "tile-3275",
         "x": 49,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -38197,6 +41472,7 @@
         "id": "tile-3276",
         "x": 51,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -38208,6 +41484,7 @@
         "id": "tile-3277",
         "x": 53,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -38219,6 +41496,7 @@
         "id": "tile-3278",
         "x": 55,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38230,6 +41508,7 @@
         "id": "tile-3279",
         "x": 57,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38241,6 +41520,7 @@
         "id": "tile-3280",
         "x": 59,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38252,6 +41532,7 @@
         "id": "tile-3281",
         "x": 61,
         "y": 65,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -38263,6 +41544,7 @@
         "id": "tile-3282",
         "x": 63,
         "y": 65,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "resource": "Saltpeter"
@@ -38275,6 +41557,7 @@
         "id": "tile-3283",
         "x": 65,
         "y": 65,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -38286,6 +41569,7 @@
         "id": "tile-3284",
         "x": 67,
         "y": 65,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -38297,6 +41581,7 @@
         "id": "tile-3285",
         "x": 69,
         "y": 65,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -38308,6 +41593,7 @@
         "id": "tile-3286",
         "x": 71,
         "y": 65,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -38325,6 +41611,7 @@
         "id": "tile-3287",
         "x": 73,
         "y": 65,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -38342,6 +41629,7 @@
         "id": "tile-3288",
         "x": 75,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38353,6 +41641,7 @@
         "id": "tile-3289",
         "x": 77,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -38364,6 +41653,7 @@
         "id": "tile-3290",
         "x": 79,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -38375,6 +41665,7 @@
         "id": "tile-3291",
         "x": 81,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -38386,6 +41677,7 @@
         "id": "tile-3292",
         "x": 83,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -38397,6 +41689,7 @@
         "id": "tile-3293",
         "x": 85,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -38408,6 +41701,7 @@
         "id": "tile-3294",
         "x": 87,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -38419,6 +41713,7 @@
         "id": "tile-3295",
         "x": 89,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -38430,6 +41725,7 @@
         "id": "tile-3296",
         "x": 91,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -38441,6 +41737,7 @@
         "id": "tile-3297",
         "x": 93,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -38452,6 +41749,7 @@
         "id": "tile-3298",
         "x": 95,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -38463,6 +41761,7 @@
         "id": "tile-3299",
         "x": 97,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -38474,6 +41773,7 @@
         "id": "tile-3300",
         "x": 99,
         "y": 65,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -38485,6 +41785,7 @@
         "id": "tile-3301",
         "x": 0,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -38496,6 +41797,7 @@
         "id": "tile-3302",
         "x": 2,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38507,6 +41809,7 @@
         "id": "tile-3303",
         "x": 4,
         "y": 66,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -38523,6 +41826,7 @@
         "id": "tile-3304",
         "x": 6,
         "y": 66,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -38540,6 +41844,7 @@
         "id": "tile-3305",
         "x": 8,
         "y": 66,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "resource": "Furs"
@@ -38552,6 +41857,7 @@
         "id": "tile-3306",
         "x": 10,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38563,6 +41869,7 @@
         "id": "tile-3307",
         "x": 12,
         "y": 66,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -38577,6 +41884,7 @@
         "id": "tile-3308",
         "x": 14,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38588,6 +41896,7 @@
         "id": "tile-3309",
         "x": 16,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38599,6 +41908,7 @@
         "id": "tile-3310",
         "x": 18,
         "y": 66,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "resource": "Sugar",
@@ -38614,6 +41924,7 @@
         "id": "tile-3311",
         "x": 20,
         "y": 66,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -38625,6 +41936,7 @@
         "id": "tile-3312",
         "x": 22,
         "y": 66,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -38639,6 +41951,7 @@
         "id": "tile-3313",
         "x": 24,
         "y": 66,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -38650,6 +41963,7 @@
         "id": "tile-3314",
         "x": 26,
         "y": 66,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "resource": "Saltpeter"
@@ -38662,6 +41976,7 @@
         "id": "tile-3315",
         "x": 28,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38673,6 +41988,7 @@
         "id": "tile-3316",
         "x": 30,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38684,6 +42000,7 @@
         "id": "tile-3317",
         "x": 32,
         "y": 66,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "resource": "Rubber"
@@ -38696,6 +42013,7 @@
         "id": "tile-3318",
         "x": 34,
         "y": 66,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "features": [
@@ -38710,6 +42028,7 @@
         "id": "tile-3319",
         "x": 36,
         "y": 66,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -38728,6 +42047,7 @@
         "id": "tile-3320",
         "x": 38,
         "y": 66,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -38743,6 +42063,7 @@
         "id": "tile-3321",
         "x": 40,
         "y": 66,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -38757,6 +42078,7 @@
         "id": "tile-3322",
         "x": 42,
         "y": 66,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -38768,6 +42090,7 @@
         "id": "tile-3323",
         "x": 44,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38779,6 +42102,7 @@
         "id": "tile-3324",
         "x": 46,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -38790,6 +42114,7 @@
         "id": "tile-3325",
         "x": 48,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -38801,6 +42126,7 @@
         "id": "tile-3326",
         "x": 50,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -38812,6 +42138,7 @@
         "id": "tile-3327",
         "x": 52,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -38823,6 +42150,7 @@
         "id": "tile-3328",
         "x": 54,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -38834,6 +42162,7 @@
         "id": "tile-3329",
         "x": 56,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38845,6 +42174,7 @@
         "id": "tile-3330",
         "x": 58,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38856,6 +42186,7 @@
         "id": "tile-3331",
         "x": 60,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38867,6 +42198,7 @@
         "id": "tile-3332",
         "x": 62,
         "y": 66,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -38878,6 +42210,7 @@
         "id": "tile-3333",
         "x": 64,
         "y": 66,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -38889,6 +42222,7 @@
         "id": "tile-3334",
         "x": 66,
         "y": 66,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -38900,6 +42234,7 @@
         "id": "tile-3335",
         "x": 68,
         "y": 66,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -38911,6 +42246,7 @@
         "id": "tile-3336",
         "x": 70,
         "y": 66,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -38925,6 +42261,7 @@
         "id": "tile-3337",
         "x": 72,
         "y": 66,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "flood plain",
         "features": [
@@ -38940,6 +42277,7 @@
         "id": "tile-3338",
         "x": 74,
         "y": 66,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "features": [
@@ -38955,6 +42293,7 @@
         "id": "tile-3339",
         "x": 76,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -38966,6 +42305,7 @@
         "id": "tile-3340",
         "x": 78,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -38977,6 +42317,7 @@
         "id": "tile-3341",
         "x": 80,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -38988,6 +42329,7 @@
         "id": "tile-3342",
         "x": 82,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -38999,6 +42341,7 @@
         "id": "tile-3343",
         "x": 84,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39010,6 +42353,7 @@
         "id": "tile-3344",
         "x": 86,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39021,6 +42365,7 @@
         "id": "tile-3345",
         "x": 88,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39032,6 +42377,7 @@
         "id": "tile-3346",
         "x": 90,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39043,6 +42389,7 @@
         "id": "tile-3347",
         "x": 92,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39054,6 +42401,7 @@
         "id": "tile-3348",
         "x": 94,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39065,6 +42413,7 @@
         "id": "tile-3349",
         "x": 96,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39076,6 +42425,7 @@
         "id": "tile-3350",
         "x": 98,
         "y": 66,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39087,6 +42437,7 @@
         "id": "tile-3351",
         "x": 1,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -39098,6 +42449,7 @@
         "id": "tile-3352",
         "x": 3,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -39109,6 +42461,7 @@
         "id": "tile-3353",
         "x": 5,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "resource": "Rubber",
@@ -39125,6 +42478,7 @@
         "id": "tile-3354",
         "x": 7,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -39136,6 +42490,7 @@
         "id": "tile-3355",
         "x": 9,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -39147,6 +42502,7 @@
         "id": "tile-3356",
         "x": 11,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -39158,6 +42514,7 @@
         "id": "tile-3357",
         "x": 13,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -39169,6 +42526,7 @@
         "id": "tile-3358",
         "x": 15,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -39181,6 +42539,7 @@
         "id": "tile-3359",
         "x": 17,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -39192,6 +42551,7 @@
         "id": "tile-3360",
         "x": 19,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -39203,6 +42563,7 @@
         "id": "tile-3361",
         "x": 21,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -39217,6 +42578,7 @@
         "id": "tile-3362",
         "x": 23,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -39228,6 +42590,7 @@
         "id": "tile-3363",
         "x": 25,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -39239,6 +42602,7 @@
         "id": "tile-3364",
         "x": 27,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -39250,6 +42614,7 @@
         "id": "tile-3365",
         "x": 29,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -39264,6 +42629,7 @@
         "id": "tile-3366",
         "x": 31,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -39275,6 +42641,7 @@
         "id": "tile-3367",
         "x": 33,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -39289,6 +42656,7 @@
         "id": "tile-3368",
         "x": 35,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "features": [
@@ -39306,6 +42674,7 @@
         "id": "tile-3369",
         "x": 37,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -39322,6 +42691,7 @@
         "id": "tile-3370",
         "x": 39,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -39337,6 +42707,7 @@
         "id": "tile-3371",
         "x": 41,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "features": [
@@ -39351,6 +42722,7 @@
         "id": "tile-3372",
         "x": 43,
         "y": 67,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -39362,6 +42734,7 @@
         "id": "tile-3373",
         "x": 45,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -39373,6 +42746,7 @@
         "id": "tile-3374",
         "x": 47,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -39384,6 +42758,7 @@
         "id": "tile-3375",
         "x": 49,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39395,6 +42770,7 @@
         "id": "tile-3376",
         "x": 51,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39406,6 +42782,7 @@
         "id": "tile-3377",
         "x": 53,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39417,6 +42794,7 @@
         "id": "tile-3378",
         "x": 55,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -39428,6 +42806,7 @@
         "id": "tile-3379",
         "x": 57,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -39439,6 +42818,7 @@
         "id": "tile-3380",
         "x": 59,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -39450,6 +42830,7 @@
         "id": "tile-3381",
         "x": 61,
         "y": 67,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -39464,6 +42845,7 @@
         "id": "tile-3382",
         "x": 63,
         "y": 67,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -39475,6 +42857,7 @@
         "id": "tile-3383",
         "x": 65,
         "y": 67,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -39486,6 +42869,7 @@
         "id": "tile-3384",
         "x": 67,
         "y": 67,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -39497,6 +42881,7 @@
         "id": "tile-3385",
         "x": 69,
         "y": 67,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -39508,6 +42893,7 @@
         "id": "tile-3386",
         "x": 71,
         "y": 67,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -39522,6 +42908,7 @@
         "id": "tile-3387",
         "x": 73,
         "y": 67,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "features": [
@@ -39537,6 +42924,7 @@
         "id": "tile-3388",
         "x": 75,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -39548,6 +42936,7 @@
         "id": "tile-3389",
         "x": 77,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -39559,6 +42948,7 @@
         "id": "tile-3390",
         "x": 79,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -39570,6 +42960,7 @@
         "id": "tile-3391",
         "x": 81,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -39581,6 +42972,7 @@
         "id": "tile-3392",
         "x": 83,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39592,6 +42984,7 @@
         "id": "tile-3393",
         "x": 85,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39603,6 +42996,7 @@
         "id": "tile-3394",
         "x": 87,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39614,6 +43008,7 @@
         "id": "tile-3395",
         "x": 89,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39625,6 +43020,7 @@
         "id": "tile-3396",
         "x": 91,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39636,6 +43032,7 @@
         "id": "tile-3397",
         "x": 93,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39647,6 +43044,7 @@
         "id": "tile-3398",
         "x": 95,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39658,6 +43056,7 @@
         "id": "tile-3399",
         "x": 97,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39669,6 +43068,7 @@
         "id": "tile-3400",
         "x": 99,
         "y": 67,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39680,6 +43080,7 @@
         "id": "tile-3401",
         "x": 0,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -39691,6 +43092,7 @@
         "id": "tile-3402",
         "x": 2,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -39703,6 +43105,7 @@
         "id": "tile-3403",
         "x": 4,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -39714,6 +43117,7 @@
         "id": "tile-3404",
         "x": 6,
         "y": 68,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -39728,6 +43132,7 @@
         "id": "tile-3405",
         "x": 8,
         "y": 68,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -39742,6 +43147,7 @@
         "id": "tile-3406",
         "x": 10,
         "y": 68,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -39753,6 +43159,7 @@
         "id": "tile-3407",
         "x": 12,
         "y": 68,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -39767,6 +43174,7 @@
         "id": "tile-3408",
         "x": 14,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -39778,6 +43186,7 @@
         "id": "tile-3409",
         "x": 16,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -39789,6 +43198,7 @@
         "id": "tile-3410",
         "x": 18,
         "y": 68,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -39803,6 +43213,7 @@
         "id": "tile-3411",
         "x": 20,
         "y": 68,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -39817,6 +43228,7 @@
         "id": "tile-3412",
         "x": 22,
         "y": 68,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -39828,6 +43240,7 @@
         "id": "tile-3413",
         "x": 24,
         "y": 68,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Iron",
@@ -39843,6 +43256,7 @@
         "id": "tile-3414",
         "x": 26,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -39854,6 +43268,7 @@
         "id": "tile-3415",
         "x": 28,
         "y": 68,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -39868,6 +43283,7 @@
         "id": "tile-3416",
         "x": 30,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -39879,6 +43295,7 @@
         "id": "tile-3417",
         "x": 32,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -39890,6 +43307,7 @@
         "id": "tile-3418",
         "x": 34,
         "y": 68,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -39906,6 +43324,7 @@
         "id": "tile-3419",
         "x": 36,
         "y": 68,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -39922,6 +43341,7 @@
         "id": "tile-3420",
         "x": 38,
         "y": 68,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -39933,6 +43353,7 @@
         "id": "tile-3421",
         "x": 40,
         "y": 68,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -39947,6 +43368,7 @@
         "id": "tile-3422",
         "x": 42,
         "y": 68,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -39958,6 +43380,7 @@
         "id": "tile-3423",
         "x": 44,
         "y": 68,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -39969,6 +43392,7 @@
         "id": "tile-3424",
         "x": 46,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -39980,6 +43404,7 @@
         "id": "tile-3425",
         "x": 48,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -39991,6 +43416,7 @@
         "id": "tile-3426",
         "x": 50,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40002,6 +43428,7 @@
         "id": "tile-3427",
         "x": 52,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40013,6 +43440,7 @@
         "id": "tile-3428",
         "x": 54,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40024,6 +43452,7 @@
         "id": "tile-3429",
         "x": 56,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -40035,6 +43464,7 @@
         "id": "tile-3430",
         "x": 58,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -40046,6 +43476,7 @@
         "id": "tile-3431",
         "x": 60,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -40057,6 +43488,7 @@
         "id": "tile-3432",
         "x": 62,
         "y": 68,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "resource": "Oasis"
@@ -40069,6 +43501,7 @@
         "id": "tile-3433",
         "x": 64,
         "y": 68,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -40083,6 +43516,7 @@
         "id": "tile-3434",
         "x": 66,
         "y": 68,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -40097,6 +43531,7 @@
         "id": "tile-3435",
         "x": 68,
         "y": 68,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -40108,6 +43543,7 @@
         "id": "tile-3436",
         "x": 70,
         "y": 68,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -40119,6 +43555,7 @@
         "id": "tile-3437",
         "x": 72,
         "y": 68,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "resource": "Oasis",
@@ -40134,6 +43571,7 @@
         "id": "tile-3438",
         "x": 74,
         "y": 68,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -40148,6 +43586,7 @@
         "id": "tile-3439",
         "x": 76,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -40159,6 +43598,7 @@
         "id": "tile-3440",
         "x": 78,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -40170,6 +43610,7 @@
         "id": "tile-3441",
         "x": 80,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -40181,6 +43622,7 @@
         "id": "tile-3442",
         "x": 82,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40192,6 +43634,7 @@
         "id": "tile-3443",
         "x": 84,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40203,6 +43646,7 @@
         "id": "tile-3444",
         "x": 86,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40214,6 +43658,7 @@
         "id": "tile-3445",
         "x": 88,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40225,6 +43670,7 @@
         "id": "tile-3446",
         "x": 90,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40236,6 +43682,7 @@
         "id": "tile-3447",
         "x": 92,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40247,6 +43694,7 @@
         "id": "tile-3448",
         "x": 94,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40258,6 +43706,7 @@
         "id": "tile-3449",
         "x": 96,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40269,6 +43718,7 @@
         "id": "tile-3450",
         "x": 98,
         "y": 68,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40280,6 +43730,7 @@
         "id": "tile-3451",
         "x": 1,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40291,6 +43742,7 @@
         "id": "tile-3452",
         "x": 3,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -40302,6 +43754,7 @@
         "id": "tile-3453",
         "x": 5,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -40313,6 +43766,7 @@
         "id": "tile-3454",
         "x": 7,
         "y": 69,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -40324,6 +43778,7 @@
         "id": "tile-3455",
         "x": 9,
         "y": 69,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -40335,6 +43790,7 @@
         "id": "tile-3456",
         "x": 11,
         "y": 69,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -40349,6 +43805,7 @@
         "id": "tile-3457",
         "x": 13,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -40360,6 +43817,7 @@
         "id": "tile-3458",
         "x": 15,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -40372,6 +43830,7 @@
         "id": "tile-3459",
         "x": 17,
         "y": 69,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -40386,6 +43845,7 @@
         "id": "tile-3460",
         "x": 19,
         "y": 69,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -40400,6 +43860,7 @@
         "id": "tile-3461",
         "x": 21,
         "y": 69,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -40414,6 +43875,7 @@
         "id": "tile-3462",
         "x": 23,
         "y": 69,
+        "continent": 7,
         "baseTerrain": "desert",
         "overlayTerrain": "desert",
         "features": [
@@ -40428,6 +43890,7 @@
         "id": "tile-3463",
         "x": 25,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -40439,6 +43902,7 @@
         "id": "tile-3464",
         "x": 27,
         "y": 69,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -40450,6 +43914,7 @@
         "id": "tile-3465",
         "x": 29,
         "y": 69,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -40464,6 +43929,7 @@
         "id": "tile-3466",
         "x": 31,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -40475,6 +43941,7 @@
         "id": "tile-3467",
         "x": 33,
         "y": 69,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -40489,6 +43956,7 @@
         "id": "tile-3468",
         "x": 35,
         "y": 69,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -40505,6 +43973,7 @@
         "id": "tile-3469",
         "x": 37,
         "y": 69,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -40516,6 +43985,7 @@
         "id": "tile-3470",
         "x": 39,
         "y": 69,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -40532,6 +44002,7 @@
         "id": "tile-3471",
         "x": 41,
         "y": 69,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "resource": "Sugar",
@@ -40547,6 +44018,7 @@
         "id": "tile-3472",
         "x": 43,
         "y": 69,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -40561,6 +44033,7 @@
         "id": "tile-3473",
         "x": 45,
         "y": 69,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -40572,6 +44045,7 @@
         "id": "tile-3474",
         "x": 47,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -40583,6 +44057,7 @@
         "id": "tile-3475",
         "x": 49,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -40594,6 +44069,7 @@
         "id": "tile-3476",
         "x": 51,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -40605,6 +44081,7 @@
         "id": "tile-3477",
         "x": 53,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40616,6 +44093,7 @@
         "id": "tile-3478",
         "x": 55,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40627,6 +44105,7 @@
         "id": "tile-3479",
         "x": 57,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40638,6 +44117,7 @@
         "id": "tile-3480",
         "x": 59,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -40649,6 +44129,7 @@
         "id": "tile-3481",
         "x": 61,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -40660,6 +44141,7 @@
         "id": "tile-3482",
         "x": 63,
         "y": 69,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -40674,6 +44156,7 @@
         "id": "tile-3483",
         "x": 65,
         "y": 69,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -40685,6 +44168,7 @@
         "id": "tile-3484",
         "x": 67,
         "y": 69,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -40699,6 +44183,7 @@
         "id": "tile-3485",
         "x": 69,
         "y": 69,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -40710,6 +44195,7 @@
         "id": "tile-3486",
         "x": 71,
         "y": 69,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -40724,6 +44210,7 @@
         "id": "tile-3487",
         "x": 73,
         "y": 69,
+        "continent": 5,
         "baseTerrain": "desert",
         "overlayTerrain": "desert"
       },
@@ -40735,6 +44222,7 @@
         "id": "tile-3488",
         "x": 75,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -40746,6 +44234,7 @@
         "id": "tile-3489",
         "x": 77,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -40757,6 +44246,7 @@
         "id": "tile-3490",
         "x": 79,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -40768,6 +44258,7 @@
         "id": "tile-3491",
         "x": 81,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40779,6 +44270,7 @@
         "id": "tile-3492",
         "x": 83,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40790,6 +44282,7 @@
         "id": "tile-3493",
         "x": 85,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40801,6 +44294,7 @@
         "id": "tile-3494",
         "x": 87,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40812,6 +44306,7 @@
         "id": "tile-3495",
         "x": 89,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40823,6 +44318,7 @@
         "id": "tile-3496",
         "x": 91,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40834,6 +44330,7 @@
         "id": "tile-3497",
         "x": 93,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40845,6 +44342,7 @@
         "id": "tile-3498",
         "x": 95,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40856,6 +44354,7 @@
         "id": "tile-3499",
         "x": 97,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40867,6 +44366,7 @@
         "id": "tile-3500",
         "x": 99,
         "y": 69,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40878,6 +44378,7 @@
         "id": "tile-3501",
         "x": 0,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -40889,6 +44390,7 @@
         "id": "tile-3502",
         "x": 2,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -40900,6 +44402,7 @@
         "id": "tile-3503",
         "x": 4,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -40911,6 +44414,7 @@
         "id": "tile-3504",
         "x": 6,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -40925,6 +44429,7 @@
         "id": "tile-3505",
         "x": 8,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -40939,6 +44444,7 @@
         "id": "tile-3506",
         "x": 10,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Sugar",
@@ -40954,6 +44460,7 @@
         "id": "tile-3507",
         "x": 12,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -40965,6 +44472,7 @@
         "id": "tile-3508",
         "x": 14,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -40976,6 +44484,7 @@
         "id": "tile-3509",
         "x": 16,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -40987,6 +44496,7 @@
         "id": "tile-3510",
         "x": 18,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -41001,6 +44511,7 @@
         "id": "tile-3511",
         "x": 20,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -41015,6 +44526,7 @@
         "id": "tile-3512",
         "x": 22,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -41029,6 +44541,7 @@
         "id": "tile-3513",
         "x": 24,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -41040,6 +44553,7 @@
         "id": "tile-3514",
         "x": 26,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -41054,6 +44568,7 @@
         "id": "tile-3515",
         "x": 28,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -41068,6 +44583,7 @@
         "id": "tile-3516",
         "x": 30,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -41079,6 +44595,7 @@
         "id": "tile-3517",
         "x": 32,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -41090,6 +44607,7 @@
         "id": "tile-3518",
         "x": 34,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -41101,6 +44619,7 @@
         "id": "tile-3519",
         "x": 36,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -41112,6 +44631,7 @@
         "id": "tile-3520",
         "x": 38,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -41127,6 +44647,7 @@
         "id": "tile-3521",
         "x": 40,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -41142,6 +44663,7 @@
         "id": "tile-3522",
         "x": 42,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -41156,6 +44678,7 @@
         "id": "tile-3523",
         "x": 44,
         "y": 70,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -41170,6 +44693,7 @@
         "id": "tile-3524",
         "x": 46,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -41181,6 +44705,7 @@
         "id": "tile-3525",
         "x": 48,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -41192,6 +44717,7 @@
         "id": "tile-3526",
         "x": 50,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -41203,6 +44729,7 @@
         "id": "tile-3527",
         "x": 52,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -41214,6 +44741,7 @@
         "id": "tile-3528",
         "x": 54,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -41225,6 +44753,7 @@
         "id": "tile-3529",
         "x": 56,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -41236,6 +44765,7 @@
         "id": "tile-3530",
         "x": 58,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -41247,6 +44777,7 @@
         "id": "tile-3531",
         "x": 60,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -41258,6 +44789,7 @@
         "id": "tile-3532",
         "x": 62,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -41269,6 +44801,7 @@
         "id": "tile-3533",
         "x": 64,
         "y": 70,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -41280,6 +44813,7 @@
         "id": "tile-3534",
         "x": 66,
         "y": 70,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -41294,6 +44828,7 @@
         "id": "tile-3535",
         "x": 68,
         "y": 70,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -41305,6 +44840,7 @@
         "id": "tile-3536",
         "x": 70,
         "y": 70,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -41316,6 +44852,7 @@
         "id": "tile-3537",
         "x": 72,
         "y": 70,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -41330,6 +44867,7 @@
         "id": "tile-3538",
         "x": 74,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -41341,6 +44879,7 @@
         "id": "tile-3539",
         "x": 76,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -41352,6 +44891,7 @@
         "id": "tile-3540",
         "x": 78,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -41363,6 +44903,7 @@
         "id": "tile-3541",
         "x": 80,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -41374,6 +44915,7 @@
         "id": "tile-3542",
         "x": 82,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -41385,6 +44927,7 @@
         "id": "tile-3543",
         "x": 84,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -41396,6 +44939,7 @@
         "id": "tile-3544",
         "x": 86,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -41407,6 +44951,7 @@
         "id": "tile-3545",
         "x": 88,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -41418,6 +44963,7 @@
         "id": "tile-3546",
         "x": 90,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -41429,6 +44975,7 @@
         "id": "tile-3547",
         "x": 92,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -41440,6 +44987,7 @@
         "id": "tile-3548",
         "x": 94,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -41451,6 +44999,7 @@
         "id": "tile-3549",
         "x": 96,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -41462,6 +45011,7 @@
         "id": "tile-3550",
         "x": 98,
         "y": 70,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -41473,6 +45023,7 @@
         "id": "tile-3551",
         "x": 1,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -41484,6 +45035,7 @@
         "id": "tile-3552",
         "x": 3,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -41495,6 +45047,7 @@
         "id": "tile-3553",
         "x": 5,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -41506,6 +45059,7 @@
         "id": "tile-3554",
         "x": 7,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -41520,6 +45074,7 @@
         "id": "tile-3555",
         "x": 9,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -41534,6 +45089,7 @@
         "id": "tile-3556",
         "x": 11,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -41548,6 +45104,7 @@
         "id": "tile-3557",
         "x": 13,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -41559,6 +45116,7 @@
         "id": "tile-3558",
         "x": 15,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -41570,6 +45128,7 @@
         "id": "tile-3559",
         "x": 17,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -41584,6 +45143,7 @@
         "id": "tile-3560",
         "x": 19,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -41598,6 +45158,7 @@
         "id": "tile-3561",
         "x": 21,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -41609,6 +45170,7 @@
         "id": "tile-3562",
         "x": 23,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -41623,6 +45185,7 @@
         "id": "tile-3563",
         "x": 25,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -41634,6 +45197,7 @@
         "id": "tile-3564",
         "x": 27,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -41645,6 +45209,7 @@
         "id": "tile-3565",
         "x": 29,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -41659,6 +45224,7 @@
         "id": "tile-3566",
         "x": 31,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -41673,6 +45239,7 @@
         "id": "tile-3567",
         "x": 33,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -41687,6 +45254,7 @@
         "id": "tile-3568",
         "x": 35,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -41701,6 +45269,7 @@
         "id": "tile-3569",
         "x": 37,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "resource": "Coal",
@@ -41718,6 +45287,7 @@
         "id": "tile-3570",
         "x": 39,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -41737,6 +45307,7 @@
         "id": "tile-3571",
         "x": 41,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -41754,6 +45325,7 @@
         "id": "tile-3572",
         "x": 43,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -41770,6 +45342,7 @@
         "id": "tile-3573",
         "x": 45,
         "y": 71,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -41784,6 +45357,7 @@
         "id": "tile-3574",
         "x": 47,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -41795,6 +45369,7 @@
         "id": "tile-3575",
         "x": 49,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -41806,6 +45381,7 @@
         "id": "tile-3576",
         "x": 51,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -41817,6 +45393,7 @@
         "id": "tile-3577",
         "x": 53,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -41828,6 +45405,7 @@
         "id": "tile-3578",
         "x": 55,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -41839,6 +45417,7 @@
         "id": "tile-3579",
         "x": 57,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -41850,6 +45429,7 @@
         "id": "tile-3580",
         "x": 59,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -41861,6 +45441,7 @@
         "id": "tile-3581",
         "x": 61,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -41872,6 +45453,7 @@
         "id": "tile-3582",
         "x": 63,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -41883,6 +45465,7 @@
         "id": "tile-3583",
         "x": 65,
         "y": 71,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -41897,6 +45480,7 @@
         "id": "tile-3584",
         "x": 67,
         "y": 71,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -41911,6 +45495,7 @@
         "id": "tile-3585",
         "x": 69,
         "y": 71,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -41925,6 +45510,7 @@
         "id": "tile-3586",
         "x": 71,
         "y": 71,
+        "continent": 5,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Horses",
@@ -41940,6 +45526,7 @@
         "id": "tile-3587",
         "x": 73,
         "y": 71,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -41954,6 +45541,7 @@
         "id": "tile-3588",
         "x": 75,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -41965,6 +45553,7 @@
         "id": "tile-3589",
         "x": 77,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -41976,6 +45565,7 @@
         "id": "tile-3590",
         "x": 79,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -41987,6 +45577,7 @@
         "id": "tile-3591",
         "x": 81,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -41998,6 +45589,7 @@
         "id": "tile-3592",
         "x": 83,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42009,6 +45601,7 @@
         "id": "tile-3593",
         "x": 85,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42020,6 +45613,7 @@
         "id": "tile-3594",
         "x": 87,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42031,6 +45625,7 @@
         "id": "tile-3595",
         "x": 89,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42042,6 +45637,7 @@
         "id": "tile-3596",
         "x": 91,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42053,6 +45649,7 @@
         "id": "tile-3597",
         "x": 93,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42064,6 +45661,7 @@
         "id": "tile-3598",
         "x": 95,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42075,6 +45673,7 @@
         "id": "tile-3599",
         "x": 97,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42086,6 +45685,7 @@
         "id": "tile-3600",
         "x": 99,
         "y": 71,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42097,6 +45697,7 @@
         "id": "tile-3601",
         "x": 0,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42108,6 +45709,7 @@
         "id": "tile-3602",
         "x": 2,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -42119,6 +45721,7 @@
         "id": "tile-3603",
         "x": 4,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -42130,6 +45733,7 @@
         "id": "tile-3604",
         "x": 6,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -42144,6 +45748,7 @@
         "id": "tile-3605",
         "x": 8,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -42155,6 +45760,7 @@
         "id": "tile-3606",
         "x": 10,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest"
       },
@@ -42166,6 +45772,7 @@
         "id": "tile-3607",
         "x": 12,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -42177,6 +45784,7 @@
         "id": "tile-3608",
         "x": 14,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -42189,6 +45797,7 @@
         "id": "tile-3609",
         "x": 16,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -42200,6 +45809,7 @@
         "id": "tile-3610",
         "x": 18,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -42214,6 +45824,7 @@
         "id": "tile-3611",
         "x": 20,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -42228,6 +45839,7 @@
         "id": "tile-3612",
         "x": 22,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -42243,6 +45855,7 @@
         "id": "tile-3613",
         "x": 24,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -42254,6 +45867,7 @@
         "id": "tile-3614",
         "x": 26,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Aluminum",
@@ -42269,6 +45883,7 @@
         "id": "tile-3615",
         "x": 28,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -42284,6 +45899,7 @@
         "id": "tile-3616",
         "x": 30,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -42300,6 +45916,7 @@
         "id": "tile-3617",
         "x": 32,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -42317,6 +45934,7 @@
         "id": "tile-3618",
         "x": 34,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -42334,6 +45952,7 @@
         "id": "tile-3619",
         "x": 36,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -42348,6 +45967,7 @@
         "id": "tile-3620",
         "x": 38,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -42364,6 +45984,7 @@
         "id": "tile-3621",
         "x": 40,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -42381,6 +46002,7 @@
         "id": "tile-3622",
         "x": 42,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -42399,6 +46021,7 @@
         "id": "tile-3623",
         "x": 44,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -42415,6 +46038,7 @@
         "id": "tile-3624",
         "x": 46,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -42429,6 +46053,7 @@
         "id": "tile-3625",
         "x": 48,
         "y": 72,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -42444,6 +46069,7 @@
         "id": "tile-3626",
         "x": 50,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -42455,6 +46081,7 @@
         "id": "tile-3627",
         "x": 52,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -42466,6 +46093,7 @@
         "id": "tile-3628",
         "x": 54,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -42477,6 +46105,7 @@
         "id": "tile-3629",
         "x": 56,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42488,6 +46117,7 @@
         "id": "tile-3630",
         "x": 58,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42499,6 +46129,7 @@
         "id": "tile-3631",
         "x": 60,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42510,6 +46141,7 @@
         "id": "tile-3632",
         "x": 62,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -42521,6 +46153,7 @@
         "id": "tile-3633",
         "x": 64,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -42532,6 +46165,7 @@
         "id": "tile-3634",
         "x": 66,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -42543,6 +46177,7 @@
         "id": "tile-3635",
         "x": 68,
         "y": 72,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -42557,6 +46192,7 @@
         "id": "tile-3636",
         "x": 70,
         "y": 72,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -42571,6 +46207,7 @@
         "id": "tile-3637",
         "x": 72,
         "y": 72,
+        "continent": 5,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -42582,6 +46219,7 @@
         "id": "tile-3638",
         "x": 74,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -42593,6 +46231,7 @@
         "id": "tile-3639",
         "x": 76,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -42604,6 +46243,7 @@
         "id": "tile-3640",
         "x": 78,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -42615,6 +46255,7 @@
         "id": "tile-3641",
         "x": 80,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42626,6 +46267,7 @@
         "id": "tile-3642",
         "x": 82,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42637,6 +46279,7 @@
         "id": "tile-3643",
         "x": 84,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42648,6 +46291,7 @@
         "id": "tile-3644",
         "x": 86,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42659,6 +46303,7 @@
         "id": "tile-3645",
         "x": 88,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42670,6 +46315,7 @@
         "id": "tile-3646",
         "x": 90,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42681,6 +46327,7 @@
         "id": "tile-3647",
         "x": 92,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42692,6 +46339,7 @@
         "id": "tile-3648",
         "x": 94,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42703,6 +46351,7 @@
         "id": "tile-3649",
         "x": 96,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42714,6 +46363,7 @@
         "id": "tile-3650",
         "x": 98,
         "y": 72,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -42725,6 +46375,7 @@
         "id": "tile-3651",
         "x": 1,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -42736,6 +46387,7 @@
         "id": "tile-3652",
         "x": 3,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -42747,6 +46399,7 @@
         "id": "tile-3653",
         "x": 5,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -42761,6 +46414,7 @@
         "id": "tile-3654",
         "x": 7,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -42776,6 +46430,7 @@
         "id": "tile-3655",
         "x": 9,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Saltpeter",
@@ -42791,6 +46446,7 @@
         "id": "tile-3656",
         "x": 11,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -42806,6 +46462,7 @@
         "id": "tile-3657",
         "x": 13,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -42817,6 +46474,7 @@
         "id": "tile-3658",
         "x": 15,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -42828,6 +46486,7 @@
         "id": "tile-3659",
         "x": 17,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -42839,6 +46498,7 @@
         "id": "tile-3660",
         "x": 19,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -42853,6 +46513,7 @@
         "id": "tile-3661",
         "x": 21,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -42867,6 +46528,7 @@
         "id": "tile-3662",
         "x": 23,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -42881,6 +46543,7 @@
         "id": "tile-3663",
         "x": 25,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -42893,6 +46556,7 @@
         "id": "tile-3664",
         "x": 27,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -42904,6 +46568,7 @@
         "id": "tile-3665",
         "x": 29,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -42920,6 +46585,7 @@
         "id": "tile-3666",
         "x": 31,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Horses",
@@ -42939,6 +46605,7 @@
         "id": "tile-3667",
         "x": 33,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -42957,6 +46624,7 @@
         "id": "tile-3668",
         "x": 35,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -42975,6 +46643,7 @@
         "id": "tile-3669",
         "x": 37,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -42989,6 +46658,7 @@
         "id": "tile-3670",
         "x": 39,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -43000,6 +46670,7 @@
         "id": "tile-3671",
         "x": 41,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -43015,6 +46686,7 @@
         "id": "tile-3672",
         "x": 43,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -43031,6 +46703,7 @@
         "id": "tile-3673",
         "x": 45,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -43049,6 +46722,7 @@
         "id": "tile-3674",
         "x": 47,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -43066,6 +46740,7 @@
         "id": "tile-3675",
         "x": 49,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "features": [
@@ -43081,6 +46756,7 @@
         "id": "tile-3676",
         "x": 51,
         "y": 73,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "resource": "Silks"
@@ -43093,6 +46769,7 @@
         "id": "tile-3677",
         "x": 53,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -43104,6 +46781,7 @@
         "id": "tile-3678",
         "x": 55,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -43115,6 +46793,7 @@
         "id": "tile-3679",
         "x": 57,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43126,6 +46805,7 @@
         "id": "tile-3680",
         "x": 59,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43137,6 +46817,7 @@
         "id": "tile-3681",
         "x": 61,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43148,6 +46829,7 @@
         "id": "tile-3682",
         "x": 63,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -43159,6 +46841,7 @@
         "id": "tile-3683",
         "x": 65,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -43170,6 +46853,7 @@
         "id": "tile-3684",
         "x": 67,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -43181,6 +46865,7 @@
         "id": "tile-3685",
         "x": 69,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -43192,6 +46877,7 @@
         "id": "tile-3686",
         "x": 71,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -43203,6 +46889,7 @@
         "id": "tile-3687",
         "x": 73,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -43214,6 +46901,7 @@
         "id": "tile-3688",
         "x": 75,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -43225,6 +46913,7 @@
         "id": "tile-3689",
         "x": 77,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43236,6 +46925,7 @@
         "id": "tile-3690",
         "x": 79,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43247,6 +46937,7 @@
         "id": "tile-3691",
         "x": 81,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43258,6 +46949,7 @@
         "id": "tile-3692",
         "x": 83,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43269,6 +46961,7 @@
         "id": "tile-3693",
         "x": 85,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43280,6 +46973,7 @@
         "id": "tile-3694",
         "x": 87,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43291,6 +46985,7 @@
         "id": "tile-3695",
         "x": 89,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43302,6 +46997,7 @@
         "id": "tile-3696",
         "x": 91,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43313,6 +47009,7 @@
         "id": "tile-3697",
         "x": 93,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43324,6 +47021,7 @@
         "id": "tile-3698",
         "x": 95,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43335,6 +47033,7 @@
         "id": "tile-3699",
         "x": 97,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43346,6 +47045,7 @@
         "id": "tile-3700",
         "x": 99,
         "y": 73,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43357,6 +47057,7 @@
         "id": "tile-3701",
         "x": 0,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -43368,6 +47069,7 @@
         "id": "tile-3702",
         "x": 2,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -43379,6 +47081,7 @@
         "id": "tile-3703",
         "x": 4,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -43393,6 +47096,7 @@
         "id": "tile-3704",
         "x": 6,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -43408,6 +47112,7 @@
         "id": "tile-3705",
         "x": 8,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -43422,6 +47127,7 @@
         "id": "tile-3706",
         "x": 10,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -43436,6 +47142,7 @@
         "id": "tile-3707",
         "x": 12,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -43447,6 +47154,7 @@
         "id": "tile-3708",
         "x": 14,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -43458,6 +47166,7 @@
         "id": "tile-3709",
         "x": 16,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -43472,6 +47181,7 @@
         "id": "tile-3710",
         "x": 18,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -43486,6 +47196,7 @@
         "id": "tile-3711",
         "x": 20,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -43500,6 +47211,7 @@
         "id": "tile-3712",
         "x": 22,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -43515,6 +47227,7 @@
         "id": "tile-3713",
         "x": 24,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -43529,6 +47242,7 @@
         "id": "tile-3714",
         "x": 26,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -43540,6 +47254,7 @@
         "id": "tile-3715",
         "x": 28,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -43556,6 +47271,7 @@
         "id": "tile-3716",
         "x": 30,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -43574,6 +47290,7 @@
         "id": "tile-3717",
         "x": 32,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -43589,6 +47306,7 @@
         "id": "tile-3718",
         "x": 34,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -43606,6 +47324,7 @@
         "id": "tile-3719",
         "x": 36,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -43622,6 +47341,7 @@
         "id": "tile-3720",
         "x": 38,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -43636,6 +47356,7 @@
         "id": "tile-3721",
         "x": 40,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -43650,6 +47371,7 @@
         "id": "tile-3722",
         "x": 42,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "resource": "Sugar"
@@ -43662,6 +47384,7 @@
         "id": "tile-3723",
         "x": 44,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -43677,6 +47400,7 @@
         "id": "tile-3724",
         "x": 46,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -43694,6 +47418,7 @@
         "id": "tile-3725",
         "x": 48,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -43710,6 +47435,7 @@
         "id": "tile-3726",
         "x": 50,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "resource": "Silks"
@@ -43722,6 +47448,7 @@
         "id": "tile-3727",
         "x": 52,
         "y": 74,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "resource": "Silks",
@@ -43737,6 +47464,7 @@
         "id": "tile-3728",
         "x": 54,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -43748,6 +47476,7 @@
         "id": "tile-3729",
         "x": 56,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -43759,6 +47488,7 @@
         "id": "tile-3730",
         "x": 58,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43770,6 +47500,7 @@
         "id": "tile-3731",
         "x": 60,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43781,6 +47512,7 @@
         "id": "tile-3732",
         "x": 62,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43792,6 +47524,7 @@
         "id": "tile-3733",
         "x": 64,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -43803,6 +47536,7 @@
         "id": "tile-3734",
         "x": 66,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -43815,6 +47549,7 @@
         "id": "tile-3735",
         "x": 68,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -43826,6 +47561,7 @@
         "id": "tile-3736",
         "x": 70,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -43837,6 +47573,7 @@
         "id": "tile-3737",
         "x": 72,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -43848,6 +47585,7 @@
         "id": "tile-3738",
         "x": 74,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -43859,6 +47597,7 @@
         "id": "tile-3739",
         "x": 76,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43870,6 +47609,7 @@
         "id": "tile-3740",
         "x": 78,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43881,6 +47621,7 @@
         "id": "tile-3741",
         "x": 80,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43892,6 +47633,7 @@
         "id": "tile-3742",
         "x": 82,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43903,6 +47645,7 @@
         "id": "tile-3743",
         "x": 84,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43914,6 +47657,7 @@
         "id": "tile-3744",
         "x": 86,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43925,6 +47669,7 @@
         "id": "tile-3745",
         "x": 88,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43936,6 +47681,7 @@
         "id": "tile-3746",
         "x": 90,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43947,6 +47693,7 @@
         "id": "tile-3747",
         "x": 92,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43958,6 +47705,7 @@
         "id": "tile-3748",
         "x": 94,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43969,6 +47717,7 @@
         "id": "tile-3749",
         "x": 96,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43980,6 +47729,7 @@
         "id": "tile-3750",
         "x": 98,
         "y": 74,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -43991,6 +47741,7 @@
         "id": "tile-3751",
         "x": 1,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -44002,6 +47753,7 @@
         "id": "tile-3752",
         "x": 3,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -44013,6 +47765,7 @@
         "id": "tile-3753",
         "x": 5,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Tobacco",
@@ -44028,6 +47781,7 @@
         "id": "tile-3754",
         "x": 7,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Tobacco",
@@ -44043,6 +47797,7 @@
         "id": "tile-3755",
         "x": 9,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44057,6 +47812,7 @@
         "id": "tile-3756",
         "x": 11,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -44068,6 +47824,7 @@
         "id": "tile-3757",
         "x": 13,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -44080,6 +47837,7 @@
         "id": "tile-3758",
         "x": 15,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -44091,6 +47849,7 @@
         "id": "tile-3759",
         "x": 17,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44105,6 +47864,7 @@
         "id": "tile-3760",
         "x": 19,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44119,6 +47879,7 @@
         "id": "tile-3761",
         "x": 21,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44134,6 +47895,7 @@
         "id": "tile-3762",
         "x": 23,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -44149,6 +47911,7 @@
         "id": "tile-3763",
         "x": 25,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -44160,6 +47923,7 @@
         "id": "tile-3764",
         "x": 27,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -44171,6 +47935,7 @@
         "id": "tile-3765",
         "x": 29,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44188,6 +47953,7 @@
         "id": "tile-3766",
         "x": 31,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44202,6 +47968,7 @@
         "id": "tile-3767",
         "x": 33,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44216,6 +47983,7 @@
         "id": "tile-3768",
         "x": 35,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44232,6 +48000,7 @@
         "id": "tile-3769",
         "x": 37,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -44246,6 +48015,7 @@
         "id": "tile-3770",
         "x": 39,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -44257,6 +48027,7 @@
         "id": "tile-3771",
         "x": 41,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -44268,6 +48039,7 @@
         "id": "tile-3772",
         "x": 43,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -44279,6 +48051,7 @@
         "id": "tile-3773",
         "x": 45,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44295,6 +48068,7 @@
         "id": "tile-3774",
         "x": 47,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44310,6 +48084,7 @@
         "id": "tile-3775",
         "x": 49,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest"
       },
@@ -44321,6 +48096,7 @@
         "id": "tile-3776",
         "x": 51,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "features": [
@@ -44335,6 +48111,7 @@
         "id": "tile-3777",
         "x": 53,
         "y": 75,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -44349,6 +48126,7 @@
         "id": "tile-3778",
         "x": 55,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -44360,6 +48138,7 @@
         "id": "tile-3779",
         "x": 57,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -44372,6 +48151,7 @@
         "id": "tile-3780",
         "x": 59,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44383,6 +48163,7 @@
         "id": "tile-3781",
         "x": 61,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44394,6 +48175,7 @@
         "id": "tile-3782",
         "x": 63,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44405,6 +48187,7 @@
         "id": "tile-3783",
         "x": 65,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -44416,6 +48199,7 @@
         "id": "tile-3784",
         "x": 67,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -44427,6 +48211,7 @@
         "id": "tile-3785",
         "x": 69,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -44438,6 +48223,7 @@
         "id": "tile-3786",
         "x": 71,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -44449,6 +48235,7 @@
         "id": "tile-3787",
         "x": 73,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -44460,6 +48247,7 @@
         "id": "tile-3788",
         "x": 75,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44471,6 +48259,7 @@
         "id": "tile-3789",
         "x": 77,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44482,6 +48271,7 @@
         "id": "tile-3790",
         "x": 79,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44493,6 +48283,7 @@
         "id": "tile-3791",
         "x": 81,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44504,6 +48295,7 @@
         "id": "tile-3792",
         "x": 83,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44515,6 +48307,7 @@
         "id": "tile-3793",
         "x": 85,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44526,6 +48319,7 @@
         "id": "tile-3794",
         "x": 87,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44537,6 +48331,7 @@
         "id": "tile-3795",
         "x": 89,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44548,6 +48343,7 @@
         "id": "tile-3796",
         "x": 91,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44559,6 +48355,7 @@
         "id": "tile-3797",
         "x": 93,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44570,6 +48367,7 @@
         "id": "tile-3798",
         "x": 95,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44581,6 +48379,7 @@
         "id": "tile-3799",
         "x": 97,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44592,6 +48391,7 @@
         "id": "tile-3800",
         "x": 99,
         "y": 75,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44603,6 +48403,7 @@
         "id": "tile-3801",
         "x": 0,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -44614,6 +48415,7 @@
         "id": "tile-3802",
         "x": 2,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -44625,6 +48427,7 @@
         "id": "tile-3803",
         "x": 4,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44639,6 +48442,7 @@
         "id": "tile-3804",
         "x": 6,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44653,6 +48457,7 @@
         "id": "tile-3805",
         "x": 8,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44667,6 +48472,7 @@
         "id": "tile-3806",
         "x": 10,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "resource": "Gold"
@@ -44679,6 +48485,7 @@
         "id": "tile-3807",
         "x": 12,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -44690,6 +48497,7 @@
         "id": "tile-3808",
         "x": 14,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -44701,6 +48509,7 @@
         "id": "tile-3809",
         "x": 16,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -44712,6 +48521,7 @@
         "id": "tile-3810",
         "x": 18,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -44723,6 +48533,7 @@
         "id": "tile-3811",
         "x": 20,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44738,6 +48549,7 @@
         "id": "tile-3812",
         "x": 22,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44752,6 +48564,7 @@
         "id": "tile-3813",
         "x": 24,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -44763,6 +48576,7 @@
         "id": "tile-3814",
         "x": 26,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -44774,6 +48588,7 @@
         "id": "tile-3815",
         "x": 28,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -44785,6 +48600,7 @@
         "id": "tile-3816",
         "x": 30,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44800,6 +48616,7 @@
         "id": "tile-3817",
         "x": 32,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44814,6 +48631,7 @@
         "id": "tile-3818",
         "x": 34,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -44828,6 +48646,7 @@
         "id": "tile-3819",
         "x": 36,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44843,6 +48662,7 @@
         "id": "tile-3820",
         "x": 38,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -44857,6 +48677,7 @@
         "id": "tile-3821",
         "x": 40,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -44871,6 +48692,7 @@
         "id": "tile-3822",
         "x": 42,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44885,6 +48707,7 @@
         "id": "tile-3823",
         "x": 44,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44899,6 +48722,7 @@
         "id": "tile-3824",
         "x": 46,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -44913,6 +48737,7 @@
         "id": "tile-3825",
         "x": 48,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -44924,6 +48749,7 @@
         "id": "tile-3826",
         "x": 50,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -44938,6 +48764,7 @@
         "id": "tile-3827",
         "x": 52,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "features": [
@@ -44952,6 +48779,7 @@
         "id": "tile-3828",
         "x": 54,
         "y": 76,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains"
       },
@@ -44963,6 +48791,7 @@
         "id": "tile-3829",
         "x": 56,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -44974,6 +48803,7 @@
         "id": "tile-3830",
         "x": 58,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -44985,6 +48815,7 @@
         "id": "tile-3831",
         "x": 60,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -44996,6 +48827,7 @@
         "id": "tile-3832",
         "x": 62,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45007,6 +48839,7 @@
         "id": "tile-3833",
         "x": 64,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45018,6 +48851,7 @@
         "id": "tile-3834",
         "x": 66,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45029,6 +48863,7 @@
         "id": "tile-3835",
         "x": 68,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -45040,6 +48875,7 @@
         "id": "tile-3836",
         "x": 70,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -45051,6 +48887,7 @@
         "id": "tile-3837",
         "x": 72,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -45062,6 +48899,7 @@
         "id": "tile-3838",
         "x": 74,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45073,6 +48911,7 @@
         "id": "tile-3839",
         "x": 76,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45084,6 +48923,7 @@
         "id": "tile-3840",
         "x": 78,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45095,6 +48935,7 @@
         "id": "tile-3841",
         "x": 80,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45106,6 +48947,7 @@
         "id": "tile-3842",
         "x": 82,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45117,6 +48959,7 @@
         "id": "tile-3843",
         "x": 84,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45128,6 +48971,7 @@
         "id": "tile-3844",
         "x": 86,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45139,6 +48983,7 @@
         "id": "tile-3845",
         "x": 88,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45150,6 +48995,7 @@
         "id": "tile-3846",
         "x": 90,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45161,6 +49007,7 @@
         "id": "tile-3847",
         "x": 92,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45172,6 +49019,7 @@
         "id": "tile-3848",
         "x": 94,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45183,6 +49031,7 @@
         "id": "tile-3849",
         "x": 96,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45194,6 +49043,7 @@
         "id": "tile-3850",
         "x": 98,
         "y": 76,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45205,6 +49055,7 @@
         "id": "tile-3851",
         "x": 1,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -45217,6 +49068,7 @@
         "id": "tile-3852",
         "x": 3,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -45228,6 +49080,7 @@
         "id": "tile-3853",
         "x": 5,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -45243,6 +49096,7 @@
         "id": "tile-3854",
         "x": 7,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -45258,6 +49112,7 @@
         "id": "tile-3855",
         "x": 9,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -45273,6 +49128,7 @@
         "id": "tile-3856",
         "x": 11,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -45284,6 +49140,7 @@
         "id": "tile-3857",
         "x": 13,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -45295,6 +49152,7 @@
         "id": "tile-3858",
         "x": 15,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -45310,6 +49168,7 @@
         "id": "tile-3859",
         "x": 17,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -45321,6 +49180,7 @@
         "id": "tile-3860",
         "x": 19,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -45335,6 +49195,7 @@
         "id": "tile-3861",
         "x": 21,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -45349,6 +49210,7 @@
         "id": "tile-3862",
         "x": 23,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -45360,6 +49222,7 @@
         "id": "tile-3863",
         "x": 25,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -45371,6 +49234,7 @@
         "id": "tile-3864",
         "x": 27,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -45382,6 +49246,7 @@
         "id": "tile-3865",
         "x": 29,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -45396,6 +49261,7 @@
         "id": "tile-3866",
         "x": 31,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -45411,6 +49277,7 @@
         "id": "tile-3867",
         "x": 33,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -45425,6 +49292,7 @@
         "id": "tile-3868",
         "x": 35,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -45439,6 +49307,7 @@
         "id": "tile-3869",
         "x": 37,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -45454,6 +49323,7 @@
         "id": "tile-3870",
         "x": 39,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -45468,6 +49338,7 @@
         "id": "tile-3871",
         "x": 41,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -45482,6 +49353,7 @@
         "id": "tile-3872",
         "x": 43,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -45496,6 +49368,7 @@
         "id": "tile-3873",
         "x": 45,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -45510,6 +49383,7 @@
         "id": "tile-3874",
         "x": 47,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -45524,6 +49398,7 @@
         "id": "tile-3875",
         "x": 49,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -45538,6 +49413,7 @@
         "id": "tile-3876",
         "x": 51,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "forest",
         "resource": "Rubber"
@@ -45550,6 +49426,7 @@
         "id": "tile-3877",
         "x": 53,
         "y": 77,
+        "continent": 7,
         "baseTerrain": "plains",
         "overlayTerrain": "plains",
         "features": [
@@ -45564,6 +49441,7 @@
         "id": "tile-3878",
         "x": 55,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -45575,6 +49453,7 @@
         "id": "tile-3879",
         "x": 57,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -45586,6 +49465,7 @@
         "id": "tile-3880",
         "x": 59,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45597,6 +49477,7 @@
         "id": "tile-3881",
         "x": 61,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45608,6 +49489,7 @@
         "id": "tile-3882",
         "x": 63,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45619,6 +49501,7 @@
         "id": "tile-3883",
         "x": 65,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45630,6 +49513,7 @@
         "id": "tile-3884",
         "x": 67,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45641,6 +49525,7 @@
         "id": "tile-3885",
         "x": 69,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45652,6 +49537,7 @@
         "id": "tile-3886",
         "x": 71,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45663,6 +49549,7 @@
         "id": "tile-3887",
         "x": 73,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45674,6 +49561,7 @@
         "id": "tile-3888",
         "x": 75,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45685,6 +49573,7 @@
         "id": "tile-3889",
         "x": 77,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45696,6 +49585,7 @@
         "id": "tile-3890",
         "x": 79,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45707,6 +49597,7 @@
         "id": "tile-3891",
         "x": 81,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45718,6 +49609,7 @@
         "id": "tile-3892",
         "x": 83,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45729,6 +49621,7 @@
         "id": "tile-3893",
         "x": 85,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45740,6 +49633,7 @@
         "id": "tile-3894",
         "x": 87,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45751,6 +49645,7 @@
         "id": "tile-3895",
         "x": 89,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45762,6 +49657,7 @@
         "id": "tile-3896",
         "x": 91,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45773,6 +49669,7 @@
         "id": "tile-3897",
         "x": 93,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45784,6 +49681,7 @@
         "id": "tile-3898",
         "x": 95,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45795,6 +49693,7 @@
         "id": "tile-3899",
         "x": 97,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45806,6 +49705,7 @@
         "id": "tile-3900",
         "x": 99,
         "y": 77,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45817,6 +49717,7 @@
         "id": "tile-3901",
         "x": 0,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -45828,6 +49729,7 @@
         "id": "tile-3902",
         "x": 2,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -45839,6 +49741,7 @@
         "id": "tile-3903",
         "x": 4,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -45850,6 +49753,7 @@
         "id": "tile-3904",
         "x": 6,
         "y": 78,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -45864,6 +49768,7 @@
         "id": "tile-3905",
         "x": 8,
         "y": 78,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -45878,6 +49783,7 @@
         "id": "tile-3906",
         "x": 10,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -45889,6 +49795,7 @@
         "id": "tile-3907",
         "x": 12,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -45900,6 +49807,7 @@
         "id": "tile-3908",
         "x": 14,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -45911,6 +49819,7 @@
         "id": "tile-3909",
         "x": 16,
         "y": 78,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "resource": "Uranium"
@@ -45923,6 +49832,7 @@
         "id": "tile-3910",
         "x": 18,
         "y": 78,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -45937,6 +49847,7 @@
         "id": "tile-3911",
         "x": 20,
         "y": 78,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -45951,6 +49862,7 @@
         "id": "tile-3912",
         "x": 22,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -45962,6 +49874,7 @@
         "id": "tile-3913",
         "x": 24,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -45973,6 +49886,7 @@
         "id": "tile-3914",
         "x": 26,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -45984,6 +49898,7 @@
         "id": "tile-3915",
         "x": 28,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -45995,6 +49910,7 @@
         "id": "tile-3916",
         "x": 30,
         "y": 78,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -46009,6 +49925,7 @@
         "id": "tile-3917",
         "x": 32,
         "y": 78,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -46023,6 +49940,7 @@
         "id": "tile-3918",
         "x": 34,
         "y": 78,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -46038,6 +49956,7 @@
         "id": "tile-3919",
         "x": 36,
         "y": 78,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -46052,6 +49971,7 @@
         "id": "tile-3920",
         "x": 38,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -46063,6 +49983,7 @@
         "id": "tile-3921",
         "x": 40,
         "y": 78,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Horses"
@@ -46075,6 +49996,7 @@
         "id": "tile-3922",
         "x": 42,
         "y": 78,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -46090,6 +50012,7 @@
         "id": "tile-3923",
         "x": 44,
         "y": 78,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "resource": "Cattle",
@@ -46105,6 +50028,7 @@
         "id": "tile-3924",
         "x": 46,
         "y": 78,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -46120,6 +50044,7 @@
         "id": "tile-3925",
         "x": 48,
         "y": 78,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -46134,6 +50059,7 @@
         "id": "tile-3926",
         "x": 50,
         "y": 78,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -46145,6 +50071,7 @@
         "id": "tile-3927",
         "x": 52,
         "y": 78,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -46159,6 +50086,7 @@
         "id": "tile-3928",
         "x": 54,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -46170,6 +50098,7 @@
         "id": "tile-3929",
         "x": 56,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -46181,6 +50110,7 @@
         "id": "tile-3930",
         "x": 58,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46192,6 +50122,7 @@
         "id": "tile-3931",
         "x": 60,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46203,6 +50134,7 @@
         "id": "tile-3932",
         "x": 62,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46214,6 +50146,7 @@
         "id": "tile-3933",
         "x": 64,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46225,6 +50158,7 @@
         "id": "tile-3934",
         "x": 66,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46236,6 +50170,7 @@
         "id": "tile-3935",
         "x": 68,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46247,6 +50182,7 @@
         "id": "tile-3936",
         "x": 70,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46258,6 +50194,7 @@
         "id": "tile-3937",
         "x": 72,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46269,6 +50206,7 @@
         "id": "tile-3938",
         "x": 74,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46280,6 +50218,7 @@
         "id": "tile-3939",
         "x": 76,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46291,6 +50230,7 @@
         "id": "tile-3940",
         "x": 78,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46302,6 +50242,7 @@
         "id": "tile-3941",
         "x": 80,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46313,6 +50254,7 @@
         "id": "tile-3942",
         "x": 82,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46324,6 +50266,7 @@
         "id": "tile-3943",
         "x": 84,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46335,6 +50278,7 @@
         "id": "tile-3944",
         "x": 86,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46346,6 +50290,7 @@
         "id": "tile-3945",
         "x": 88,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46357,6 +50302,7 @@
         "id": "tile-3946",
         "x": 90,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46368,6 +50314,7 @@
         "id": "tile-3947",
         "x": 92,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46379,6 +50326,7 @@
         "id": "tile-3948",
         "x": 94,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46390,6 +50338,7 @@
         "id": "tile-3949",
         "x": 96,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46401,6 +50350,7 @@
         "id": "tile-3950",
         "x": 98,
         "y": 78,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46412,6 +50362,7 @@
         "id": "tile-3951",
         "x": 1,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46423,6 +50374,7 @@
         "id": "tile-3952",
         "x": 3,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -46434,6 +50386,7 @@
         "id": "tile-3953",
         "x": 5,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -46445,6 +50398,7 @@
         "id": "tile-3954",
         "x": 7,
         "y": 79,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -46460,6 +50414,7 @@
         "id": "tile-3955",
         "x": 9,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -46471,6 +50426,7 @@
         "id": "tile-3956",
         "x": 11,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -46482,6 +50438,7 @@
         "id": "tile-3957",
         "x": 13,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -46493,6 +50450,7 @@
         "id": "tile-3958",
         "x": 15,
         "y": 79,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -46507,6 +50465,7 @@
         "id": "tile-3959",
         "x": 17,
         "y": 79,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -46521,6 +50480,7 @@
         "id": "tile-3960",
         "x": 19,
         "y": 79,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -46535,6 +50495,7 @@
         "id": "tile-3961",
         "x": 21,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -46546,6 +50507,7 @@
         "id": "tile-3962",
         "x": 23,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -46557,6 +50519,7 @@
         "id": "tile-3963",
         "x": 25,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46568,6 +50531,7 @@
         "id": "tile-3964",
         "x": 27,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -46579,6 +50543,7 @@
         "id": "tile-3965",
         "x": 29,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -46590,6 +50555,7 @@
         "id": "tile-3966",
         "x": 31,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -46601,6 +50567,7 @@
         "id": "tile-3967",
         "x": 33,
         "y": 79,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -46616,6 +50583,7 @@
         "id": "tile-3968",
         "x": 35,
         "y": 79,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -46631,6 +50599,7 @@
         "id": "tile-3969",
         "x": 37,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -46642,6 +50611,7 @@
         "id": "tile-3970",
         "x": 39,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -46653,6 +50623,7 @@
         "id": "tile-3971",
         "x": 41,
         "y": 79,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -46667,6 +50638,7 @@
         "id": "tile-3972",
         "x": 43,
         "y": 79,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -46681,6 +50653,7 @@
         "id": "tile-3973",
         "x": 45,
         "y": 79,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -46695,6 +50668,7 @@
         "id": "tile-3974",
         "x": 47,
         "y": 79,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -46709,6 +50683,7 @@
         "id": "tile-3975",
         "x": 49,
         "y": 79,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills"
       },
@@ -46720,6 +50695,7 @@
         "id": "tile-3976",
         "x": 51,
         "y": 79,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -46734,6 +50710,7 @@
         "id": "tile-3977",
         "x": 53,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -46745,6 +50722,7 @@
         "id": "tile-3978",
         "x": 55,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -46756,6 +50734,7 @@
         "id": "tile-3979",
         "x": 57,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46767,6 +50746,7 @@
         "id": "tile-3980",
         "x": 59,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46778,6 +50758,7 @@
         "id": "tile-3981",
         "x": 61,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46789,6 +50770,7 @@
         "id": "tile-3982",
         "x": 63,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46800,6 +50782,7 @@
         "id": "tile-3983",
         "x": 65,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46811,6 +50794,7 @@
         "id": "tile-3984",
         "x": 67,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46822,6 +50806,7 @@
         "id": "tile-3985",
         "x": 69,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46833,6 +50818,7 @@
         "id": "tile-3986",
         "x": 71,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46844,6 +50830,7 @@
         "id": "tile-3987",
         "x": 73,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46855,6 +50842,7 @@
         "id": "tile-3988",
         "x": 75,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46866,6 +50854,7 @@
         "id": "tile-3989",
         "x": 77,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46877,6 +50866,7 @@
         "id": "tile-3990",
         "x": 79,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46888,6 +50878,7 @@
         "id": "tile-3991",
         "x": 81,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46899,6 +50890,7 @@
         "id": "tile-3992",
         "x": 83,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46910,6 +50902,7 @@
         "id": "tile-3993",
         "x": 85,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46921,6 +50914,7 @@
         "id": "tile-3994",
         "x": 87,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46932,6 +50926,7 @@
         "id": "tile-3995",
         "x": 89,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46943,6 +50938,7 @@
         "id": "tile-3996",
         "x": 91,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46954,6 +50950,7 @@
         "id": "tile-3997",
         "x": 93,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46965,6 +50962,7 @@
         "id": "tile-3998",
         "x": 95,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46976,6 +50974,7 @@
         "id": "tile-3999",
         "x": 97,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46987,6 +50986,7 @@
         "id": "tile-4000",
         "x": 99,
         "y": 79,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -46998,6 +50998,7 @@
         "id": "tile-4001",
         "x": 0,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47009,6 +51010,7 @@
         "id": "tile-4002",
         "x": 2,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47020,6 +51022,7 @@
         "id": "tile-4003",
         "x": 4,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -47031,6 +51034,7 @@
         "id": "tile-4004",
         "x": 6,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47042,6 +51046,7 @@
         "id": "tile-4005",
         "x": 8,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47053,6 +51058,7 @@
         "id": "tile-4006",
         "x": 10,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -47064,6 +51070,7 @@
         "id": "tile-4007",
         "x": 12,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -47075,6 +51082,7 @@
         "id": "tile-4008",
         "x": 14,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47086,6 +51094,7 @@
         "id": "tile-4009",
         "x": 16,
         "y": 80,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -47100,6 +51109,7 @@
         "id": "tile-4010",
         "x": 18,
         "y": 80,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -47111,6 +51121,7 @@
         "id": "tile-4011",
         "x": 20,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47122,6 +51133,7 @@
         "id": "tile-4012",
         "x": 22,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -47133,6 +51145,7 @@
         "id": "tile-4013",
         "x": 24,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47144,6 +51157,7 @@
         "id": "tile-4014",
         "x": 26,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47155,6 +51169,7 @@
         "id": "tile-4015",
         "x": 28,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -47166,6 +51181,7 @@
         "id": "tile-4016",
         "x": 30,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47177,6 +51193,7 @@
         "id": "tile-4017",
         "x": 32,
         "y": 80,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -47191,6 +51208,7 @@
         "id": "tile-4018",
         "x": 34,
         "y": 80,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -47205,6 +51223,7 @@
         "id": "tile-4019",
         "x": 36,
         "y": 80,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -47219,6 +51238,7 @@
         "id": "tile-4020",
         "x": 38,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47230,6 +51250,7 @@
         "id": "tile-4021",
         "x": 40,
         "y": 80,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -47244,6 +51265,7 @@
         "id": "tile-4022",
         "x": 42,
         "y": 80,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -47258,6 +51280,7 @@
         "id": "tile-4023",
         "x": 44,
         "y": 80,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains",
         "features": [
@@ -47272,6 +51295,7 @@
         "id": "tile-4024",
         "x": 46,
         "y": 80,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "mountains"
       },
@@ -47283,6 +51307,7 @@
         "id": "tile-4025",
         "x": 48,
         "y": 80,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -47297,6 +51322,7 @@
         "id": "tile-4026",
         "x": 50,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47308,6 +51334,7 @@
         "id": "tile-4027",
         "x": 52,
         "y": 80,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -47323,6 +51350,7 @@
         "id": "tile-4028",
         "x": 54,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47334,6 +51362,7 @@
         "id": "tile-4029",
         "x": 56,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -47345,6 +51374,7 @@
         "id": "tile-4030",
         "x": 58,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47356,6 +51386,7 @@
         "id": "tile-4031",
         "x": 60,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47367,6 +51398,7 @@
         "id": "tile-4032",
         "x": 62,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47378,6 +51410,7 @@
         "id": "tile-4033",
         "x": 64,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47389,6 +51422,7 @@
         "id": "tile-4034",
         "x": 66,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47400,6 +51434,7 @@
         "id": "tile-4035",
         "x": 68,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47411,6 +51446,7 @@
         "id": "tile-4036",
         "x": 70,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47422,6 +51458,7 @@
         "id": "tile-4037",
         "x": 72,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47433,6 +51470,7 @@
         "id": "tile-4038",
         "x": 74,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47444,6 +51482,7 @@
         "id": "tile-4039",
         "x": 76,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47455,6 +51494,7 @@
         "id": "tile-4040",
         "x": 78,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47466,6 +51506,7 @@
         "id": "tile-4041",
         "x": 80,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47477,6 +51518,7 @@
         "id": "tile-4042",
         "x": 82,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -47488,6 +51530,7 @@
         "id": "tile-4043",
         "x": 84,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47499,6 +51542,7 @@
         "id": "tile-4044",
         "x": 86,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47510,6 +51554,7 @@
         "id": "tile-4045",
         "x": 88,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47521,6 +51566,7 @@
         "id": "tile-4046",
         "x": 90,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47532,6 +51578,7 @@
         "id": "tile-4047",
         "x": 92,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47543,6 +51590,7 @@
         "id": "tile-4048",
         "x": 94,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47554,6 +51602,7 @@
         "id": "tile-4049",
         "x": 96,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47565,6 +51614,7 @@
         "id": "tile-4050",
         "x": 98,
         "y": 80,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47576,6 +51626,7 @@
         "id": "tile-4051",
         "x": 1,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47587,6 +51638,7 @@
         "id": "tile-4052",
         "x": 3,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47598,6 +51650,7 @@
         "id": "tile-4053",
         "x": 5,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -47609,6 +51662,7 @@
         "id": "tile-4054",
         "x": 7,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47620,6 +51674,7 @@
         "id": "tile-4055",
         "x": 9,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -47631,6 +51686,7 @@
         "id": "tile-4056",
         "x": 11,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -47642,6 +51698,7 @@
         "id": "tile-4057",
         "x": 13,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47653,6 +51710,7 @@
         "id": "tile-4058",
         "x": 15,
         "y": 81,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -47667,6 +51725,7 @@
         "id": "tile-4059",
         "x": 17,
         "y": 81,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -47681,6 +51740,7 @@
         "id": "tile-4060",
         "x": 19,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -47693,6 +51753,7 @@
         "id": "tile-4061",
         "x": 21,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -47704,6 +51765,7 @@
         "id": "tile-4062",
         "x": 23,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47715,6 +51777,7 @@
         "id": "tile-4063",
         "x": 25,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47726,6 +51789,7 @@
         "id": "tile-4064",
         "x": 27,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47737,6 +51801,7 @@
         "id": "tile-4065",
         "x": 29,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -47748,6 +51813,7 @@
         "id": "tile-4066",
         "x": 31,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47759,6 +51825,7 @@
         "id": "tile-4067",
         "x": 33,
         "y": 81,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -47773,6 +51840,7 @@
         "id": "tile-4068",
         "x": 35,
         "y": 81,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -47787,6 +51855,7 @@
         "id": "tile-4069",
         "x": 37,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47798,6 +51867,7 @@
         "id": "tile-4070",
         "x": 39,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47809,6 +51879,7 @@
         "id": "tile-4071",
         "x": 41,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47820,6 +51891,7 @@
         "id": "tile-4072",
         "x": 43,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47831,6 +51903,7 @@
         "id": "tile-4073",
         "x": 45,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47842,6 +51915,7 @@
         "id": "tile-4074",
         "x": 47,
         "y": 81,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -47856,6 +51930,7 @@
         "id": "tile-4075",
         "x": 49,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47867,6 +51942,7 @@
         "id": "tile-4076",
         "x": 51,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47878,6 +51954,7 @@
         "id": "tile-4077",
         "x": 53,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -47889,6 +51966,7 @@
         "id": "tile-4078",
         "x": 55,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -47901,6 +51979,7 @@
         "id": "tile-4079",
         "x": 57,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47912,6 +51991,7 @@
         "id": "tile-4080",
         "x": 59,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47923,6 +52003,7 @@
         "id": "tile-4081",
         "x": 61,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47934,6 +52015,7 @@
         "id": "tile-4082",
         "x": 63,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47945,6 +52027,7 @@
         "id": "tile-4083",
         "x": 65,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47956,6 +52039,7 @@
         "id": "tile-4084",
         "x": 67,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47967,6 +52051,7 @@
         "id": "tile-4085",
         "x": 69,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47978,6 +52063,7 @@
         "id": "tile-4086",
         "x": 71,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -47989,6 +52075,7 @@
         "id": "tile-4087",
         "x": 73,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48000,6 +52087,7 @@
         "id": "tile-4088",
         "x": 75,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48011,6 +52099,7 @@
         "id": "tile-4089",
         "x": 77,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48022,6 +52111,7 @@
         "id": "tile-4090",
         "x": 79,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48033,6 +52123,7 @@
         "id": "tile-4091",
         "x": 81,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48044,6 +52135,7 @@
         "id": "tile-4092",
         "x": 83,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48055,6 +52147,7 @@
         "id": "tile-4093",
         "x": 85,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48066,6 +52159,7 @@
         "id": "tile-4094",
         "x": 87,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48077,6 +52171,7 @@
         "id": "tile-4095",
         "x": 89,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48088,6 +52183,7 @@
         "id": "tile-4096",
         "x": 91,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48099,6 +52195,7 @@
         "id": "tile-4097",
         "x": 93,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48110,6 +52207,7 @@
         "id": "tile-4098",
         "x": 95,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48121,6 +52219,7 @@
         "id": "tile-4099",
         "x": 97,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48132,6 +52231,7 @@
         "id": "tile-4100",
         "x": 99,
         "y": 81,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48143,6 +52243,7 @@
         "id": "tile-4101",
         "x": 0,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48154,6 +52255,7 @@
         "id": "tile-4102",
         "x": 2,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48165,6 +52267,7 @@
         "id": "tile-4103",
         "x": 4,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48176,6 +52279,7 @@
         "id": "tile-4104",
         "x": 6,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48187,6 +52291,7 @@
         "id": "tile-4105",
         "x": 8,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48198,6 +52303,7 @@
         "id": "tile-4106",
         "x": 10,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48209,6 +52315,7 @@
         "id": "tile-4107",
         "x": 12,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -48220,6 +52327,7 @@
         "id": "tile-4108",
         "x": 14,
         "y": 82,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -48234,6 +52342,7 @@
         "id": "tile-4109",
         "x": 16,
         "y": 82,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -48245,6 +52354,7 @@
         "id": "tile-4110",
         "x": 18,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -48256,6 +52366,7 @@
         "id": "tile-4111",
         "x": 20,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48267,6 +52378,7 @@
         "id": "tile-4112",
         "x": 22,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48278,6 +52390,7 @@
         "id": "tile-4113",
         "x": 24,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48289,6 +52402,7 @@
         "id": "tile-4114",
         "x": 26,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48300,6 +52414,7 @@
         "id": "tile-4115",
         "x": 28,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48311,6 +52426,7 @@
         "id": "tile-4116",
         "x": 30,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48322,6 +52438,7 @@
         "id": "tile-4117",
         "x": 32,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -48333,6 +52450,7 @@
         "id": "tile-4118",
         "x": 34,
         "y": 82,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -48347,6 +52465,7 @@
         "id": "tile-4119",
         "x": 36,
         "y": 82,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -48362,6 +52481,7 @@
         "id": "tile-4120",
         "x": 38,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -48373,6 +52493,7 @@
         "id": "tile-4121",
         "x": 40,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -48384,6 +52505,7 @@
         "id": "tile-4122",
         "x": 42,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -48395,6 +52517,7 @@
         "id": "tile-4123",
         "x": 44,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -48407,6 +52530,7 @@
         "id": "tile-4124",
         "x": 46,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -48418,6 +52542,7 @@
         "id": "tile-4125",
         "x": 48,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -48429,6 +52554,7 @@
         "id": "tile-4126",
         "x": 50,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48440,6 +52566,7 @@
         "id": "tile-4127",
         "x": 52,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -48451,6 +52578,7 @@
         "id": "tile-4128",
         "x": 54,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48462,6 +52590,7 @@
         "id": "tile-4129",
         "x": 56,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48473,6 +52602,7 @@
         "id": "tile-4130",
         "x": 58,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48484,6 +52614,7 @@
         "id": "tile-4131",
         "x": 60,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48495,6 +52626,7 @@
         "id": "tile-4132",
         "x": 62,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48506,6 +52638,7 @@
         "id": "tile-4133",
         "x": 64,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48517,6 +52650,7 @@
         "id": "tile-4134",
         "x": 66,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48528,6 +52662,7 @@
         "id": "tile-4135",
         "x": 68,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48539,6 +52674,7 @@
         "id": "tile-4136",
         "x": 70,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48550,6 +52686,7 @@
         "id": "tile-4137",
         "x": 72,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48561,6 +52698,7 @@
         "id": "tile-4138",
         "x": 74,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48572,6 +52710,7 @@
         "id": "tile-4139",
         "x": 76,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48583,6 +52722,7 @@
         "id": "tile-4140",
         "x": 78,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48594,6 +52734,7 @@
         "id": "tile-4141",
         "x": 80,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48605,6 +52746,7 @@
         "id": "tile-4142",
         "x": 82,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48616,6 +52758,7 @@
         "id": "tile-4143",
         "x": 84,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48627,6 +52770,7 @@
         "id": "tile-4144",
         "x": 86,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48638,6 +52782,7 @@
         "id": "tile-4145",
         "x": 88,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48649,6 +52794,7 @@
         "id": "tile-4146",
         "x": 90,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48660,6 +52806,7 @@
         "id": "tile-4147",
         "x": 92,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48671,6 +52818,7 @@
         "id": "tile-4148",
         "x": 94,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48682,6 +52830,7 @@
         "id": "tile-4149",
         "x": 96,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48693,6 +52842,7 @@
         "id": "tile-4150",
         "x": 98,
         "y": 82,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48704,6 +52854,7 @@
         "id": "tile-4151",
         "x": 1,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48715,6 +52866,7 @@
         "id": "tile-4152",
         "x": 3,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48726,6 +52878,7 @@
         "id": "tile-4153",
         "x": 5,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48737,6 +52890,7 @@
         "id": "tile-4154",
         "x": 7,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48748,6 +52902,7 @@
         "id": "tile-4155",
         "x": 9,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48759,6 +52914,7 @@
         "id": "tile-4156",
         "x": 11,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48770,6 +52926,7 @@
         "id": "tile-4157",
         "x": 13,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -48781,6 +52938,7 @@
         "id": "tile-4158",
         "x": 15,
         "y": 83,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -48795,6 +52953,7 @@
         "id": "tile-4159",
         "x": 17,
         "y": 83,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -48809,6 +52968,7 @@
         "id": "tile-4160",
         "x": 19,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -48820,6 +52980,7 @@
         "id": "tile-4161",
         "x": 21,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48831,6 +52992,7 @@
         "id": "tile-4162",
         "x": 23,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48842,6 +53004,7 @@
         "id": "tile-4163",
         "x": 25,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48853,6 +53016,7 @@
         "id": "tile-4164",
         "x": 27,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -48864,6 +53028,7 @@
         "id": "tile-4165",
         "x": 29,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48875,6 +53040,7 @@
         "id": "tile-4166",
         "x": 31,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -48886,6 +53052,7 @@
         "id": "tile-4167",
         "x": 33,
         "y": 83,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland",
         "features": [
@@ -48900,6 +53067,7 @@
         "id": "tile-4168",
         "x": 35,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -48911,6 +53079,7 @@
         "id": "tile-4169",
         "x": 37,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -48922,6 +53091,7 @@
         "id": "tile-4170",
         "x": 39,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48933,6 +53103,7 @@
         "id": "tile-4171",
         "x": 41,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48944,6 +53115,7 @@
         "id": "tile-4172",
         "x": 43,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48955,6 +53127,7 @@
         "id": "tile-4173",
         "x": 45,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48966,6 +53139,7 @@
         "id": "tile-4174",
         "x": 47,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -48977,6 +53151,7 @@
         "id": "tile-4175",
         "x": 49,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48988,6 +53163,7 @@
         "id": "tile-4176",
         "x": 51,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -48999,6 +53175,7 @@
         "id": "tile-4177",
         "x": 53,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -49010,6 +53187,7 @@
         "id": "tile-4178",
         "x": 55,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49021,6 +53199,7 @@
         "id": "tile-4179",
         "x": 57,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49032,6 +53211,7 @@
         "id": "tile-4180",
         "x": 59,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49043,6 +53223,7 @@
         "id": "tile-4181",
         "x": 61,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49054,6 +53235,7 @@
         "id": "tile-4182",
         "x": 63,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49065,6 +53247,7 @@
         "id": "tile-4183",
         "x": 65,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49076,6 +53259,7 @@
         "id": "tile-4184",
         "x": 67,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49087,6 +53271,7 @@
         "id": "tile-4185",
         "x": 69,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49098,6 +53283,7 @@
         "id": "tile-4186",
         "x": 71,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49109,6 +53295,7 @@
         "id": "tile-4187",
         "x": 73,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49120,6 +53307,7 @@
         "id": "tile-4188",
         "x": 75,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49131,6 +53319,7 @@
         "id": "tile-4189",
         "x": 77,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49142,6 +53331,7 @@
         "id": "tile-4190",
         "x": 79,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49153,6 +53343,7 @@
         "id": "tile-4191",
         "x": 81,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49164,6 +53355,7 @@
         "id": "tile-4192",
         "x": 83,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49175,6 +53367,7 @@
         "id": "tile-4193",
         "x": 85,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49186,6 +53379,7 @@
         "id": "tile-4194",
         "x": 87,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49197,6 +53391,7 @@
         "id": "tile-4195",
         "x": 89,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49208,6 +53403,7 @@
         "id": "tile-4196",
         "x": 91,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49219,6 +53415,7 @@
         "id": "tile-4197",
         "x": 93,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49230,6 +53427,7 @@
         "id": "tile-4198",
         "x": 95,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49241,6 +53439,7 @@
         "id": "tile-4199",
         "x": 97,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49252,6 +53451,7 @@
         "id": "tile-4200",
         "x": 99,
         "y": 83,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49263,6 +53463,7 @@
         "id": "tile-4201",
         "x": 0,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49274,6 +53475,7 @@
         "id": "tile-4202",
         "x": 2,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49285,6 +53487,7 @@
         "id": "tile-4203",
         "x": 4,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49296,6 +53499,7 @@
         "id": "tile-4204",
         "x": 6,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49307,6 +53511,7 @@
         "id": "tile-4205",
         "x": 8,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49318,6 +53523,7 @@
         "id": "tile-4206",
         "x": 10,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -49329,6 +53535,7 @@
         "id": "tile-4207",
         "x": 12,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -49340,6 +53547,7 @@
         "id": "tile-4208",
         "x": 14,
         "y": 84,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "forest",
         "features": [
@@ -49354,6 +53562,7 @@
         "id": "tile-4209",
         "x": 16,
         "y": 84,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "grassland"
       },
@@ -49365,6 +53574,7 @@
         "id": "tile-4210",
         "x": 18,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -49376,6 +53586,7 @@
         "id": "tile-4211",
         "x": 20,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -49387,6 +53598,7 @@
         "id": "tile-4212",
         "x": 22,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49398,6 +53610,7 @@
         "id": "tile-4213",
         "x": 24,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49409,6 +53622,7 @@
         "id": "tile-4214",
         "x": 26,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49420,6 +53634,7 @@
         "id": "tile-4215",
         "x": 28,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49431,6 +53646,7 @@
         "id": "tile-4216",
         "x": 30,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -49442,6 +53658,7 @@
         "id": "tile-4217",
         "x": 32,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -49453,6 +53670,7 @@
         "id": "tile-4218",
         "x": 34,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -49464,6 +53682,7 @@
         "id": "tile-4219",
         "x": 36,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -49475,6 +53694,7 @@
         "id": "tile-4220",
         "x": 38,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Whales"
@@ -49487,6 +53707,7 @@
         "id": "tile-4221",
         "x": 40,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -49498,6 +53719,7 @@
         "id": "tile-4222",
         "x": 42,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -49509,6 +53731,7 @@
         "id": "tile-4223",
         "x": 44,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -49520,6 +53743,7 @@
         "id": "tile-4224",
         "x": 46,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -49531,6 +53755,7 @@
         "id": "tile-4225",
         "x": 48,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -49542,6 +53767,7 @@
         "id": "tile-4226",
         "x": 50,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -49553,6 +53779,7 @@
         "id": "tile-4227",
         "x": 52,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -49564,6 +53791,7 @@
         "id": "tile-4228",
         "x": 54,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49575,6 +53803,7 @@
         "id": "tile-4229",
         "x": 56,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49586,6 +53815,7 @@
         "id": "tile-4230",
         "x": 58,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49597,6 +53827,7 @@
         "id": "tile-4231",
         "x": 60,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49608,6 +53839,7 @@
         "id": "tile-4232",
         "x": 62,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49619,6 +53851,7 @@
         "id": "tile-4233",
         "x": 64,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49630,6 +53863,7 @@
         "id": "tile-4234",
         "x": 66,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49641,6 +53875,7 @@
         "id": "tile-4235",
         "x": 68,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49652,6 +53887,7 @@
         "id": "tile-4236",
         "x": 70,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49663,6 +53899,7 @@
         "id": "tile-4237",
         "x": 72,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49674,6 +53911,7 @@
         "id": "tile-4238",
         "x": 74,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49685,6 +53923,7 @@
         "id": "tile-4239",
         "x": 76,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49696,6 +53935,7 @@
         "id": "tile-4240",
         "x": 78,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49707,6 +53947,7 @@
         "id": "tile-4241",
         "x": 80,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49718,6 +53959,7 @@
         "id": "tile-4242",
         "x": 82,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49729,6 +53971,7 @@
         "id": "tile-4243",
         "x": 84,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49740,6 +53983,7 @@
         "id": "tile-4244",
         "x": 86,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49751,6 +53995,7 @@
         "id": "tile-4245",
         "x": 88,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49762,6 +54007,7 @@
         "id": "tile-4246",
         "x": 90,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49773,6 +54019,7 @@
         "id": "tile-4247",
         "x": 92,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49784,6 +54031,7 @@
         "id": "tile-4248",
         "x": 94,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49795,6 +54043,7 @@
         "id": "tile-4249",
         "x": 96,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49806,6 +54055,7 @@
         "id": "tile-4250",
         "x": 98,
         "y": 84,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49817,6 +54067,7 @@
         "id": "tile-4251",
         "x": 1,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49828,6 +54079,7 @@
         "id": "tile-4252",
         "x": 3,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49839,6 +54091,7 @@
         "id": "tile-4253",
         "x": 5,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49850,6 +54103,7 @@
         "id": "tile-4254",
         "x": 7,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49861,6 +54115,7 @@
         "id": "tile-4255",
         "x": 9,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -49872,6 +54127,7 @@
         "id": "tile-4256",
         "x": 11,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -49883,6 +54139,7 @@
         "id": "tile-4257",
         "x": 13,
         "y": 85,
+        "continent": 7,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -49897,6 +54154,7 @@
         "id": "tile-4258",
         "x": 15,
         "y": 85,
+        "continent": 7,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -49911,6 +54169,7 @@
         "id": "tile-4259",
         "x": 17,
         "y": 85,
+        "continent": 7,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "resource": "Oil",
@@ -49926,6 +54185,7 @@
         "id": "tile-4260",
         "x": 19,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -49937,6 +54197,7 @@
         "id": "tile-4261",
         "x": 21,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -49948,6 +54209,7 @@
         "id": "tile-4262",
         "x": 23,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49959,6 +54221,7 @@
         "id": "tile-4263",
         "x": 25,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49970,6 +54233,7 @@
         "id": "tile-4264",
         "x": 27,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49981,6 +54245,7 @@
         "id": "tile-4265",
         "x": 29,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -49992,6 +54257,7 @@
         "id": "tile-4266",
         "x": 31,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea",
         "resource": "Fish"
@@ -50004,6 +54270,7 @@
         "id": "tile-4267",
         "x": 33,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -50015,6 +54282,7 @@
         "id": "tile-4268",
         "x": 35,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -50026,6 +54294,7 @@
         "id": "tile-4269",
         "x": 37,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -50037,6 +54306,7 @@
         "id": "tile-4270",
         "x": 39,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50048,6 +54318,7 @@
         "id": "tile-4271",
         "x": 41,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50059,6 +54330,7 @@
         "id": "tile-4272",
         "x": 43,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50070,6 +54342,7 @@
         "id": "tile-4273",
         "x": 45,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50081,6 +54354,7 @@
         "id": "tile-4274",
         "x": 47,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -50092,6 +54366,7 @@
         "id": "tile-4275",
         "x": 49,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -50103,6 +54378,7 @@
         "id": "tile-4276",
         "x": 51,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50114,6 +54390,7 @@
         "id": "tile-4277",
         "x": 53,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50125,6 +54402,7 @@
         "id": "tile-4278",
         "x": 55,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50136,6 +54414,7 @@
         "id": "tile-4279",
         "x": 57,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50147,6 +54426,7 @@
         "id": "tile-4280",
         "x": 59,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50158,6 +54438,7 @@
         "id": "tile-4281",
         "x": 61,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50169,6 +54450,7 @@
         "id": "tile-4282",
         "x": 63,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50180,6 +54462,7 @@
         "id": "tile-4283",
         "x": 65,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50191,6 +54474,7 @@
         "id": "tile-4284",
         "x": 67,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50202,6 +54486,7 @@
         "id": "tile-4285",
         "x": 69,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -50213,6 +54498,7 @@
         "id": "tile-4286",
         "x": 71,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50224,6 +54510,7 @@
         "id": "tile-4287",
         "x": 73,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50235,6 +54522,7 @@
         "id": "tile-4288",
         "x": 75,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50246,6 +54534,7 @@
         "id": "tile-4289",
         "x": 77,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50257,6 +54546,7 @@
         "id": "tile-4290",
         "x": 79,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50268,6 +54558,7 @@
         "id": "tile-4291",
         "x": 81,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50279,6 +54570,7 @@
         "id": "tile-4292",
         "x": 83,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50290,6 +54582,7 @@
         "id": "tile-4293",
         "x": 85,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50301,6 +54594,7 @@
         "id": "tile-4294",
         "x": 87,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50312,6 +54606,7 @@
         "id": "tile-4295",
         "x": 89,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50323,6 +54618,7 @@
         "id": "tile-4296",
         "x": 91,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50334,6 +54630,7 @@
         "id": "tile-4297",
         "x": 93,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50345,6 +54642,7 @@
         "id": "tile-4298",
         "x": 95,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50356,6 +54654,7 @@
         "id": "tile-4299",
         "x": 97,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50367,6 +54666,7 @@
         "id": "tile-4300",
         "x": 99,
         "y": 85,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50378,6 +54678,7 @@
         "id": "tile-4301",
         "x": 0,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50389,6 +54690,7 @@
         "id": "tile-4302",
         "x": 2,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50400,6 +54702,7 @@
         "id": "tile-4303",
         "x": 4,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50411,6 +54714,7 @@
         "id": "tile-4304",
         "x": 6,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50422,6 +54726,7 @@
         "id": "tile-4305",
         "x": 8,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50433,6 +54738,7 @@
         "id": "tile-4306",
         "x": 10,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -50444,6 +54750,7 @@
         "id": "tile-4307",
         "x": 12,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -50455,6 +54762,7 @@
         "id": "tile-4308",
         "x": 14,
         "y": 86,
+        "continent": 7,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "features": [
@@ -50469,6 +54777,7 @@
         "id": "tile-4309",
         "x": 16,
         "y": 86,
+        "continent": 7,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -50483,6 +54792,7 @@
         "id": "tile-4310",
         "x": 18,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -50494,6 +54804,7 @@
         "id": "tile-4311",
         "x": 20,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -50505,6 +54816,7 @@
         "id": "tile-4312",
         "x": 22,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50516,6 +54828,7 @@
         "id": "tile-4313",
         "x": 24,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50527,6 +54840,7 @@
         "id": "tile-4314",
         "x": 26,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50538,6 +54852,7 @@
         "id": "tile-4315",
         "x": 28,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50549,6 +54864,7 @@
         "id": "tile-4316",
         "x": 30,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50560,6 +54876,7 @@
         "id": "tile-4317",
         "x": 32,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -50571,6 +54888,7 @@
         "id": "tile-4318",
         "x": 34,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -50582,6 +54900,7 @@
         "id": "tile-4319",
         "x": 36,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -50593,6 +54912,7 @@
         "id": "tile-4320",
         "x": 38,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50604,6 +54924,7 @@
         "id": "tile-4321",
         "x": 40,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50615,6 +54936,7 @@
         "id": "tile-4322",
         "x": 42,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50626,6 +54948,7 @@
         "id": "tile-4323",
         "x": 44,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50637,6 +54960,7 @@
         "id": "tile-4324",
         "x": 46,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50648,6 +54972,7 @@
         "id": "tile-4325",
         "x": 48,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50659,6 +54984,7 @@
         "id": "tile-4326",
         "x": 50,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50670,6 +54996,7 @@
         "id": "tile-4327",
         "x": 52,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50681,6 +55008,7 @@
         "id": "tile-4328",
         "x": 54,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50692,6 +55020,7 @@
         "id": "tile-4329",
         "x": 56,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50703,6 +55032,7 @@
         "id": "tile-4330",
         "x": 58,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50714,6 +55044,7 @@
         "id": "tile-4331",
         "x": 60,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50725,6 +55056,7 @@
         "id": "tile-4332",
         "x": 62,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50736,6 +55068,7 @@
         "id": "tile-4333",
         "x": 64,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50747,6 +55080,7 @@
         "id": "tile-4334",
         "x": 66,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50758,6 +55092,7 @@
         "id": "tile-4335",
         "x": 68,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50769,6 +55104,7 @@
         "id": "tile-4336",
         "x": 70,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -50780,6 +55116,7 @@
         "id": "tile-4337",
         "x": 72,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50791,6 +55128,7 @@
         "id": "tile-4338",
         "x": 74,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50802,6 +55140,7 @@
         "id": "tile-4339",
         "x": 76,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50813,6 +55152,7 @@
         "id": "tile-4340",
         "x": 78,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50824,6 +55164,7 @@
         "id": "tile-4341",
         "x": 80,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50835,6 +55176,7 @@
         "id": "tile-4342",
         "x": 82,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50846,6 +55188,7 @@
         "id": "tile-4343",
         "x": 84,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50857,6 +55200,7 @@
         "id": "tile-4344",
         "x": 86,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50868,6 +55212,7 @@
         "id": "tile-4345",
         "x": 88,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50879,6 +55224,7 @@
         "id": "tile-4346",
         "x": 90,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50890,6 +55236,7 @@
         "id": "tile-4347",
         "x": 92,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50901,6 +55248,7 @@
         "id": "tile-4348",
         "x": 94,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50912,6 +55260,7 @@
         "id": "tile-4349",
         "x": 96,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50923,6 +55272,7 @@
         "id": "tile-4350",
         "x": 98,
         "y": 86,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50934,6 +55284,7 @@
         "id": "tile-4351",
         "x": 1,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50945,6 +55296,7 @@
         "id": "tile-4352",
         "x": 3,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50956,6 +55308,7 @@
         "id": "tile-4353",
         "x": 5,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50967,6 +55320,7 @@
         "id": "tile-4354",
         "x": 7,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -50978,6 +55332,7 @@
         "id": "tile-4355",
         "x": 9,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -50989,6 +55344,7 @@
         "id": "tile-4356",
         "x": 11,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -51000,6 +55356,7 @@
         "id": "tile-4357",
         "x": 13,
         "y": 87,
+        "continent": 7,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -51014,6 +55371,7 @@
         "id": "tile-4358",
         "x": 15,
         "y": 87,
+        "continent": 7,
         "baseTerrain": "tundra",
         "overlayTerrain": "forest",
         "resource": "Game",
@@ -51029,6 +55387,7 @@
         "id": "tile-4359",
         "x": 17,
         "y": 87,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -51044,6 +55403,7 @@
         "id": "tile-4360",
         "x": 19,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -51055,6 +55415,7 @@
         "id": "tile-4361",
         "x": 21,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -51066,6 +55427,7 @@
         "id": "tile-4362",
         "x": 23,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51077,6 +55439,7 @@
         "id": "tile-4363",
         "x": 25,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51088,6 +55451,7 @@
         "id": "tile-4364",
         "x": 27,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51099,6 +55463,7 @@
         "id": "tile-4365",
         "x": 29,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51110,6 +55475,7 @@
         "id": "tile-4366",
         "x": 31,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51121,6 +55487,7 @@
         "id": "tile-4367",
         "x": 33,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -51132,6 +55499,7 @@
         "id": "tile-4368",
         "x": 35,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51143,6 +55511,7 @@
         "id": "tile-4369",
         "x": 37,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51154,6 +55523,7 @@
         "id": "tile-4370",
         "x": 39,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51165,6 +55535,7 @@
         "id": "tile-4371",
         "x": 41,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51176,6 +55547,7 @@
         "id": "tile-4372",
         "x": 43,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51187,6 +55559,7 @@
         "id": "tile-4373",
         "x": 45,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51198,6 +55571,7 @@
         "id": "tile-4374",
         "x": 47,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51209,6 +55583,7 @@
         "id": "tile-4375",
         "x": 49,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51220,6 +55595,7 @@
         "id": "tile-4376",
         "x": 51,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51231,6 +55607,7 @@
         "id": "tile-4377",
         "x": 53,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51242,6 +55619,7 @@
         "id": "tile-4378",
         "x": 55,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51253,6 +55631,7 @@
         "id": "tile-4379",
         "x": 57,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51264,6 +55643,7 @@
         "id": "tile-4380",
         "x": 59,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51275,6 +55655,7 @@
         "id": "tile-4381",
         "x": 61,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51286,6 +55667,7 @@
         "id": "tile-4382",
         "x": 63,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51297,6 +55679,7 @@
         "id": "tile-4383",
         "x": 65,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51308,6 +55691,7 @@
         "id": "tile-4384",
         "x": 67,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51319,6 +55703,7 @@
         "id": "tile-4385",
         "x": 69,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -51330,6 +55715,7 @@
         "id": "tile-4386",
         "x": 71,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51341,6 +55727,7 @@
         "id": "tile-4387",
         "x": 73,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51352,6 +55739,7 @@
         "id": "tile-4388",
         "x": 75,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51363,6 +55751,7 @@
         "id": "tile-4389",
         "x": 77,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51374,6 +55763,7 @@
         "id": "tile-4390",
         "x": 79,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51385,6 +55775,7 @@
         "id": "tile-4391",
         "x": 81,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51396,6 +55787,7 @@
         "id": "tile-4392",
         "x": 83,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51407,6 +55799,7 @@
         "id": "tile-4393",
         "x": 85,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51418,6 +55811,7 @@
         "id": "tile-4394",
         "x": 87,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51429,6 +55823,7 @@
         "id": "tile-4395",
         "x": 89,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51440,6 +55835,7 @@
         "id": "tile-4396",
         "x": 91,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51451,6 +55847,7 @@
         "id": "tile-4397",
         "x": 93,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51462,6 +55859,7 @@
         "id": "tile-4398",
         "x": 95,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51473,6 +55871,7 @@
         "id": "tile-4399",
         "x": 97,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51484,6 +55883,7 @@
         "id": "tile-4400",
         "x": 99,
         "y": 87,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51495,6 +55895,7 @@
         "id": "tile-4401",
         "x": 0,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51506,6 +55907,7 @@
         "id": "tile-4402",
         "x": 2,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51517,6 +55919,7 @@
         "id": "tile-4403",
         "x": 4,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51528,6 +55931,7 @@
         "id": "tile-4404",
         "x": 6,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51539,6 +55943,7 @@
         "id": "tile-4405",
         "x": 8,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51550,6 +55955,7 @@
         "id": "tile-4406",
         "x": 10,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -51561,6 +55967,7 @@
         "id": "tile-4407",
         "x": 12,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -51572,6 +55979,7 @@
         "id": "tile-4408",
         "x": 14,
         "y": 88,
+        "continent": 7,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -51586,6 +55994,7 @@
         "id": "tile-4409",
         "x": 16,
         "y": 88,
+        "continent": 7,
         "baseTerrain": "grassland",
         "overlayTerrain": "hills",
         "features": [
@@ -51600,6 +56009,7 @@
         "id": "tile-4410",
         "x": 18,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -51611,6 +56021,7 @@
         "id": "tile-4411",
         "x": 20,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -51622,6 +56033,7 @@
         "id": "tile-4412",
         "x": 22,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51633,6 +56045,7 @@
         "id": "tile-4413",
         "x": 24,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51644,6 +56057,7 @@
         "id": "tile-4414",
         "x": 26,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51655,6 +56069,7 @@
         "id": "tile-4415",
         "x": 28,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51666,6 +56081,7 @@
         "id": "tile-4416",
         "x": 30,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51677,6 +56093,7 @@
         "id": "tile-4417",
         "x": 32,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -51688,6 +56105,7 @@
         "id": "tile-4418",
         "x": 34,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51699,6 +56117,7 @@
         "id": "tile-4419",
         "x": 36,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51710,6 +56129,7 @@
         "id": "tile-4420",
         "x": 38,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51721,6 +56141,7 @@
         "id": "tile-4421",
         "x": 40,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51732,6 +56153,7 @@
         "id": "tile-4422",
         "x": 42,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51743,6 +56165,7 @@
         "id": "tile-4423",
         "x": 44,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51754,6 +56177,7 @@
         "id": "tile-4424",
         "x": 46,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51765,6 +56189,7 @@
         "id": "tile-4425",
         "x": 48,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51776,6 +56201,7 @@
         "id": "tile-4426",
         "x": 50,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51787,6 +56213,7 @@
         "id": "tile-4427",
         "x": 52,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51798,6 +56225,7 @@
         "id": "tile-4428",
         "x": 54,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51809,6 +56237,7 @@
         "id": "tile-4429",
         "x": 56,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51820,6 +56249,7 @@
         "id": "tile-4430",
         "x": 58,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51831,6 +56261,7 @@
         "id": "tile-4431",
         "x": 60,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51842,6 +56273,7 @@
         "id": "tile-4432",
         "x": 62,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51853,6 +56285,7 @@
         "id": "tile-4433",
         "x": 64,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51864,6 +56297,7 @@
         "id": "tile-4434",
         "x": 66,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51875,6 +56309,7 @@
         "id": "tile-4435",
         "x": 68,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51886,6 +56321,7 @@
         "id": "tile-4436",
         "x": 70,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -51897,6 +56333,7 @@
         "id": "tile-4437",
         "x": 72,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51908,6 +56345,7 @@
         "id": "tile-4438",
         "x": 74,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51919,6 +56357,7 @@
         "id": "tile-4439",
         "x": 76,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51930,6 +56369,7 @@
         "id": "tile-4440",
         "x": 78,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51941,6 +56381,7 @@
         "id": "tile-4441",
         "x": 80,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51952,6 +56393,7 @@
         "id": "tile-4442",
         "x": 82,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51963,6 +56405,7 @@
         "id": "tile-4443",
         "x": 84,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51974,6 +56417,7 @@
         "id": "tile-4444",
         "x": 86,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51985,6 +56429,7 @@
         "id": "tile-4445",
         "x": 88,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -51996,6 +56441,7 @@
         "id": "tile-4446",
         "x": 90,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52007,6 +56453,7 @@
         "id": "tile-4447",
         "x": 92,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52018,6 +56465,7 @@
         "id": "tile-4448",
         "x": 94,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52029,6 +56477,7 @@
         "id": "tile-4449",
         "x": 96,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52040,6 +56489,7 @@
         "id": "tile-4450",
         "x": 98,
         "y": 88,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52051,6 +56501,7 @@
         "id": "tile-4451",
         "x": 1,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52062,6 +56513,7 @@
         "id": "tile-4452",
         "x": 3,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52073,6 +56525,7 @@
         "id": "tile-4453",
         "x": 5,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52084,6 +56537,7 @@
         "id": "tile-4454",
         "x": 7,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52095,6 +56549,7 @@
         "id": "tile-4455",
         "x": 9,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52106,6 +56561,7 @@
         "id": "tile-4456",
         "x": 11,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -52117,6 +56573,7 @@
         "id": "tile-4457",
         "x": 13,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -52128,6 +56585,7 @@
         "id": "tile-4458",
         "x": 15,
         "y": 89,
+        "continent": 7,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -52142,6 +56600,7 @@
         "id": "tile-4459",
         "x": 17,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -52153,6 +56612,7 @@
         "id": "tile-4460",
         "x": 19,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -52164,6 +56624,7 @@
         "id": "tile-4461",
         "x": 21,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52175,6 +56636,7 @@
         "id": "tile-4462",
         "x": 23,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52186,6 +56648,7 @@
         "id": "tile-4463",
         "x": 25,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52197,6 +56660,7 @@
         "id": "tile-4464",
         "x": 27,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52208,6 +56672,7 @@
         "id": "tile-4465",
         "x": 29,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52219,6 +56684,7 @@
         "id": "tile-4466",
         "x": 31,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52230,6 +56696,7 @@
         "id": "tile-4467",
         "x": 33,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52241,6 +56708,7 @@
         "id": "tile-4468",
         "x": 35,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52252,6 +56720,7 @@
         "id": "tile-4469",
         "x": 37,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52263,6 +56732,7 @@
         "id": "tile-4470",
         "x": 39,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52274,6 +56744,7 @@
         "id": "tile-4471",
         "x": 41,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52285,6 +56756,7 @@
         "id": "tile-4472",
         "x": 43,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52296,6 +56768,7 @@
         "id": "tile-4473",
         "x": 45,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52307,6 +56780,7 @@
         "id": "tile-4474",
         "x": 47,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52318,6 +56792,7 @@
         "id": "tile-4475",
         "x": 49,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52329,6 +56804,7 @@
         "id": "tile-4476",
         "x": 51,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52340,6 +56816,7 @@
         "id": "tile-4477",
         "x": 53,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52351,6 +56828,7 @@
         "id": "tile-4478",
         "x": 55,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52362,6 +56840,7 @@
         "id": "tile-4479",
         "x": 57,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52373,6 +56852,7 @@
         "id": "tile-4480",
         "x": 59,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52384,6 +56864,7 @@
         "id": "tile-4481",
         "x": 61,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52395,6 +56876,7 @@
         "id": "tile-4482",
         "x": 63,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52406,6 +56888,7 @@
         "id": "tile-4483",
         "x": 65,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52417,6 +56900,7 @@
         "id": "tile-4484",
         "x": 67,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52428,6 +56912,7 @@
         "id": "tile-4485",
         "x": 69,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -52439,6 +56924,7 @@
         "id": "tile-4486",
         "x": 71,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52450,6 +56936,7 @@
         "id": "tile-4487",
         "x": 73,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52461,6 +56948,7 @@
         "id": "tile-4488",
         "x": 75,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52472,6 +56960,7 @@
         "id": "tile-4489",
         "x": 77,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52483,6 +56972,7 @@
         "id": "tile-4490",
         "x": 79,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52494,6 +56984,7 @@
         "id": "tile-4491",
         "x": 81,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52505,6 +56996,7 @@
         "id": "tile-4492",
         "x": 83,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52516,6 +57008,7 @@
         "id": "tile-4493",
         "x": 85,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52527,6 +57020,7 @@
         "id": "tile-4494",
         "x": 87,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52538,6 +57032,7 @@
         "id": "tile-4495",
         "x": 89,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52549,6 +57044,7 @@
         "id": "tile-4496",
         "x": 91,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52560,6 +57056,7 @@
         "id": "tile-4497",
         "x": 93,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52571,6 +57068,7 @@
         "id": "tile-4498",
         "x": 95,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52582,6 +57080,7 @@
         "id": "tile-4499",
         "x": 97,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52593,6 +57092,7 @@
         "id": "tile-4500",
         "x": 99,
         "y": 89,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52604,6 +57104,7 @@
         "id": "tile-4501",
         "x": 0,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52615,6 +57116,7 @@
         "id": "tile-4502",
         "x": 2,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52626,6 +57128,7 @@
         "id": "tile-4503",
         "x": 4,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52637,6 +57140,7 @@
         "id": "tile-4504",
         "x": 6,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52648,6 +57152,7 @@
         "id": "tile-4505",
         "x": 8,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52659,6 +57164,7 @@
         "id": "tile-4506",
         "x": 10,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -52670,6 +57176,7 @@
         "id": "tile-4507",
         "x": 12,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -52681,6 +57188,7 @@
         "id": "tile-4508",
         "x": 14,
         "y": 90,
+        "continent": 7,
         "baseTerrain": "tundra",
         "overlayTerrain": "tundra",
         "features": [
@@ -52695,6 +57203,7 @@
         "id": "tile-4509",
         "x": 16,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -52706,6 +57215,7 @@
         "id": "tile-4510",
         "x": 18,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -52717,6 +57227,7 @@
         "id": "tile-4511",
         "x": 20,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52728,6 +57239,7 @@
         "id": "tile-4512",
         "x": 22,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52739,6 +57251,7 @@
         "id": "tile-4513",
         "x": 24,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52750,6 +57263,7 @@
         "id": "tile-4514",
         "x": 26,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52761,6 +57275,7 @@
         "id": "tile-4515",
         "x": 28,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52772,6 +57287,7 @@
         "id": "tile-4516",
         "x": 30,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52783,6 +57299,7 @@
         "id": "tile-4517",
         "x": 32,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52794,6 +57311,7 @@
         "id": "tile-4518",
         "x": 34,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52805,6 +57323,7 @@
         "id": "tile-4519",
         "x": 36,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52816,6 +57335,7 @@
         "id": "tile-4520",
         "x": 38,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52827,6 +57347,7 @@
         "id": "tile-4521",
         "x": 40,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52838,6 +57359,7 @@
         "id": "tile-4522",
         "x": 42,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52849,6 +57371,7 @@
         "id": "tile-4523",
         "x": 44,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52860,6 +57383,7 @@
         "id": "tile-4524",
         "x": 46,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52871,6 +57395,7 @@
         "id": "tile-4525",
         "x": 48,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52882,6 +57407,7 @@
         "id": "tile-4526",
         "x": 50,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52893,6 +57419,7 @@
         "id": "tile-4527",
         "x": 52,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52904,6 +57431,7 @@
         "id": "tile-4528",
         "x": 54,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52915,6 +57443,7 @@
         "id": "tile-4529",
         "x": 56,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52926,6 +57455,7 @@
         "id": "tile-4530",
         "x": 58,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52937,6 +57467,7 @@
         "id": "tile-4531",
         "x": 60,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52948,6 +57479,7 @@
         "id": "tile-4532",
         "x": 62,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52959,6 +57491,7 @@
         "id": "tile-4533",
         "x": 64,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52970,6 +57503,7 @@
         "id": "tile-4534",
         "x": 66,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52981,6 +57515,7 @@
         "id": "tile-4535",
         "x": 68,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -52992,6 +57527,7 @@
         "id": "tile-4536",
         "x": 70,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -53003,6 +57539,7 @@
         "id": "tile-4537",
         "x": 72,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53014,6 +57551,7 @@
         "id": "tile-4538",
         "x": 74,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53025,6 +57563,7 @@
         "id": "tile-4539",
         "x": 76,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53036,6 +57575,7 @@
         "id": "tile-4540",
         "x": 78,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53047,6 +57587,7 @@
         "id": "tile-4541",
         "x": 80,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53058,6 +57599,7 @@
         "id": "tile-4542",
         "x": 82,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53069,6 +57611,7 @@
         "id": "tile-4543",
         "x": 84,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53080,6 +57623,7 @@
         "id": "tile-4544",
         "x": 86,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53091,6 +57635,7 @@
         "id": "tile-4545",
         "x": 88,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53102,6 +57647,7 @@
         "id": "tile-4546",
         "x": 90,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53113,6 +57659,7 @@
         "id": "tile-4547",
         "x": 92,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53124,6 +57671,7 @@
         "id": "tile-4548",
         "x": 94,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53135,6 +57683,7 @@
         "id": "tile-4549",
         "x": 96,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53146,6 +57695,7 @@
         "id": "tile-4550",
         "x": 98,
         "y": 90,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53157,6 +57707,7 @@
         "id": "tile-4551",
         "x": 1,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53168,6 +57719,7 @@
         "id": "tile-4552",
         "x": 3,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53179,6 +57731,7 @@
         "id": "tile-4553",
         "x": 5,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53190,6 +57743,7 @@
         "id": "tile-4554",
         "x": 7,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53201,6 +57755,7 @@
         "id": "tile-4555",
         "x": 9,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53212,6 +57767,7 @@
         "id": "tile-4556",
         "x": 11,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -53223,6 +57779,7 @@
         "id": "tile-4557",
         "x": 13,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -53234,6 +57791,7 @@
         "id": "tile-4558",
         "x": 15,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast",
         "resource": "Fish"
@@ -53246,6 +57804,7 @@
         "id": "tile-4559",
         "x": 17,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -53257,6 +57816,7 @@
         "id": "tile-4560",
         "x": 19,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -53268,6 +57828,7 @@
         "id": "tile-4561",
         "x": 21,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53279,6 +57840,7 @@
         "id": "tile-4562",
         "x": 23,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53290,6 +57852,7 @@
         "id": "tile-4563",
         "x": 25,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53301,6 +57864,7 @@
         "id": "tile-4564",
         "x": 27,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53312,6 +57876,7 @@
         "id": "tile-4565",
         "x": 29,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53323,6 +57888,7 @@
         "id": "tile-4566",
         "x": 31,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53334,6 +57900,7 @@
         "id": "tile-4567",
         "x": 33,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53345,6 +57912,7 @@
         "id": "tile-4568",
         "x": 35,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53356,6 +57924,7 @@
         "id": "tile-4569",
         "x": 37,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53367,6 +57936,7 @@
         "id": "tile-4570",
         "x": 39,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53378,6 +57948,7 @@
         "id": "tile-4571",
         "x": 41,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53389,6 +57960,7 @@
         "id": "tile-4572",
         "x": 43,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53400,6 +57972,7 @@
         "id": "tile-4573",
         "x": 45,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53411,6 +57984,7 @@
         "id": "tile-4574",
         "x": 47,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53422,6 +57996,7 @@
         "id": "tile-4575",
         "x": 49,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53433,6 +58008,7 @@
         "id": "tile-4576",
         "x": 51,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53444,6 +58020,7 @@
         "id": "tile-4577",
         "x": 53,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53455,6 +58032,7 @@
         "id": "tile-4578",
         "x": 55,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53466,6 +58044,7 @@
         "id": "tile-4579",
         "x": 57,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53477,6 +58056,7 @@
         "id": "tile-4580",
         "x": 59,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53488,6 +58068,7 @@
         "id": "tile-4581",
         "x": 61,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53499,6 +58080,7 @@
         "id": "tile-4582",
         "x": 63,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53510,6 +58092,7 @@
         "id": "tile-4583",
         "x": 65,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53521,6 +58104,7 @@
         "id": "tile-4584",
         "x": 67,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53532,6 +58116,7 @@
         "id": "tile-4585",
         "x": 69,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53543,6 +58128,7 @@
         "id": "tile-4586",
         "x": 71,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53554,6 +58140,7 @@
         "id": "tile-4587",
         "x": 73,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53565,6 +58152,7 @@
         "id": "tile-4588",
         "x": 75,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53576,6 +58164,7 @@
         "id": "tile-4589",
         "x": 77,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53587,6 +58176,7 @@
         "id": "tile-4590",
         "x": 79,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53598,6 +58188,7 @@
         "id": "tile-4591",
         "x": 81,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53609,6 +58200,7 @@
         "id": "tile-4592",
         "x": 83,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53620,6 +58212,7 @@
         "id": "tile-4593",
         "x": 85,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53631,6 +58224,7 @@
         "id": "tile-4594",
         "x": 87,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53642,6 +58236,7 @@
         "id": "tile-4595",
         "x": 89,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53653,6 +58248,7 @@
         "id": "tile-4596",
         "x": 91,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53664,6 +58260,7 @@
         "id": "tile-4597",
         "x": 93,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53675,6 +58272,7 @@
         "id": "tile-4598",
         "x": 95,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53686,6 +58284,7 @@
         "id": "tile-4599",
         "x": 97,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53697,6 +58296,7 @@
         "id": "tile-4600",
         "x": 99,
         "y": 91,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53708,6 +58308,7 @@
         "id": "tile-4601",
         "x": 0,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53719,6 +58320,7 @@
         "id": "tile-4602",
         "x": 2,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53730,6 +58332,7 @@
         "id": "tile-4603",
         "x": 4,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53741,6 +58344,7 @@
         "id": "tile-4604",
         "x": 6,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53752,6 +58356,7 @@
         "id": "tile-4605",
         "x": 8,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53763,6 +58368,7 @@
         "id": "tile-4606",
         "x": 10,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53774,6 +58380,7 @@
         "id": "tile-4607",
         "x": 12,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -53785,6 +58392,7 @@
         "id": "tile-4608",
         "x": 14,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "coast",
         "overlayTerrain": "coast"
       },
@@ -53796,6 +58404,7 @@
         "id": "tile-4609",
         "x": 16,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -53807,6 +58416,7 @@
         "id": "tile-4610",
         "x": 18,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53818,6 +58428,7 @@
         "id": "tile-4611",
         "x": 20,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53829,6 +58440,7 @@
         "id": "tile-4612",
         "x": 22,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53840,6 +58452,7 @@
         "id": "tile-4613",
         "x": 24,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53851,6 +58464,7 @@
         "id": "tile-4614",
         "x": 26,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53862,6 +58476,7 @@
         "id": "tile-4615",
         "x": 28,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53873,6 +58488,7 @@
         "id": "tile-4616",
         "x": 30,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53884,6 +58500,7 @@
         "id": "tile-4617",
         "x": 32,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53895,6 +58512,7 @@
         "id": "tile-4618",
         "x": 34,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53906,6 +58524,7 @@
         "id": "tile-4619",
         "x": 36,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53917,6 +58536,7 @@
         "id": "tile-4620",
         "x": 38,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53928,6 +58548,7 @@
         "id": "tile-4621",
         "x": 40,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53939,6 +58560,7 @@
         "id": "tile-4622",
         "x": 42,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53950,6 +58572,7 @@
         "id": "tile-4623",
         "x": 44,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53961,6 +58584,7 @@
         "id": "tile-4624",
         "x": 46,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53972,6 +58596,7 @@
         "id": "tile-4625",
         "x": 48,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53983,6 +58608,7 @@
         "id": "tile-4626",
         "x": 50,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -53994,6 +58620,7 @@
         "id": "tile-4627",
         "x": 52,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54005,6 +58632,7 @@
         "id": "tile-4628",
         "x": 54,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54016,6 +58644,7 @@
         "id": "tile-4629",
         "x": 56,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54027,6 +58656,7 @@
         "id": "tile-4630",
         "x": 58,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54038,6 +58668,7 @@
         "id": "tile-4631",
         "x": 60,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54049,6 +58680,7 @@
         "id": "tile-4632",
         "x": 62,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54060,6 +58692,7 @@
         "id": "tile-4633",
         "x": 64,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54071,6 +58704,7 @@
         "id": "tile-4634",
         "x": 66,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54082,6 +58716,7 @@
         "id": "tile-4635",
         "x": 68,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54093,6 +58728,7 @@
         "id": "tile-4636",
         "x": 70,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54104,6 +58740,7 @@
         "id": "tile-4637",
         "x": 72,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54115,6 +58752,7 @@
         "id": "tile-4638",
         "x": 74,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54126,6 +58764,7 @@
         "id": "tile-4639",
         "x": 76,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54137,6 +58776,7 @@
         "id": "tile-4640",
         "x": 78,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54148,6 +58788,7 @@
         "id": "tile-4641",
         "x": 80,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54159,6 +58800,7 @@
         "id": "tile-4642",
         "x": 82,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54170,6 +58812,7 @@
         "id": "tile-4643",
         "x": 84,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54181,6 +58824,7 @@
         "id": "tile-4644",
         "x": 86,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54192,6 +58836,7 @@
         "id": "tile-4645",
         "x": 88,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54203,6 +58848,7 @@
         "id": "tile-4646",
         "x": 90,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54214,6 +58860,7 @@
         "id": "tile-4647",
         "x": 92,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54225,6 +58872,7 @@
         "id": "tile-4648",
         "x": 94,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54236,6 +58884,7 @@
         "id": "tile-4649",
         "x": 96,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54247,6 +58896,7 @@
         "id": "tile-4650",
         "x": 98,
         "y": 92,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54258,6 +58908,7 @@
         "id": "tile-4651",
         "x": 1,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54269,6 +58920,7 @@
         "id": "tile-4652",
         "x": 3,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54280,6 +58932,7 @@
         "id": "tile-4653",
         "x": 5,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54291,6 +58944,7 @@
         "id": "tile-4654",
         "x": 7,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54302,6 +58956,7 @@
         "id": "tile-4655",
         "x": 9,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54313,6 +58968,7 @@
         "id": "tile-4656",
         "x": 11,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54324,6 +58980,7 @@
         "id": "tile-4657",
         "x": 13,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -54335,6 +58992,7 @@
         "id": "tile-4658",
         "x": 15,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -54346,6 +59004,7 @@
         "id": "tile-4659",
         "x": 17,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54357,6 +59016,7 @@
         "id": "tile-4660",
         "x": 19,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54368,6 +59028,7 @@
         "id": "tile-4661",
         "x": 21,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54379,6 +59040,7 @@
         "id": "tile-4662",
         "x": 23,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54390,6 +59052,7 @@
         "id": "tile-4663",
         "x": 25,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54401,6 +59064,7 @@
         "id": "tile-4664",
         "x": 27,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54412,6 +59076,7 @@
         "id": "tile-4665",
         "x": 29,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54423,6 +59088,7 @@
         "id": "tile-4666",
         "x": 31,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54434,6 +59100,7 @@
         "id": "tile-4667",
         "x": 33,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54445,6 +59112,7 @@
         "id": "tile-4668",
         "x": 35,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54456,6 +59124,7 @@
         "id": "tile-4669",
         "x": 37,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54467,6 +59136,7 @@
         "id": "tile-4670",
         "x": 39,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54478,6 +59148,7 @@
         "id": "tile-4671",
         "x": 41,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54489,6 +59160,7 @@
         "id": "tile-4672",
         "x": 43,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54500,6 +59172,7 @@
         "id": "tile-4673",
         "x": 45,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54511,6 +59184,7 @@
         "id": "tile-4674",
         "x": 47,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54522,6 +59196,7 @@
         "id": "tile-4675",
         "x": 49,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54533,6 +59208,7 @@
         "id": "tile-4676",
         "x": 51,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54544,6 +59220,7 @@
         "id": "tile-4677",
         "x": 53,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54555,6 +59232,7 @@
         "id": "tile-4678",
         "x": 55,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54566,6 +59244,7 @@
         "id": "tile-4679",
         "x": 57,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54577,6 +59256,7 @@
         "id": "tile-4680",
         "x": 59,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54588,6 +59268,7 @@
         "id": "tile-4681",
         "x": 61,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54599,6 +59280,7 @@
         "id": "tile-4682",
         "x": 63,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54610,6 +59292,7 @@
         "id": "tile-4683",
         "x": 65,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54621,6 +59304,7 @@
         "id": "tile-4684",
         "x": 67,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54632,6 +59316,7 @@
         "id": "tile-4685",
         "x": 69,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54643,6 +59328,7 @@
         "id": "tile-4686",
         "x": 71,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54654,6 +59340,7 @@
         "id": "tile-4687",
         "x": 73,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54665,6 +59352,7 @@
         "id": "tile-4688",
         "x": 75,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54676,6 +59364,7 @@
         "id": "tile-4689",
         "x": 77,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54687,6 +59376,7 @@
         "id": "tile-4690",
         "x": 79,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54698,6 +59388,7 @@
         "id": "tile-4691",
         "x": 81,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54709,6 +59400,7 @@
         "id": "tile-4692",
         "x": 83,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54720,6 +59412,7 @@
         "id": "tile-4693",
         "x": 85,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54731,6 +59424,7 @@
         "id": "tile-4694",
         "x": 87,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54742,6 +59436,7 @@
         "id": "tile-4695",
         "x": 89,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54753,6 +59448,7 @@
         "id": "tile-4696",
         "x": 91,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54764,6 +59460,7 @@
         "id": "tile-4697",
         "x": 93,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54775,6 +59472,7 @@
         "id": "tile-4698",
         "x": 95,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54786,6 +59484,7 @@
         "id": "tile-4699",
         "x": 97,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54797,6 +59496,7 @@
         "id": "tile-4700",
         "x": 99,
         "y": 93,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54808,6 +59508,7 @@
         "id": "tile-4701",
         "x": 0,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54819,6 +59520,7 @@
         "id": "tile-4702",
         "x": 2,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54830,6 +59532,7 @@
         "id": "tile-4703",
         "x": 4,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54841,6 +59544,7 @@
         "id": "tile-4704",
         "x": 6,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54852,6 +59556,7 @@
         "id": "tile-4705",
         "x": 8,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54863,6 +59568,7 @@
         "id": "tile-4706",
         "x": 10,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54874,6 +59580,7 @@
         "id": "tile-4707",
         "x": 12,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54885,6 +59592,7 @@
         "id": "tile-4708",
         "x": 14,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "sea",
         "overlayTerrain": "sea"
       },
@@ -54896,6 +59604,7 @@
         "id": "tile-4709",
         "x": 16,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54907,6 +59616,7 @@
         "id": "tile-4710",
         "x": 18,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54918,6 +59628,7 @@
         "id": "tile-4711",
         "x": 20,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54929,6 +59640,7 @@
         "id": "tile-4712",
         "x": 22,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54940,6 +59652,7 @@
         "id": "tile-4713",
         "x": 24,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54951,6 +59664,7 @@
         "id": "tile-4714",
         "x": 26,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54962,6 +59676,7 @@
         "id": "tile-4715",
         "x": 28,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54973,6 +59688,7 @@
         "id": "tile-4716",
         "x": 30,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54984,6 +59700,7 @@
         "id": "tile-4717",
         "x": 32,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -54995,6 +59712,7 @@
         "id": "tile-4718",
         "x": 34,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55006,6 +59724,7 @@
         "id": "tile-4719",
         "x": 36,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55017,6 +59736,7 @@
         "id": "tile-4720",
         "x": 38,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55028,6 +59748,7 @@
         "id": "tile-4721",
         "x": 40,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55039,6 +59760,7 @@
         "id": "tile-4722",
         "x": 42,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55050,6 +59772,7 @@
         "id": "tile-4723",
         "x": 44,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55061,6 +59784,7 @@
         "id": "tile-4724",
         "x": 46,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55072,6 +59796,7 @@
         "id": "tile-4725",
         "x": 48,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55083,6 +59808,7 @@
         "id": "tile-4726",
         "x": 50,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55094,6 +59820,7 @@
         "id": "tile-4727",
         "x": 52,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55105,6 +59832,7 @@
         "id": "tile-4728",
         "x": 54,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55116,6 +59844,7 @@
         "id": "tile-4729",
         "x": 56,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55127,6 +59856,7 @@
         "id": "tile-4730",
         "x": 58,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55138,6 +59868,7 @@
         "id": "tile-4731",
         "x": 60,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55149,6 +59880,7 @@
         "id": "tile-4732",
         "x": 62,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55160,6 +59892,7 @@
         "id": "tile-4733",
         "x": 64,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55171,6 +59904,7 @@
         "id": "tile-4734",
         "x": 66,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55182,6 +59916,7 @@
         "id": "tile-4735",
         "x": 68,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55193,6 +59928,7 @@
         "id": "tile-4736",
         "x": 70,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55204,6 +59940,7 @@
         "id": "tile-4737",
         "x": 72,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55215,6 +59952,7 @@
         "id": "tile-4738",
         "x": 74,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55226,6 +59964,7 @@
         "id": "tile-4739",
         "x": 76,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55237,6 +59976,7 @@
         "id": "tile-4740",
         "x": 78,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55248,6 +59988,7 @@
         "id": "tile-4741",
         "x": 80,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55259,6 +60000,7 @@
         "id": "tile-4742",
         "x": 82,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55270,6 +60012,7 @@
         "id": "tile-4743",
         "x": 84,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55281,6 +60024,7 @@
         "id": "tile-4744",
         "x": 86,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55292,6 +60036,7 @@
         "id": "tile-4745",
         "x": 88,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55303,6 +60048,7 @@
         "id": "tile-4746",
         "x": 90,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55314,6 +60060,7 @@
         "id": "tile-4747",
         "x": 92,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55325,6 +60072,7 @@
         "id": "tile-4748",
         "x": 94,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55336,6 +60084,7 @@
         "id": "tile-4749",
         "x": 96,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55347,6 +60096,7 @@
         "id": "tile-4750",
         "x": 98,
         "y": 94,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55358,6 +60108,7 @@
         "id": "tile-4751",
         "x": 1,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55369,6 +60120,7 @@
         "id": "tile-4752",
         "x": 3,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55380,6 +60132,7 @@
         "id": "tile-4753",
         "x": 5,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55391,6 +60144,7 @@
         "id": "tile-4754",
         "x": 7,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55402,6 +60156,7 @@
         "id": "tile-4755",
         "x": 9,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55413,6 +60168,7 @@
         "id": "tile-4756",
         "x": 11,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55424,6 +60180,7 @@
         "id": "tile-4757",
         "x": 13,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55435,6 +60192,7 @@
         "id": "tile-4758",
         "x": 15,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55446,6 +60204,7 @@
         "id": "tile-4759",
         "x": 17,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55457,6 +60216,7 @@
         "id": "tile-4760",
         "x": 19,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55468,6 +60228,7 @@
         "id": "tile-4761",
         "x": 21,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55479,6 +60240,7 @@
         "id": "tile-4762",
         "x": 23,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55490,6 +60252,7 @@
         "id": "tile-4763",
         "x": 25,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55501,6 +60264,7 @@
         "id": "tile-4764",
         "x": 27,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55512,6 +60276,7 @@
         "id": "tile-4765",
         "x": 29,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55523,6 +60288,7 @@
         "id": "tile-4766",
         "x": 31,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55534,6 +60300,7 @@
         "id": "tile-4767",
         "x": 33,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55545,6 +60312,7 @@
         "id": "tile-4768",
         "x": 35,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55556,6 +60324,7 @@
         "id": "tile-4769",
         "x": 37,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55567,6 +60336,7 @@
         "id": "tile-4770",
         "x": 39,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55578,6 +60348,7 @@
         "id": "tile-4771",
         "x": 41,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55589,6 +60360,7 @@
         "id": "tile-4772",
         "x": 43,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55600,6 +60372,7 @@
         "id": "tile-4773",
         "x": 45,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55611,6 +60384,7 @@
         "id": "tile-4774",
         "x": 47,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55622,6 +60396,7 @@
         "id": "tile-4775",
         "x": 49,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55633,6 +60408,7 @@
         "id": "tile-4776",
         "x": 51,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55644,6 +60420,7 @@
         "id": "tile-4777",
         "x": 53,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55655,6 +60432,7 @@
         "id": "tile-4778",
         "x": 55,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55666,6 +60444,7 @@
         "id": "tile-4779",
         "x": 57,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55677,6 +60456,7 @@
         "id": "tile-4780",
         "x": 59,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55688,6 +60468,7 @@
         "id": "tile-4781",
         "x": 61,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55699,6 +60480,7 @@
         "id": "tile-4782",
         "x": 63,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55710,6 +60492,7 @@
         "id": "tile-4783",
         "x": 65,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55721,6 +60504,7 @@
         "id": "tile-4784",
         "x": 67,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55732,6 +60516,7 @@
         "id": "tile-4785",
         "x": 69,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55743,6 +60528,7 @@
         "id": "tile-4786",
         "x": 71,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55754,6 +60540,7 @@
         "id": "tile-4787",
         "x": 73,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55765,6 +60552,7 @@
         "id": "tile-4788",
         "x": 75,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55776,6 +60564,7 @@
         "id": "tile-4789",
         "x": 77,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55787,6 +60576,7 @@
         "id": "tile-4790",
         "x": 79,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55798,6 +60588,7 @@
         "id": "tile-4791",
         "x": 81,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55809,6 +60600,7 @@
         "id": "tile-4792",
         "x": 83,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55820,6 +60612,7 @@
         "id": "tile-4793",
         "x": 85,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55831,6 +60624,7 @@
         "id": "tile-4794",
         "x": 87,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55842,6 +60636,7 @@
         "id": "tile-4795",
         "x": 89,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55853,6 +60648,7 @@
         "id": "tile-4796",
         "x": 91,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55864,6 +60660,7 @@
         "id": "tile-4797",
         "x": 93,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55875,6 +60672,7 @@
         "id": "tile-4798",
         "x": 95,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55886,6 +60684,7 @@
         "id": "tile-4799",
         "x": 97,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55897,6 +60696,7 @@
         "id": "tile-4800",
         "x": 99,
         "y": 95,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55908,6 +60708,7 @@
         "id": "tile-4801",
         "x": 0,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55919,6 +60720,7 @@
         "id": "tile-4802",
         "x": 2,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55930,6 +60732,7 @@
         "id": "tile-4803",
         "x": 4,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55941,6 +60744,7 @@
         "id": "tile-4804",
         "x": 6,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55952,6 +60756,7 @@
         "id": "tile-4805",
         "x": 8,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55963,6 +60768,7 @@
         "id": "tile-4806",
         "x": 10,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55974,6 +60780,7 @@
         "id": "tile-4807",
         "x": 12,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55985,6 +60792,7 @@
         "id": "tile-4808",
         "x": 14,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -55996,6 +60804,7 @@
         "id": "tile-4809",
         "x": 16,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56007,6 +60816,7 @@
         "id": "tile-4810",
         "x": 18,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56018,6 +60828,7 @@
         "id": "tile-4811",
         "x": 20,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56029,6 +60840,7 @@
         "id": "tile-4812",
         "x": 22,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56040,6 +60852,7 @@
         "id": "tile-4813",
         "x": 24,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56051,6 +60864,7 @@
         "id": "tile-4814",
         "x": 26,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56062,6 +60876,7 @@
         "id": "tile-4815",
         "x": 28,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56073,6 +60888,7 @@
         "id": "tile-4816",
         "x": 30,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56084,6 +60900,7 @@
         "id": "tile-4817",
         "x": 32,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56095,6 +60912,7 @@
         "id": "tile-4818",
         "x": 34,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56106,6 +60924,7 @@
         "id": "tile-4819",
         "x": 36,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56117,6 +60936,7 @@
         "id": "tile-4820",
         "x": 38,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56128,6 +60948,7 @@
         "id": "tile-4821",
         "x": 40,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56139,6 +60960,7 @@
         "id": "tile-4822",
         "x": 42,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56150,6 +60972,7 @@
         "id": "tile-4823",
         "x": 44,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56161,6 +60984,7 @@
         "id": "tile-4824",
         "x": 46,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56172,6 +60996,7 @@
         "id": "tile-4825",
         "x": 48,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56183,6 +61008,7 @@
         "id": "tile-4826",
         "x": 50,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56194,6 +61020,7 @@
         "id": "tile-4827",
         "x": 52,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56205,6 +61032,7 @@
         "id": "tile-4828",
         "x": 54,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56216,6 +61044,7 @@
         "id": "tile-4829",
         "x": 56,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56227,6 +61056,7 @@
         "id": "tile-4830",
         "x": 58,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56238,6 +61068,7 @@
         "id": "tile-4831",
         "x": 60,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56249,6 +61080,7 @@
         "id": "tile-4832",
         "x": 62,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56260,6 +61092,7 @@
         "id": "tile-4833",
         "x": 64,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56271,6 +61104,7 @@
         "id": "tile-4834",
         "x": 66,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56282,6 +61116,7 @@
         "id": "tile-4835",
         "x": 68,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56293,6 +61128,7 @@
         "id": "tile-4836",
         "x": 70,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56304,6 +61140,7 @@
         "id": "tile-4837",
         "x": 72,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56315,6 +61152,7 @@
         "id": "tile-4838",
         "x": 74,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56326,6 +61164,7 @@
         "id": "tile-4839",
         "x": 76,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56337,6 +61176,7 @@
         "id": "tile-4840",
         "x": 78,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56348,6 +61188,7 @@
         "id": "tile-4841",
         "x": 80,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56359,6 +61200,7 @@
         "id": "tile-4842",
         "x": 82,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56370,6 +61212,7 @@
         "id": "tile-4843",
         "x": 84,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56381,6 +61224,7 @@
         "id": "tile-4844",
         "x": 86,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56392,6 +61236,7 @@
         "id": "tile-4845",
         "x": 88,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56403,6 +61248,7 @@
         "id": "tile-4846",
         "x": 90,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56414,6 +61260,7 @@
         "id": "tile-4847",
         "x": 92,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56425,6 +61272,7 @@
         "id": "tile-4848",
         "x": 94,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56436,6 +61284,7 @@
         "id": "tile-4849",
         "x": 96,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56447,6 +61296,7 @@
         "id": "tile-4850",
         "x": 98,
         "y": 96,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56458,6 +61308,7 @@
         "id": "tile-4851",
         "x": 1,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56469,6 +61320,7 @@
         "id": "tile-4852",
         "x": 3,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56480,6 +61332,7 @@
         "id": "tile-4853",
         "x": 5,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56491,6 +61344,7 @@
         "id": "tile-4854",
         "x": 7,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56502,6 +61356,7 @@
         "id": "tile-4855",
         "x": 9,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56513,6 +61368,7 @@
         "id": "tile-4856",
         "x": 11,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56524,6 +61380,7 @@
         "id": "tile-4857",
         "x": 13,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56535,6 +61392,7 @@
         "id": "tile-4858",
         "x": 15,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56546,6 +61404,7 @@
         "id": "tile-4859",
         "x": 17,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56557,6 +61416,7 @@
         "id": "tile-4860",
         "x": 19,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56568,6 +61428,7 @@
         "id": "tile-4861",
         "x": 21,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56579,6 +61440,7 @@
         "id": "tile-4862",
         "x": 23,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56590,6 +61452,7 @@
         "id": "tile-4863",
         "x": 25,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56601,6 +61464,7 @@
         "id": "tile-4864",
         "x": 27,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56612,6 +61476,7 @@
         "id": "tile-4865",
         "x": 29,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56623,6 +61488,7 @@
         "id": "tile-4866",
         "x": 31,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56634,6 +61500,7 @@
         "id": "tile-4867",
         "x": 33,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56645,6 +61512,7 @@
         "id": "tile-4868",
         "x": 35,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56656,6 +61524,7 @@
         "id": "tile-4869",
         "x": 37,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56667,6 +61536,7 @@
         "id": "tile-4870",
         "x": 39,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56678,6 +61548,7 @@
         "id": "tile-4871",
         "x": 41,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56689,6 +61560,7 @@
         "id": "tile-4872",
         "x": 43,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56700,6 +61572,7 @@
         "id": "tile-4873",
         "x": 45,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56711,6 +61584,7 @@
         "id": "tile-4874",
         "x": 47,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56722,6 +61596,7 @@
         "id": "tile-4875",
         "x": 49,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56733,6 +61608,7 @@
         "id": "tile-4876",
         "x": 51,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56744,6 +61620,7 @@
         "id": "tile-4877",
         "x": 53,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56755,6 +61632,7 @@
         "id": "tile-4878",
         "x": 55,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56766,6 +61644,7 @@
         "id": "tile-4879",
         "x": 57,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56777,6 +61656,7 @@
         "id": "tile-4880",
         "x": 59,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56788,6 +61668,7 @@
         "id": "tile-4881",
         "x": 61,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56799,6 +61680,7 @@
         "id": "tile-4882",
         "x": 63,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56810,6 +61692,7 @@
         "id": "tile-4883",
         "x": 65,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56821,6 +61704,7 @@
         "id": "tile-4884",
         "x": 67,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56832,6 +61716,7 @@
         "id": "tile-4885",
         "x": 69,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56843,6 +61728,7 @@
         "id": "tile-4886",
         "x": 71,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56854,6 +61740,7 @@
         "id": "tile-4887",
         "x": 73,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56865,6 +61752,7 @@
         "id": "tile-4888",
         "x": 75,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56876,6 +61764,7 @@
         "id": "tile-4889",
         "x": 77,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56887,6 +61776,7 @@
         "id": "tile-4890",
         "x": 79,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56898,6 +61788,7 @@
         "id": "tile-4891",
         "x": 81,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56909,6 +61800,7 @@
         "id": "tile-4892",
         "x": 83,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56920,6 +61812,7 @@
         "id": "tile-4893",
         "x": 85,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56931,6 +61824,7 @@
         "id": "tile-4894",
         "x": 87,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56942,6 +61836,7 @@
         "id": "tile-4895",
         "x": 89,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56953,6 +61848,7 @@
         "id": "tile-4896",
         "x": 91,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56964,6 +61860,7 @@
         "id": "tile-4897",
         "x": 93,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56975,6 +61872,7 @@
         "id": "tile-4898",
         "x": 95,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56986,6 +61884,7 @@
         "id": "tile-4899",
         "x": 97,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -56997,6 +61896,7 @@
         "id": "tile-4900",
         "x": 99,
         "y": 97,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57008,6 +61908,7 @@
         "id": "tile-4901",
         "x": 0,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57019,6 +61920,7 @@
         "id": "tile-4902",
         "x": 2,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57030,6 +61932,7 @@
         "id": "tile-4903",
         "x": 4,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57041,6 +61944,7 @@
         "id": "tile-4904",
         "x": 6,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57052,6 +61956,7 @@
         "id": "tile-4905",
         "x": 8,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57063,6 +61968,7 @@
         "id": "tile-4906",
         "x": 10,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57074,6 +61980,7 @@
         "id": "tile-4907",
         "x": 12,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57085,6 +61992,7 @@
         "id": "tile-4908",
         "x": 14,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57096,6 +62004,7 @@
         "id": "tile-4909",
         "x": 16,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57107,6 +62016,7 @@
         "id": "tile-4910",
         "x": 18,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57118,6 +62028,7 @@
         "id": "tile-4911",
         "x": 20,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57129,6 +62040,7 @@
         "id": "tile-4912",
         "x": 22,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57140,6 +62052,7 @@
         "id": "tile-4913",
         "x": 24,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57151,6 +62064,7 @@
         "id": "tile-4914",
         "x": 26,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57162,6 +62076,7 @@
         "id": "tile-4915",
         "x": 28,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57173,6 +62088,7 @@
         "id": "tile-4916",
         "x": 30,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57184,6 +62100,7 @@
         "id": "tile-4917",
         "x": 32,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57195,6 +62112,7 @@
         "id": "tile-4918",
         "x": 34,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57206,6 +62124,7 @@
         "id": "tile-4919",
         "x": 36,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57217,6 +62136,7 @@
         "id": "tile-4920",
         "x": 38,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57228,6 +62148,7 @@
         "id": "tile-4921",
         "x": 40,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57239,6 +62160,7 @@
         "id": "tile-4922",
         "x": 42,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57250,6 +62172,7 @@
         "id": "tile-4923",
         "x": 44,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57261,6 +62184,7 @@
         "id": "tile-4924",
         "x": 46,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57272,6 +62196,7 @@
         "id": "tile-4925",
         "x": 48,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57283,6 +62208,7 @@
         "id": "tile-4926",
         "x": 50,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57294,6 +62220,7 @@
         "id": "tile-4927",
         "x": 52,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57305,6 +62232,7 @@
         "id": "tile-4928",
         "x": 54,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57316,6 +62244,7 @@
         "id": "tile-4929",
         "x": 56,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57327,6 +62256,7 @@
         "id": "tile-4930",
         "x": 58,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57338,6 +62268,7 @@
         "id": "tile-4931",
         "x": 60,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57349,6 +62280,7 @@
         "id": "tile-4932",
         "x": 62,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57360,6 +62292,7 @@
         "id": "tile-4933",
         "x": 64,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57371,6 +62304,7 @@
         "id": "tile-4934",
         "x": 66,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57382,6 +62316,7 @@
         "id": "tile-4935",
         "x": 68,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57393,6 +62328,7 @@
         "id": "tile-4936",
         "x": 70,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57404,6 +62340,7 @@
         "id": "tile-4937",
         "x": 72,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57415,6 +62352,7 @@
         "id": "tile-4938",
         "x": 74,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57426,6 +62364,7 @@
         "id": "tile-4939",
         "x": 76,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57437,6 +62376,7 @@
         "id": "tile-4940",
         "x": 78,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57448,6 +62388,7 @@
         "id": "tile-4941",
         "x": 80,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57459,6 +62400,7 @@
         "id": "tile-4942",
         "x": 82,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57470,6 +62412,7 @@
         "id": "tile-4943",
         "x": 84,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57481,6 +62424,7 @@
         "id": "tile-4944",
         "x": 86,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57492,6 +62436,7 @@
         "id": "tile-4945",
         "x": 88,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57503,6 +62448,7 @@
         "id": "tile-4946",
         "x": 90,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57514,6 +62460,7 @@
         "id": "tile-4947",
         "x": 92,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57525,6 +62472,7 @@
         "id": "tile-4948",
         "x": 94,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57536,6 +62484,7 @@
         "id": "tile-4949",
         "x": 96,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57547,6 +62496,7 @@
         "id": "tile-4950",
         "x": 98,
         "y": 98,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57558,6 +62508,7 @@
         "id": "tile-4951",
         "x": 1,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57569,6 +62520,7 @@
         "id": "tile-4952",
         "x": 3,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57580,6 +62532,7 @@
         "id": "tile-4953",
         "x": 5,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57591,6 +62544,7 @@
         "id": "tile-4954",
         "x": 7,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57602,6 +62556,7 @@
         "id": "tile-4955",
         "x": 9,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57613,6 +62568,7 @@
         "id": "tile-4956",
         "x": 11,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57624,6 +62580,7 @@
         "id": "tile-4957",
         "x": 13,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57635,6 +62592,7 @@
         "id": "tile-4958",
         "x": 15,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57646,6 +62604,7 @@
         "id": "tile-4959",
         "x": 17,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57657,6 +62616,7 @@
         "id": "tile-4960",
         "x": 19,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57668,6 +62628,7 @@
         "id": "tile-4961",
         "x": 21,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57679,6 +62640,7 @@
         "id": "tile-4962",
         "x": 23,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57690,6 +62652,7 @@
         "id": "tile-4963",
         "x": 25,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57701,6 +62664,7 @@
         "id": "tile-4964",
         "x": 27,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57712,6 +62676,7 @@
         "id": "tile-4965",
         "x": 29,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57723,6 +62688,7 @@
         "id": "tile-4966",
         "x": 31,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57734,6 +62700,7 @@
         "id": "tile-4967",
         "x": 33,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57745,6 +62712,7 @@
         "id": "tile-4968",
         "x": 35,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57756,6 +62724,7 @@
         "id": "tile-4969",
         "x": 37,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57767,6 +62736,7 @@
         "id": "tile-4970",
         "x": 39,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57778,6 +62748,7 @@
         "id": "tile-4971",
         "x": 41,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57789,6 +62760,7 @@
         "id": "tile-4972",
         "x": 43,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57800,6 +62772,7 @@
         "id": "tile-4973",
         "x": 45,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57811,6 +62784,7 @@
         "id": "tile-4974",
         "x": 47,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57822,6 +62796,7 @@
         "id": "tile-4975",
         "x": 49,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57833,6 +62808,7 @@
         "id": "tile-4976",
         "x": 51,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57844,6 +62820,7 @@
         "id": "tile-4977",
         "x": 53,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57855,6 +62832,7 @@
         "id": "tile-4978",
         "x": 55,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57866,6 +62844,7 @@
         "id": "tile-4979",
         "x": 57,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57877,6 +62856,7 @@
         "id": "tile-4980",
         "x": 59,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57888,6 +62868,7 @@
         "id": "tile-4981",
         "x": 61,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57899,6 +62880,7 @@
         "id": "tile-4982",
         "x": 63,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57910,6 +62892,7 @@
         "id": "tile-4983",
         "x": 65,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57921,6 +62904,7 @@
         "id": "tile-4984",
         "x": 67,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57932,6 +62916,7 @@
         "id": "tile-4985",
         "x": 69,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57943,6 +62928,7 @@
         "id": "tile-4986",
         "x": 71,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57954,6 +62940,7 @@
         "id": "tile-4987",
         "x": 73,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57965,6 +62952,7 @@
         "id": "tile-4988",
         "x": 75,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57976,6 +62964,7 @@
         "id": "tile-4989",
         "x": 77,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57987,6 +62976,7 @@
         "id": "tile-4990",
         "x": 79,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -57998,6 +62988,7 @@
         "id": "tile-4991",
         "x": 81,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -58009,6 +63000,7 @@
         "id": "tile-4992",
         "x": 83,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -58020,6 +63012,7 @@
         "id": "tile-4993",
         "x": 85,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -58031,6 +63024,7 @@
         "id": "tile-4994",
         "x": 87,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -58042,6 +63036,7 @@
         "id": "tile-4995",
         "x": 89,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -58053,6 +63048,7 @@
         "id": "tile-4996",
         "x": 91,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -58064,6 +63060,7 @@
         "id": "tile-4997",
         "x": 93,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -58075,6 +63072,7 @@
         "id": "tile-4998",
         "x": 95,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -58086,6 +63084,7 @@
         "id": "tile-4999",
         "x": 97,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       },
@@ -58097,6 +63096,7 @@
         "id": "tile-5000",
         "x": 99,
         "y": 99,
+        "continent": -1,
         "baseTerrain": "ocean",
         "overlayTerrain": "ocean"
       }

--- a/C7Engine/AI/CityProductionAI.cs
+++ b/C7Engine/AI/CityProductionAI.cs
@@ -32,7 +32,7 @@ namespace C7Engine {
 			List<StrategicPriority> priorities = city.owner.strategicPriorityData;
 			IEnumerable<IProducible> unitPrototypes = city.ListProductionOptions();
 
-			log.Information($"Choosing what to produce next in {city.name}");
+			log.Debug($"Choosing what to produce next in {city.name}");
 
 			List<IProducible> prototypes = new List<IProducible>();
 			List<float> weights = new List<float>();
@@ -53,7 +53,7 @@ namespace C7Engine {
 				}
 
 				// Exclude settlers if we don't have anywhere to build a city.
-				if (unitPrototype.actions.Contains("unit_build_city") && SettlerLocationAI.findSettlerLocation(city.location, city.owner) == Tile.NONE) {
+				if (unitPrototype.actions.Contains(C7Action.UnitBuildCity) && SettlerLocationAI.findSettlerLocation(city.location, city.owner) == Tile.NONE) {
 					flatAdjustedScore = 0;
 				}
 
@@ -120,7 +120,7 @@ namespace C7Engine {
 			int idx = 0;
 			foreach (double cutoff in cutoffs) {
 				if (randomDouble < cutoff) {
-					log.Information($"Chose item {items[idx]}");
+					log.Debug($"Chose item {items[idx]}");
 					return items[idx];
 				}
 				idx++;

--- a/C7Engine/AI/Pathing/AStarAlgorithm.cs
+++ b/C7Engine/AI/Pathing/AStarAlgorithm.cs
@@ -35,6 +35,13 @@ namespace C7Engine.Pathing {
 		}
 
 		public override TilePath PathFrom(Tile start, Tile destination) {
+			// Exit early if we're starting and ending on land, and we're on
+			// different continents. Don't waste time checking every tile on the
+			// continent just to discover the path is impossible.
+			if (start.IsLand() && destination.IsLand() && start.continent != destination.continent) {
+				return TilePath.EmptyPath(destination);
+			}
+
 			// The set of tiles to explore next, ordered by their cumulative cost
 			// so far and the estimate of the cost to the goal.
 			BinaryMinHeap<TileAndCost> openSet = new();

--- a/C7Engine/AI/UnitAI/SettlerLocationAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerLocationAI.cs
@@ -39,7 +39,8 @@ namespace C7Engine {
 
 		public static Dictionary<Tile, int> GetScoredSettlerCandidates(Tile start, Player player) {
 			List<MapUnit> playerUnits = player.units;
-			IEnumerable<Tile> candidates = player.tileKnowledge.AllKnownTiles().Where(t => !IsInvalidCityLocation(t));
+			// TODO: handle settling other continents
+			IEnumerable<Tile> candidates = player.tileKnowledge.AllKnownTiles().Where(t => !IsInvalidCityLocation(t) && t.continent == start.continent);
 			Dictionary<Tile, int> scores = AssignTileScores(start, player, candidates, playerUnits.FindAll(u => u.unitType.name == "Settler"));
 			return scores;
 		}

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -95,6 +95,7 @@ namespace C7GameData {
 					extraInfo = extra,
 					X = X,
 					Y = Y,
+					continent = civ3Tile.Continent,
 					baseTerrain = save.TerrainTypes[civ3Tile.BaseTerrain].Key,
 					overlayTerrain = save.TerrainTypes[civ3Tile.OverlayTerrain].Key,
 				};
@@ -196,6 +197,7 @@ namespace C7GameData {
 					extraInfo = extra,
 					X = X,
 					Y = Y,
+					continent = civ3Tile.Continent,
 					baseTerrain = save.TerrainTypes[civ3Tile.BaseTerrain].Key,
 					overlayTerrain = save.TerrainTypes[civ3Tile.OverlayTerrain].Key,
 				};

--- a/C7GameData/Save/SaveTile.cs
+++ b/C7GameData/Save/SaveTile.cs
@@ -14,6 +14,7 @@ namespace C7GameData.Save {
 			extraInfo = tile.ExtraInfo;
 			X = tile.XCoordinate;
 			Y = tile.YCoordinate;
+			continent = tile.continent;
 			baseTerrain = tile.baseTerrainTypeKey;
 			overlayTerrain = tile.overlayTerrainTypeKey;
 			if (tile.Resource != Resource.NONE) {
@@ -57,6 +58,7 @@ namespace C7GameData.Save {
 				ExtraInfo = extraInfo,
 				XCoordinate = X,
 				YCoordinate = Y,
+				continent = continent,
 				baseTerrainTypeKey = baseTerrain,
 				baseTerrainType = terrainTypes.Find(tt => tt.Key == baseTerrain),
 				overlayTerrainTypeKey = overlayTerrain,
@@ -92,6 +94,7 @@ namespace C7GameData.Save {
 		public ID id;
 		public int X;
 		public int Y;
+		public int continent;
 		[JsonRequired]
 		public string baseTerrain;
 		public string overlayTerrain;

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -10,6 +10,14 @@ namespace C7GameData {
 		public Civ3ExtraInfo ExtraInfo;
 		public int XCoordinate;
 		public int YCoordinate;
+
+		// An arbitrary number indicating which landmass this tile is part of,
+		// for land-based tiles, or -1 for water.
+		//
+		// This is used to avoid the expensive process of pathfinding between
+		// two land tiles just to discover they have no land connection.
+		public int continent;
+
 		public City owningCity; // The city whose border contains this tile
 		public string baseTerrainTypeKey { get; set; }
 		[JsonIgnore]


### PR DESCRIPTION
While working to speed up the AI turns after turn 100, I found that the AI was repeatedly attempting to send settlers to other continents by foot. Attempting this pathing is the worst case scenario for the pathing algorithms, as it has to check every tile on the continent to discover there is no route.

To solve this, we just add an identifier to each land mass, to make it trivial to exit early if no land route is possible. I'm fairly certain the base game did something similar, since the base game had an existing "continents" field for each tile.

To backfill continent information for the static save, I used this code snipped in `SaveTest.cs`:

```
		GameData gameData = ToGameData(saveNeverGameData);

		int nextContinent = 0;
		HashSet<Tile> seen = new();

		foreach (Tile t in gameData.map.tiles) {
			if (!t.IsLand()) {
				t.continent = -1;
				continue;
			} 

			if (seen.Contains(t)) {
				continue;
			}
			
			t.continent = nextContinent;
			seen.Add(t);

			Queue<Tile> toCheck = new();
			toCheck.Enqueue(t);

			while (toCheck.Count > 0) {
				Tile x = toCheck.Dequeue();
				x.continent = nextContinent;

				foreach (Tile n in x.neighbors.Values) {
					if (!seen.Contains(n) && n.IsLand()) {
						seen.Add(n);
						toCheck.Enqueue(n);
					}
				}
			}
			++nextContinent;
		}

		SaveGame saveWasGameData = SaveGame.FromGameData(gameData);
```