### PR TITLE
Simplify the process for ignoring uninteresting animations

### DIFF
--- a/C7/AnimationTracker.cs
+++ b/C7/AnimationTracker.cs
@@ -72,7 +72,7 @@ public partial class AnimationTracker {
 		return activeAnims.ContainsKey(unit.id);
 	}
 
-	public (MapUnit.AnimatedAction, float) getCurrentActionAndProgress(ID id) {
+	public (MapUnit.AnimatedAction, float, AnimationEnding) getCurrentActionAndProgress(ID id) {
 		ActiveAnimation aa = activeAnims[id];
 
 		var durationMS = (double)(aa.endTimeMS - aa.startTimeMS);
@@ -85,14 +85,14 @@ public partial class AnimationTracker {
 		else if (progress > 1.0)
 			progress = 1.0;
 
-		return (aa.anim.action, (float)progress);
+		return (aa.anim.action, (float)progress, aa.ending);
 	}
 
-	public (MapUnit.AnimatedAction, float) getCurrentActionAndProgress(MapUnit unit) {
+	public (MapUnit.AnimatedAction, float, AnimationEnding) getCurrentActionAndProgress(MapUnit unit) {
 		return getCurrentActionAndProgress(unit.id);
 	}
 
-	public (MapUnit.AnimatedAction, float) getCurrentActionAndProgress(Tile tile) {
+	public (MapUnit.AnimatedAction, float, AnimationEnding) getCurrentActionAndProgress(Tile tile) {
 		return getCurrentActionAndProgress(tile.Id);
 	}
 
@@ -114,7 +114,7 @@ public partial class AnimationTracker {
 
 	public MapUnit.Appearance getUnitAppearance(MapUnit unit) {
 		if (hasCurrentAction(unit)) {
-			var (action, progress) = getCurrentActionAndProgress(unit);
+			var (action, progress, ending) = getCurrentActionAndProgress(unit);
 
 			float offsetX = 0, offsetY = 0;
 			if (action == MapUnit.AnimatedAction.RUN) {
@@ -128,7 +128,8 @@ public partial class AnimationTracker {
 				direction = unit.facingDirection,
 				progress = progress,
 				offsetX = offsetX,
-				offsetY = offsetY
+				offsetY = offsetY,
+				ending = ending,
 			};
 		} else {
 			return new MapUnit.Appearance {
@@ -136,7 +137,7 @@ public partial class AnimationTracker {
 				direction = unit.facingDirection,
 				progress = 1f,
 				offsetX = 0f,
-				offsetY = 0f
+				offsetY = 0f,
 			};
 		}
 	}

--- a/C7/Map/UnitLayer.cs
+++ b/C7/Map/UnitLayer.cs
@@ -230,7 +230,7 @@ public partial class UnitLayer : LooseLayer {
 		// First draw animated effects. These will always appear over top of units regardless of draw order due to z-index.
 		C7Animation tileEffect = looseView.mapView.game.animTracker.getTileEffect(tile);
 		if (tileEffect != null) {
-			(_, float progress) = looseView.mapView.game.animTracker.getCurrentActionAndProgress(tile);
+			(_, float progress, _) = looseView.mapView.game.animTracker.getCurrentActionAndProgress(tile);
 			drawEffectAnimFrame(looseView, tileEffect, progress, tileCenter);
 		}
 

--- a/C7GameData/MapUnit.cs
+++ b/C7GameData/MapUnit.cs
@@ -113,6 +113,7 @@ namespace C7GameData {
 			public TileDirection direction;
 			public float progress; // Varies 0 to 1
 			public float offsetX, offsetY; // Offset is in grid cells from the unit's location
+			public AnimationEnding ending;
 
 			// When true, indicates that the animation is still playing (f.e. a unit is still running between tiles) so the UI shouldn't yet
 			// autoselect another unit.
@@ -120,7 +121,7 @@ namespace C7GameData {
 				// TODO: Special rules for different animations. We don't need to see workers do their thing but we do want to watch units
 				// move. IMO we should also not show units fortifying even though I know the original game does.
 				// This may also be the culprit behind why we can fortify a unit that is in motion.
-				if (action == AnimatedAction.IRRIGATE || action == AnimatedAction.MINE || action == AnimatedAction.ROAD || action == AnimatedAction.BLANK || action == AnimatedAction.DEFAULT) {
+				if (ending == AnimationEnding.Repeat) {
 					return false;
 				}
 				return progress < 1.0;


### PR DESCRIPTION
This avoids the need to keep adding animations to the list of conditions we `||` on.