### PR TITLE
Implement war declarations via the diplomacy UI 

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -12,6 +12,7 @@
 [ext_resource type="Script" path="res://UIElements/UnitButtons/UnitButtons.cs" id="12"]
 [ext_resource type="PackedScene" uid="uid://bvncm1bgcii5e" path="res://UIElements/civ3_file_dialog.tscn" id="12_yjlfl"]
 [ext_resource type="Script" path="res://UIElements/CityScreen/CityScreen.cs" id="13"]
+[ext_resource type="Script" path="res://UIElements/Diplomacy/Diplomacy.cs" id="14"]
 
 [sub_resource type="Animation" id="2"]
 length = 0.001
@@ -60,29 +61,17 @@ _data = {
 "SlideOutAnimation": SubResource("1")
 }
 
-[node name="C7Game" type="Node2D" node_paths=PackedStringArray("Toolbar", "popupOverlay", "cityScreen", "advisor", "slider", "animationPlayer")]
+[node name="C7Game" type="Node2D" node_paths=PackedStringArray("Toolbar", "popupOverlay", "cityScreen", "advisor", "diplomacy", "slider", "animationPlayer")]
 script = ExtResource("1")
 Toolbar = NodePath("CanvasLayer/Control/ToolBar/MarginContainer/HBoxContainer")
 popupOverlay = NodePath("CanvasLayer/PopupOverlay")
 cityScreen = NodePath("CanvasLayer/CityScreen")
 advisor = NodePath("CanvasLayer/Advisor")
+diplomacy = NodePath("CanvasLayer/Diplomacy")
 slider = NodePath("CanvasLayer/Control/SlideOutBar/VBoxContainer/Zoom")
 animationPlayer = NodePath("CanvasLayer/Control/SlideOutBar/AnimationPlayer")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
-
-[node name="PopupOverlay" type="HBoxContainer" parent="CanvasLayer" node_paths=PackedStringArray("control")]
-visible = false
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 0
-size_flags_horizontal = 3
-alignment = 2
-script = ExtResource("9")
-control = NodePath("../Control")
-
-[node name="PopupSound" type="AudioStreamPlayer" parent="CanvasLayer/PopupOverlay"]
 
 [node name="Control" type="Control" parent="CanvasLayer"]
 layout_mode = 3
@@ -270,6 +259,29 @@ script = ExtResource("13")
 unique_name_in_owner = true
 visible = false
 
+[node name="Diplomacy" type="CenterContainer" parent="CanvasLayer" node_paths=PackedStringArray("popupOverlay")]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("10")
+script = ExtResource("14")
+popupOverlay = NodePath("../PopupOverlay")
+
+[node name="PopupOverlay" type="HBoxContainer" parent="CanvasLayer" node_paths=PackedStringArray("control")]
+visible = false
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 0
+size_flags_horizontal = 3
+alignment = 2
+script = ExtResource("9")
+control = NodePath("../Control")
+
+[node name="PopupSound" type="AudioStreamPlayer" parent="CanvasLayer/PopupOverlay"]
+
 [connection signal="NewAutoselectedUnit" from="." to="CanvasLayer/Control/GameStatus" method="OnNewUnitSelected"]
 [connection signal="NewAutoselectedUnit" from="." to="CanvasLayer/Control/UnitButtons" method="OnNewUnitSelected"]
 [connection signal="NoMoreAutoselectableUnits" from="." to="CanvasLayer/Control/GameStatus" method="OnNoMoreAutoselectableUnits"]
@@ -282,6 +294,7 @@ visible = false
 [connection signal="Quit" from="CanvasLayer/PopupOverlay" to="." method="OnQuitTheGame"]
 [connection signal="Retire" from="CanvasLayer/PopupOverlay" to="." method="_on_QuitButton_pressed"]
 [connection signal="UnitDisbanded" from="CanvasLayer/PopupOverlay" to="." method="OnUnitDisbanded"]
