### PR TITLE
Rework the logic for chosing which cities to defend 

### DIFF
--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -99,13 +99,13 @@ namespace C7Engine {
 			} else if (unit.unitType.name == "Worker") {
 				return new WorkerAI(WorkerAI.MakeAiData(unit, player));
 			} else if (unit.location.cityAtTile != null && unit.location.unitsOnTile.Count(u => u.unitType.defense > 0 && u != unit) == 0) {
-				return new DefenderAI(DefenderAI.MakeAiData(unit, player));
+				return new DefenderAI(DefenderAI.MakeAiDataForDefendInPlace(unit, player));
 			} else if (GetCombatAIIfUnitCanAttackNearbyBarbCamp(unit, player) is UnitAI unitAI && unitAI != null) {
 				log.Information("Set unit " + unit + " to take out barb camp");
 				return unitAI;
 			} else if (unit.unitType.name == "Catapult") {
 				//For now tell catapults to sit tight.  It's getting really annoying watching them pointlessly bombard barb camps forever
-				return new DefenderAI(DefenderAI.MakeAiData(unit, player));
+				return new DefenderAI(DefenderAI.MakeAiDataForDefendInPlace(unit, player));
 			} else {
 				// As long as we don't have too many explorers yet, start a new
 				// exploring unit.
@@ -136,18 +136,7 @@ namespace C7Engine {
 
 				//As of today (4/7/2022), let's tackle just one of those - adequate defense of cities.  The AI is really good at losing cities to barbs right now,
 				//and that's a problem.
-
-				City nearestCityToDefend = FindNearbyCityToDefend(unit, player);
-
-				DefenderAIData newUnitAIData = new DefenderAIData();
-				newUnitAIData.destination = nearestCityToDefend.location;
-				newUnitAIData.goal = DefenderAIData.DefenderGoal.DEFEND_CITY;
-
-				PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
-				newUnitAIData.pathToDestination = algorithm.PathFrom(unit.location, newUnitAIData.destination);
-
-				log.Information($"Unit {unit} tasked with defending {nearestCityToDefend.name}");
-				return new DefenderAI(newUnitAIData);
+				return new DefenderAI(DefenderAI.MakeAiDataForDefendAtRiskCity(unit, player));
 			}
 		}
 
@@ -178,38 +167,6 @@ namespace C7Engine {
 				return new CombatAI(caid);
 			}
 			return null;
