### PR TITLE
CityProductionAI: Allow cities to force building defense when unguarded

### DIFF
--- a/C7/LogManager.cs
+++ b/C7/LogManager.cs
@@ -20,12 +20,15 @@ public partial class LogManager : Node {
 		//   "@l = 'Information' OR SourceContext like 'C7Engine.AI.%'"
 		// Includes all logs of an 'Information' level regardless of namespace, and all logs of
 		// the C7Engine.AI namespace regardless of log level.
+		string filter = "(@l = 'Fatal' OR @l = 'Error' OR @l = 'Warning' OR @l = 'Information')";
+		// suggested:  
+		// filter += " OR SourceContext like 'C7Engine.AI.%'"; // (insert the namespace you need to debug)
+
 		Log.Logger = new LoggerConfiguration()
 			// .WriteTo.GodotSink(formatter: consoleTemplate)	//Writing to console can slow the game down considerably (see #278).  Thus it is disabled by default.
 			.WriteTo.File("log.txt", buffered: true, flushToDiskInterval: TimeSpan.FromMilliseconds(2500), fileSizeLimitBytes: 52428800, //50 MB
 						  outputTemplate: "[{Level:u3}] {Timestamp:HH:mm:ss} {SourceContext}: {Message:lj} {NewLine}{Exception}")
-
-			.Filter.ByIncludingOnly("(@l = 'Fatal' OR @l = 'Error' OR @l = 'Warning' OR @l = 'Information')")   //suggested:  OR SourceContext like 'C7Engine.AI.%' (insert the namespace you need to debug)
+			.Filter.ByIncludingOnly(filter)
 			.MinimumLevel.Debug()
 			.CreateLogger();
 

--- a/C7Engine/AI/CityProductionAI.cs
+++ b/C7Engine/AI/CityProductionAI.cs
@@ -59,11 +59,14 @@ namespace C7Engine {
 
 				// Below here are multiplicative adjusters
 				float popAdjustedScore = AdjustScoreByPopCost(city, unitPrototype, flatAdjustedScore);
-				log.Debug($" {unitPrototype.name} pop-adjusted-scores {popAdjustedScore}");
+				log.Debug($"  {unitPrototype.name} pop-adjusted-scores {popAdjustedScore}");
 				float priorityAdjustedScore = AdjustScoreByPriorities(priorities, unitPrototype, popAdjustedScore);
-				log.Debug($" {unitPrototype.name} priority-adjusted-scores {priorityAdjustedScore}");
+				log.Debug($"  {unitPrototype.name} priority-adjusted-scores {priorityAdjustedScore}");
+				float cityAdjustedScore = AdjustScoreForCity(city, unitPrototype, priorityAdjustedScore);
+				log.Debug($"  {unitPrototype.name} city-adjusted-scores {cityAdjustedScore}");
+
 				prototypes.Add(unitPrototype);
-				weights.Add(priorityAdjustedScore);
+				weights.Add(cityAdjustedScore);
 			}
 
 			IProducible chosen = ChooseWeightedPriority(prototypes, weights, Weighting.WEIGHTED_QUADRATIC);
@@ -126,6 +129,23 @@ namespace C7Engine {
 				idx++;
 			}
 			return items[0];    //TODO: Fallback
+		}
+
+		private static float AdjustScoreForCity(City city, UnitPrototype unit, float score) {
+			// If the city is guarded, let our other priorities determine what
+			// we do.
+			if (city.location.unitsOnTile.Count(u => u.CanDefendOnLand()) > 0) {
+				return score;
+			}
+
+			// Otherwise if we're unguarded, we should build a defending unit
+			// quickly
+			if (unit.categories.Contains("Land") && unit.defense > 0) {
+				return score;
+			} else {
+				// Prefer not to build non-defense units in unguarded cities. 
+				return 0;
+			}
 		}
 
 		public static float AdjustScoreByPopCost(City city, UnitPrototype unitPrototype, float baseScore) {

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -80,6 +80,11 @@ namespace C7Engine {
 						break;
 					}
 
+					if (unit.hitPointsRemaining <= 0) {
+						unit.currentAI = null;
+						break;
+					}
+
 					// Otherwise we need a new plan for next turn. Pick it now
 					// to avoid things like new units being preferred for
 					// exploration instead of units already far away from home

--- a/C7Engine/AI/UnitAI/SettlerAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerAI.cs
@@ -23,7 +23,7 @@ namespace C7Engine {
 					//by another colonist.  Longer-term, the AI shouldn't be building settlers if that is the case,
 					//but right now we'll just spike the football to stop the clock and avoid building immediately next to another city.
 					settlerAiData.goal = SettlerAIData.SettlerGoal.JOIN_CITY;
-					log.Information("Set AI for unit to JOIN_CITY due to lack of locations to settle");
+					log.Information($"Set AI for unit {unit.id} of {unit.owner.civilization.name} to JOIN_CITY due to lack of locations to settle");
 				} else {
 					PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
 					settlerAiData.pathToDestination = algorithm.PathFrom(unit.location, settlerAiData.destination);


### PR DESCRIPTION
The first defensive unit they build will always become a defender, so we might as well coordinate between PlayerAI and CityProductionAI.

I plan to also use this logic to force cities to build escorts for their settlers if they don't have one in a future PR.