### PR TITLE
Fix the problem of excessive boat production for exploring 

### DIFF
--- a/C7Engine/AI/CityProductionAI.cs
+++ b/C7Engine/AI/CityProductionAI.cs
@@ -47,9 +47,13 @@ namespace C7Engine {
 				float flatAdjustedScore = baseScore + flatAdjuster;
 				log.Debug($"  Flat-adjusted score for {unitPrototype} is {flatAdjustedScore}");
 
-				// Exclude naval units from land-only cities
-				if (unitPrototype.categories.Contains("Sea") && !city.location.NeighborsWater()) {
-					flatAdjustedScore = 0.0f;
+				// Handle excluding naval units for things like:
+				//  - inland cities
+				//  - having fully explored the ocean (we don't have logic to do
+				//    anything else with boats yet)
+				//  - having too many boats 
+				if (unitPrototype.categories.Contains("Sea")) {
+					flatAdjustedScore = ApplyNavalUnitAdjustments(flatAdjustedScore, unitPrototype, city);
 				}
 
 				// Exclude settlers if we don't have anywhere to build a city.
@@ -96,6 +100,33 @@ namespace C7Engine {
 				return baseScore;
 			}
 			return 0.0f;
+		}
+
+		private static float ApplyNavalUnitAdjustments(float score, UnitPrototype prototype, City city) {
+			// Exclude naval units from land-only cities
+			//
+			// TODO: this should also apply to inland seas
+			if (!city.location.NeighborsWater()) {
+				score = 0.0f;
+			}
+
+			// Don't build naval units if we can't explore anything more
+			// with them.
+			if (city.owner.tileKnowledge.fullyExploredOceans) {
+				score = 0;
+			}
+
+			int boats = 0;
+			foreach (MapUnit u in city.owner.units) {
+				if (!u.IsLandUnit()) {
+					++boats;
+				}
+			}
+			if (boats > PlayerAI.MAX_WATER_EXPLORERS) {
+				score = 0;
+			}
+
+			return score;
 		}
 
 		private static IProducible ChooseWeightedPriority(List<IProducible> items, List<float> weights, Weighting weighting) {

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -14,6 +14,9 @@ namespace C7Engine {
 	public class PlayerAI {
 		private static ILogger log = Log.ForContext<PlayerAI>();
 
+		public static readonly int MAX_LAND_EXPLORERS = 10;
+		public static readonly int MAX_WATER_EXPLORERS = 4;
+
 		public static void PlayTurn(Player player, Random rng, List<Tech> techs) {
 			if (player.isHuman || player.isBarbarians) {
 				return;
@@ -129,43 +132,44 @@ namespace C7Engine {
 			} else if (unit.unitType.name == "Catapult") {
 				//For now tell catapults to sit tight.  It's getting really annoying watching them pointlessly bombard barb camps forever
 				return new DefenderAI(DefenderAI.MakeAiDataForDefendInPlace(unit, player));
-			} else {
-				// If there's an unescorted settler, escort it.
-				EscortAIData? maybeEscortData = EscortAI.MaybeMakeAiData(unit, player);
-				if (maybeEscortData != null) {
-					return new EscortAI(maybeEscortData);
-				}
-
-				// As long as we don't have too many explorers yet of this unit's
-				// type (land vs sea), start a new exploring unit.
-				int numRelevantExplorers = 0;
-				foreach (MapUnit u in player.units) {
-					if (u.currentAI is ExplorerAI && u.IsLandUnit() == unit.IsLandUnit()) {
-						++numRelevantExplorers;
-					}
-				}
-
-				if (numRelevantExplorers < 10) {
-					ExplorerAIData? maybeAiData = ExplorerAI.MaybeMakeAiData(unit, player);
-					if (maybeAiData != null) {
-						return new ExplorerAI(maybeAiData);
-					}
-				}
-
-				//Nowhere to explore or too many explorers.  What to do now?
-				//Priority 1: Adequate defense of cities.
-				//Priority 2: Clearing out barbs
-				//Priority 3: Defending chokepoints
-				//Priority 4: ???
-				//Priority 5: Profit!
-				//(Realistically, as we evolve there will be a lot of options, such as defending borders from barbs, preparing attackers on other civs, defending
-				//resources.  I expect we'll have some sort of arbiter that decides between competing priorities, with each being given a score as to how important
-				//they are, including a weight by how far away the task is.  But this will evolve gradually over a long time)
-
-				//As of today (4/7/2022), let's tackle just one of those - adequate defense of cities.  The AI is really good at losing cities to barbs right now,
-				//and that's a problem.
-				return new DefenderAI(DefenderAI.MakeAiDataForDefendAtRiskCity(unit, player));
 			}
+
+			// If there's an unescorted settler, escort it.
+			EscortAIData? maybeEscortData = EscortAI.MaybeMakeAiData(unit, player);
+			if (maybeEscortData != null) {
+				return new EscortAI(maybeEscortData);
+			}
+
+			// As long as we don't have too many explorers yet of this unit's
+			// type (land vs sea), start a new exploring unit.
+			int numRelevantExplorers = 0;
+			int maxExplorers = unit.IsLandUnit() ? MAX_LAND_EXPLORERS : MAX_WATER_EXPLORERS;
+			foreach (MapUnit u in player.units) {
+				if (u.currentAI is ExplorerAI && u.IsLandUnit() == unit.IsLandUnit()) {
+					++numRelevantExplorers;
+				}
+			}
+
+			if (numRelevantExplorers < maxExplorers) {
+				ExplorerAIData? maybeAiData = ExplorerAI.MaybeMakeAiData(unit, player);
+				if (maybeAiData != null) {
+					return new ExplorerAI(maybeAiData);
+				}
+			}
+
+			//Nowhere to explore or too many explorers.  What to do now?
+			//Priority 1: Adequate defense of cities.
+			//Priority 2: Clearing out barbs
+			//Priority 3: Defending chokepoints
+			//Priority 4: ???
+			//Priority 5: Profit!
+			//(Realistically, as we evolve there will be a lot of options, such as defending borders from barbs, preparing attackers on other civs, defending
+			//resources.  I expect we'll have some sort of arbiter that decides between competing priorities, with each being given a score as to how important
+			//they are, including a weight by how far away the task is.  But this will evolve gradually over a long time)
+
+			//As of today (4/7/2022), let's tackle just one of those - adequate defense of cities.  The AI is really good at losing cities to barbs right now,
+			//and that's a problem.
+			return new DefenderAI(DefenderAI.MakeAiDataForDefendAtRiskCity(unit, player));
 		}
 
 		private static UnitAI GetCombatAIIfUnitCanAttackNearbyBarbCamp(MapUnit unit, Player player) {

--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -23,6 +23,10 @@ namespace C7Engine {
 			ExplorerAIData? result = PickBestTileToExplore(unit, CalculateExplorationScores(player, unit, candidates));
 
 			if (result == null) {
+				if (!unit.IsLandUnit()) {
+					player.tileKnowledge.fullyExploredOceans = true;
+				}
+
 				return result;
 			}
 
@@ -34,6 +38,11 @@ namespace C7Engine {
 		UnitAI.Result UnitAI.PlayTurnImpl(Player player, MapUnit unit) {
 			if (data == null) {
 				return UnitAI.Result.Error;
+			}
+
+			if (player.tileKnowledge.isTileKnown(data.destination)) {
+				player.tileKnowledge.aiExplorationTargets.Remove(data.destination);
+				return UnitAI.Result.Done;
 			}
 
 			// If we're at the destination we're done.

--- a/C7GameData/AIData/TileKnowledge.cs
+++ b/C7GameData/AIData/TileKnowledge.cs
@@ -6,6 +6,10 @@ namespace C7GameData {
 		public HashSet<Tile> borderTiles { get; private set; } = new();
 		HashSet<Tile> visibleTiles = new();
 
+		// Has this player explored all known ocean tiles?
+		// TODO: this should be split out for coast/ocean
+		public bool fullyExploredOceans = false;
+
 		// The set of tiles this player currently has explorers headed towards.
 		public HashSet<Tile> aiExplorationTargets = new();
 

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -120,7 +120,6 @@ namespace C7GameData {
 		}
 
 		// Rules taken from https://forums.civfanatics.com/threads/the-eight-laws-of-border-dynamics.106882/
-
 		private City ResolveTileOwnershipConflict(City a, City b, Tile t) {
 			int aRank = a.location.rankDistanceTo(t);
 			int bRank = b.location.rankDistanceTo(t);


### PR DESCRIPTION
Right now the only thing we use boats for is exploring the oceans, so once we've finished exploring the oceans we should stop sending out more boats. I noticed this while using observer mode on some random saves I had laying around that had more coastal cities.

I also updated the explorer logic a bit, to track whether we've finished exploring the oceans, and also to check whether the tile we're headed to has already been explored. If it has, we reroute.