### PR TITLE
Implement basic human->AI trading of techs and gold 

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -15,7 +15,6 @@ public partial class Game : Node2D {
 	[Signal] public delegate void ShowSpecificAdvisorEventHandler();
 	[Signal] public delegate void NewAutoselectedUnitEventHandler();
 	[Signal] public delegate void NoMoreAutoselectableUnitsEventHandler();
-	[Signal] public delegate void UpdateTechProgressEventHandler();
 	[Signal] public delegate void ShowCityScreenEventHandler();
 
 	private ILogger log = LogManager.ForContext<Game>();
@@ -408,13 +407,6 @@ public partial class Game : Node2D {
 			}
 
 			EmitSignal(SignalName.TurnStarted, turnNumber, player.gold, /*goldPerTurn=*/0);
-
-			Tech tech = gameDataAccess.gameData.techs.Find(x => x.id == player.currentlyResearchedTech);
-			if (tech != null) {
-				EmitSignal(SignalName.UpdateTechProgress, tech.Name, player.EstimateTurnsToResearch(tech));
-			} else {
-				EmitSignal(SignalName.UpdateTechProgress, "Not selected", int.MaxValue);
-			}
 			CurrentState = GameState.PlayerTurn;
 
 			GetNextAutoselectedUnit(gameDataAccess.gameData);
@@ -476,6 +468,12 @@ public partial class Game : Node2D {
 	}
 
 	public override void _UnhandledInput(InputEvent @event) {
+		// Don't handle mouse actions if UI elements are visible
+		if (popupOverlay.Visible || cityScreen.Visible || advisor.Visible || diplomacy.Visible) {
+			IsMovingCamera = false;
+			return;
+		}
+
 		// Control node must not be in the way and/or have mouse pass enabled
 		if (@event is InputEventMouseButton eventMouseButton) {
 			if (eventMouseButton.ButtonIndex == MouseButton.Left) {
@@ -576,6 +574,7 @@ public partial class Game : Node2D {
 						popupOverlay.ShowPopup(
 							new TextDialog("How many turns to fast forward through?",
 											"Turns: ", "100",
+											BoxContainer.AlignmentMode.Begin,
 											(string turns) => { turnsLeftToFastForward = int.Parse(turns); }),
 								PopupOverlay.PopupCategory.Advisor);
 					} else {

--- a/C7/UIElements/Diplomacy/DealScreen.cs
+++ b/C7/UIElements/Diplomacy/DealScreen.cs
@@ -1,0 +1,183 @@
+using C7Engine;
+using C7GameData;
+using Godot;
+using System;
+using System.Collections.Generic;
+using ConvertCiv3Media;
+
+// At a high level the deal screen has 4 parts; 2 "TradingTree"s per player, and
+// 2 "TradeOfferUi"s per player.
+//
+// The trading tree is the far left and right parts of the screen, where sections
+// can be collapsed (like technology, gold, etc). The trade offer ui is the part
+// in the middle, where we show what is actually being offered.
+//
+// The basic idea is to have all the possible items present in both components,
+// and then use the shared TradeOffer object to determine what is visible. So
+// when a technology is clicked in the trading tree, it is added to the 
+// TradeOffer object, and then we refresh the UIs of the trading tree and the
+// trade offer ui to swap the visibility.
+//
+// Things that aren't yet implemented:
+//  - Gifts
+//  - Demands
+//  - What do you need for ...
+//  - What will you give me for ...
+//  - Per-turn deals
+//  - Interesting messages from the opponent player
+public partial class DealScreen : TextureRect {
+	private ID humanPlayerId;
+	private ID opponentPlayerId;
+
+	Theme fontTheme = new();
+	FontFile font = new();
+
+	TradingTree opponentTree;
+	TradingTree humanTree;
+
+	TradeOfferUi opponentOfferUi;
+	TradeOfferUi humanOfferUi;
+
+	Button acceptDeal;
+	Label opponentResponse;
+
+	TradeOffer opponentOffer = new();
+	TradeOffer humanOffer = new();
+
+	public DealScreen(ID humanPlayer, ID opponentPlayer) {
+		this.humanPlayerId = humanPlayer;
+		this.opponentPlayerId = opponentPlayer;
+	}
+
+	public override void _Ready() {
+		this.CreateUI();
+	}
+
+	private void CreateUI() {
+		// Load the font we'll use.
+		//
+		// We skip the cache so that we can change the size without affecting other
+		// code using the same font.
+		font = ResourceLoader.Load<FontFile>("res://Fonts/NotoSans-Regular.ttf", null, ResourceLoader.CacheMode.Ignore);
+		font.FixedSize = 13;
+		fontTheme.DefaultFont = font;
+
+		Theme blueFontTheme = new();
+		blueFontTheme.DefaultFont = font;
+		blueFontTheme.SetColor("font_color", "Label", Colors.Blue);
+
+		this.Texture = Util.LoadTextureFromPCX("Art/Diplomacy/counter.pcx");
+
+		using UIGameDataAccess gameDataAccess = new();
+		GameData gD = gameDataAccess.gameData;
+		Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
+		Player humanPlayer = gD.players.Find(x => x.id == humanPlayerId);
+		GetParent<Diplomacy>().AddLeaderHeadAndLabel(this, opponentPlayer, fontTheme);
+
+		// Figure out which technologies can be traded by each player, if any.
+		List<Tech> techsOpponentCanTrade = gD.techs.FindAll(x => {
+			return opponentPlayer.knownTechs.Contains(x.id) && !humanPlayer.knownTechs.Contains(x.id);
+		});
+		List<Tech> techsHumanCanTrade = gD.techs.FindAll(x => {
+			return humanPlayer.knownTechs.Contains(x.id) && !opponentPlayer.knownTechs.Contains(x.id);
+		});
+
+		// Left hand side UI components.
+		opponentTree = new TradingTree(fontTheme, opponentPlayer.gold, techsOpponentCanTrade, opponentOffer);
+		AddChild(opponentTree);
+		opponentTree.Position = new Vector2(45, 220);
+
+		Label weWant = new();
+		weWant.Text = "We Want";
+		weWant.SetPosition(new Vector2(320, 440));
+		weWant.Theme = blueFontTheme;
+		AddChild(weWant);
+
+		opponentOfferUi = new(fontTheme, techsOpponentCanTrade, opponentPlayer.gold, opponentOffer, HorizontalAlignment.Left);
+		AddChild(opponentOfferUi);
+		opponentOfferUi.Position = new Vector2(314, 453);
+
+		// Right hand side UI components.
+		humanTree = new TradingTree(fontTheme, humanPlayer.gold, techsHumanCanTrade, humanOffer);
+		AddChild(humanTree);
+		humanTree.Position = new Vector2(789, 220);
+
+		Label weOffer = new();
+		weOffer.Text = "We Offer";
+		weOffer.SetPosition(new Vector2(660, 440));
+		weOffer.Theme = blueFontTheme;
+		AddChild(weOffer);
+
+		humanOfferUi = new(fontTheme, techsHumanCanTrade, humanPlayer.gold, humanOffer, HorizontalAlignment.Right);
+		AddChild(humanOfferUi);
+		humanOfferUi.Position = new Vector2(527, 453);
+
+		// Link up the tree components appropriately.
+		opponentTree.HandleClicks(humanTree, () => {
+			opponentOfferUi.RefreshUiForOffer();
+			UpdateText();
+		});
+		humanTree.HandleClicks(opponentTree, () => {
+			humanOfferUi.RefreshUiForOffer();
+			UpdateText();
+		});
+
+		humanOfferUi.HandleClicks(() => {
+			humanTree.RefreshUiForOffer();
+			UpdateText();
+		});
+		opponentOfferUi.HandleClicks(() => {
+			opponentTree.RefreshUiForOffer();
+			UpdateText();
+		});
+
+		// Add the buttons at the bottom.
+		acceptDeal = new();
+		acceptDeal.Text = "\"Will you accept this deal?\"";
+		acceptDeal.SetPosition(new Vector2(512 - 205, 650));
+		acceptDeal.Theme = fontTheme;
+		acceptDeal.Pressed += AttemptDeal;
+		AddChild(acceptDeal);
+
+		Button goodbye = new();
+		goodbye.Text = "\"Never mind...\"";
+		goodbye.SetPosition(new Vector2(512 - 205, 670));
+		goodbye.Theme = fontTheme;
+		goodbye.Pressed += () => { GetParent<Diplomacy>().Hide(); };
+		AddChild(goodbye);
+
+		// And the text from the opponent, if they reject a deal.
+		opponentResponse = new();
+		opponentResponse.Text = "\"Let's get down to business...\"";
+		opponentResponse.SetPosition(new Vector2(512 - 205, 345));
+		opponentResponse.Theme = fontTheme;
+		AddChild(opponentResponse);
+	}
+
+	private void AttemptDeal() {
+		using UIGameDataAccess gameDataAccess = new();
+		GameData gD = gameDataAccess.gameData;
+		Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
+		Player humanPlayer = gD.players.Find(x => x.id == humanPlayerId);
+
+		// If the deal is acceptable, execute it and go back to the previous
+		// screen.
+		if (opponentPlayer.WouldAcceptDealFrom(humanPlayer, humanOffer, opponentOffer)) {
+			opponentPlayer.ExecuteDeal(humanPlayer, humanOffer, opponentOffer);
+
+			GetParent<Diplomacy>().ShowTalkScreenForPlayer(humanPlayerId, opponentPlayerId);
+			return;
+		}
+	}
+
+	private void UpdateText() {
+		using UIGameDataAccess gameDataAccess = new();
+		GameData gD = gameDataAccess.gameData;
+		Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
+		Player humanPlayer = gD.players.Find(x => x.id == humanPlayerId);
+
+		int theirGoldValue = opponentOffer.GoldEquivalentFor(opponentPlayer);
+		int ourGoldValue = humanOffer.GoldEquivalentFor(opponentPlayer);
+		opponentResponse.Text = $"\"I value my offer at {theirGoldValue} gold and I value your offer at {ourGoldValue} gold\"";
+	}
+}

--- a/C7/UIElements/Diplomacy/Diplomacy.cs
+++ b/C7/UIElements/Diplomacy/Diplomacy.cs
@@ -3,6 +3,7 @@ using System;
 using C7GameData;
 using C7Engine;
 using Serilog;
+using ConvertCiv3Media;
 using System.Collections.Generic;
 
 
@@ -14,16 +15,33 @@ public partial class Diplomacy : CenterContainer {
 	public PopupOverlay popupOverlay;
 
 	private TalkScreen talkScreen;
+	private DealScreen dealScreen;
 
 	public override void _Ready() {
 		this.Hide();
 	}
 
-	public void ShowTalkScreenForPlayer(ID humanPlayer, ID opponentPlayer) {
+	private void RemoveOtherScreens() {
 		if (talkScreen != null) {
 			RemoveChild(talkScreen);
 			talkScreen = null;
 		}
+		if (dealScreen != null) {
+			RemoveChild(dealScreen);
+			dealScreen = null;
+		}
+	}
+
+	public void ShowDealScreenForPlayer(ID humanPlayer, ID opponentPlayer) {
+		RemoveOtherScreens();
+
+		dealScreen = new DealScreen(humanPlayer, opponentPlayer);
+		AddChild(dealScreen);
+		this.Show();
+	}
+
+	public void ShowTalkScreenForPlayer(ID humanPlayer, ID opponentPlayer) {
+		RemoveOtherScreens();
 
 		using (UIGameDataAccess gameDataAccess = new()) {
 			GameData gd = gameDataAccess.gameData;
@@ -41,5 +59,41 @@ public partial class Diplomacy : CenterContainer {
 		talkScreen = new TalkScreen(humanPlayer, opponentPlayer);
 		AddChild(talkScreen);
 		this.Show();
+	}
+
+	public void AddLeaderHeadAndLabel(TextureRect node, Player player, Theme fontTheme) {
+		ColorRect headBackground = new();
+		headBackground.Color = Colors.Black;
+		headBackground.Size = new Vector2(200, 240);
+		headBackground.SetPosition(new Vector2(512 - 100, 59));
+		node.AddChild(headBackground);
+
+		TextureRect leaderHead = new();
+		{
+			int xOffset = player.EraIndex() * 115;
+
+			// TODO: track mood in the player relationship data structure.
+			int yOffset = 115;  // 0 is annoyed, 115*2 is mad.
+
+			Pcx headPcx = Util.LoadPCX(player.civilization.leaderArtFile);
+			leaderHead.Texture = PCXToGodot.getImageTextureFromPCX(
+						headPcx,
+						new(xOffset, yOffset, 115, 115),
+						new(false, [255]));
+			leaderHead.Scale = new Vector2(1.7f, 1.7f);
+		}
+		leaderHead.SetPosition(new Vector2(512 - (115 * 1.7f) / 2, 59 + 120 - (115 * 1.7f) / 2));
+		node.AddChild(leaderHead);
+
+		string civNameText = $"{player.civilization.name} (Cautious)";
+		Label civName = new();
+		civName.SetPosition(new Vector2(0, 330));
+		node.AddChild(civName);
+		civName.Text = civNameText;
+		civName.HorizontalAlignment = HorizontalAlignment.Center;
+		civName.AnchorLeft = 0.5f;
+		civName.AnchorRight = 0.5f;
+		civName.OffsetLeft = -1 * (civName.Size.X / 2.0f);
+		civName.Theme = fontTheme;
 	}
 }

--- a/C7/UIElements/Diplomacy/TalkScreen.cs
+++ b/C7/UIElements/Diplomacy/TalkScreen.cs
@@ -32,52 +32,23 @@ public partial class TalkScreen : TextureRect {
 
 		this.Texture = Util.LoadTextureFromPCX("Art/Diplomacy/talk_offer.pcx");
 
-		ColorRect headBackground = new();
-		headBackground.Color = Colors.Black;
-		headBackground.Size = new Vector2(200, 240);
-		headBackground.SetPosition(new Vector2(512 - 100, 59));
-		AddChild(headBackground);
-
-		TextureRect leaderHead = new();
 		string civNameText;
 		string leaderName;
 		using (UIGameDataAccess gameDataAccess = new()) {
 			GameData gD = gameDataAccess.gameData;
 			Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
+			GetParent<Diplomacy>().AddLeaderHeadAndLabel(this, opponentPlayer, fontTheme);
 			civNameText = $"{opponentPlayer.civilization.name} (Cautious)";
 			leaderName = opponentPlayer.civilization.leader;
-
-			int xOffset = opponentPlayer.EraIndex() * 115;
-
-			// TODO: track mood in the player relationship data structure.
-			int yOffset = 115;  // 0 is annoyed, 115*2 is mad.
-
-			Pcx headPcx = Util.LoadPCX(opponentPlayer.civilization.leaderArtFile);
-			leaderHead.Texture = PCXToGodot.getImageTextureFromPCX(
-						headPcx,
-						new(xOffset, yOffset, 115, 115),
-						new(false, []));
-			leaderHead.Scale = new Vector2(1.7f, 1.7f);
 		}
-
-		leaderHead.SetPosition(new Vector2(512 - (115 * 1.7f) / 2, 59 + 120 - (115 * 1.7f) / 2));
-		AddChild(leaderHead);
-
-		Label civName = new();
-		civName.SetPosition(new Vector2(0, 330));
-		AddChild(civName);
-		civName.Text = civNameText;
-		civName.HorizontalAlignment = HorizontalAlignment.Center;
-		civName.AnchorLeft = 0.5f;
-		civName.AnchorRight = 0.5f;
-		civName.OffsetLeft = -1 * (civName.Size.X / 2.0f);
-		civName.Theme = fontTheme;
 
 		Button proposeDeal = new();
 		proposeDeal.Text = "We would like to propose a deal...";
 		proposeDeal.SetPosition(new Vector2(512 - 205, 500));
 		proposeDeal.Theme = fontTheme;
-		// TODO: Advance to the next screen.
+		proposeDeal.Pressed += () => {
+			GetParent<Diplomacy>().ShowDealScreenForPlayer(humanPlayerId, opponentPlayerId);
+		};
 		AddChild(proposeDeal);
 
 		Button declareWar = new();

--- a/C7/UIElements/Diplomacy/TradeOfferUi.cs
+++ b/C7/UIElements/Diplomacy/TradeOfferUi.cs
@@ -1,0 +1,103 @@
+using C7Engine;
+using C7GameData;
+using Godot;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using ConvertCiv3Media;
+
+public partial class TradeOfferUi : Tree {
+	TreeItem lumpSumGold;
+	List<TreeItem> techs = new();
+	TradeOffer currentOffer;
+	List<Tech> tradeableTechs;
+	int playerGold;
+
+	public TradeOfferUi(Theme fontTheme, List<Tech> tradeableTechs, int playerGold,
+						TradeOffer currentOffer, HorizontalAlignment alignment) {
+		this.currentOffer = currentOffer;
+		this.tradeableTechs = tradeableTechs;
+		this.playerGold = playerGold;
+		this.Columns = 1;
+		this.AllowRmbSelect = true;
+		TreeItem root = TradingTree.ConfigureTreeTheme(this, fontTheme);
+
+		// Match the size of the texture used in the deal screen.
+		this.Size = new Vector2(190, 100);
+
+        // Add tree items for all the possible things that could be traded - we
+        // determine whether they're visible based on the current offer in
+        // RefreshUiForOffer.
+		lumpSumGold = this.CreateItem(root);
+		lumpSumGold.SetTextAlignment(0, alignment);
+
+		foreach (Tech tech in tradeableTechs) {
+			TreeItem child = this.CreateItem(root);
+			child.SetTextAlignment(0, alignment);
+			child.SetText(0, tech.Name);
+			techs.Add(child);
+		}
+
+		RefreshUiForOffer();
+	}
+
+	public void HandleClicks(Action offerUpdated) {
+		this.ItemMouseSelected += (Vector2 mousePos, long mouseButtonIndex) => {
+			TreeItem ti = this.GetSelected();
+			ti.Deselect(0);
+
+			// Handle techs being clicked on.
+			if (techs.Contains(ti)) {
+				Tech t = tradeableTechs.Find(x => x.Name == ti.GetText(0));
+				currentOffer.techs.Remove(t);
+			}
+			if (ti == lumpSumGold && mouseButtonIndex != 2) {
+				currentOffer.gold = null;
+			}
+
+			// Allow right clicking the gold amount to change it.
+			if (ti == lumpSumGold && mouseButtonIndex == 2) {
+				var handleTextInput = (string input) => {
+					int gold = 0;
+					bool parsed = int.TryParse(input, out gold);
+					if (!parsed) {
+						return;
+					}
+					if (gold > playerGold || gold <= 0) {
+						GetParent<DealScreen>().GetParent<Diplomacy>().popupOverlay
+							.ShowPopup(new InformationalPopup("Insufficient gold"),
+									   PopupOverlay.PopupCategory.Advisor);
+						return;
+					}
+
+					currentOffer.gold = gold;
+					offerUpdated();
+					RefreshUiForOffer();
+				};
+
+				GetParent<DealScreen>().GetParent<Diplomacy>().popupOverlay
+					.ShowPopup(new TextDialog("Enter amount...",
+											"Gold: ", "" + currentOffer.gold.Value,
+											BoxContainer.AlignmentMode.Center,
+											handleTextInput),
+								PopupOverlay.PopupCategory.Advisor);
+			}
+
+			offerUpdated();
+			RefreshUiForOffer();
+		};
+	}
+
+	public void RefreshUiForOffer() {
+		if (currentOffer.gold.HasValue) {
+			lumpSumGold.SetText(0, $"{currentOffer.gold.Value} gold");
+			lumpSumGold.Visible = true;
+		} else {
+			lumpSumGold.Visible = false;
+		}
+
+		foreach (TreeItem ti in techs) {
+			ti.Visible = currentOffer.techs.Any(x => x.Name == ti.GetText(0));
+		}
+	}
+}

--- a/C7/UIElements/Diplomacy/TradingTree.cs
+++ b/C7/UIElements/Diplomacy/TradingTree.cs
@@ -1,0 +1,148 @@
+using C7Engine;
+using System.Linq;
+using C7GameData;
+using Godot;
+using System;
+using System.Collections.Generic;
+using ConvertCiv3Media;
+
+public partial class TradingTree : Tree {
+	TreeItem goldHeader;
+	TreeItem techHeader;
+	TreeItem lumpSum;
+	List<TreeItem> techItems = new();
+
+	List<Tech> tradeableTechs;
+	TradeOffer currentOffer;
+	int playerGold;
+
+	public TradingTree(Theme fontTheme,
+						int playerGold,
+						List<Tech> tradeableTechs,
+						TradeOffer currentOffer) {
+		this.tradeableTechs = tradeableTechs;
+		this.currentOffer = currentOffer;
+		this.playerGold = playerGold;
+		this.Columns = 1;
+		TreeItem root = ConfigureTreeTheme(this, fontTheme);
+
+		// Match the size of the texture used in the deal screen.
+		this.Size = new Vector2(190, 400);
+
+		// Gold
+		{
+			goldHeader = this.CreateItem(root);
+			goldHeader.SetText(0, $"Gold ({playerGold} in treasury)");
+			goldHeader.Collapsed = true;
+
+			// TODO: per-turn gold
+
+			lumpSum = this.CreateItem(goldHeader);
+			lumpSum.SetText(0, "Lump sum");
+		}
+
+		if (tradeableTechs.Count > 0) {
+			techHeader = this.CreateItem(root);
+			techHeader.SetText(0, "Technology");
+			techHeader.Collapsed = true;
+
+			foreach (Tech tech in tradeableTechs) {
+				TreeItem child = this.CreateItem(techHeader);
+				child.SetText(0, tech.Name);
+				techItems.Add(child);
+			}
+		}
+	}
+
+	public void HandleClicks(TradingTree other, Action offerUpdated) {
+		this.ItemSelected += () => {
+			TreeItem ti = this.GetSelected();
+
+			// Implement header collapsing.
+			ti.Collapsed = !ti.Collapsed;
+			ti.Deselect(0);
+
+			// Ensure that we are synced with the folding of the other tree.
+			if (ti == goldHeader && other.goldHeader != null) {
+				other.goldHeader.Collapsed = goldHeader.Collapsed;
+			}
+			if (ti == techHeader && other.techHeader != null) {
+				other.techHeader.Collapsed = techHeader.Collapsed;
+			}
+
+			// Handle techs being clicked on.
+			if (ti.GetParent() == techHeader) {
+				Tech t = tradeableTechs.Find(x => x.Name == ti.GetText(0));
+				currentOffer.techs.Add(t);
+			}
+
+            // Allow user input for gold amounts.
+			if (ti == lumpSum) {
+				var handleTextInput = (string input) => {
+					int gold = 0;
+					bool parsed = int.TryParse(input, out gold);
+					if (!parsed) {
+						return;
+					}
+					if (gold > playerGold || gold <= 0) {
+						GetParent<DealScreen>().GetParent<Diplomacy>().popupOverlay
+							.ShowPopup(new InformationalPopup("Insufficient gold"),
+									   PopupOverlay.PopupCategory.Advisor);
+						return;
+					}
+
+					currentOffer.gold = gold;
+					offerUpdated();
+					RefreshUiForOffer();
+				};
+
+				GetParent<DealScreen>().GetParent<Diplomacy>().popupOverlay
+					.ShowPopup(new TextDialog("Enter amount...",
+											"Gold: ", "0",
+											BoxContainer.AlignmentMode.Center,
+											handleTextInput),
+								PopupOverlay.PopupCategory.Advisor);
+			}
+
+			offerUpdated();
+			RefreshUiForOffer();
+		};
+	}
+
+	public void RefreshUiForOffer() {
+		lumpSum.Visible = !currentOffer.gold.HasValue;
+
+		foreach (TreeItem ti in techItems) {
+			ti.Visible = !currentOffer.techs.Any(x => x.Name == ti.GetText(0));
+		}
+	}
+
+    // The central styling for the trading tree and trade offer ui trees.
+	public static TreeItem ConfigureTreeTheme(Tree tree, Theme fontTheme) {
+		// All trees have one root, but we don't want a single root, so hide it.
+		TreeItem root = tree.CreateItem();
+		tree.HideRoot = true;
+		tree.HideFolding = true;
+
+		// Configure the tree to look like we expect it to in civ - a transparent
+		// background with no lines between items.
+		Color transparent = new Color(0, 0, 0, 0);
+		tree.Theme = fontTheme;
+		StyleBoxFlat styleBox = (StyleBoxFlat)tree.GetThemeStylebox("bg", "Tree");
+		styleBox.BgColor = transparent;
+		styleBox.BorderWidthLeft = 0;
+		styleBox.BorderWidthRight = 0;
+		styleBox.BorderWidthTop = 0;
+		styleBox.BorderWidthBottom = 0;
+		tree.AddThemeStyleboxOverride("panel", styleBox);
+		tree.AddThemeStyleboxOverride("focus", styleBox);
+		tree.AddThemeColorOverride("font_color", Colors.Black);
+		tree.AddThemeColorOverride("children_hl_line_color", transparent);
+		tree.AddThemeColorOverride("parent_hl_line_color", transparent);
+		tree.AddThemeColorOverride("relationship_line_color", transparent);
+		tree.AddThemeColorOverride("guide_color", transparent);
+		tree.AddThemeConstantOverride("v_separation", 1);
+
+		return root;
+	}
+}

--- a/C7/UIElements/Popups/TextDialog.cs
+++ b/C7/UIElements/Popups/TextDialog.cs
@@ -6,14 +6,20 @@ public partial class TextDialog : Popup {
 	private string header;
 	private string prompt;
 	private string defaultText;
+	private BoxContainer.AlignmentMode alignment;
 	Action<string> handleText;
 
 
-	public TextDialog(string header, string prompt, string defaultText, Action<string> handleText) {
+	public TextDialog(string header,
+					  string prompt,
+					  string defaultText,
+					  BoxContainer.AlignmentMode alignment,
+					  Action<string> handleText) {
 		this.defaultText = defaultText;
 		this.prompt = prompt;
 		this.header = header;
 		this.handleText = handleText;
+		this.alignment = alignment;
 
 		textEditBox.Theme = ThemeFactory.DefaultTheme;
 		textEditBox.CaretBlink = true;
@@ -29,7 +35,7 @@ public partial class TextDialog : Popup {
 		AddHeader(header, 120);
 
 		HBoxContainer labelAndTextBox = new HBoxContainer();
-		labelAndTextBox.Alignment = BoxContainer.AlignmentMode.Begin;
+		labelAndTextBox.Alignment = alignment;
 		labelAndTextBox.SizeFlagsHorizontal = SizeFlags.ExpandFill;
 		labelAndTextBox.SizeFlagsStretchRatio = 1;
 		labelAndTextBox.AnchorLeft = 0.0f;

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -303,10 +303,10 @@ namespace C7Engine {
 			// tiles. Also civ3 only counts border-based discovery from rank 1
 			// tiles, not rank 2+.
 			foreach (Tile t in tile.neighbors.Values) {
-				if (t.unitsOnTile.Count > 0) {
+				if (t.unitsOnTile.Count > 0 && unit.owner != t.unitsOnTile[0].owner) {
 					unit.owner.EnsureRelationshipExists(t.unitsOnTile[0].owner);
 				}
-				if (t.owningCity != null) {
+				if (t.owningCity != null && unit.owner != t.owningCity.owner) {
 					unit.owner.EnsureRelationshipExists(t.owningCity.owner);
 				}
 			}

--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -3,9 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using C7Engine.AI.StrategicAI;
 using C7GameData.Save;
+using Serilog;
 
 namespace C7GameData {
 	public class Player {
+		private static ILogger log = Log.ForContext<Player>();
+
 		public ID id { get; internal set; }
 		public int colorIndex;
 		public bool isBarbarians = false;
@@ -211,21 +214,37 @@ namespace C7GameData {
 			return result;
 		}
 
+		public bool WouldAcceptDealFrom(Player other, TradeOffer theirOffer, TradeOffer ourOffer) {
+			// TODO: consider any factors like trade reputations here
+			int theirGoldValue = theirOffer.GoldEquivalentFor(this);
+			int ourGoldValue = ourOffer.GoldEquivalentFor(this);
+			return theirGoldValue >= ourGoldValue;
+		}
+
+		public void ExecuteDeal(Player other, TradeOffer theirOffer, TradeOffer ourOffer) {
+			if (ourOffer.gold.HasValue) {
+				other.gold += ourOffer.gold.Value;
+				this.gold -= ourOffer.gold.Value;
+				log.Information($"Moved {ourOffer.gold.Value} gold from {this} to {other}");
+			}
+			if (theirOffer.gold.HasValue) {
+				this.gold += theirOffer.gold.Value;
+				other.gold -= theirOffer.gold.Value;
+				log.Information($"Moved {theirOffer.gold.Value} gold from {other} to {this}");
+			}
+
+			foreach (Tech t in ourOffer.techs) {
+				other.knownTechs.Add(t.id);
+				log.Information($"{this} taught {t.Name} to {other}");
+			}
+
+			foreach (Tech t in theirOffer.techs) {
+				this.knownTechs.Add(t.id);
+				log.Information($"{other} taught {t.Name} to {this}");
+			}
+		}
+
 		public int EstimateTurnsToResearch(Tech tech) {
-			// Cost formula from https://forums.civfanatics.com/threads/research-cost-formula-v1-29f.29485/.
-			// Research Cost = [MM * [10*COST * (1 - N/[CL*1.75])]/(CF * 10)] - progress
-			//
-			// MM = map modifier (tiny=160, small=200, standard=240, large=320, huge=400)
-			// COST = tech cost
-			// CF = difficulty factor, range 10 (easy) to 6 (hard)
-			// N = number of known civs that have discovered the tech
-			// CL = civs left in game
-			//
-			// We also have the min/max turns to research of 4 and 50.
-			// TODO: the min/max costs are in the biq, we should load them.
-			// TODO: implement the civ-related parts of the equation
-			// TODO: figure out what map size we are
-			// TODO: See this this whole equation can be configurable
 			int beakersPerTurn = 0;
 			foreach (City city in cities) {
 				beakersPerTurn += city.CurrentCommerceYield().beakers;
@@ -236,10 +255,7 @@ namespace C7GameData {
 				return int.MaxValue;
 			}
 
-			int mapModifier = 160;  // small, to make testing faster
-			int difficultyFactor = 10; // easy difficulty
-			int researchCost = mapModifier * 10 * tech.Cost / (difficultyFactor * 10);
-			int remainingCost = researchCost - beakers;
+			int remainingCost = tech.TechCostFor(this) - beakers;
 			int turnsRemaining = (int)Math.Ceiling((double)remainingCost / beakersPerTurn);
 
 			// We never spend more than 50 turns per tech.

--- a/C7GameData/Tech.cs
+++ b/C7GameData/Tech.cs
@@ -23,6 +23,28 @@ namespace C7GameData {
 
 		public List<Tech> Prerequisites = new();
 
+		public int TechCostFor(Player player) {
+			// Cost formula from https://forums.civfanatics.com/threads/research-cost-formula-v1-29f.29485/.
+			// Research Cost = [MM * [10*COST * (1 - N/[CL*1.75])]/(CF * 10)] - progress
+			//
+			// MM = map modifier (tiny=160, small=200, standard=240, large=320, huge=400)
+			// COST = tech cost
+			// CF = difficulty factor, range 10 (easy) to 6 (hard)
+			// N = number of known civs that have discovered the tech
+			// CL = civs left in game
+			//
+			// We also have the min/max turns to research of 4 and 50.
+			// TODO: the min/max costs are in the biq, we should load them.
+			// TODO: implement the civ-related parts of the equation
+			// TODO: figure out what map size we are
+			// TODO: See this this whole equation can be configurable
+			int mapModifier = 160;  // small, to make testing faster
+			int difficultyFactor = 10; // easy difficulty
+			int researchCost = mapModifier * 10 * Cost / (difficultyFactor * 10);
+
+			return researchCost;
+		}
+
 		public C7GameData.Save.SaveTech ToSaveTech() {
 			C7GameData.Save.SaveTech result = new() {
 				id = this.id,

--- a/C7GameData/TradeOffer.cs
+++ b/C7GameData/TradeOffer.cs
@@ -1,0 +1,25 @@
+
+using System.Collections.Generic;
+
+namespace C7GameData {
+	// A class representing one side of a diplomatic agreement between two civs.
+	public class TradeOffer {
+		public int? gold = null;
+		public List<Tech> techs = new();
+
+		// Calculate how much this trade offer is worth for a given player. This
+		// has to be per-player because tech costs vary based on how many civs
+		// a player have already researched the tech.
+		public int GoldEquivalentFor(Player p) {
+			int result = 0;
+			if (gold.HasValue) {
+				result += gold.Value;
+			}
+			foreach (Tech t in techs) {
+				result += t.TechCostFor(p);
+			}
+
+			return result;
+		}
+	}
+}


### PR DESCRIPTION
This adds for a fairly important game mechanic, and allows the player to tech much faster than if they just researched techs themselves.

Having the basic structure in place to do these trades will also set the stage for peace treaties.

I didn't try and implement all the clever dialog that civ3 does, and instead just had the opponent say how much they thought each offer was worth. That should be good enough for a while, and makes it easier to debug things if we need to.

#571

Screenshots:

Starting tech situation:  
![image](https://github.com/user-attachments/assets/69c0cdf6-07ab-4a14-9f34-af3ee6a1d650)

We start the deal, but notice that the Aztecs really value alphabet:

![image](https://github.com/user-attachments/assets/890e17e3-1983-488a-999e-754a4a074630)

So we ask for more gold and get it:

![image](https://github.com/user-attachments/assets/b111dcb3-9489-4ed6-b8e2-0895ac372f8b)

and now we know pottery:

![image](https://github.com/user-attachments/assets/99112945-ce08-40ac-89f9-c084a129b37f)
