### PR TITLE
Optimize city drawing

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -213,6 +213,7 @@ public partial class Game : Node2D {
 					}
 					break;
 				case MsgStartTurn mST:
+					mapView.cityLayer.RedrawCities();
 					OnPlayerStartTurn();
 					break;
 				case MsgCityCreated mCC:
@@ -253,6 +254,9 @@ public partial class Game : Node2D {
 					// F1 is the science advisor.
 					// TODO: Move the F* key strings to a set of constants/enum.
 					EmitSignal(SignalName.ShowSpecificAdvisor, "F1");
+					break;
+				case MsgUpdateCityProductionUI mCPC:
+					mapView.cityLayer.RedrawCity(mCPC.city);
 					break;
 			}
 		}

--- a/C7/Map/CityLayer.cs
+++ b/C7/Map/CityLayer.cs
@@ -12,8 +12,18 @@ namespace C7.Map {
 
 		public void UpdateAfterCityDestruction(City city) {
 			citySceneLookup.Remove(city, out CityScene cityScene);
-			if (cityScene != null) {
-				cityScene.Hide();
+			cityScene?.Hide();
+		}
+
+		public void RedrawCities() {
+			foreach (CityScene scene in citySceneLookup.Values) {
+				scene.QueueRedraw();
+			}
+		}
+
+		public void RedrawCity(City city) {
+			if (citySceneLookup.TryGetValue(city, out CityScene cityScene)) {
+				cityScene.QueueRedraw();
 			}
 		}
 
@@ -27,9 +37,6 @@ namespace C7.Map {
 				CityScene cityScene = new CityScene(city, tile, new Vector2I((int)tileCenter.X, (int)tileCenter.Y));
 				looseView.AddChild(cityScene);
 				citySceneLookup[city] = cityScene;
-			} else {
-				CityScene scene = citySceneLookup[city];
-				scene._Draw();
 			}
 		}
 	}

--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -120,6 +120,8 @@ public partial class CityScreen : CenterContainer {
 							RenderFoodDetails(tileAssignmentLayer.city);
 							RenderCommerceDetails(tileAssignmentLayer.city);
 							RenderProductionDetails(tileAssignmentLayer.city);
+
+							new MsgUpdateCityProductionUI(tileAssignmentLayer.city).send();
 						}
 					}
 				}

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -256,7 +256,7 @@ public partial class RightClickCityMenu : RightClickMenu {
 }
 
 public partial class RightClickChooseProductionMenu : RightClickMenu {
-	private ID cityID;
+	private City city;
 
 	private ImageTexture GetProducibleIcon(IProducible producible) {
 		if (producible is UnitPrototype proto) {
@@ -269,7 +269,7 @@ public partial class RightClickChooseProductionMenu : RightClickMenu {
 	}
 
 	public RightClickChooseProductionMenu(Game game, City city) : base(game) {
-		cityID = city.id;
+		this.city = city;
 		foreach (IProducible option in city.ListProductionOptions()) {
 			int buildTime = city.TurnsToProduce(option);
 			AddItem($"{option.name} ({buildTime} turns)", () => ChooseProduction(option.name), GetProducibleIcon(option));
@@ -277,7 +277,8 @@ public partial class RightClickChooseProductionMenu : RightClickMenu {
 	}
 
 	public void ChooseProduction(string producibleName) {
-		new MsgChooseProduction(cityID, producibleName).send();
+		new MsgChooseProduction(city.id, producibleName).send();
+		new MsgUpdateCityProductionUI(city).send();
 		CloseAndDelete();
 	}
 }

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -59,4 +59,8 @@ namespace C7Engine {
 			this.city = city;
 		}
 	}
+
+	public class MsgUpdateCityProductionUI(City city) : MessageToUI {
+		public City city = city;
+	}
 }


### PR DESCRIPTION
This commit removes unnecessary redrawing of city scenes on each frame. Instead, it redraws them only when production or citizen assignment changes, or at the beginning of the turn.

This change improves the frame rate when scrolling the map with a large number of cities.