### PR TITLE
Implement a basic handling of wars, offensively and defensively 

### DIFF
--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using C7Engine.Pathing;
 using C7GameData;
+using C7GameData.Save;
 using C7GameData.AIData;
 using C7Engine.AI;
 using C7Engine.AI.StrategicAI;
@@ -36,6 +37,12 @@ namespace C7Engine {
 
 				string summary = string.Join(',', player.strategicPriorityData);
 				log.Information($"Player {player.civilization.name} now has priorities of: {summary}. {player.turnsUntilPriorityReevaluation} turns until next re-evaluation");
+
+				// Wake up any fortified units so our new strategy (if we have one)
+				// takes effect.
+				foreach (MapUnit u in player.units) {
+					u.wake();
+				}
 			} else {
 				player.turnsUntilPriorityReevaluation--;
 			}
@@ -134,6 +141,29 @@ namespace C7Engine {
 				return new DefenderAI(DefenderAI.MakeAiDataForDefendInPlace(unit, player));
 			}
 
+			// Special case: we're at war.
+			if (PlayerIsAtWarWithOtherPlayer(player)) {
+				// Priority 1: ensure we don't have any unguarded cities.
+				//
+				// If this is an offensive unit only go defend if there are
+				// fewer than 3 units in a city, otherwise consider offensive
+				// action.
+				int minDefenders = unit.unitType.attack >= unit.unitType.defense ? 3 : int.MaxValue;
+				DefenderAIData maybeDefend = DefenderAI.MakeAiDataForDefendAtRiskCity(unit, player, minDefenders);
+				if (maybeDefend != null) {
+					return new DefenderAI(maybeDefend);
+				}
+
+				// Priority 2: go on the offensive.
+				CombatAIData maybeCombat = CombatAI.MakeAiData(unit, player);
+				if (maybeCombat != null) {
+					return new CombatAI(maybeCombat);
+				}
+
+				// Priority 3: defend our cities.
+				return new DefenderAI(DefenderAI.MakeAiDataForDefendAtRiskCity(unit, player, /*minDefenders=*/int.MaxValue));
+			}
+
 			// If there's an unescorted settler, escort it.
 			EscortAIData? maybeEscortData = EscortAI.MaybeMakeAiData(unit, player);
 			if (maybeEscortData != null) {
@@ -169,7 +199,21 @@ namespace C7Engine {
 
 			//As of today (4/7/2022), let's tackle just one of those - adequate defense of cities.  The AI is really good at losing cities to barbs right now,
 			//and that's a problem.
-			return new DefenderAI(DefenderAI.MakeAiDataForDefendAtRiskCity(unit, player));
+			return new DefenderAI(DefenderAI.MakeAiDataForDefendAtRiskCity(unit, player, /*minDefenders=*/int.MaxValue));
+		}
+
+		private static bool PlayerIsAtWarWithOtherPlayer(Player player) {
+			foreach (KeyValuePair<ID, PlayerRelationship> p in player.playerRelationships) {
+				if (p.Value.atWar) {
+					Player other = EngineStorage.gameData.players.Find(x => x.id == p.Key);
+					if (other.isBarbarians) {
+						continue;
+					}
+
+					return true;
+				}
+			}
+			return false;
 		}
 
 		private static UnitAI GetCombatAIIfUnitCanAttackNearbyBarbCamp(MapUnit unit, Player player) {

--- a/C7Engine/AI/UnitAI/CombatAI.cs
+++ b/C7Engine/AI/UnitAI/CombatAI.cs
@@ -1,7 +1,11 @@
 using System.Collections.Generic;
 using C7GameData;
+using C7GameData.Save;
 using C7GameData.AIData;
 using Serilog;
+using System;
+using C7Engine.Pathing;
+using System.Linq;
 
 namespace C7Engine.AI.UnitAI {
 	/// <summary>
@@ -11,30 +15,183 @@ namespace C7Engine.AI.UnitAI {
 	/// This first iteration is focused on defeating barbarians.
 	/// </summary>
 	public class CombatAI : C7GameData.UnitAI {
-		private CombatAIData combatAIData;
+		private CombatAIData data;
 
-		private ILogger log = Log.ForContext<CombatAI>();
+		private static ILogger log = Log.ForContext<CombatAI>();
 
 		public CombatAI(CombatAIData d) {
-			combatAIData = d;
+			data = d;
+		}
+
+		public static CombatAIData? MakeAiData(MapUnit unit, Player player) {
+			CombatAIData? result = GetBestTileToAttack(unit, player, GetPlayersAtWarWith(player));
+			if (result == null) {
+				return result;
+			}
+
+			log.Information($"{unit} is planning to attack {result.destination}");
+			return result;
 		}
 
 		public void UpdateOnDeath() { }
 
 		public C7GameData.UnitAI.Result PlayTurnImpl(Player player, MapUnit unit) {
-			if (unit.location == combatAIData.destination) {
+			if (data == null) {
+				return C7GameData.UnitAI.Result.Error;
+			}
+
+			if (unit.location == data.destination) {
 				return C7GameData.UnitAI.Result.Done;
 			}
 
-			//Move along the path to the place where the unit plans to enter combat.
-			//This might initiate combat.
-			//Once there are more combat goals than run to a barbarian camp,
-			//we will need fancier algorithms
-			return this.TryToMoveAlongPath(unit, ref combatAIData.path, /*allowCombat=*/true);
+			// If there is a no longer an enemy on the tile we were heading
+			// towards, ensure we recalculate our plan.
+			Tile dest = data.destination;
+			bool destinationHasEnemyUnits = dest.unitsOnTile.Count > 0
+				&& !dest.unitsOnTile[0].owner.IsAtPeaceWith(unit.owner);
+			bool destinationHasEnemyCity = dest.cityAtTile != null
+				&& !data.destination.cityAtTile.owner.IsAtPeaceWith(unit.owner);
+
+			if (!destinationHasEnemyCity && !destinationHasEnemyUnits) {
+				return C7GameData.UnitAI.Result.Done;
+			}
+
+			// See if we need to re-evaluate our target if we walk next to an
+			// enemy unit or city. We don't return an error here to avoid the
+			// case of looping forever if our target didn't change.
+			if (data.path.PathLength() > 1) {
+				foreach (Tile t in unit.location.neighbors.Values) {
+					bool nextToEnemyCity = t.cityAtTile != null && !t.cityAtTile.owner.IsAtPeaceWith(unit.owner);
+					bool nextToEnemyUnit = t.unitsOnTile.Count > 0 && !t.unitsOnTile[0].owner.IsAtPeaceWith(unit.owner);
+
+					if (!nextToEnemyCity && !nextToEnemyUnit) {
+						continue;
+					}
+
+					// Once we re-evaluate once, break out of the loop. There's
+					// no point in doing it again if nothing changed.
+					CombatAIData? maybeData = MakeAiData(unit, player);
+					if (maybeData != null && maybeData.destination != data.destination) {
+						data = maybeData;
+					}
+					break;
+				}
+			}
+
+			// Move along the path, initiating combat if we reach our target.
+			return this.TryToMoveAlongPath(unit, ref data.path, /*allowCombat=*/true);
 		}
 
 		public string SummarizePlan() {
-			return "CombateAI: " + combatAIData.ToString();
+			return "CombateAI: " + data.ToString();
+		}
+
+		private static HashSet<ID> GetPlayersAtWarWith(Player player) {
+			HashSet<ID> enemyIds = new();
+			foreach (KeyValuePair<ID, PlayerRelationship> p in player.playerRelationships) {
+				if (p.Value.atWar) {
+					enemyIds.Add(p.Key);
+				}
+			}
+			return enemyIds;
+		}
+
+		private static CombatAIData? GetBestTileToAttack(MapUnit unit, Player player, HashSet<ID> enemyIds) {
+			Dictionary<Tile, float> scoredTiles = new();
+
+			// First we want to check all the tiles in our visible knowledge for
+			// enemy units. As of 2025-03-09, we don't track known and visible
+			// tiles separately, so this should be updated in the future.
+			foreach (Tile t in player.tileKnowledge.knownTiles) {
+				scoredTiles.Add(t, ScoreTile(t, unit, player, enemyIds));
+			}
+
+			if (scoredTiles.Count == 0) {
+				return null;
+			}
+
+			// Find the best target to attack.
+			IOrderedEnumerable<KeyValuePair<Tile, float>> sortedScoredTiles =
+				scoredTiles.OrderByDescending(x => x.Value);
+			PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
+
+			foreach (KeyValuePair<Tile, float> p in sortedScoredTiles) {
+				CombatAIData result = new();
+				result.destination = p.Key;
+				result.path = algorithm.PathFrom(unit.location, result.destination);
+
+				// If we can't reach the destination, go to the next candidate.
+				if ((result.path?.PathLength() ?? -1) == -1) {
+					continue;
+				}
+
+				return result;
+			}
+
+			return null;
+		}
+
+		private static float ScoreTile(Tile t, MapUnit unit, Player player, HashSet<ID> enemyIds) {
+			bool hasEnemyCity = t.cityAtTile != null && enemyIds.Contains(t.cityAtTile.owner.id);
+			bool hasEnemyUnits = t.unitsOnTile.Count > 0 && enemyIds.Contains(t.unitsOnTile[0].owner.id);
+			float score = 0;
+
+			// Ignore tiles without units or cities.
+			if (!hasEnemyCity && !hasEnemyUnits) {
+				return int.MinValue;
+			}
+
+			// Ignore land tiles for sea units, and vice versa.
+			if (t.IsLand() != unit.IsLandUnit()) {
+				return int.MinValue;
+			}
+
+			// Handle the case of units running around.
+			//
+			// Note: Civ3 rates unit strength using this formula:
+			//   HP * (1.5* AttackPoints + 1 * DefensePoints ) 0.175 * Bombard Points
+			//   (https://forums.civfanatics.com/threads/study-of-inner-workings-of-military-advisor.83599/)
+			//
+			// TODO: We should figure out how to incorporate this.
+			if (hasEnemyUnits && !hasEnemyCity) {
+				MapUnit defender = t.FindTopDefender(unit);
+
+				// Units in our territory are a threat.
+				if (t.owningCity != null && t.owningCity.owner == player) {
+					score += 3 * defender.unitType.attack;
+				}
+
+				foreach (Tile neighbor in t.neighbors.Values) {
+					// Units next to our cities are an even bigger threat. Note
+					// that it is possible for an enemy unit to be next to a 
+					// city but not in our borders if two cities are very close 
+					// together.
+					if (neighbor.cityAtTile != null && neighbor.cityAtTile.owner == player) {
+						score += 3 * defender.unitType.attack;
+					}
+
+					if (neighbor == unit.location) {
+						// Units next to us are also a threat.
+						score += 1 * defender.unitType.attack;
+					}
+				}
+			}
+
+			if (hasEnemyCity) {
+				// Unguarded cities are pretty tempting.
+				if (!hasEnemyUnits) {
+					score += 20;
+				} else {
+					// TODO: this should incorporate defender strength
+					// TODO: we really want stack attacks
+					score += 10;
+				}
+			}
+
+			// Prefer to attack nearer targets.
+			score -= (float)Math.Pow(t.distanceTo(unit.location), 2);
+
+			return score;
 		}
 	}
 }

--- a/C7Engine/AI/UnitAI/DefenderAI.cs
+++ b/C7Engine/AI/UnitAI/DefenderAI.cs
@@ -18,8 +18,16 @@ namespace C7Engine.AI.UnitAI {
 			return ai;
 		}
 
-		public static DefenderAIData MakeAiDataForDefendAtRiskCity(MapUnit unit, Player player) {
-			City cityToDefend = FindAtRiskCityToDefend(unit, player);
+		public static DefenderAIData? MakeAiDataForDefendAtRiskCity(MapUnit unit, Player player, int minDefenders) {
+			if (!unit.CanDefendOnLand()) {
+				// Just fortify in place if we can't defend on land.
+				return MakeAiDataForDefendInPlace(unit, player);
+			}
+
+			City cityToDefend = FindAtRiskCityToDefend(unit, player, minDefenders);
+			if (cityToDefend == null) {
+				return null;
+			}
 
 			DefenderAIData ai = new DefenderAIData();
 			ai.destination = cityToDefend.location;
@@ -61,7 +69,7 @@ namespace C7Engine.AI.UnitAI {
 		 * This is not a brilliant method, with many flaws such as whether the 
 		 * city needs more defenders, or if the units present are defenders.
 		 */
-		private static City FindAtRiskCityToDefend(MapUnit unit, Player player) {
+		private static City FindAtRiskCityToDefend(MapUnit unit, Player player, int minDefenders) {
 			if (player.cities.Count == 0) {
 				return City.NONE;
 			}
@@ -70,10 +78,12 @@ namespace C7Engine.AI.UnitAI {
 			// we want to send our unit to.
 			Dictionary<City, float> cityScores = new();
 			foreach (City c in player.cities) {
-				int score = 0;
-				if (c.location.unitsOnTile.Count(u => u.CanDefendOnLand()) < 3) {
-					// Add to the score if there aren't many defenders.
-					score += 10;
+				int numDefenders = c.location.unitsOnTile.Count(u => u.CanDefendOnLand());
+				float score = 0;
+				if (numDefenders < minDefenders) {
+					// Add to the score if there aren't many defenders, with a
+					// larger score for less defended cities.
+					score += 10f;
 				}
 
 				// Penalize cities for being far away.
@@ -87,12 +97,29 @@ namespace C7Engine.AI.UnitAI {
 			foreach (MapUnit u in player.units) {
 				if (u.currentAI is DefenderAI defenderAi) {
 					if (defenderAi.data.destination.cityAtTile != null) {
-						cityScores[defenderAi.data.destination.cityAtTile] -= 3;
+						cityScores[defenderAi.data.destination.cityAtTile] -= 3f;
 					}
 				}
 			}
 
-			return cityScores.MaxBy(t => t.Value).Key;
+			float bestScore = (float)int.MinValue;
+			City bestCity = null;
+			foreach (KeyValuePair<City, float> p in cityScores) {
+				if (p.Value > bestScore) {
+					bestScore = p.Value;
+					bestCity = p.Key;
+				}
+			}
+
+			// If there are no cities in need of defending at this defense level,
+			// don't return a city. This will let us decide to use units for
+			// offense instead. We can always call this method with a larger
+			// min defenders value if we really want to use defenders.
+			if (bestScore <= 0 && minDefenders != int.MaxValue) {
+				return null;
+			}
+
+			return bestCity;
 		}
 	}
 }

--- a/C7Engine/AI/UnitAiExtension.cs
+++ b/C7Engine/AI/UnitAiExtension.cs
@@ -17,7 +17,7 @@ namespace C7Engine {
 			}
 			Tile nextTile = path.Next();
 			if (nextTile == Tile.NONE || !unit.CanEnterTile(nextTile, allowCombat)) {
-				log.Information($"Attempting to repath from {unit.location} to {path.destination}");
+				log.Information($"Attempting to repath {unit} from {unit.location} to {path.destination}");
 				// Attempt to repath. If we succeed, return inprogress so we get
 				// called again.
 				path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, path.destination);

--- a/C7GameData/AIData/TileKnowledge.cs
+++ b/C7GameData/AIData/TileKnowledge.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace C7GameData {
 	public class TileKnowledge {
-		HashSet<Tile> knownTiles = new();
+		public HashSet<Tile> knownTiles { get; private set; } = new();
 		public HashSet<Tile> borderTiles { get; private set; } = new();
 		HashSet<Tile> visibleTiles = new();
 

--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -92,6 +92,10 @@ namespace C7GameData {
 				return false;
 			}
 
+			if (other == this) {
+				return true;
+			}
+
 			if (playerRelationships.ContainsKey(other.id)) {
 				return !playerRelationships[other.id].atWar;
 			}
@@ -108,6 +112,10 @@ namespace C7GameData {
 
 			playerRelationships[other.id].atWar = true;
 			other.playerRelationships[this.id].atWar = true;
+
+			// Whenever war is declared, re-evaluate priorities.
+			turnsUntilPriorityReevaluation = 0;
+			other.turnsUntilPriorityReevaluation = 0;
 		}
 
 		public bool SitsOutFirstTurn() {


### PR DESCRIPTION
We now achieve a minimal defensive position and then allow offensive units to attack. The attackers have some basic prioritization (intercept other attackers, take cities, focus on closer targets, etc).

In practice this results in two AIs at war smashing into each other with a large stack, and then singleton attacks afterwards, but it's a start.

We also haven't implemented peace treaties yet, so once at war civs are always at war, and will stop building settlers and such. I'll add that in a new PR.

This was tested by running in observer mode for ~100 turns, declaring war by doing a manual attack, and then running observer mode again. We don't yet have AIs declaring war themselves.
