### PR TITLE
Determine producible units

### DIFF
--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -65157,7 +65157,7 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 48,
-      "unproducible": false,
+      "unproducible": true,
       "categories": [
         "Land"
       ],

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -59001,6 +59001,7 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 0,
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59024,6 +59025,7 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 1,
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59050,6 +59052,8 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 2,
+      "upgradeTo": "Explorer",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59073,6 +59077,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 3,
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59096,6 +59101,7 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 4,
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59119,6 +59125,7 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 5,
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59141,6 +59148,8 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 6,
+      "upgradeTo": "Swordsman",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59164,6 +59173,8 @@
       "bombard": 1,
       "movement": 1,
       "iconIndex": 7,
+      "upgradeTo": "Longbowman",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59187,6 +59198,8 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 8,
+      "upgradeTo": "Pikeman",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59210,6 +59223,8 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 9,
+      "upgradeTo": "Medieval Infantry",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59233,6 +59248,8 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 10,
+      "upgradeTo": "Horseman",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59256,6 +59273,8 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 11,
+      "upgradeTo": "Knight",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59279,6 +59298,8 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 12,
+      "upgradeTo": "Musketman",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59302,6 +59323,8 @@
       "bombard": 2,
       "movement": 1,
       "iconIndex": 13,
+      "upgradeTo": "Guerilla",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59325,6 +59348,8 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 14,
+      "upgradeTo": "Rifleman",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59348,6 +59373,8 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 15,
+      "upgradeTo": "Cavalry",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59371,6 +59398,8 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 16,
+      "upgradeTo": "Infantry",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59394,6 +59423,7 @@
       "bombard": 0,
       "movement": 3,
       "iconIndex": 17,
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59417,6 +59447,8 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 18,
+      "upgradeTo": "Mech Infantry",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59440,6 +59472,8 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 19,
+      "upgradeTo": "Modern Armor",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59463,6 +59497,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 20,
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59486,6 +59521,7 @@
       "bombard": 0,
       "movement": 3,
       "iconIndex": 21,
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59509,6 +59545,8 @@
       "bombard": 4,
       "movement": 1,
       "iconIndex": 22,
+      "upgradeTo": "Trebuchet",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59533,6 +59571,8 @@
       "bombard": 8,
       "movement": 1,
       "iconIndex": 23,
+      "upgradeTo": "Artillery",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59557,6 +59597,8 @@
       "bombard": 12,
       "movement": 1,
       "iconIndex": 24,
+      "upgradeTo": "Radar Artillery",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59581,6 +59623,7 @@
       "bombard": 16,
       "movement": 2,
       "iconIndex": 25,
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59605,6 +59648,7 @@
       "bombard": 16,
       "movement": 1,
       "iconIndex": 26,
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59628,6 +59672,7 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 27,
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59652,6 +59697,7 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 28,
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -59675,6 +59721,8 @@
       "bombard": 0,
       "movement": 3,
       "iconIndex": 29,
+      "upgradeTo": "Caravel",
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -59698,6 +59746,8 @@
       "bombard": 0,
       "movement": 4,
       "iconIndex": 30,
+      "upgradeTo": "Galleon",
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -59721,6 +59771,7 @@
       "bombard": 3,
       "movement": 5,
       "iconIndex": 31,
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -59745,6 +59796,8 @@
       "bombard": 0,
       "movement": 4,
       "iconIndex": 32,
+      "upgradeTo": "Transport",
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -59768,6 +59821,8 @@
       "bombard": 6,
       "movement": 3,
       "iconIndex": 33,
+      "upgradeTo": "Destroyer",
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -59792,6 +59847,7 @@
       "bombard": 0,
       "movement": 6,
       "iconIndex": 34,
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -59815,6 +59871,7 @@
       "bombard": 0,
       "movement": 7,
       "iconIndex": 35,
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -59838,6 +59895,7 @@
       "bombard": 0,
       "movement": 4,
       "iconIndex": 36,
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -59861,6 +59919,7 @@
       "bombard": 6,
       "movement": 8,
       "iconIndex": 37,
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -59885,6 +59944,7 @@
       "bombard": 8,
       "movement": 5,
       "iconIndex": 38,
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -59909,6 +59969,7 @@
       "bombard": 6,
       "movement": 7,
       "iconIndex": 39,
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -59933,6 +59994,7 @@
       "bombard": 0,
       "movement": 5,
       "iconIndex": 40,
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -59956,6 +60018,8 @@
       "bombard": 3,
       "movement": 1,
       "iconIndex": 41,
+      "upgradeTo": "Jet Fighter",
+      "unproducible": false,
       "categories": [
         "Air"
       ],
@@ -59977,6 +60041,7 @@
       "bombard": 12,
       "movement": 1,
       "iconIndex": 42,
+      "unproducible": false,
       "categories": [
         "Air"
       ],
@@ -59998,6 +60063,7 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 43,
+      "unproducible": false,
       "categories": [
         "Air"
       ],
@@ -60019,6 +60085,7 @@
       "bombard": 3,
       "movement": 1,
       "iconIndex": 44,
+      "unproducible": false,
       "categories": [
         "Air"
       ],
