### PR TITLE
Implement contact refusal during war and track some extra info

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -762,6 +762,8 @@ public partial class Game : Node2D {
 		if (info == null || info.moveCost == -1) {
 			return;
 		}
+		using UIGameDataAccess gameDataAccess = new();
+		int currentTurn = gameDataAccess.gameData.turn;
 
 		// If this move would require declaring war, display a popup that checks
 		// if the player really wants to declare war. If they do, declare the
@@ -770,14 +772,13 @@ public partial class Game : Node2D {
 			GotoInfo stashed = info;
 			popupOverlay.ShowPopup(new WarConfirmation(stashed.requiresWarDeclarationOnPlayer,
 				() => {
-					controller.DeclareWarOn(info.requiresWarDeclarationOnPlayer);
+					controller.DeclareWarOn(info.requiresWarDeclarationOnPlayer, currentTurn);
 					stashed.requiresWarDeclarationOnPlayer = null;
 					HandleGotoClick(stashed);
 				}), PopupOverlay.PopupCategory.Advisor);
 			return;
 		}
 
-		using UIGameDataAccess gameDataAccess = new();
 		new MsgSetUnitPath(CurrentlySelectedUnit.id, info.path).send();
 	}
 

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -1,6 +1,7 @@
 {
   "version": "0.0.0",
   "seed": -1,
+  "turnNumber": 0,
   "map": {
     "tilesWide": 100,
     "tilesTall": 100,

--- a/C7/UIElements/Diplomacy/Diplomacy.cs
+++ b/C7/UIElements/Diplomacy/Diplomacy.cs
@@ -1,6 +1,7 @@
 using Godot;
 using System;
 using C7GameData;
+using C7Engine;
 using Serilog;
 using System.Collections.Generic;
 
@@ -22,6 +23,19 @@ public partial class Diplomacy : CenterContainer {
 		if (talkScreen != null) {
 			RemoveChild(talkScreen);
 			talkScreen = null;
+		}
+
+		using (UIGameDataAccess gameDataAccess = new()) {
+			GameData gd = gameDataAccess.gameData;
+			Player opponent = gd.players.Find(x => x.id == opponentPlayer);
+			Player human = gd.players.Find(x => x.id == humanPlayer);
+			if (!opponent.WillAcceptCommunicationFrom(human, gd.turn)) {
+				popupOverlay.ShowPopup(
+					new InformationalPopup(
+						$"The {opponent.civilization.noun} refused to acknowledge our envoy!"),
+						PopupOverlay.PopupCategory.Advisor);
+				return;
+			}
 		}
 
 		talkScreen = new TalkScreen(humanPlayer, opponentPlayer);

--- a/C7/UIElements/Diplomacy/TalkScreen.cs
+++ b/C7/UIElements/Diplomacy/TalkScreen.cs
@@ -102,7 +102,7 @@ public partial class TalkScreen : TextureRect {
 		Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
 		GetParent<Diplomacy>().popupOverlay.ShowPopup(new WarConfirmation(opponentPlayer,
 				() => {
-					humanPlayer.DeclareWarOn(opponentPlayer);
+					humanPlayer.DeclareWarOn(opponentPlayer, gD.turn);
 					GetParent<Diplomacy>().Hide();
 				}), PopupOverlay.PopupCategory.Advisor);
 	}

--- a/C7/UIElements/Popups/DiplomacySelection.cs
+++ b/C7/UIElements/Popups/DiplomacySelection.cs
@@ -31,8 +31,9 @@ public partial class DiplomacySelection : Popup {
 		foreach (KeyValuePair<ID, PlayerRelationship> kvp in player.playerRelationships) {
 			string status = kvp.Value.atWar ? "War" : "Peace";
 			AddButton($"{allPlayers.Find(x => x.id == kvp.Key).civilization.noun} (at {status})", vOffset, () => {
-				GetParent().EmitSignal(PopupOverlay.SignalName.DiplomacySelection, new ParameterWrapper<ID>(kvp.Key));
-				GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
+				Node parent = GetParent();
+				parent.EmitSignal(PopupOverlay.SignalName.HidePopup);
+				parent.EmitSignal(PopupOverlay.SignalName.DiplomacySelection, new ParameterWrapper<ID>(kvp.Key));
 			});
 			vOffset += 25;
 		}

--- a/C7/UIElements/Popups/InformationalPopup.cs
+++ b/C7/UIElements/Popups/InformationalPopup.cs
@@ -1,0 +1,44 @@
+using Godot;
+using System;
+using System.Diagnostics;
+using C7GameData;
+using Serilog;
+
+// A generic popup for some sort of information.
+// TODO: support other advisors
+// TODO: support advisor moods
+public partial class InformationalPopup : Popup {
+	string message;
+
+	public InformationalPopup(string message) {
+		alignment = BoxContainer.AlignmentMode.End;
+		margins = new Margins(right: 10);
+		this.message = message;
+	}
+
+	public override void _Ready() {
+		base._Ready();
+
+		int width = 430;
+		int height = 230;
+
+		ImageTexture AdvisorHappy = Util.LoadTextureFromPCX("Art/SmallHeads/popupFOREIGN.pcx", 1, 40, 149, 110, false);
+		TextureRect AdvisorHead = new TextureRect();
+		AdvisorHead.Texture = AdvisorHappy;
+		AdvisorHead.SetPosition(new Vector2(275, 0));
+		AddChild(AdvisorHead);
+
+		AddTexture(width, height);
+		AddBackground(width, height - 110, 110);
+		AddHeader("Foreign Advisor", 120);
+
+		Label messageLabel = new();
+		messageLabel.Text = message;
+		messageLabel.SetPosition(new Vector2(25, 160));
+		AddChild(messageLabel);
+
+		AddConfirmButton(new Vector2(width - 40, height - 40), () => {
+			GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
+		});
+	}
+}

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -304,18 +304,11 @@ namespace C7Engine {
 			// tiles, not rank 2+.
 			foreach (Tile t in tile.neighbors.Values) {
 				if (t.unitsOnTile.Count > 0) {
-					MaybeAddPlayerKnowledge(t.unitsOnTile[0].owner, unit.owner);
+					unit.owner.EnsureRelationshipExists(t.unitsOnTile[0].owner);
 				}
 				if (t.owningCity != null) {
-					MaybeAddPlayerKnowledge(t.owningCity.owner, unit.owner);
+					unit.owner.EnsureRelationshipExists(t.owningCity.owner);
 				}
-			}
-		}
-
-		private static void MaybeAddPlayerKnowledge(Player a, Player b) {
-			if (a != b && !a.playerRelationships.ContainsKey(b.id)) {
-				a.playerRelationships.Add(b.id, new PlayerRelationship());
-				b.playerRelationships.Add(a.id, new PlayerRelationship());
 			}
 		}
 

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -71,6 +71,7 @@ namespace C7GameData {
 			savData = new SavData(Util.ReadFile(savePath), defaultBicBytes);
 			biq = savData.Bic;
 			pediaIcons = new(getPediaIconsPath(biq.Game[0].ScenarioSearchFolders));
+			save.TurnNumber = savData.Game.TurnNumber;
 
 			ImportSharedBiqData();
 			ImportSavLeaders();
@@ -452,10 +453,17 @@ namespace C7GameData {
 			foreach (QueryCiv3.Sav.LEAD leader in savData.Lead) {
 				List<int> contacts = leader.GetContact();
 				List<bool> warStatus = leader.GetWarStatuses();
+				List<int> refuseContactForTurns = leader.GetRefuseContactForTurns();
 				for (int j = 0; j < contacts.Count; ++j) {
 					if (contacts[j] > 0) {
+						QueryCiv3.Sav.LEAD_LEAD relationship = savData.ReputationRelationship[i][j];
 						save.Players[i].playerRelationships.Add(save.Players[j].id.ToString(), new PlayerRelationship() {
 							atWar = warStatus[j],
+							warDeclarationCount = relationship.WarDeclarationCount,
+							wasSneakAttacked = relationship.WasSneakAttacked == 1,
+							refuseContactUntilTurn =
+								refuseContactForTurns[j] > 0 ?
+									save.TurnNumber + refuseContactForTurns[j] : -1,
 						});
 					}
 				}
@@ -1190,8 +1198,15 @@ namespace C7GameData {
 		// comparing SAV files.
 		private void DumpObject(string label, object o) {
 			Console.WriteLine(label);
-			foreach (PropertyDescriptor descriptor in TypeDescriptor.GetProperties(o)) {
-				Console.WriteLine($"\t{descriptor.Name}={descriptor.GetValue(o)}");
+			foreach (System.Reflection.PropertyInfo propertyInfo in o.GetType().GetProperties(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)) {
+				Console.WriteLine($"\t{propertyInfo.Name}={propertyInfo.GetValue(o)}");
+			}
+			foreach (System.Reflection.MethodInfo method in o.GetType().GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)) {
+				// Print the common case of methods returning lists with no argments
+				if (typeof(List<int>).IsAssignableFrom(method.ReturnType) && method.ReturnType != typeof(string)) {
+					List<int> result = (List<int>)method.Invoke(o, null);
+					Console.WriteLine($"\t{method.Name}=" + string.Join(", ", result));
+				}
 			}
 			foreach (System.Reflection.FieldInfo fieldInfo in o.GetType().GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)) {
 				Console.WriteLine($"\t{fieldInfo.Name}={fieldInfo.GetValue(o)}");

--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -117,20 +117,60 @@ namespace C7GameData {
 			return true;
 		}
 
-		public void DeclareWarOn(Player other) {
+		public void EnsureRelationshipExists(Player other) {
 			if (!playerRelationships.ContainsKey(other.id)) {
 				playerRelationships.Add(other.id, new PlayerRelationship());
 			}
 			if (!other.playerRelationships.ContainsKey(this.id)) {
 				other.playerRelationships.Add(this.id, new PlayerRelationship());
 			}
+		}
+
+		public void DeclareWarOn(Player other, int currentTurn) {
+			EnsureRelationshipExists(other);
 
 			playerRelationships[other.id].atWar = true;
-			other.playerRelationships[this.id].atWar = true;
+
+			PlayerRelationship pr = other.playerRelationships[this.id];
+			pr.atWar = true;
+			pr.warDeclarationCount += 1;
+
+			// Check to see if there was a sneak attack - we consider a sneak
+			// attack any attack where the player's units were inside the
+			// borders of the civ they're declaring war on.
+			foreach (Tile t in other.tileKnowledge.knownTiles) {
+				if (t.owningCity == null || t.owningCity.owner != other) {
+					continue;
+				}
+				if (t.unitsOnTile.Count == 0) {
+					continue;
+				}
+				if (t.unitsOnTile[0].owner == this) {
+					pr.wasSneakAttacked = true;
+					break;
+				}
+			}
+
+
+			// Refuse contact from the aggressor civ until enough turns have
+			// elapsed. The exact civ3 mechanism here is unknown, so we just
+			// pick some reasonable random number. To penalize sneak attacks we
+			// use a higher upper bound.
+			pr.refuseContactUntilTurn = currentTurn + new Random().Next(5, pr.wasSneakAttacked ? 16 : 12);
 
 			// Whenever war is declared, re-evaluate priorities.
 			turnsUntilPriorityReevaluation = 0;
 			other.turnsUntilPriorityReevaluation = 0;
+		}
+
+		public bool WillAcceptCommunicationFrom(Player other, int currentTurn) {
+			EnsureRelationshipExists(other);
+
+			PlayerRelationship pr = playerRelationships[other.id];
+			if (!pr.atWar) {
+				return true;
+			}
+			return currentTurn >= pr.refuseContactUntilTurn;
 		}
 
 		public bool SitsOutFirstTurn() {

--- a/C7GameData/Save/SaveGame.cs
+++ b/C7GameData/Save/SaveGame.cs
@@ -50,6 +50,7 @@ namespace C7GameData.Save {
 		public static SaveGame FromGameData(GameData data) {
 			SaveGame save = new SaveGame{
 				Seed = data.seed,
+				TurnNumber = data.turn,
 				Civilizations = data.civilizations,
 				Map = new SaveMap(data.map),
 				TerrainTypes = data.terrainTypes,
@@ -109,6 +110,7 @@ namespace C7GameData.Save {
 			// copy data without references
 			return new GameData {
 				seed = Seed,
+				turn = TurnNumber,
 				terrainTypes = TerrainTypes,
 				Resources = Resources,
 				scenarioSearchPath = ScenarioSearchPath,
@@ -271,6 +273,7 @@ namespace C7GameData.Save {
 
 		public string Version = "0.0.0";
 		public int Seed = -1;
+		public int TurnNumber = 0;
 		public SaveMap Map = new SaveMap();
 		public List<TerrainType> TerrainTypes = new List<TerrainType>();
 		public List<Resource> Resources = new List<Resource>();

--- a/C7GameData/Save/SavePlayer.cs
+++ b/C7GameData/Save/SavePlayer.cs
@@ -4,6 +4,18 @@ namespace C7GameData.Save {
 	// A class holding all the state of the relationship between two civs.
 	public class PlayerRelationship {
 		public bool atWar = false;
+
+		// p1.playerRelationships[p2].warDeclarationCount is the number of times
+		// p2 declared war on p1.
+		public int warDeclarationCount = 0;
+
+		// true if a war declaration happened with units inside the player's
+		// borders.
+		public bool wasSneakAttacked = false;
+
+		// If at war, refuse contact with the relevant player until this turn
+		// has been reached.
+		public int refuseContactUntilTurn = -1;
 	}
 
 	public class SavePlayer {

--- a/C7GameDataTests/SaveTest.cs
+++ b/C7GameDataTests/SaveTest.cs
@@ -237,6 +237,7 @@ public class SaveTests {
 		foreach (FileInfo saveFileInfo in saveFiles) {
 			SaveGame game = null;
 			GameData gd = null;
+			Console.WriteLine(saveFileInfo.FullName);
 			Exception ex = Record.Exception(() => {
 				game = ImportCiv3.ImportSav(saveFileInfo.FullName, defaultBicPath, (relativeModePath) => {
 					return defaultPediaIconsPath;

--- a/QueryCiv3/SavSections/Lead.cs
+++ b/QueryCiv3/SavSections/Lead.cs
@@ -5,11 +5,19 @@ using System.Collections.Generic;
 namespace QueryCiv3.Sav {
 	[StructLayout(LayoutKind.Sequential, Pack = 1)]
 	public unsafe struct LEAD_LEAD {
-		private int UnknownBuffer;
+		// ReputationRelationship[i][j] is the number of times player j declared
+		// war on player i.
+		public int WarDeclarationCount;
+
 		public int CancelledDeal;
 		private long UnknownBuffer2;
 		public int CaughtSpy;
-		private int UnknownBuffer3;
+
+		// This is 1 for ReputationRelationship[i][j] if player j declared war
+		// on player i by attacking player i within player i's borders without
+		// declaring war first (i.e. a sneak attack).
+		public int WasSneakAttacked;
+
 		public int Tribute;
 		private long UnknownBuffer4;
 		public int Gift;
@@ -102,6 +110,15 @@ namespace QueryCiv3.Sav {
 
 		private fixed byte UnknownBuffer7[128];
 		public fixed int RefuseContactForTurns[32];
+
+		public List<int> GetRefuseContactForTurns() {
+			List<int> result = new();
+			for (int i = 0; i < 32; ++i) {
+				result.Add(RefuseContactForTurns[i]);
+			}
+			return result;
+		}
+
 		private fixed byte UnknownBuffer8[128];
 		private fixed int WarWearinessPoints[32];
 


### PR DESCRIPTION
... like who the aggressor was and whether a war was a sneak attack.

The previously unknown buffer fields were determined by crafting a couple of save games on the same file, loading them in `SaveTest` and dumping object contents until I saw the pattern.

Screenshot: 
![image](https://github.com/user-attachments/assets/4c99b1be-7f21-4716-bfe9-b3fd0e839891)
