### PR TITLE
Rewrite CityLabelScene with Godot UI nodes

### DIFF
--- a/C7/Map/CityLabelScene.cs
+++ b/C7/Map/CityLabelScene.cs
@@ -1,42 +1,49 @@
-using System;
 using C7GameData;
 using ConvertCiv3Media;
 using Godot;
-using Serilog;
-using Serilog.Events;
 
 namespace C7.Map {
 	public partial class CityLabelScene : Node2D {
-		private ILogger log = LogManager.ForContext<CityLabelScene>();
+		City city;
+		Vector2I tileCenter;
+		Color civColor;
 
-		private City city;
-		private Tile tile;
-		private Vector2I tileCenter;
-
-		private ImageTexture cityTexture;
-
+		const byte TRANSPARENCY = 192; // 25%
 		const int CITY_LABEL_HEIGHT = 23;
 		const int LEFT_RIGHT_BOXES_WIDTH = 24;
 		const int LEFT_RIGHT_BOXES_HEIGHT = CITY_LABEL_HEIGHT - 2;
-		const int TEXT_ROW_HEIGHT = 9;
+		const int CENTRAL_PANEL_SEPARATOR_WIDTH = 4;
 
-		ImageTexture cityLabel = new ImageTexture();
+		static Pcx cityIcons = Util.LoadPCX("Art/Cities/city icons.pcx");
+		static Image nonEmbassyStar;
+		static Theme smallFontTheme = new();
+		static Theme popThemeRed = new();
+		static Theme popSizeTheme = new();
 
-		private TextureRect labelTextureRect = new TextureRect();
-		Label cityNameLabel = new Label();
-		Label productionLabel = new Label();
-		Label popSizeLabel = new Label();
+		PanelContainer labelPanel = new();
+		HBoxContainer mainContainer = new();
+		PanelContainer popSizePanel = new();
+		VBoxContainer centerContainer = new();
+		PanelContainer capitalPanel = new();
+		HSeparator centerDivider = new();
 
-		private static FontFile smallFont = new FontFile();
-		private static FontFile midSizedFont = new FontFile();
+		HSeparator borderTop = new();
+		HSeparator borderBottom = new();
 
-		private static Pcx cityIcons = Util.LoadPCX("Art/Cities/city icons.pcx");
-		private static Image nonEmbassyStar;
-		private static Theme smallFontTheme = new Theme();
-		private static Theme popThemeRed = new Theme();
-		private static Theme popSizeTheme = new Theme();
+		VSeparator leftSeparator = new();
+		VSeparator rightSeparator = new();
 
-		private int lastLabelWidth = 0;
+		Label cityNameLabel = new();
+		Label productionLabel = new();
+		Label popSizeLabel = new();
+
+		static FontFile smallFont = new();
+		static FontFile midSizedFont = new();
+
+		Color topRowGrey = Color.Color8(32, 32, 32, TRANSPARENCY);
+		Color bottomRowGrey = Color.Color8(48, 48, 48, TRANSPARENCY);
+		Color backgroundGrey = Color.Color8(64, 64, 64, TRANSPARENCY);
+		Color borderGrey = Color.Color8(80, 80, 80, TRANSPARENCY);
 
 		static CityLabelScene() {
 			smallFontTheme.DefaultFont = smallFont;
@@ -60,144 +67,161 @@ namespace C7.Map {
 			nonEmbassyStar = PCXToGodot.getImageFromPCX(cityIcons, new(20, 1, 18, 18));
 		}
 
-		public CityLabelScene(City city, Tile tile, Vector2I tileCenter) {
+		public CityLabelScene(City city, Vector2I tileCenter) {
 			this.city = city;
-			this.tile = tile;
 			this.tileCenter = tileCenter;
 
+			civColor = new Color(Util.LoadColor(city.owner.colorIndex), TRANSPARENCY);
 
-			labelTextureRect.MouseFilter = Control.MouseFilterEnum.Ignore;
-			cityNameLabel.MouseFilter = Control.MouseFilterEnum.Ignore;
-			productionLabel.MouseFilter = Control.MouseFilterEnum.Ignore;
-			popSizeLabel.MouseFilter = Control.MouseFilterEnum.Ignore;
+			// Set up UI hierarchy
+			AddChild(labelPanel);
+			labelPanel.AddChild(mainContainer);
 
-			AddChild(labelTextureRect);
-			AddChild(cityNameLabel);
-			AddChild(productionLabel);
-			AddChild(popSizeLabel);
+			// Left side (population)
+			mainContainer.AddChild(popSizePanel);
+			popSizePanel.AddChild(popSizeLabel);
+
+			// Center (city name, production and population growth)
+			mainContainer.AddChild(leftSeparator);
+			mainContainer.AddChild(centerContainer);
+			mainContainer.AddChild(rightSeparator);
+			SetupCenterPanel();
+
+			mainContainer.AddThemeConstantOverride("separation", 0);
+			centerContainer.AddThemeConstantOverride("separation", 0);
+
+			borderTop.AddThemeConstantOverride("separation", 1);
+			borderBottom.AddThemeConstantOverride("separation", 1);
+			centerDivider.AddThemeConstantOverride("separation", 1);
+
+			popSizeLabel.HorizontalAlignment = HorizontalAlignment.Center;
+			popSizeLabel.VerticalAlignment = VerticalAlignment.Center;
+			popSizePanel.CustomMinimumSize = new Vector2(LEFT_RIGHT_BOXES_WIDTH, LEFT_RIGHT_BOXES_HEIGHT);
+
+			labelPanel.MouseFilter = Control.MouseFilterEnum.Ignore;
+
+			cityNameLabel.Theme = smallFontTheme;
+			productionLabel.Theme = smallFontTheme;
+			popSizeLabel.Theme = popSizeTheme;
+
+			ApplyStyles();
+		}
+
+		private void SetupCenterPanel() {
+			centerContainer.AddChild(borderTop);
+			centerContainer.AddChild(cityNameLabel);
+			centerContainer.AddChild(centerDivider);
+			centerContainer.AddChild(productionLabel);
+			centerContainer.AddChild(borderBottom);
+
+			centerContainer.CustomMinimumSize = new Vector2(60, -1);
+
+			cityNameLabel.HorizontalAlignment = HorizontalAlignment.Center;
+			cityNameLabel.VerticalAlignment = VerticalAlignment.Center;
+
+			productionLabel.HorizontalAlignment = HorizontalAlignment.Center;
+			productionLabel.VerticalAlignment = VerticalAlignment.Center;
+		}
+
+		private void SetupCapitalPanel() {
+			capitalPanel = new PanelContainer();
+
+			StyleBoxFlat capitalStyle = new() {
+				BgColor = civColor
+			};
+
+			capitalPanel.AddThemeStyleboxOverride("panel", capitalStyle);
+			capitalPanel.CustomMinimumSize = new Vector2(LEFT_RIGHT_BOXES_WIDTH, LEFT_RIGHT_BOXES_HEIGHT);
+
+			TextureRect starTextureRect = new() {
+				Texture = ImageTexture.CreateFromImage(nonEmbassyStar),
+				StretchMode = TextureRect.StretchModeEnum.KeepCentered
+			};
+
+			capitalPanel.AddChild(starTextureRect);
+		}
+
+		private void ApplyStyles() {
+			// style for the main panel
+			StyleBoxFlat labelStyle = new() {
+				BgColor = backgroundGrey,
+				BorderColor = borderGrey,
+				BorderWidthBottom = 1,
+				BorderWidthLeft = 1,
+				BorderWidthRight = 1,
+				BorderWidthTop = 1
+			};
+
+			StyleBoxFlat popStyle = new() {
+				BgColor = civColor
+			};
+
+			StyleBoxLine centerSeparatorStyle = new() {
+				Color = civColor,
+				GrowBegin = CENTRAL_PANEL_SEPARATOR_WIDTH,
+				GrowEnd = CENTRAL_PANEL_SEPARATOR_WIDTH,
+			};
+
+			StyleBoxLine bottomBorderStyle = new() {
+				Color = bottomRowGrey,
+				GrowBegin = CENTRAL_PANEL_SEPARATOR_WIDTH,
+				GrowEnd = CENTRAL_PANEL_SEPARATOR_WIDTH,
+			};
+
+			StyleBoxLine topBorderStyle = new() {
+				Color = topRowGrey,
+				GrowBegin = CENTRAL_PANEL_SEPARATOR_WIDTH,
+				GrowEnd = CENTRAL_PANEL_SEPARATOR_WIDTH,
+			};
+
+			StyleBoxLine separatorStyle = new() {
+				Color = new Color(0, 0, 0, 0), // transparent,
+				Thickness = CENTRAL_PANEL_SEPARATOR_WIDTH,
+				Vertical = true
+			};
+
+			labelPanel.AddThemeStyleboxOverride("panel", labelStyle);
+			popSizePanel.AddThemeStyleboxOverride("panel", popStyle);
+			centerDivider.AddThemeStyleboxOverride("separator", centerSeparatorStyle);
+			borderTop.AddThemeStyleboxOverride("separator", topBorderStyle);
+			borderBottom.AddThemeStyleboxOverride("separator", bottomBorderStyle);
+			leftSeparator.AddThemeStyleboxOverride("separator", separatorStyle);
+			rightSeparator.AddThemeStyleboxOverride("separator", separatorStyle);
 		}
 
 		public override void _Draw() {
-			base._Draw();
+			UpdateContent();
+		}
 
+		private void UpdateContent() {
 			int turnsUntilGrowth = city.TurnsUntilGrowth();
 			string turnsUntilGrowthText = turnsUntilGrowth == int.MaxValue || turnsUntilGrowth < 0 ? "- -" : "" + turnsUntilGrowth;
-			string cityNameAndGrowth = $"{city.name} : {turnsUntilGrowthText}";
-			string productionDescription = city.itemBeingProduced.name + " : " + city.TurnsUntilProductionFinished();
 
-			int cityNameAndGrowthWidth = (int)smallFont.GetStringSize(cityNameAndGrowth).X;
-			int productionDescriptionWidth = (int)smallFont.GetStringSize(productionDescription).X;
-			int maxTextWidth = Math.Max(cityNameAndGrowthWidth, productionDescriptionWidth);
+			cityNameLabel.Text = $"{city.name} : {turnsUntilGrowthText}";
+			productionLabel.Text = $"{city.itemBeingProduced.name} : {city.TurnsUntilProductionFinished()}";
+			popSizeLabel.Text = city.size.ToString();
 
-			int cityLabelWidth = maxTextWidth + (city.IsCapital()? 70 : 45);    //TODO: Is 65 right?  70?  Will depend on whether it's capital, too
-			int textAreaWidth = cityLabelWidth - (city.IsCapital() ? 50 : 25);
-			if (log.IsEnabled(LogEventLevel.Verbose)) {
-				log.Verbose("Width of city name = " + maxTextWidth);
-				log.Verbose("City label width: " + cityLabelWidth);
-				log.Verbose("Text area width: " + textAreaWidth);
-			}
-
-			if (cityLabelWidth != lastLabelWidth) {
-				Image labelBackground = CreateLabelBackground(cityLabelWidth, city, textAreaWidth);
-				cityLabel = ImageTexture.CreateFromImage(labelBackground);
-				lastLabelWidth = cityLabelWidth;
-			}
-
-			DrawLabelOnScreen(tileCenter, cityLabelWidth, city, cityLabel);
-			DrawTextOnLabel(tileCenter, cityNameAndGrowthWidth, productionDescriptionWidth, city, cityNameAndGrowth, productionDescription, cityLabelWidth);
-		}
-
-		private void DrawLabelOnScreen(Vector2I tileCenter, int cityLabelWidth, City city, ImageTexture cityLabel) {
-			labelTextureRect.OffsetLeft = tileCenter.X + (cityLabelWidth / -2);
-			labelTextureRect.OffsetTop = tileCenter.Y + 24;
-			labelTextureRect.Texture = cityLabel;
-		}
-
-		private void DrawTextOnLabel(Vector2I tileCenter, int cityNameAndGrowthWidth, int productionDescriptionWidth, City city, string cityNameAndGrowth, string productionDescription, int cityLabelWidth) {
-
-			//Destination for font is based on lower-left of baseline of font, not upper left as for blitted rectangles
-			int cityNameOffset = cityNameAndGrowthWidth / -2;
-			int prodDescriptionOffset = productionDescriptionWidth / -2;
-			if (!city.IsCapital()) {
-				cityNameOffset += 12;
-				prodDescriptionOffset += 12;
-			}
-
-			cityNameLabel.Theme = smallFontTheme;
-			cityNameLabel.Text = cityNameAndGrowth;
-			cityNameLabel.OffsetLeft = tileCenter.X + cityNameOffset;
-			cityNameLabel.OffsetTop = tileCenter.Y + 22;
-
-			productionLabel.Theme = smallFontTheme;
-			productionLabel.Text = productionDescription;
-			productionLabel.OffsetLeft = tileCenter.X + prodDescriptionOffset;
-			productionLabel.OffsetTop = tileCenter.Y + 32;
-
-			//City pop size
-			string popSizeString = "" + city.size;
-			int popSizeWidth = (int)midSizedFont.GetStringSize(popSizeString).X;
-			int popSizeOffset = LEFT_RIGHT_BOXES_WIDTH / 2 - popSizeWidth / 2;
-
-			popSizeLabel.Theme = popSizeTheme;
-
+			// Update population label color based on growth
 			if (city.TurnsUntilGrowth() < 0) {
 				popSizeLabel.Theme = popThemeRed;
+			} else {
+				popSizeLabel.Theme = popSizeTheme;
 			}
 
-			popSizeLabel.Text = popSizeString;
-			popSizeLabel.OffsetLeft = tileCenter.X + cityLabelWidth / -2 + popSizeOffset;
-			popSizeLabel.OffsetTop = tileCenter.Y + 22;
-		}
+			// Update the panel with the capital star
+			bool hasCapitalIndicator = capitalPanel.GetParent() == mainContainer;
 
-		private Image CreateLabelBackground(int cityLabelWidth, City city, int textAreaWidth) {
-			//Label/name/producing area
-			Image labelImage = Image.Create(cityLabelWidth, CITY_LABEL_HEIGHT, false, Image.Format.Rgba8);
-			labelImage.Fill(Color.Color8(0, 0, 0, 0));
-			byte transparencyLevel = 192; //25%
-			Color civColor = Util.LoadColor(city.owner.colorIndex);
-			civColor = new Color(civColor, transparencyLevel);
-			Color civColorDarker = Color.Color8(0, 0, 138, transparencyLevel); //todo: automate the darker() function.  maybe less transparency?
-			Color topRowGrey = Color.Color8(32, 32, 32, transparencyLevel);
-			Color bottomRowGrey = Color.Color8(48, 48, 48, transparencyLevel);
-			Color backgroundGrey = Color.Color8(64, 64, 64, transparencyLevel);
-			Color borderGrey = Color.Color8(80, 80, 80, transparencyLevel);
-
-			Image horizontalBorder = Image.Create(cityLabelWidth - 2, 1, false, Image.Format.Rgba8);
-			horizontalBorder.Fill(borderGrey);
-			labelImage.BlitRect(horizontalBorder, new Rect2I(0, 0, new Vector2I(cityLabelWidth - 2, 1)), new Vector2I(1, 0));
-			labelImage.BlitRect(horizontalBorder, new Rect2I(0, 0, new Vector2I(cityLabelWidth - 2, 1)), new Vector2I(1, 22));
-
-			Image verticalBorder = Image.Create(1, CITY_LABEL_HEIGHT - 2, false, Image.Format.Rgba8);
-			verticalBorder.Fill(borderGrey);
-			labelImage.BlitRect(verticalBorder, new Rect2I(0, 0, new Vector2I(1, 23)), new Vector2I(0, 1));
-			labelImage.BlitRect(verticalBorder, new Rect2I(0, 0, new Vector2I(1, 23)), new Vector2I(cityLabelWidth - 1, 1));
-
-			Image bottomRow = Image.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
-			bottomRow.Fill(bottomRowGrey);
-			labelImage.BlitRect(bottomRow, new Rect2I(0, 0, new Vector2I(textAreaWidth, 1)), new Vector2I(25, 21));
-
-			Image topRow = Image.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
-			topRow.Fill(topRowGrey);
-			labelImage.BlitRect(topRow, new Rect2I(0, 0, new Vector2I(textAreaWidth, 1)), new Vector2I(25, 1));
-
-			Image background = Image.Create(textAreaWidth, TEXT_ROW_HEIGHT, false, Image.Format.Rgba8);
-			background.Fill(backgroundGrey);
-			labelImage.BlitRect(background, new Rect2I(0, 0, new Vector2I(textAreaWidth, 9)), new Vector2I(25, 2));
-			labelImage.BlitRect(background, new Rect2I(0, 0, new Vector2I(textAreaWidth, 9)), new Vector2I(25, 12));
-
-			Image centerDivider = Image.Create(textAreaWidth, 1, false, Image.Format.Rgba8);
-			centerDivider.Fill(civColor);
-			labelImage.BlitRect(centerDivider, new Rect2I(0, 0, new Vector2I(textAreaWidth, 1)), new Vector2I(25, 11));
-
-			Image leftAndRightBoxes = Image.Create(LEFT_RIGHT_BOXES_WIDTH, LEFT_RIGHT_BOXES_HEIGHT, false, Image.Format.Rgba8);
-			leftAndRightBoxes.Fill(civColor);
-			labelImage.BlitRect(leftAndRightBoxes, new Rect2I(0, 0, new Vector2I(24, 21)), new Vector2I(1, 1));
-			if (city.IsCapital()) {
-				labelImage.BlitRect(leftAndRightBoxes, new Rect2I(0, 0, new Vector2I(24, 21)), new Vector2I(cityLabelWidth - 25, 1));
-				labelImage.BlendRect(nonEmbassyStar, new Rect2I(0, 0, new Vector2I(18, 18)), new Vector2I(cityLabelWidth - 24, 2));
+			if (city.IsCapital() && !hasCapitalIndicator) {
+				SetupCapitalPanel();
+				mainContainer.AddChild(capitalPanel);
+			} else if (!city.IsCapital() && hasCapitalIndicator) {
+				mainContainer.RemoveChild(capitalPanel);
 			}
-			//todo: darker shades of civ color around edges
-			return labelImage;
+
+			labelPanel.Position = new Vector2(tileCenter.X - labelPanel.Size.X / 2, tileCenter.Y + 24);
+
+			// Force the layout to recalculate
+			labelPanel.Size = Vector2.Zero;
 		}
 	}
 }

--- a/C7/Map/CityLayer.cs
+++ b/C7/Map/CityLayer.cs
@@ -24,7 +24,7 @@ namespace C7.Map {
 
 			City city = tile.cityAtTile;
 			if (!citySceneLookup.ContainsKey(city)) {
-				CityScene cityScene = new CityScene(city, tile, new Vector2I((int)tileCenter.X, (int)tileCenter.Y));
+				CityScene cityScene = new CityScene(city, new Vector2I((int)tileCenter.X, (int)tileCenter.Y));
 				looseView.AddChild(cityScene);
 				citySceneLookup[city] = cityScene;
 			} else {

--- a/C7/Map/CityScene.cs
+++ b/C7/Map/CityScene.cs
@@ -13,8 +13,8 @@ namespace C7.Map {
 		private TextureRect cityGraphics = new TextureRect();
 		private CityLabelScene cityLabelScene;
 
-		public CityScene(City city, Tile tile, Vector2I tileCenter) {
-			cityLabelScene = new CityLabelScene(city, tile, tileCenter);
+		public CityScene(City city, Vector2I tileCenter) {
+			cityLabelScene = new CityLabelScene(city, tileCenter);
 
 			//TODO: Generalize, support multiple city types, etc.
 			Pcx pcx = Util.LoadPCX("Art/Cities/rMIDEAST.PCX");


### PR DESCRIPTION
This PR ports the custom drawing logic in the CityLabelScene class to Godot UI nodes. The new approach improves city rendering performance and makes code easier to maintain. It also solves some minor visual issues with text centering.

Before: 
![image_2025-03-24_23-36-40](https://github.com/user-attachments/assets/a6ba0039-c775-49f4-bbe4-38f773206fef)

After:
![image](https://github.com/user-attachments/assets/8622d8e7-ab71-4581-a576-07cd2470ec06)
