### PR TITLE
Fix pathing issues at the wraparound point

### DIFF
--- a/C7GameData/AIData/TileKnowledge.cs
+++ b/C7GameData/AIData/TileKnowledge.cs
@@ -25,10 +25,17 @@ namespace C7GameData {
 			borderTiles.Remove(unitLocation);
 
 			foreach (Tile t in unitLocation.neighbors.Values) {
+				if (t == Tile.NONE) {
+					continue;
+				}
+
 				knownTiles.Add(t);
 				borderTiles.Remove(t);
 
 				foreach (Tile border in t.neighbors.Values) {
+					if (border == Tile.NONE) {
+						continue;
+					}
 					if (!knownTiles.Contains(border)) {
 						borderTiles.Add(border);
 					}
@@ -45,6 +52,9 @@ namespace C7GameData {
 			borderTiles.Remove(unitLocation);
 
 			foreach (Tile border in unitLocation.neighbors.Values) {
+				if (border == Tile.NONE) {
+					continue;
+				}
 				if (!knownTiles.Contains(border)) {
 					borderTiles.Add(border);
 				}

--- a/C7GameData/GameMap.cs
+++ b/C7GameData/GameMap.cs
@@ -49,6 +49,7 @@ namespace C7GameData {
 					neighbors[direction] = tileNeighbor(tile, direction);
 				}
 				tile.neighbors = neighbors;
+				tile.map = this;
 			}
 		}
 
@@ -122,6 +123,36 @@ namespace C7GameData {
 			TileLocation neighbor = Tile.NeighborCoordinate(new TileLocation(center), direction);
 			//TODO: World wrap should also be accounted for.
 			return tileAt(neighbor.X, neighbor.Y);
+		}
+
+		// Calculates X1 - X2, handling world wrap.
+		public int CalculateXDelta(int X1, int X2) {
+			if (!wrapHorizontally) {
+				return X1 - X2;
+			}
+
+			int rawDelta = X1 - X2;
+			if (rawDelta > numTilesWide / 2) {
+				return rawDelta - numTilesWide;
+			} else if (rawDelta < -numTilesWide / 2) {
+				return rawDelta + numTilesWide;
+			}
+			return rawDelta;
+		}
+
+		// Calculates Y1 - Y2, handling world wrap.
+		public int CalculateYDelta(int Y1, int Y2) {
+			if (!wrapVertically) {
+				return Y1 - Y2;
+			}
+
+			int rawDelta = Y1 - Y2;
+			if (rawDelta > numTilesTall / 2) {
+				return rawDelta - numTilesTall;
+			} else if (rawDelta < -numTilesTall / 2) {
+				return rawDelta + numTilesTall;
+			}
+			return rawDelta;
 		}
 
 		public delegate int[,] TerrainNoiseMapGenerator(int rng, int width, int height);

--- a/C7GameData/Tile.cs
+++ b/C7GameData/Tile.cs
@@ -11,6 +11,10 @@ namespace C7GameData {
 		public int XCoordinate;
 		public int YCoordinate;
 
+		// Needed for coordinate wrapping.
+		[JsonIgnore]
+		public GameMap map;
+
 		// An arbitrary number indicating which landmass this tile is part of,
 		// for land-based tiles, or -1 for water.
 		//
@@ -152,14 +156,16 @@ namespace C7GameData {
 		}
 
 		public TileDirection directionTo(Tile other) {
-			// TODO: Consider edge wrapping, the direction should point along the shortest path as the crow flies.
-
 			if ((this == NONE) || (other == NONE))
 				throw new System.Exception("Can't get direction toward NONE Tile since it doesn't have a meaningful location");
 
-			// y calculation is reversed so dy is in typical Cartesian coords instead of tile coords, where y is inverted
-			int dx = other.XCoordinate - this.XCoordinate;
-			int dy = this.YCoordinate - other.YCoordinate;
+			// We have to use the map helper functions to handle edge wrapping
+			// correctly.
+			//
+			// y calculation is reversed so dy is in typical Cartesian coords
+			// instead of tile coords, where y is inverted
+			int dx = map.CalculateXDelta(other.XCoordinate, this.XCoordinate);
+			int dy = map.CalculateYDelta(this.YCoordinate, other.YCoordinate);
 			double angle = Math.Atan2(dy, dx); // angle is in interval [-pi, pi]
 
 			if (angle > 7.0 / 8.0 * Math.PI) return TileDirection.WEST;
@@ -178,7 +184,7 @@ namespace C7GameData {
 		 * This is a rough metric only.
 		 */
 		public int distanceTo(Tile other) {
-			return (Math.Abs(other.XCoordinate - this.XCoordinate) + Math.Abs(other.YCoordinate - this.YCoordinate)) / 2;
+			return (Math.Abs(map.CalculateXDelta(other.XCoordinate, this.XCoordinate)) + Math.Abs(map.CalculateYDelta(other.YCoordinate, this.YCoordinate))) / 2;
 		}
 
 		// Returns the number of "ranks" to another tile, where each rank is a
@@ -188,8 +194,8 @@ namespace C7GameData {
 			// We use sqrt(2) to try and "unskew" issues caused by the rotated
 			// rectangular grid. We need N/E/S/W tiles to be slightly further
 			// away than NE/SE/NW/SW tiles.
-			double deltaX = Math.Abs(other.XCoordinate - this.XCoordinate) * Math.Sqrt(2);
-			double deltaY = Math.Abs(other.YCoordinate - this.YCoordinate) * Math.Sqrt(2);
+			double deltaX = Math.Abs(map.CalculateXDelta(other.XCoordinate, this.XCoordinate)) * Math.Sqrt(2);
+			double deltaY = Math.Abs(map.CalculateYDelta(other.YCoordinate, this.YCoordinate)) * Math.Sqrt(2);
 
 			// Calculating the euclidian distance with an exponent of 1.8 instead
 			// of 2 gives us the correct results up to 99k culture (20k is a

--- a/C7GameDataTests/SaveTest.cs
+++ b/C7GameDataTests/SaveTest.cs
@@ -12,6 +12,7 @@ using C7Engine;
 using C7GameData.Save;
 using QueryCiv3;
 using System.Runtime.InteropServices;
+using C7Engine.Pathing;
 
 public class SaveTests {
 
@@ -186,6 +187,30 @@ public class SaveTests {
 		// And they should be the same, despite round-tripping through the GameData format.
 		Assert.Equal(directSaveLines, roundTrippedSaveLines);
 	}
+
+	[Fact]
+	public void WorldWrapDetails() {
+		string developerSave = getBasePath("../C7/Text/c7-static-map-save.json");
+		Player human = CreateHeadlessGame(developerSave);
+		WaitForStartTurnMessage();
+
+		using UIGameDataAccess gda = new();
+		GameData gd = gda.gameData;
+
+		Tile t0 = gd.map.tileAt(97, 33);
+		Tile t1 = gd.map.tileAt(99, 33);
+		Tile t2 = gd.map.tileAt(1, 33);
+
+		Assert.Equal(t0.distanceTo(t1), 1);
+		Assert.Equal(t1.distanceTo(t0), 1);
+
+		Assert.Equal(t1.distanceTo(t2), 1);
+		Assert.Equal(t2.distanceTo(t1), 1);
+
+		Assert.Equal(t0.distanceTo(t2), 2);
+		Assert.Equal(t2.distanceTo(t0), 2);
+	}
+
 
 	[Fact]
 	public async void LoadSampleSaves() {


### PR DESCRIPTION
... and add a test that would have caught this.

The changes to `TileKnowledge.cs` were required to avoid situations where we computed a distance with `Tile.NONE` which doesn't have a valid map reference.