+[connection signal="DiplomacySelection" from="CanvasLayer/PopupOverlay" to="." method="OnDiplomacySelected"]
 [connection signal="ActionRequested" from="CanvasLayer/Control/UnitButtons" to="." method="ProcessAction"]
 [connection signal="BlinkyEndTurnButtonPressed" from="CanvasLayer/Control/GameStatus" to="." method="OnPlayerEndTurn"]
 [connection signal="pressed" from="CanvasLayer/Control/ToolBar/MarginContainer/HBoxContainer/AdvisorButton" to="CanvasLayer/Advisor" method="ShowLatestAdvisor"]

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -76,6 +76,8 @@ public partial class Game : Node2D {
 	[Export]
 	private Advisors advisor;
 	[Export]
+	private Diplomacy diplomacy;
+	[Export]
 	private VSlider slider;
 	[Export]
 	private AnimationPlayer animationPlayer;
@@ -630,8 +632,13 @@ public partial class Game : Node2D {
 			return;
 		}
 
+		if (currentAction == C7Action.Escape && diplomacy.Visible) {
+			diplomacy.Hide();
+			return;
+		}
+
 		// never poll for actions if UI elements are visible
-		if (popupOverlay.Visible || cityScreen.Visible || advisor.Visible) {
+		if (popupOverlay.Visible || cityScreen.Visible || advisor.Visible || diplomacy.Visible) {
 			return;
 		}
 
@@ -858,5 +865,9 @@ public partial class Game : Node2D {
 
 	public void ShowCityScreenForCity(City city) {
 		EmitSignal(SignalName.ShowCityScreen, new ParameterWrapper<City>(city));
+	}
+
+	private void OnDiplomacySelected(ParameterWrapper<ID> opponentPlayer) {
+		diplomacy.ShowTalkScreenForPlayer(controller.id, opponentPlayer.Value);
 	}
 }

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -68400,6 +68400,7 @@
       "leader": "Caesar",
       "colorIndex": 1,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\CE_all.pcx",
       "cityNames": [
         "Rome",
         "Veii",
@@ -68457,6 +68458,7 @@
       "leader": "Cleopatra",
       "colorIndex": 3,
       "leaderGender": "female",
+      "leaderArtFile": "art\\advisors\\CL_all.pcx",
       "cityNames": [
         "Thebes",
         "Memphis",
@@ -68499,6 +68501,7 @@
       "leader": "Alexander",
       "colorIndex": 10,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\AL_all.pcx",
       "cityNames": [
         "Athens",
         "Sparta",
@@ -68541,6 +68544,7 @@
       "leader": "Hammurabi",
       "colorIndex": 1,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\HA_all.pcx",
       "cityNames": [
         "Babylon",
         "Nineveh",
@@ -68581,6 +68585,7 @@
       "leader": "Bismarck",
       "colorIndex": 6,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\BS_all.pcx",
       "cityNames": [
         "Berlin",
         "Leipzig",
@@ -68610,6 +68615,7 @@
       "leader": "Catherine",
       "colorIndex": 9,
       "leaderGender": "female",
+      "leaderArtFile": "art\\advisors\\CA_all.pcx",
       "cityNames": [
         "Moscow",
         "St. Petersburg",
@@ -68662,6 +68668,7 @@
       "leader": "Mao",
       "colorIndex": 5,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\MO_all.pcx",
       "cityNames": [
         "Beijing",
         "Shanghai",
@@ -68693,6 +68700,7 @@
       "leader": "Lincoln",
       "colorIndex": 5,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\AB_all.pcx",
       "cityNames": [
         "Washington",
         "New York",
@@ -68746,6 +68754,7 @@
       "leader": "Tokugawa",
       "colorIndex": 4,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\TO_all.pcx",
       "cityNames": [
         "Kyoto",
         "Osaka",
@@ -68785,6 +68794,7 @@
       "leader": "Joan d\u0027Arc",
       "colorIndex": 7,
       "leaderGender": "female",
+      "leaderArtFile": "art\\advisors\\JO_all.pcx",
       "cityNames": [
         "Paris",
         "Orleans",
@@ -68819,6 +68829,7 @@
       "leader": "Gandhi",
       "colorIndex": 8,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\GH_all.pcx",
       "cityNames": [
         "Delhi",
         "Bombay",
@@ -68849,6 +68860,7 @@
       "leader": "Xerxes",
       "colorIndex": 10,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\XE_all.pcx",
       "cityNames": [
         "Persepolis",
         "Pasargadae",
@@ -68891,6 +68903,7 @@
       "leader": "Montezuma",
       "colorIndex": 4,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\MN_all.pcx",
       "cityNames": [
         "Tenochtitlan",
         "Teotihuacan",
@@ -68940,6 +68953,7 @@
       "leader": "Shaka",
       "colorIndex": 3,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\ZU_all.pcx",
       "cityNames": [
         "Zimbabwe",
         "Ulundi",
@@ -68969,6 +68983,7 @@
       "leader": "Hiawatha",
       "colorIndex": 8,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\HI_all.pcx",
       "cityNames": [
         "Salamanca",
         "Niagara Falls",
@@ -69011,6 +69026,7 @@
       "leader": "Elizabeth",
       "colorIndex": 2,
       "leaderGender": "female",
+      "leaderArtFile": "art\\advisors\\LZ_all.pcx",
       "cityNames": [
         "London",
         "York",
@@ -69398,6 +69414,7 @@
       "leader": "Gilgamesh",
       "colorIndex": 5,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\x2_Gilgamesh advisor.pcx",
       "cityNames": [
         "Ur",
         "Sumer",
@@ -69436,6 +69453,7 @@
       "leader": "Mursilis",
       "colorIndex": 14,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\x2_Mursilis advisor.pcx",
       "cityNames": [
         "Hattusas",
         "Tarsus",
@@ -69474,6 +69492,7 @@
       "leader": "William",
       "colorIndex": 2,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\x2_William advisor.pcx",
       "cityNames": [
         "Amsterdam",
         "Rotterdam",
@@ -69512,6 +69531,7 @@
       "leader": "Henry",
       "colorIndex": 8,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\x2_Henry advisor.pcx",
       "cityNames": [
         "Lisbon",
         "Oporto",
@@ -69561,6 +69581,7 @@
       "leader": "Theodora",
       "colorIndex": 11,
       "leaderGender": "female",
+      "leaderArtFile": "art\\advisors\\x2_Theodora advisor.pcx",
       "cityNames": [
         "Constantinople",
         "Adrianople",
@@ -69599,6 +69620,7 @@
       "leader": "Pachacuti",
       "colorIndex": 7,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\x2_Pachacuti advisor.pcx",
       "cityNames": [
         "Cuzco",
         "Tiwanaku",
@@ -69637,6 +69659,7 @@
       "leader": "Smoke-Jaguar",
       "colorIndex": 6,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\x2_Smoke-Jaguar_advisor.pcx",
       "cityNames": [
         "Chich\u00E9n Itza",
         "Cop\u00E1n",

--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -268,16 +268,7 @@ public partial class CityScreen : CenterContainer {
 		}
 		popHeads.Clear();
 
-		int eraNum = 0;
-		if (city.owner.eraCivilopediaName == "ERAS_Ancient_Times") {
-			eraNum = 0;
-		} else if (city.owner.eraCivilopediaName == "ERAS_Middle_Ages") {
-			eraNum = 1;
-		} else if (city.owner.eraCivilopediaName == "ERAS_Industrial_Age") {
-			eraNum = 2;
-		} else if (city.owner.eraCivilopediaName == "ERAS_Modern_Era") {
-			eraNum = 3;
-		}
+		int eraNum = city.owner.EraIndex();
 
 		// The pop head textures are 50 x 50, but have a 1px border on all sides
 		//

--- a/C7/UIElements/Diplomacy/Diplomacy.cs
+++ b/C7/UIElements/Diplomacy/Diplomacy.cs
@@ -1,0 +1,31 @@
+using Godot;
+using System;
+using C7GameData;
+using Serilog;
+using System.Collections.Generic;
+
+
+// A container for all the diplomacy-related screens that aren't simple popups.
+public partial class Diplomacy : CenterContainer {
+	private ILogger log = LogManager.ForContext<Diplomacy>();
+
+	[Export]
+	public PopupOverlay popupOverlay;
+
+	private TalkScreen talkScreen;
+
+	public override void _Ready() {
+		this.Hide();
+	}
+
+	public void ShowTalkScreenForPlayer(ID humanPlayer, ID opponentPlayer) {
+		if (talkScreen != null) {
+			RemoveChild(talkScreen);
+			talkScreen = null;
+		}
+
+		talkScreen = new TalkScreen(humanPlayer, opponentPlayer);
+		AddChild(talkScreen);
+		this.Show();
+	}
+}

--- a/C7/UIElements/Diplomacy/TalkScreen.cs
+++ b/C7/UIElements/Diplomacy/TalkScreen.cs
@@ -1,0 +1,109 @@
+using C7Engine;
+using C7GameData;
+using Godot;
+using System;
+using System.Collections.Generic;
+using ConvertCiv3Media;
+
+public partial class TalkScreen : TextureRect {
+	private ID humanPlayerId;
+	private ID opponentPlayerId;
+
+	Theme fontTheme = new();
+	FontFile font = new();
+
+	public TalkScreen(ID humanPlayer, ID opponentPlayer) {
+		this.humanPlayerId = humanPlayer;
+		this.opponentPlayerId = opponentPlayer;
+	}
+
+	public override void _Ready() {
+		this.CreateUI();
+	}
+
+	private void CreateUI() {
+		// Load the font we'll use.
+		//
+		// We skip the cache so that we can change the size without affecting other
+		// code using the same font.
+		font = ResourceLoader.Load<FontFile>("res://Fonts/NotoSans-Regular.ttf", null, ResourceLoader.CacheMode.Ignore);
+		font.FixedSize = 14;
+		fontTheme.DefaultFont = font;
+
+		this.Texture = Util.LoadTextureFromPCX("Art/Diplomacy/talk_offer.pcx");
+
+		ColorRect headBackground = new();
+		headBackground.Color = Colors.Black;
+		headBackground.Size = new Vector2(200, 240);
+		headBackground.SetPosition(new Vector2(512 - 100, 59));
+		AddChild(headBackground);
+
+		TextureRect leaderHead = new();
+		string civNameText;
+		string leaderName;
+		using (UIGameDataAccess gameDataAccess = new()) {
+			GameData gD = gameDataAccess.gameData;
+			Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
+			civNameText = $"{opponentPlayer.civilization.name} (Cautious)";
+			leaderName = opponentPlayer.civilization.leader;
+
+			int xOffset = opponentPlayer.EraIndex() * 115;
+
+			// TODO: track mood in the player relationship data structure.
+			int yOffset = 115;  // 0 is annoyed, 115*2 is mad.
+
+			Pcx headPcx = Util.LoadPCX(opponentPlayer.civilization.leaderArtFile);
+			leaderHead.Texture = PCXToGodot.getImageTextureFromPCX(
+						headPcx,
+						new(xOffset, yOffset, 115, 115),
+						new(false, []));
+			leaderHead.Scale = new Vector2(1.7f, 1.7f);
+		}
+
+		leaderHead.SetPosition(new Vector2(512 - (115 * 1.7f) / 2, 59 + 120 - (115 * 1.7f) / 2));
+		AddChild(leaderHead);
+
+		Label civName = new();
+		civName.SetPosition(new Vector2(0, 330));
+		AddChild(civName);
+		civName.Text = civNameText;
+		civName.HorizontalAlignment = HorizontalAlignment.Center;
+		civName.AnchorLeft = 0.5f;
+		civName.AnchorRight = 0.5f;
+		civName.OffsetLeft = -1 * (civName.Size.X / 2.0f);
+		civName.Theme = fontTheme;
+
+		Button proposeDeal = new();
+		proposeDeal.Text = "We would like to propose a deal...";
+		proposeDeal.SetPosition(new Vector2(512 - 205, 500));
+		proposeDeal.Theme = fontTheme;
+		// TODO: Advance to the next screen.
+		AddChild(proposeDeal);
+
+		Button declareWar = new();
+		declareWar.Text = "That's it! Prepare for WAR!";
+		declareWar.SetPosition(new Vector2(512 - 205, 520));
+		declareWar.Theme = fontTheme;
+		declareWar.Pressed += DeclareWar;
+		AddChild(declareWar);
+
+		Button goodbye = new();
+		goodbye.Text = $"That's it. Goodbye, {leaderName}";
+		goodbye.SetPosition(new Vector2(512 - 205, 540));
+		goodbye.Theme = fontTheme;
+		goodbye.Pressed += () => { GetParent<Diplomacy>().Hide(); };
+		AddChild(goodbye);
+	}
+
+	private void DeclareWar() {
+		using UIGameDataAccess gameDataAccess = new();
+		GameData gD = gameDataAccess.gameData;
+		Player humanPlayer = gD.players.Find(x => x.id == humanPlayerId);
+		Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
+		GetParent<Diplomacy>().popupOverlay.ShowPopup(new WarConfirmation(opponentPlayer,
+				() => {
+					humanPlayer.DeclareWarOn(opponentPlayer);
+					GetParent<Diplomacy>().Hide();
+				}), PopupOverlay.PopupCategory.Advisor);
+	}
+}

--- a/C7/UIElements/Popups/DiplomacySelection.cs
+++ b/C7/UIElements/Popups/DiplomacySelection.cs
@@ -30,7 +30,10 @@ public partial class DiplomacySelection : Popup {
 		int vOffset = 65;
 		foreach (KeyValuePair<ID, PlayerRelationship> kvp in player.playerRelationships) {
 			string status = kvp.Value.atWar ? "War" : "Peace";
-			AddButton($"{allPlayers.Find(x => x.id == kvp.Key).civilization.noun} (at {status})", vOffset, () => { });
+			AddButton($"{allPlayers.Find(x => x.id == kvp.Key).civilization.noun} (at {status})", vOffset, () => {
+				GetParent().EmitSignal(PopupOverlay.SignalName.DiplomacySelection, new ParameterWrapper<ID>(kvp.Key));
+				GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
+			});
 			vOffset += 25;
 		}
 

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -1,4 +1,5 @@
 using Godot;
+using C7GameData;
 using Serilog;
 
 [GlobalClass]
@@ -10,6 +11,7 @@ public partial class PopupOverlay : HBoxContainer {
 	[Signal] public delegate void QuitEventHandler();
 	[Signal] public delegate void RetireEventHandler();
 	[Signal] public delegate void BuildCityEventHandler(string name);
+	[Signal] public delegate void DiplomacySelectionEventHandler(ParameterWrapper<ID> opponentPlayer);
 	[Signal] public delegate void HidePopupEventHandler();
 
 	Control currentChild = null;

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -629,6 +629,12 @@ namespace C7Engine {
 		}
 
 		public static void playAutomatedTurn(this MapUnit unit) {
+			if (unit.currentAI == null) {
+				// TODO: handle giving automated workers from loaded saves the
+				// proper unit ai.
+				unit.isAutomated = false;
+				return;
+			}
 			UnitAI.Result result = unit.currentAI.PlayTurn(unit.owner, unit);
 			if (result == UnitAI.Result.Done) {
 				if (unit.currentAI is WorkerAI) {
@@ -642,6 +648,5 @@ namespace C7Engine {
 			// nothing after an progress result, so that next turn continues the
 			// AI action.
 		}
-
 	}
 }

--- a/C7GameData/Civilization.cs
+++ b/C7GameData/Civilization.cs
@@ -25,6 +25,9 @@ namespace C7GameData {
 		public int colorIndex;
 		public Gender leaderGender;
 
+		// Like `art\advisors\LZ_all.pcx` for the English.
+		public string leaderArtFile;
+
 		public List<string> cityNames = new List<string>();
 
 		// The IDs of all the techs that this civ starts with.

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -352,6 +352,11 @@ namespace C7GameData {
 				foreach (RACE_City city in theBiq.RaceCityName[i]) {
 					civ.cityNames.Add(city.Name);
 				}
+				// Look up the image for non-barbarian civs.
+				string artName = pediaIcons.GetLeaderArtName(race.CivilopediaEntry);
+				if (artName != null) {
+					civ.leaderArtFile = artName;
+				}
 				save.Civilizations.Add(civ);
 				i++;
 			}

--- a/C7GameData/PediaIcons.cs
+++ b/C7GameData/PediaIcons.cs
@@ -19,6 +19,11 @@ namespace C7GameData {
 		// the small icon used in the science advisor display.
 		private readonly Dictionary<string, string> techSmallIconMapping = new();
 
+		// A mapping from the all caps name of a race (BABYLON, GERMANS, 
+		// RUSSIAN, etc) to the art file with happy/neutral/mad images of the
+		// leader in each era, like `art\advisors\LZ_all.pcx`.
+		private readonly Dictionary<string, string> raceToArtMapping = new();
+
 		private readonly string pediaIconsPath;
 
 		public PediaIcons(string path) {
@@ -47,6 +52,12 @@ namespace C7GameData {
 					// and then the next line is the icon path.
 					techSmallIconMapping[lines[i].Substring(1)] = lines[i + 1];
 				}
+
+				if (lines[i].StartsWith("#RACE") && i + 2 < lines.Length) {
+					// +2 because the line at +1 is the leaderheads neutral
+					// victory image.
+					raceToArtMapping[lines[i]] = lines[i + 2];
+				}
 			}
 		}
 
@@ -61,6 +72,14 @@ namespace C7GameData {
 				return "Warrior";
 			}
 			return artName;
+		}
+
+		public string GetLeaderArtName(string civilopediaEntry) {
+			string key = "#" + civilopediaEntry;
+			if (!raceToArtMapping.ContainsKey(key)) {
+				return null;
+			}
+			return raceToArtMapping[key];
 		}
 	}
 

--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -59,6 +59,19 @@ namespace C7GameData {
 		// The number of turns the player has been researching the current tech.
 		public int turnsResearched = 0;
 
+		public int EraIndex() {
+			if (eraCivilopediaName == "ERAS_Ancient_Times") {
+				return 0;
+			} else if (eraCivilopediaName == "ERAS_Middle_Ages") {
+				return 1;
+			} else if (eraCivilopediaName == "ERAS_Industrial_Age") {
+				return 2;
+			} else if (eraCivilopediaName == "ERAS_Modern_Era") {
+				return 3;
+			}
+			return -1;
+		}
+
 		public void AddUnit(MapUnit unit) {
 			this.units.Add(unit);
 		}


### PR DESCRIPTION
We can now declar war on any civs that we have met, and they will properly be at war with us.

This doesn't implement peace treaties yet, doesn't handle the actual flc files for leaders (and just uses the pcx of the head), doesn't handle leader emotions (just hardcodes cautious), and doesn't handle refusing to answer communication. Howver, this PR is already pretty big and adds a pretty important bit of functionality.

The pedia icons logic is stuff we'll need eventually, so even though we might want the real flc files in the future, this is a good standin and can be reused for the foreign advisor screen.

Other notes:
 - I had to reorder the popup position in the godot file to get the z index stuff to work
 - The MapUnitExtension fix was found when I was loading some save files that had automated units
 - The "are you sure" popup from this screen should be the military advisor eventually 
 
---

Screenshots!

![image](https://github.com/user-attachments/assets/be5f3aa6-277b-4746-8fe1-7fb164266edd)

![image](https://github.com/user-attachments/assets/955494ae-0918-4697-af12-865a1b73f68d)

![image](https://github.com/user-attachments/assets/ae210edc-c078-42b9-8f69-348a9f488db0)

![image](https://github.com/user-attachments/assets/c25cbc2d-86ab-4df5-8ac6-886325435bcc)
