### PR TITLE
Remove the duplicate logic for confirm/cancel buttons in popups

### DIFF
--- a/C7/UIElements/Popups/BuildCityDialog.cs
+++ b/C7/UIElements/Popups/BuildCityDialog.cs
@@ -59,28 +59,8 @@ public partial class BuildCityDialog : Popup {
 
 		cityName.TextSubmitted += OnCityNameEntered;
 
-		//Cancel/confirm buttons.  Note the X button is thinner than the O button.
-		ImageTexture circleTexture= Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 1, 1, 19, 19);
-		ImageTexture xTexture = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 21, 1, 15, 19);
-		ImageTexture circleHover = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 37, 1, 19, 19);
-		ImageTexture xHover = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 57, 1, 15, 19);
-		ImageTexture circlePressed = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 73, 1, 19, 19);
-		ImageTexture xPressed = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 93, 1, 15, 19);
-		TextureButton confirmButton = new TextureButton();
-		confirmButton.TextureNormal = circleTexture;
-		confirmButton.TextureHover = circleHover;
-		confirmButton.TexturePressed = circlePressed;
-		confirmButton.SetPosition(new Vector2(475, 213));
-		AddChild(confirmButton);
-		TextureButton cancelButton = new TextureButton();
-		cancelButton.TextureNormal = xTexture;
-		cancelButton.TextureHover = xHover;
-		cancelButton.TexturePressed = xPressed;
-		cancelButton.SetPosition(new Vector2(500, 213));
-		AddChild(cancelButton);
-
-		confirmButton.Pressed += OnConfirmButtonPressed;
-		cancelButton.Pressed += GetParent<PopupOverlay>().OnHidePopup;
+		AddConfirmButton(new Vector2(475, 213), OnConfirmButtonPressed);
+		AddCancelButton(new Vector2(500, 213));
 	}
 
 	/**

--- a/C7/UIElements/Popups/DiplomacySelection.cs
+++ b/C7/UIElements/Popups/DiplomacySelection.cs
@@ -34,28 +34,8 @@ public partial class DiplomacySelection : Popup {
 			vOffset += 25;
 		}
 
-		//Cancel/confirm buttons.  Note the X button is thinner than the O button.
-		// TODO: Push this shared logic up into Popup.cs
-		ImageTexture circleTexture= Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 1, 1, 19, 19);
-		ImageTexture xTexture = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 21, 1, 15, 19);
-		ImageTexture circleHover = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 37, 1, 19, 19);
-		ImageTexture xHover = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 57, 1, 15, 19);
-		ImageTexture circlePressed = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 73, 1, 19, 19);
-		ImageTexture xPressed = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 93, 1, 15, 19);
-		TextureButton confirmButton = new TextureButton();
-		confirmButton.TextureNormal = circleTexture;
-		confirmButton.TextureHover = circleHover;
-		confirmButton.TexturePressed = circlePressed;
-		confirmButton.SetPosition(new Vector2(width - 55, height - 47));
-		AddChild(confirmButton);
-		TextureButton cancelButton = new TextureButton();
-		cancelButton.TextureNormal = xTexture;
-		cancelButton.TextureHover = xHover;
-		cancelButton.TexturePressed = xPressed;
-		cancelButton.SetPosition(new Vector2(width - 30, height - 47));
-		AddChild(cancelButton);
-
 		// TODO: Do something when the confirm button is pressed.
-		cancelButton.Pressed += GetParent<PopupOverlay>().OnHidePopup;
+		AddConfirmButton(new Vector2(width - 55, height - 47), () => { });
+		AddCancelButton(new Vector2(width - 30, height - 47));
 	}
 }

--- a/C7/UIElements/Popups/Popup.cs
+++ b/C7/UIElements/Popups/Popup.cs
@@ -163,4 +163,29 @@ public partial class Popup : TextureRect {
 		return rect;
 	}
 
+	protected void AddConfirmButton(Vector2 position, Action action) {
+		ImageTexture circleTexture= Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 1, 1, 19, 19);
+		ImageTexture circleHover = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 37, 1, 19, 19);
+		ImageTexture circlePressed = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 73, 1, 19, 19);
+		TextureButton confirmButton = new TextureButton();
+		confirmButton.TextureNormal = circleTexture;
+		confirmButton.TextureHover = circleHover;
+		confirmButton.TexturePressed = circlePressed;
+		confirmButton.SetPosition(position);
+		confirmButton.Pressed += action;
+		AddChild(confirmButton);
+	}
+
+	protected void AddCancelButton(Vector2 position) {
+		ImageTexture xTexture = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 21, 1, 15, 19);
+		ImageTexture xHover = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 57, 1, 15, 19);
+		ImageTexture xPressed = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 93, 1, 15, 19);
+		TextureButton cancelButton = new TextureButton();
+		cancelButton.TextureNormal = xTexture;
+		cancelButton.TextureHover = xHover;
+		cancelButton.TexturePressed = xPressed;
+		cancelButton.SetPosition(position);
+		cancelButton.Pressed += GetParent<PopupOverlay>().OnHidePopup;
+		AddChild(cancelButton);
+	}
 }

--- a/C7/UIElements/Popups/TextDialog.cs
+++ b/C7/UIElements/Popups/TextDialog.cs
@@ -52,28 +52,8 @@ public partial class TextDialog : Popup {
 
 		textEditBox.TextSubmitted += HandleTextInput;
 
-		//Cancel/confirm buttons.  Note the X button is thinner than the O button.
-		ImageTexture circleTexture= Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 1, 1, 19, 19);
-		ImageTexture xTexture = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 21, 1, 15, 19);
-		ImageTexture circleHover = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 37, 1, 19, 19);
-		ImageTexture xHover = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 57, 1, 15, 19);
-		ImageTexture circlePressed = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 73, 1, 19, 19);
-		ImageTexture xPressed = Util.LoadTextureFromPCX("Art/X-o_ALLstates-sprite.pcx", 93, 1, 15, 19);
-		TextureButton confirmButton = new TextureButton();
-		confirmButton.TextureNormal = circleTexture;
-		confirmButton.TextureHover = circleHover;
-		confirmButton.TexturePressed = circlePressed;
-		confirmButton.SetPosition(new Vector2(475, 213));
-		AddChild(confirmButton);
-		TextureButton cancelButton = new TextureButton();
-		cancelButton.TextureNormal = xTexture;
-		cancelButton.TextureHover = xHover;
-		cancelButton.TexturePressed = xPressed;
-		cancelButton.SetPosition(new Vector2(500, 213));
-		AddChild(cancelButton);
-
-		confirmButton.Pressed += () => { HandleTextInput(textEditBox.Text); };
-		cancelButton.Pressed += GetParent<PopupOverlay>().OnHidePopup;
+		AddConfirmButton(new Vector2(475, 213), () => { HandleTextInput(textEditBox.Text); });
+		AddCancelButton(new Vector2(500, 213));
 	}
 
 	private void HandleTextInput(string text) {


### PR DESCRIPTION
There's no need to keep copy-pasting the logic to new popups.