### PR TITLE
Ensure that barbarians don't take their turn first

### DIFF
--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -15,10 +15,6 @@ namespace C7Engine {
 
 			foreach (MapUnit mapUnit in gameData.mapUnits)
 				mapUnit.OnBeginTurn();
-
-			foreach (Player player in gameData.players) {
-				player.hasPlayedThisTurn = false;
-			}
 		}
 
 		// Implements the game loop. This method is called when the game is started and when the player signals that they're done moving.
@@ -64,7 +60,16 @@ namespace C7Engine {
 						}
 					}
 				}
+
+				// Now that the turn is ending, do all the bookkeeping for the
+				// start of the next turn. We don't put the "hasPlayedThisTurn"
+				// logic in OnBeginTurn because OnBeginTurn is called when a
+				// save game is loaded, and that would erase the saved information
+				// about which players have played.
 				OnBeginTurn();
+				foreach (Player player in gameData.players) {
+					player.hasPlayedThisTurn = false;
+				}
 			}
 		}
 
@@ -76,29 +81,35 @@ namespace C7Engine {
 		/// <returns>true when it is time for the human to take control again</returns>
 		private static bool PlayPlayerTurns(GameData gameData, bool firstTurn) {
 			foreach (Player player in gameData.players) {
-				if ((!player.hasPlayedThisTurn) &&
-					!(firstTurn && player.SitsOutFirstTurn())) {
-					if (player.isBarbarians) {
-						//Call the barbarian AI
-						//TODO: The AIs should be stored somewhere on the game state as some of them will store state (plans,
-						//strategy, etc.) For now, we only have a random AI, so that will be in a future commit
-						new BarbarianAI().PlayTurn(player, gameData);
-						player.hasPlayedThisTurn = true;
-					} else if (!player.isHuman) {
-						PlayerAI.PlayTurn(player, GameData.rng, gameData.techs);
-						player.hasPlayedThisTurn = true;
-					} else if (player.id != EngineStorage.uiControllerID) {
-						player.hasPlayedThisTurn = true;
-					}
-					//Human player check.  Let the human see what's going on even if they are in observer mode.
-					if (player.id == EngineStorage.uiControllerID) {
-						new MsgStartTurn().send();
-						return true;
-					}
+				if (player.hasPlayedThisTurn) {
+					continue;
+				}
+
+				if (firstTurn && player.SitsOutFirstTurn()) {
+					continue;
+				}
+
+				if (player.isBarbarians) {
+					//Call the barbarian AI
+					//TODO: The AIs should be stored somewhere on the game state as some of them will store state (plans,
+					//strategy, etc.) For now, we only have a random AI, so that will be in a future commit
+					new BarbarianAI().PlayTurn(player, gameData);
+					player.hasPlayedThisTurn = true;
+				} else if (!player.isHuman) {
+					PlayerAI.PlayTurn(player, GameData.rng, gameData.techs);
+					player.hasPlayedThisTurn = true;
+				} else if (player.id != EngineStorage.uiControllerID) {
+					player.hasPlayedThisTurn = true;
+				}
+				//Human player check.  Let the human see what's going on even if they are in observer mode.
+				if (player.id == EngineStorage.uiControllerID) {
+					new MsgStartTurn().send();
+					return true;
 				}
 			}
 			return false;
 		}
+
 		private static void SpawnBarbarians(GameData gameData) {
 			//Generate new barbarian units.
 			Player barbPlayer = gameData.players.Find(player => player.isBarbarians);

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -133,7 +133,7 @@ namespace C7Engine {
 			double attackerStrength = attacker.unitType.attack  * StrengthBonus.ListToMultiplier(attackBonuses),
 			   defenderStrength = defender.unitType.defense * StrengthBonus.ListToMultiplier(defenseBonuses);
 
-			log.Information($"Combat log: {attacker.unitType.name} ({attackerStrength}) attacking {defender.unitType.name} ({defenderStrength})");
+			log.Information($"Combat log: {attacker} ({attackerStrength}) attacking {defender} ({defenderStrength})");
 			log.Information($"\tAttacker: {attacker.unitType.name}, base strength {attacker.unitType.BaseStrength(CombatRole.Attack)}");
 			foreach (StrengthBonus bonus in attackBonuses)
 				log.Information($"\t\t+{100.0 * bonus.amount}%\t{bonus.description}");

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -478,7 +478,10 @@ namespace C7GameData {
 				barbarian = isBarbarian,
 				human = isHuman,
 				civilization = civ.name,
-				hasPlayedCurrentTurn = false, // TODO: find how this information is stored in a .sav
+
+				// Never let barbarians play before a real player.
+				hasPlayedCurrentTurn = isBarbarian,
+
 				cityNameIndex = cityNameIndex,
 				eraCivilopediaName = era,
 			};

--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -106,12 +106,14 @@ namespace C7GameData {
 		}
 
 		public bool IsAtPeaceWith(Player other) {
-			if (other.isBarbarians || this.isBarbarians) {
-				return false;
-			}
-
+			// Evaluate this before checking for barbarians so barbarians don't
+			// attack themselves.
 			if (other == this) {
 				return true;
+			}
+
+			if (other.isBarbarians || this.isBarbarians) {
+				return false;
 			}
 
 			if (playerRelationships.ContainsKey(other.id)) {

--- a/QueryCiv3/SavSections/Lead.cs
+++ b/QueryCiv3/SavSections/Lead.cs
@@ -97,11 +97,11 @@ namespace QueryCiv3.Sav {
 		public fixed short UnitsPerStratInProd[32]; // ???
 		public int NumberOfArmies;
 		public int NumberOfUnits;
-		private fixed byte UnknownBuffer5[4];
+		public int NumberOfMilitaryUnits; // Courtesy of https://github.com/maxpetul/C3X/blob/master/Civ3Conquests.h
 		public int NumberOfCities;
 		public int NumberOfColonies;
 		public int NumberOfContinents;
-		private fixed byte UnknownBuffer6[4];
+		private int UnknownBuffer6;
 		public int LuxuryRate;
 		public int ScienceRate;
 		public int TaxRate;
@@ -109,6 +109,7 @@ namespace QueryCiv3.Sav {
 		// Length gap: there are 32 LEAD_LEAD structs here in Sav files
 
 		private fixed byte UnknownBuffer7[128];
+
 		public fixed int RefuseContactForTurns[32];
 
 		public List<int> GetRefuseContactForTurns() {


### PR DESCRIPTION
... even when loading a save that isn't at turn 0.

Other related improvements:
 - Reduced the [line of sight](https://medium.com/@matryer/line-of-sight-in-code-186dd7cdea88) in `TurnHandling.cs` to simplify an overly complex if statement.
 - Fixed a bug in `IsAtPeaceWith` that caused barbarians to attack themselves
 - Improved combat logging to make it easier to see barbarians were what was causing the game to get stuck
 - Documented a field in `LEAD` (I've found that C3X occasionally has BIQ/SAV fields identified that we don't, and vice versa).