### PR TITLE
StrategicPriority: Strip out some unused code and make WarPriority aware of wars

### DIFF
--- a/C7Engine/AI/StrategicAI/ExpansionPriority.cs
+++ b/C7Engine/AI/StrategicAI/ExpansionPriority.cs
@@ -14,9 +14,7 @@ namespace C7GameData.AIData {
 
 		private ILogger log = Log.ForContext<ExpansionPriority>();
 
-		public ExpansionPriority() {
-			key = "Expansion";
-		}
+		public ExpansionPriority() { }
 
 		public override void CalculateWeightAndMetadata(Player player) {
 			if (player.cities.Count < 2) {

--- a/C7Engine/AI/StrategicAI/ExplorationPriority.cs
+++ b/C7Engine/AI/StrategicAI/ExplorationPriority.cs
@@ -5,9 +5,7 @@ namespace C7Engine.AI.StrategicAI {
 	public class ExplorationPriority : StrategicPriority {
 		private readonly int TEMP_GAME_LENGTH = 540;
 
-		public ExplorationPriority() {
-			key = "Exploration";
-		}
+		public ExplorationPriority() { }
 
 		public override void CalculateWeightAndMetadata(Player player) {
 			//Eventually this should consider the expected number of unknown tiles and the ability to explore them

--- a/C7Engine/AI/StrategicAI/WarPriority.cs
+++ b/C7Engine/AI/StrategicAI/WarPriority.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using C7Engine;
 using C7Engine.AI.StrategicAI;
+using C7GameData.Save;
 
 namespace C7GameData.AIData {
 	/// <summary>
@@ -14,9 +15,7 @@ namespace C7GameData.AIData {
 
 		private readonly int TEMP_WAR_PRIORITY_WEIGHT = 50; //temporary weight of this priority, if it isn't zero
 
-		public WarPriority() {
-			key = "WarPriority";
-		}
+		public WarPriority() { }
 
 		public override string ToString() {
 			return "WarPriority";
@@ -31,26 +30,35 @@ namespace C7GameData.AIData {
 		public override void CalculateWeightAndMetadata(Player player) {
 			if (player.cities.Count < 2) {
 				this.calculatedWeight = 0;
-			} else {
-				int landScore = UtilityCalculations.CalculateAvailableLandScore(player);
-				//N.B. Eventually this won't be an all-or-nothing proposition; if land is getting tight but not quite zero,
-				//the AI may decide it's time for the next phrase of the game, especially if it's aggressive.
+				return;
+			}
 
-				//nowhere else to expand
-				if (landScore == 0) {
-					//Figure out who to fight.  This should obviously be more sophisticated and should favor reachable opponents.
-					//However, we don't yet store info on who's been discovered, so for now we'll choose someone randomly
-					int opponentCount = EngineStorage.gameData.players.Count - 1;
-					foreach (Player nation in EngineStorage.gameData.players) {
-						if (nation != player) {
-							int rnd = GameData.rng.Next(opponentCount);
-							if (rnd == 0) {
-								//Let's fight this nation!
-								properties["opponent"] = nation.id.ToString();
-								calculatedWeight = TEMP_WAR_PRIORITY_WEIGHT;
-							} else {
-								opponentCount--;    //guarantees we'll eventually get an opponent selected
-							}
+			// If we're at war, make sure we're prioritizing war.
+			foreach (KeyValuePair<ID, PlayerRelationship> p in player.playerRelationships) {
+				if (p.Value.atWar) {
+					this.calculatedWeight = 1000;
+					return;
+				}
+			}
+
+			int landScore = UtilityCalculations.CalculateAvailableLandScore(player);
+			//N.B. Eventually this won't be an all-or-nothing proposition; if land is getting tight but not quite zero,
+			//the AI may decide it's time for the next phrase of the game, especially if it's aggressive.
+
+			//nowhere else to expand
+			if (landScore == 0) {
+				//Figure out who to fight.  This should obviously be more sophisticated and should favor reachable opponents.
+				//However, we don't yet store info on who's been discovered, so for now we'll choose someone randomly
+				int opponentCount = EngineStorage.gameData.players.Count - 1;
+				foreach (Player nation in EngineStorage.gameData.players) {
+					if (nation != player) {
+						int rnd = GameData.rng.Next(opponentCount);
+						if (rnd == 0) {
+							//Let's fight this nation!
+							// TODO: declare war.
+							calculatedWeight = TEMP_WAR_PRIORITY_WEIGHT;
+						} else {
+							opponentCount--;    //guarantees we'll eventually get an opponent selected
 						}
 					}
 				}

--- a/C7GameData/AIData/StrategicPriority.cs
+++ b/C7GameData/AIData/StrategicPriority.cs
@@ -41,9 +41,6 @@ namespace C7Engine.AI.StrategicAI {
 		[JsonIgnore]
 		protected float calculatedWeight;
 
-		protected string key;
-		protected Dictionary<string, string> properties = new Dictionary<string, string>();
-
 		/**
 		 * Returns a weight for how important this strategic priority is for the player.
 		 * The implementation will examine the player's data, and figure out the weight based on that.


### PR DESCRIPTION
The war priority logic doesn't do much right now, so let's make that clearer by removing unused fields like `properties`. We don't need to encourage more stringly-typed fields.