-		}
-
-		/**
-		 * Finds a nearby city that could use extra defenders.  Currently, that is a city that is tied
-		 * for the fewest units present, and among those, it's the closest.
-		 *
-		 * This is not a brilliant method, with many flaws such as not considering units already en route to defend,
-		 * whether the city needs more defenders, or if the units present are defenders.
-		 *
-		 * However, in the spirit of incrementalism, sending units to defend is still better than not sending them to defend.
-		 */
-		private static City FindNearbyCityToDefend(MapUnit unit, Player player) {
-			int minDefenders = int.MaxValue;
-			//TODO: Just being there doesn't mean a unit is a defender.
-			List<City> citiesWithFewestDefenders = new List<City>();
-			foreach (City c in player.cities) {
-				if (c.location.unitsOnTile.Count < minDefenders) {
-					minDefenders = c.location.unitsOnTile.Count;
-					citiesWithFewestDefenders.Clear();
-					citiesWithFewestDefenders.Add(c);
-				}
-			}
-			City nearestCityToDefend = City.NONE;
-			int closestCityDistance = int.MaxValue;
-			foreach (City c in citiesWithFewestDefenders) {
-				int distanceToCity = c.location.distanceTo(unit.location);
-				if (distanceToCity < closestCityDistance) {
-					nearestCityToDefend = c;
-					closestCityDistance = distanceToCity;
-				}
-			}
-			return nearestCityToDefend;
 		}
 
 		private static Tech PickTechToResearch(Player player, List<Tech> techs) {

--- a/C7Engine/AI/UnitAI/DefenderAI.cs
+++ b/C7Engine/AI/UnitAI/DefenderAI.cs
@@ -1,13 +1,16 @@
 using C7GameData;
 using C7GameData.AIData;
+using C7Engine.Pathing;
+using System.Collections.Generic;
+using System.Linq;
 using Serilog;
 
 namespace C7Engine.AI.UnitAI {
 	class DefenderAI : C7GameData.UnitAI {
 		private static ILogger log = Log.ForContext<DefenderAI>();
-		private DefenderAIData defenderAI;
+		public DefenderAIData data;
 
-		public static DefenderAIData MakeAiData(MapUnit unit, Player player) {
+		public static DefenderAIData MakeAiDataForDefendInPlace(MapUnit unit, Player player) {
 			DefenderAIData ai = new DefenderAIData();
 			ai.goal = DefenderAIData.DefenderGoal.DEFEND_CITY;
 			ai.destination = unit.location;
@@ -15,25 +18,80 @@ namespace C7Engine.AI.UnitAI {
 			return ai;
 		}
 
+		public static DefenderAIData MakeAiDataForDefendAtRiskCity(MapUnit unit, Player player) {
+			City cityToDefend = FindAtRiskCityToDefend(unit, player);
+
+			DefenderAIData ai = new DefenderAIData();
+			ai.destination = cityToDefend.location;
+			ai.goal = DefenderAIData.DefenderGoal.DEFEND_CITY;
+
+			PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
+			ai.pathToDestination = algorithm.PathFrom(unit.location, ai.destination);
+
+			log.Information($"Unit {unit} tasked with defending {cityToDefend.name}");
+			return ai;
+		}
+
 		public DefenderAI(DefenderAIData d) {
-			defenderAI = d;
+			data = d;
 		}
 
 		C7GameData.UnitAI.Result C7GameData.UnitAI.PlayTurnImpl(Player player, MapUnit unit) {
-			if (defenderAI.destination == unit.location) {
+			if (data.destination == unit.location) {
 				if (!unit.isFortified) {
 					unit.fortify();
-					log.Information("Fortifying " + unit + " at " + defenderAI.destination);
+					log.Information("Fortifying " + unit + " at " + data.destination);
 				}
 				return C7GameData.UnitAI.Result.Done;
 			} else {
-				log.Debug("Moving defender towards " + defenderAI.destination);
-				return this.TryToMoveAlongPath(unit, defenderAI.pathToDestination, /*allowCombat=*/true);
+				log.Debug("Moving defender towards " + data.destination);
+				return this.TryToMoveAlongPath(unit, data.pathToDestination, /*allowCombat=*/false);
 			}
 		}
 
 		public string SummarizePlan() {
-			return "DefenderAI: " + defenderAI.ToString();
+			return "DefenderAI: " + data.ToString();
+		}
+
+		/**
+		 * Finds a nearby city that could use extra defenders.
+		 *
+		 * This is not a brilliant method, with many flaws such as whether the 
+		 * city needs more defenders, or if the units present are defenders.
+		 */
+		private static City FindAtRiskCityToDefend(MapUnit unit, Player player) {
+			if (player.cities.Count == 0) {
+				return City.NONE;
+			}
+
+			// Assign a score to each city, where the highest score is the city
+			// we want to send our unit to.
+			Dictionary<City, float> cityScores = new();
+			foreach (City c in player.cities) {
+				int score = 0;
+				//TODO: Just being there doesn't mean a unit is a defender.
+				if (c.location.unitsOnTile.Count < 3) {
+					// Add to the score if there aren't many defenders.
+					score += 10;
+				}
+
+				// Penalize cities for being far away.
+				score -= c.location.distanceTo(unit.location);
+
+				cityScores.Add(c, score);
+			}
+
+			// Make the city less important if there are already units on the
+			// way.
+			foreach (MapUnit u in player.units) {
+				if (u.currentAI is DefenderAI defenderAi) {
+					if (defenderAi.data.destination.cityAtTile != null) {
+						cityScores[defenderAi.data.destination.cityAtTile] -= 3;
+					}
+				}
+			}
+
+			return cityScores.MaxBy(t => t.Value).Key;
 		}
 	}
 }


### PR DESCRIPTION
This allows us to put more of it in `DefenderAI`, making `PlayerAI` less of a monolith, and it also allows us to improve the logic. The previous logic would never converge and just keep shuffling new units around. This logic is much more flexible and similar to the other ranking algorithms used for the other AI types, and takes into account things like defenders on their way. It will also allow us to improve the logic incrementally once we add wars.