@@ -60040,6 +60107,7 @@
       "bombard": 6,
       "movement": 1,
       "iconIndex": 45,
+      "unproducible": false,
       "categories": [
         "Air"
       ],
@@ -60061,6 +60129,7 @@
       "bombard": 18,
       "movement": 1,
       "iconIndex": 46,
+      "unproducible": false,
       "categories": [
         "Air"
       ],
@@ -60081,6 +60150,7 @@
       "bombard": 0,
       "movement": 3,
       "iconIndex": 47,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -60103,6 +60173,7 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 48,
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60126,6 +60197,11 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 49,
+      "upgradeTo": "Swordsman",
+      "unique": {
+        "civilization": "Aztecs"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60149,6 +60225,12 @@
       "bombard": 1,
       "movement": 1,
       "iconIndex": 50,
+      "upgradeTo": "Longbowman",
+      "unique": {
+        "replace": "Archer",
+        "civilization": "Babylon"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60172,6 +60254,12 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 51,
+      "upgradeTo": "Musketman",
+      "unique": {
+        "replace": "Spearman",
+        "civilization": "Greece"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60195,6 +60283,12 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 52,
+      "upgradeTo": "Musketman",
+      "unique": {
+        "replace": "Spearman",
+        "civilization": "Zululand"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60218,6 +60312,12 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 53,
+      "upgradeTo": "Medieval Infantry",
+      "unique": {
+        "replace": "Swordsman",
+        "civilization": "Rome"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60241,6 +60341,12 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 54,
+      "upgradeTo": "Medieval Infantry",
+      "unique": {
+        "replace": "Swordsman",
+        "civilization": "Persia"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60264,6 +60370,12 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 55,
+      "upgradeTo": "Knight",
+      "unique": {
+        "replace": "Chariot",
+        "civilization": "Egypt"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60287,6 +60399,12 @@
       "bombard": 0,
       "movement": 3,
       "iconIndex": 56,
+      "upgradeTo": "Cavalry",
+      "unique": {
+        "replace": "Knight",
+        "civilization": "China"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60310,6 +60428,12 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 57,
+      "upgradeTo": "Knight",
+      "unique": {
+        "replace": "Horseman",
+        "civilization": "Iroquois"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60333,6 +60457,12 @@
       "bombard": 2,
       "movement": 1,
       "iconIndex": 58,
+      "upgradeTo": "Rifleman",
+      "unique": {
+        "replace": "Musketman",
+        "civilization": "France"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60356,6 +60486,12 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 59,
+      "upgradeTo": "Cavalry",
+      "unique": {
+        "replace": "Knight",
+        "civilization": "Japan"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60379,6 +60515,12 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 60,
+      "upgradeTo": "Cavalry",
+      "unique": {
+        "replace": "Knight",
+        "civilization": "India"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60402,6 +60544,11 @@
       "bombard": 0,
       "movement": 3,
       "iconIndex": 61,
+      "unique": {
+        "replace": "Cavalry",
+        "civilization": "Russia"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60425,6 +60572,12 @@
       "bombard": 0,
       "movement": 3,
       "iconIndex": 62,
+      "upgradeTo": "Modern Armor",
+      "unique": {
+        "replace": "Tank",
+        "civilization": "Germany"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60448,6 +60601,11 @@
       "bombard": 4,
       "movement": 5,
       "iconIndex": 63,
+      "unique": {
+        "replace": "Frigate",
+        "civilization": "England"
+      },
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -60472,6 +60630,11 @@
       "bombard": 6,
       "movement": 1,
       "iconIndex": 64,
+      "unique": {
+        "replace": "Jet Fighter",
+        "civilization": "America"
+      },
+      "unproducible": false,
       "categories": [
         "Air"
       ],
@@ -60493,6 +60656,7 @@
       "bombard": 3,
       "movement": 5,
       "iconIndex": 65,
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -60516,6 +60680,12 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 76,
+      "upgradeTo": "Cavalry",
+      "unique": {
+        "replace": "Knight",
+        "civilization": "Mongols"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60539,6 +60709,11 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 75,
+      "unique": {
+        "replace": "Explorer",
+        "civilization": "Spain"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60562,6 +60737,12 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 74,
+      "upgradeTo": "Guerilla",
+      "unique": {
+        "replace": "Longbowman",
+        "civilization": "Scandinavia"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60585,6 +60766,11 @@
       "bombard": 0,
       "movement": 3,
       "iconIndex": 77,
+      "unique": {
+        "replace": "Cavalry",
+        "civilization": "Ottomans"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60608,6 +60794,12 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 78,
+      "upgradeTo": "Medieval Infantry",
+      "unique": {
+        "replace": "Swordsman",
+        "civilization": "Celts"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60631,6 +60823,12 @@
       "bombard": 0,
       "movement": 3,
       "iconIndex": 82,
+      "upgradeTo": "Cavalry",
+      "unique": {
+        "replace": "Knight",
+        "civilization": "Arabia"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60654,6 +60852,12 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 80,
+      "upgradeTo": "Pikeman",
+      "unique": {
+        "replace": "Spearman",
+        "civilization": "Carthage"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60677,6 +60881,11 @@
       "bombard": 8,
       "movement": 1,
       "iconIndex": 79,
+      "upgradeTo": "Artillery",
+      "unique": {
+        "civilization": "Korea"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60701,6 +60910,8 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 84,
+      "upgradeTo": "Guerilla",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60724,6 +60935,8 @@
       "bombard": 3,
       "movement": 1,
       "iconIndex": 85,
+      "upgradeTo": "TOW Infantry",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -60746,6 +60959,7 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 121,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -60765,6 +60979,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 97,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -60786,6 +61001,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 100,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -60807,6 +61023,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 103,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -60828,6 +61045,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 107,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -60849,6 +61067,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 108,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -60870,6 +61089,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 116,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -60891,6 +61111,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 115,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -60912,6 +61133,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 110,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -60933,6 +61155,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 120,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -60954,6 +61177,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 99,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -60975,6 +61199,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 104,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -60996,6 +61221,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 105,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61017,6 +61243,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 117,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61038,6 +61265,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 98,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61059,6 +61287,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 101,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61080,6 +61309,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 114,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61101,6 +61331,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 113,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61122,6 +61353,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 109,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61143,6 +61375,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 119,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61164,6 +61397,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 102,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61185,6 +61419,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 111,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61206,6 +61441,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 106,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61227,6 +61463,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 112,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61248,6 +61485,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 118,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61269,6 +61507,12 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 175,
+      "upgradeTo": "Pikeman",
+      "unique": {
+        "replace": "Warrior",
+        "civilization": "Sumeria"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -61292,6 +61536,12 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 186,
+      "upgradeTo": "Knight",
+      "unique": {
+        "replace": "Chariot",
+        "civilization": "Hittites"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -61314,6 +61564,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 169,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61335,6 +61586,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 174,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61356,6 +61608,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 173,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61378,6 +61631,12 @@
       "bombard": 0,
       "movement": 4,
       "iconIndex": 198,
+      "upgradeTo": "Galleon",
+      "unique": {
+        "replace": "Caravel",
+        "civilization": "Portugal"
+      },
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -61401,6 +61660,12 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 181,
+      "upgradeTo": "Rifleman",
+      "unique": {
+        "replace": "Pikeman",
+        "civilization": "Netherlands"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -61423,6 +61688,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 172,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61445,6 +61711,8 @@
       "bombard": 6,
       "movement": 1,
       "iconIndex": 190,
+      "upgradeTo": "Cannon",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -61468,6 +61736,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 170,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61489,6 +61758,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 171,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61510,6 +61780,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 168,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61531,6 +61802,12 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 176,
+      "upgradeTo": "Explorer",
+      "unique": {
+        "replace": "Scout",
+        "civilization": "Inca"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -61554,6 +61831,12 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 177,
+      "upgradeTo": "Longbowman",
+      "unique": {
+        "replace": "Archer",
+        "civilization": "Maya"
+      },
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -61577,6 +61860,12 @@
       "bombard": 2,
       "movement": 3,
       "iconIndex": 196,
+      "upgradeTo": "Caravel",
+      "unique": {
+        "replace": "Galley",
+        "civilization": "Byzantines"
+      },
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -61601,6 +61890,8 @@
       "bombard": 7,
       "movement": 6,
       "iconIndex": 200,
+      "upgradeTo": "AEGIS Cruiser",
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -61624,6 +61915,7 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 180,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61646,6 +61938,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 187,
+      "unproducible": true,
       "categories": [
         "Land"
       ],
@@ -61669,6 +61962,8 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 195,
+      "upgradeTo": "Galley",
+      "unproducible": false,
       "categories": [
         "Sea"
       ],
@@ -61692,6 +61987,8 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 185,
+      "upgradeTo": "Modern Paratrooper",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -61715,6 +62012,7 @@
       "bombard": 6,
       "movement": 1,
       "iconIndex": 203,
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -61738,6 +62036,8 @@
       "bombard": 0,
       "movement": 1,
       "iconIndex": 205,
+      "upgradeTo": "Mobile SAM",
+      "unproducible": false,
       "categories": [
         "Land"
       ],
@@ -61761,6 +62061,7 @@
       "bombard": 0,
       "movement": 2,
       "iconIndex": 206,
+      "unproducible": false,
       "categories": [
         "Land"
       ],

--- a/C7GameData/Building.cs
+++ b/C7GameData/Building.cs
@@ -11,13 +11,12 @@ namespace C7GameData {
 		public bool isGreatWonder;
 		public bool isSmallWonder;
 
-		public Building(SaveBuilding building, Tech requiredTech) {
+		public Building(SaveBuilding building) {
 			name = building.name;
 			shieldCost = building.shieldCost;
 			populationCost = building.populationCost;
 			isGreatWonder = building.isGreatWonder;
 			isSmallWonder = building.isSmallWonder;
-			this.requiredTech = requiredTech;
 		}
 	}
 }

--- a/C7GameData/City.cs
+++ b/C7GameData/City.cs
@@ -60,13 +60,34 @@ namespace C7GameData {
 		}
 
 		public bool CanBuildUnit(UnitPrototype proto) {
-			List<string> allowedUnits = new List<string> {"Warrior", "Chariot", "Settler", "Worker", "Catapult", "Galley"};
-			if (!allowedUnits.Contains(proto.name))
+			return MeetsProductionRequirements(proto) && !IsUnitObsolete(proto);
+		}
+
+		private bool IsUnitObsolete(UnitPrototype proto) {
+			var upgradeChain = owner.civilization.GetUpgradeChain(proto);
+
+			return upgradeChain.Any(MeetsProductionRequirements);
+		}
+
+		private bool HasRequiredTechnology(IProducible producible) {
+			return producible.requiredTech == null ||
+				   owner.knownTechs.Contains(producible.requiredTech.id);
+		}
+
+		private bool MeetsProductionRequirements(UnitPrototype proto) {
+			if (!owner.civilization.IsUnitAvailable(proto)) {
 				return false;
-			if (proto.categories.Contains("Sea"))
-				return location.NeighborsWater();
-			else
-				return true;
+			}
+
+			if (!HasRequiredTechnology(proto)) {
+				return false;
+			}
+
+			if (proto.categories.Contains("Sea") && !location.NeighborsWater()) {
+				return false;
+			}
+
+			return true;
 		}
 
 		public int TurnsUntilGrowth() {

--- a/C7GameData/City.cs
+++ b/C7GameData/City.cs
@@ -63,8 +63,11 @@ namespace C7GameData {
 			return MeetsProductionRequirements(proto) && !IsUnitObsolete(proto);
 		}
 
+		// TODO: Consider golden ages when determining whether a unit is obsolete.
+		// If a golden age has not yet been triggered and a unit can trigger one,  
+		// it shouldn't be marked as obsolete, even if its upgrade is available.
 		private bool IsUnitObsolete(UnitPrototype proto) {
-			var upgradeChain = owner.civilization.GetUpgradeChain(proto);
+			List<UnitPrototype> upgradeChain = owner.civilization.GetUpgradeChain(proto);
 
 			return upgradeChain.Any(MeetsProductionRequirements);
 		}

--- a/C7GameData/Civilization.cs
+++ b/C7GameData/Civilization.cs
@@ -32,5 +32,50 @@ namespace C7GameData {
 
 		[JsonIgnore]
 		public UnitPrototype uniqueUnit;
+
+		private UnitPrototype GetDirectUpgrade(UnitPrototype unit) {
+			// Check if a regular upgrade is replaced by a unique unit
+			if (uniqueUnit != null
+				&& uniqueUnit.unique.replace != null
+				&& uniqueUnit.unique.replace == unit.upgradeTo) {
+				return uniqueUnit;
+			}
+
+			return unit.upgradeTo;
+		}
+
+		public List<UnitPrototype> GetUpgradeChain(UnitPrototype unit) {
+			List<UnitPrototype> result = [];
+			var current = unit;
+
+			while (true) {
+				var upgrade = GetDirectUpgrade(current);
+				if (upgrade == null) break;
+
+				result.Add(upgrade);
+				current = upgrade;
+			}
+
+			return result;
+		}
+
+		public bool IsUnitAvailable(UnitPrototype unit) {
+			if (unit.unproducible) {
+				return false;
+			}
+
+			// Check if unit is replaced by a unique unit
+			if (uniqueUnit != null && uniqueUnit.unique.replace == unit) {
+				return false;
+			}
+
+			// Check if unit is a unique unit from another civilization
+			if (unit.unique != null && unit.unique.civilization != this) {
+				return false;
+			}
+
+			return true;
+		}
 	}
+
 }

--- a/C7GameData/Civilization.cs
+++ b/C7GameData/Civilization.cs
@@ -24,9 +24,13 @@ namespace C7GameData {
 		public string leader;
 		public int colorIndex;
 		public Gender leaderGender;
+
 		public List<string> cityNames = new List<string>();
 
 		// The IDs of all the techs that this civ starts with.
 		public HashSet<ID> startingTechs = new();
+
+		[JsonIgnore]
+		public UnitPrototype uniqueUnit;
 	}
 }

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -44,6 +44,8 @@ namespace C7GameData {
 			ImportRaces();
 			ImportTechs();
 			ImportUnitPrototypes();
+			ImportUniqueUnitReplacements();
+			ImportUnitUpgrades();
 			ImportBuildings();
 			ImportCiv3TerrainTypes();
 			ImportCiv3ExperienceLevels();
@@ -671,6 +673,23 @@ namespace C7GameData {
 			if (prto.Explore) yield return C7Action.UnitExplore;
 			if (prto.Automate) yield return C7Action.UnitAutomate;
 		}
+
+		private SaveUnitPrototype.Unique ImportUniqueUnitData(PRTO prto) {
+			int civIndex = prto.AvailableTo.GetUniqueCivIndex();
+
+			if (civIndex == -1) {
+				return null;
+			}
+
+			return new() { civilization = save.Civilizations[civIndex].name };
+		}
+
+		private static bool IsUnproducible(PRTO prto) {
+			int[] availableTo = prto.AvailableTo.GetAvailableCivIndexes().ToArray();
+
+			return availableTo.Length == 0 || prto.ShieldCost < 1;
+		}
+
 		private void ImportUnitPrototypes() {
 			PRTO[] Prto = biq.Prto ?? defaultBiq.Prto;
 			foreach (PRTO prto in Prto) {
@@ -694,6 +713,9 @@ namespace C7GameData {
 				prototype.iconIndex = prto.IconIndex;
 				prototype.actions.UnionWith(GetUnitActions(prto));
 
+				prototype.unique = ImportUniqueUnitData(prto);
+				prototype.unproducible = IsUnproducible(prto);
+
 				if (prto.Required != -1) {
 					prototype.requiredTech = save.Techs[prto.Required].id;
 				}
@@ -702,7 +724,121 @@ namespace C7GameData {
 				if (!save.UnitPrototypes.Where(p => p.name == prototype.name).Any()) {
 					save.UnitPrototypes.Add(prototype);
 				}
+			}
+		}
 
+		// This method assigns standard units that are replaced by unique units.
+		//
+		// A unique unit replaces a standard unit if both share the same tech requirement 
+		// and the standard unit is unproducible by the civilization to which the unique unit belongs.
+		// 
+		// For example, this method updates the Mounted Warrior prototype to indicate that it replaces the Horseman.
+		private void ImportUniqueUnitReplacements() {
+			var unitPrototypeDict = save.UnitPrototypes.ToDictionary(b => b.name);
+
+			// Group unique units by civilization.
+			// In the base ruleset a civilization only has one unique unit, 
+			// but this may vary in scenarios.
+			var uniqueUnitPrototypesByCiv = save.UnitPrototypes
+					.Where(u => u.unique != null)
+					.ToLookup(u => u.unique.civilization);
+
+			PRTO[] Prto = biq.Prto ?? defaultBiq.Prto;
+
+			foreach (PRTO standardUnitPrto in Prto) {
+				string standardUnitName = standardUnitPrto.Name;
+				SaveUnitPrototype standardUnit = unitPrototypeDict[standardUnitName];
+
+				// Skip units that are either unique or unproducible (cannot be built normally)
+				if (standardUnit.unique != null) {
+					continue;
+				}
+
+				if (standardUnit.unproducible) {
+					continue;
+				}
+
+				// For each civilization that cannot build the standard unit
+				foreach (int civIndex in standardUnitPrto.AvailableTo.GetUnavailableCivIndexes()) {
+					if (civIndex >= save.Civilizations.Count) {
+						break;
+					}
+
+					var uniqueUnits = uniqueUnitPrototypesByCiv[save.Civilizations[civIndex].name];
+
+					foreach (SaveUnitPrototype uniqueUnit in uniqueUnits) {
+						// If the unique unit has the same tech requirement as the standard unit, 
+						// mark the unique unit as a replacement for the standard unit
+						if (uniqueUnit.requiredTech == standardUnit.requiredTech) {
+							uniqueUnit.unique.replace = standardUnitName;
+						}
+					}
+				}
+			}
+		}
+
+		// This method loads unit upgrades from CIV3 data. In CIV3, unique units are part of the upgrade chain. 
+		//
+		// For example, the upgrade path for Horseman looks like this:
+		// Horseman->Mounted Warrior->Three-Man Chariot->Knight->Keshik->Ansar Warrior->Rider->Samurai->War Elephant->Cavalry.
+		// see also: https://forums.civfanatics.com/threads/how-to-upgrade-regular-units-to-uus.108396/
+		//
+		// When loading this data, the method ignores the unique units in the upgrade chain.
+		// Instead, each unit of the chain will be assigned an upgrade that represents the closest non-unique unit 
+		// that also requires a tech advancement over the base unit.
+		//
+		// For example, this method will mark that Horseman upgrades to Knight and that Keshik upgrades to Cavalry.
+		private void ImportUnitUpgrades() {
+			Dictionary<SaveUnitPrototype, SaveUnitPrototype> upgradeDict = BuildUpgradeDict();
+
+			foreach (SaveUnitPrototype proto in save.UnitPrototypes) {
+				proto.upgradeTo = GetUnitUpgrade(proto, upgradeDict);
+			}
+		}
+
+		// This method builds a Dictionary of unit upgrades based on the CIV3 data.
+		// The dictionary represents the raw upgrade relationships as defined in the game files.
+		// The dictionary serves as an intermediate data structure for the ImportUnitUpgrades process,
+		// before filtering out unique units.
+		private Dictionary<SaveUnitPrototype, SaveUnitPrototype> BuildUpgradeDict() {
+			PRTO[] Prto = biq.Prto ?? defaultBiq.Prto;
+			var unitPrototypeDict = save.UnitPrototypes.ToDictionary(b => b.name);
+
+			Dictionary<SaveUnitPrototype, SaveUnitPrototype> upgradeDict = [];
+
+			foreach (PRTO prto in Prto) {
+				SaveUnitPrototype upgradeFrom = unitPrototypeDict[prto.Name];
+				if (prto.UpgradeTo != -1) {
+					SaveUnitPrototype upgradeTo = unitPrototypeDict[Prto[prto.UpgradeTo].Name];
+					upgradeDict[upgradeFrom] = upgradeTo;
+				} else {
+					upgradeDict[upgradeFrom] = null;
+				}
+			}
+
+			return upgradeDict;
+		}
+
+		// This method returns the name of the first valid unit upgrade in the upgrade chain.
+		// A valid upgrade must require a different technology than the base unit and must not be a unique unit.
+		// If no valid upgrade is found, it returns null.
+		private static string GetUnitUpgrade(SaveUnitPrototype proto, Dictionary<SaveUnitPrototype, SaveUnitPrototype> upgradeDict) {
+			SaveUnitPrototype currentProto = proto;
+
+			while (true) {
+				// Check if there's an upgrade available
+				var upgrade = upgradeDict[currentProto];
+				if (upgrade == null) {
+					return null;
+				}
+
+				// If this upgrade represents a technology advancement over the base unit and is not a unique unit, return it
+				if (upgrade.requiredTech != proto.requiredTech && upgrade.unique == null) {
+					return upgrade.name;
+				}
+
+				// Otherwise, continue checking the upgrade chain
+				currentProto = upgrade;
 			}
 		}
 

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -657,6 +657,20 @@ namespace C7GameData {
 			}
 		}
 
+		private static IEnumerable<string> GetUnitActions(PRTO prto) {
+			if (prto.BuildCity) yield return C7Action.UnitBuildCity;
+			if (prto.BuildRoad) yield return C7Action.UnitBuildRoad;
+			if (prto.BuildMine) yield return C7Action.UnitBuildMine;
+			if (prto.Irrigate) yield return C7Action.UnitIrrigate;
+			if (prto.Bombard) yield return C7Action.UnitBombard;
+			if (prto.SkipTurn) yield return C7Action.UnitHold;
+			if (prto.Wait) yield return C7Action.UnitWait;
+			if (prto.Fortify) yield return C7Action.UnitFortify;
+			if (prto.Disband) yield return C7Action.UnitDisband;
+			if (prto.GoTo) yield return C7Action.UnitGoto;
+			if (prto.Explore) yield return C7Action.UnitExplore;
+			if (prto.Automate) yield return C7Action.UnitAutomate;
+		}
 		private void ImportUnitPrototypes() {
 			PRTO[] Prto = biq.Prto ?? defaultBiq.Prto;
 			foreach (PRTO prto in Prto) {
@@ -668,6 +682,7 @@ namespace C7GameData {
 				} else if (prto.Type == PRTO.TYPE_AIR) {
 					prototype.categories.Add("Air");
 				}
+
 				prototype.name = prto.Name;
 				prototype.artName = pediaIcons.GetUnitArtName(prto.CivilopediaEntry);
 				prototype.attack = prto.Attack;
@@ -677,50 +692,17 @@ namespace C7GameData {
 				prototype.populationCost = prto.PopulationCost;
 				prototype.bombard = prto.BombardStrength;
 				prototype.iconIndex = prto.IconIndex;
-				if (prto.BuildCity) {
-					prototype.actions.Add(C7Action.UnitBuildCity);
-				}
-				if (prto.BuildRoad) {
-					prototype.actions.Add(C7Action.UnitBuildRoad);
-				}
-				if (prto.BuildMine) {
-					prototype.actions.Add(C7Action.UnitBuildMine);
-				}
-				if (prto.Irrigate) {
-					prototype.actions.Add(C7Action.UnitIrrigate);
-				}
-				if (prto.Bombard) {
-					prototype.actions.Add(C7Action.UnitBombard);
-				}
-				if (prto.SkipTurn) {
-					prototype.actions.Add(C7Action.UnitHold);
-				}
-				if (prto.Wait) {
-					prototype.actions.Add(C7Action.UnitWait);
-				}
-				if (prto.Fortify) {
-					prototype.actions.Add(C7Action.UnitFortify);
-				}
-				if (prto.Disband) {
-					prototype.actions.Add(C7Action.UnitDisband);
-				}
-				if (prto.GoTo) {
-					prototype.actions.Add(C7Action.UnitGoto);
-				}
-				if (prto.Explore) {
-					prototype.actions.Add(C7Action.UnitExplore);
-				}
-				if (prto.Automate) {
-					prototype.actions.Add(C7Action.UnitAutomate);
-				}
-				//Temporary check until #329/#330 are finished
-				if (!save.UnitPrototypes.Where(p => p.name == prototype.name).Any()) {
-					if (prto.Required != -1) {
-						prototype.requiredTech = save.Techs[prto.Required].id;
-					}
+				prototype.actions.UnionWith(GetUnitActions(prto));
 
+				if (prto.Required != -1) {
+					prototype.requiredTech = save.Techs[prto.Required].id;
+				}
+
+				//Temporary check until #330 is finished
+				if (!save.UnitPrototypes.Where(p => p.name == prototype.name).Any()) {
 					save.UnitPrototypes.Add(prototype);
 				}
+
 			}
 		}
 

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -689,7 +689,8 @@ namespace C7GameData {
 		private static bool IsUnproducible(PRTO prto) {
 			int[] availableTo = prto.AvailableTo.GetAvailableCivIndexes().ToArray();
 
-			return availableTo.Length == 0 || prto.ShieldCost < 1;
+			// TODO: Implement proper logic for Army production
+			return availableTo.Length == 0 || prto.ShieldCost < 1 || prto.Army;
 		}
 
 		private void ImportUnitPrototypes() {

--- a/C7GameData/Save/SaveGame.cs
+++ b/C7GameData/Save/SaveGame.cs
@@ -163,14 +163,37 @@ namespace C7GameData.Save {
 		}
 
 		private void ConvertUnits(GameData data) {
-			var techDict = data.techs.ToDictionary(t => t.id);
+			data.unitPrototypes = UnitPrototypes.ConvertAll(prototype => new UnitPrototype(prototype));
 
-			data.unitPrototypes = UnitPrototypes.ConvertAll(prototype =>
-				new UnitPrototype(
-					prototype,
-					prototype.requiredTech != null ? techDict[prototype.requiredTech] : null
-				)
-			);
+			var techDict = data.techs.ToDictionary(t => t.id);
+			var unitPrototypeDict = data.unitPrototypes.ToDictionary(b => b.name);
+			var civDict = data.civilizations.ToDictionary(c => c.name);
+
+			foreach (SaveUnitPrototype saveProto in UnitPrototypes) {
+				UnitPrototype proto = unitPrototypeDict[saveProto.name];
+
+				if (saveProto.upgradeTo != null) {
+					proto.upgradeTo = unitPrototypeDict[saveProto.upgradeTo];
+				}
+
+				if (saveProto.requiredTech != null) {
+					proto.requiredTech = techDict[saveProto.requiredTech];
+				}
+
+				if (saveProto.unique != null) {
+					Civilization civ = civDict[saveProto.unique.civilization];
+
+					proto.unique = new() {
+						civilization = civ
+					};
+
+					if (saveProto.unique.replace != null) {
+						proto.unique.replace = unitPrototypeDict[saveProto.unique.replace];
+					}
+
+					civ.uniqueUnit = proto;
+				}
+			}
 
 			// map units need game map and players to populate location and owner
 			data.mapUnits = Units.ConvertAll(unit =>

--- a/C7GameData/Save/SaveGame.cs
+++ b/C7GameData/Save/SaveGame.cs
@@ -144,24 +144,22 @@ namespace C7GameData.Save {
 		}
 
 		private void ConvertBuildings(GameData data) {
-			var techDict = data.techs.ToDictionary(t => t.id);
-
-			data.Buildings = Buildings.ConvertAll(building =>
-				new Building(
-					building,
-					building.requiredTech != null ? techDict[building.requiredTech] : null
-				)
-			);
+			data.Buildings = Buildings.ConvertAll(building => new Building(building));
 
 			var buildingDict = data.Buildings.ToDictionary(b => b.name);
+			var techDict = data.techs.ToDictionary(t => t.id);
 
-			data.Buildings = data.Buildings
-				.Zip(Buildings, (building, saveBuilding) => {
-					if (saveBuilding.requiredBuilding != null)
-						building.requiredBuilding = buildingDict[saveBuilding.requiredBuilding];
-					return building;
-				})
-				.ToList();
+			foreach (SaveBuilding saveBuilding in Buildings) {
+				Building building = buildingDict[saveBuilding.name];
+
+				if (saveBuilding.requiredBuilding != null) {
+					building.requiredBuilding = buildingDict[saveBuilding.requiredBuilding];
+				}
+
+				if (saveBuilding.requiredTech != null) {
+					building.requiredTech = techDict[saveBuilding.requiredTech];
+				}
+			}
 		}
 
 		private void ConvertUnits(GameData data) {

--- a/C7GameData/Save/SaveUnitPrototype.cs
+++ b/C7GameData/Save/SaveUnitPrototype.cs
@@ -31,13 +31,23 @@ namespace C7GameData.Save {
 		public SaveUnitPrototype() { }
 
 		public SaveUnitPrototype(UnitPrototype proto) {
-			(name, artName, shieldCost, populationCost,
+			(name, artName, shieldCost, populationCost, unproducible,
 			attack, defense, bombard, movement, iconIndex) =
-			(proto.name, proto.artName, proto.shieldCost, proto.populationCost,
+			(proto.name, proto.artName, proto.shieldCost, proto.populationCost, proto.unproducible,
 			 proto.attack, proto.defense, proto.bombard, proto.movement, proto.iconIndex);
 
 			if (proto.requiredTech != null)
 				requiredTech = proto.requiredTech.id;
+
+			if (proto.upgradeTo != null)
+				upgradeTo = proto.upgradeTo.name;
+
+			if (proto.unique != null) {
+				unique = new() {
+					civilization = proto.unique.civilization.name,
+					replace = proto.unique.replace?.name
+				};
+			}
 
 			categories = new HashSet<string>(proto.categories);
 			actions = new HashSet<string>(proto.actions);

--- a/C7GameData/Save/SaveUnitPrototype.cs
+++ b/C7GameData/Save/SaveUnitPrototype.cs
@@ -2,6 +2,11 @@ using System.Collections.Generic;
 
 namespace C7GameData.Save {
 	public class SaveUnitPrototype {
+		public class Unique {
+			public string replace;
+			public string civilization;
+		};
+
 		public string name { get; set; }
 		public string artName { get; set; }
 		public int shieldCost { get; set; }
@@ -12,6 +17,10 @@ namespace C7GameData.Save {
 		public int bombard { get; set; }
 		public int movement { get; set; }
 		public int iconIndex { get; set; }
+
+		public string upgradeTo;
+		public Unique unique;
+		public bool unproducible;
 
 		public HashSet<string> categories = new HashSet<string>();
 

--- a/C7GameData/UnitPrototype.cs
+++ b/C7GameData/UnitPrototype.cs
@@ -9,6 +9,11 @@ namespace C7GameData {
 	 * For example, a Spearman might have 1 attack, 2 defense, and 1 movement.
 	 **/
 	public class UnitPrototype : IProducible {
+		public class Unique {
+			public Civilization civilization;
+			public UnitPrototype replace;
+		}
+
 		public string name { get; set; }
 		// The name to use when searching for animations for this unit.
 		public string artName { get; set; }
@@ -20,6 +25,9 @@ namespace C7GameData {
 		public int bombard { get; set; }
 		public int movement { get; set; }
 		public int iconIndex { get; set; }
+		public UnitPrototype upgradeTo;
+		public Unique unique;
+		public bool unproducible;
 
 		public HashSet<string> categories = new HashSet<string>();
 
@@ -29,12 +37,10 @@ namespace C7GameData {
 
 		public UnitPrototype() { }
 
-		public UnitPrototype(SaveUnitPrototype proto, Tech requiredTech) {
-			(name, artName, shieldCost, populationCost, attack, defense, bombard, movement, iconIndex) =
+		public UnitPrototype(SaveUnitPrototype proto) {
+			(name, artName, shieldCost, populationCost, attack, defense, bombard, movement, iconIndex, unproducible) =
 			(proto.name, proto.artName, proto.shieldCost, proto.populationCost,
-			 proto.attack, proto.defense, proto.bombard, proto.movement, proto.iconIndex);
-
-			this.requiredTech = requiredTech;
+			 proto.attack, proto.defense, proto.bombard, proto.movement, proto.iconIndex, proto.unproducible);
 
 			categories = new HashSet<string>(proto.categories);
 			actions = new HashSet<string>(proto.actions);

--- a/QueryCiv3/BiqSections/Prto.cs
+++ b/QueryCiv3/BiqSections/Prto.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 namespace QueryCiv3.Biq {
@@ -17,6 +17,43 @@ namespace QueryCiv3.Biq {
 	public unsafe struct PRTORACE {
 		private fixed byte Race[4];
 		public bool this[int index] { get => Util.GetFlag(Race[index / 8], index % 8); }
+
+		private const int MAX_CIV = 32;
+
+		// Find an index of civilization to which a unit belongs an a unique unit.
+		// Returns -1 if a unit is not unique.
+		public int GetUniqueCivIndex() {
+			int civIndex = -1;
+
+			// Skip barbarians (index 0)
+			for (int i = 1; i < MAX_CIV; i++) {
+				if (this[i]) {
+					if (civIndex != -1) {
+						return -1; // More than one civilization found
+					}
+
+					civIndex = i;
+				}
+			}
+
+			return civIndex;
+		}
+
+		public IEnumerable<int> GetAvailableCivIndexes() {
+			for (int i = 0; i < MAX_CIV; i++) {
+				if (this[i]) {
+					yield return i;
+				}
+			}
+		}
+
+		public IEnumerable<int> GetUnavailableCivIndexes() {
+			for (int i = 0; i < MAX_CIV; i++) {
+				if (!this[i]) {
+					yield return i;
+				}
+			}
+		}
 	}
 
 	[StructLayout(LayoutKind.Sequential, Pack = 1)]


### PR DESCRIPTION
This PR implements logic to determine producible units. The new method considers required technology, unit obsolescence (e.g., Warrior cannot be produced if Swordsman is already available), and whether a unit is unique.

**CIV3 approach**

The approach to storing data on unique units and upgrades in this PR is quite different from how CIV3 handles it.

In CIV3, unit availability is tracked separately for each civilization. So, making a unit unique requires modifying both the unit itself (e.g., Mounted Warrior) and the unit it replaces (e.g., Horseman). Additionally, CIV3 includes unique units in upgrade data, leading to convoluted upgrade chains. For example, the game represents the Horseman's upgrade path as follows:

Horseman->Mounted Warrior->Three-Man Chariot->Knight->Keshik->Ansar Warrior->Rider->Samurai->War Elephant->Cavalry

**This PR's approach**

CIV3’s method makes unit data complex and difficult to modify. Instead of replicating it, this PR introduces a nested `Unique` class within `UnitPrototype`. This class contains two fields:

- civilization: The civilization that has access to the unique unit.
- replace: The standard unit that this unique unit replaces.

Each UnitPrototype has a `unique` field of type `Unique`. It directly links unique units to their replacements. This structure also allows filtering out unique units from upgrade chains.

**Limitations**

This approach has some limitations:

- It generally works well for the base ruleset of the game, with the exception of Three-Man Chariot (Hittite UU). In CIV3, Hittites can't build either Horseman or Chariot and can only build their UU instead. This appears to be the only case where a UU replaces not one, but two units.
- It doesn't cover ruleset of scenarios, where certain units are accessible by multiple civilizations (e.g., in the Middle Ages scenario only Byzantines and Rus can build Cataphract).
