### PR TITLE
Load initial civilization goverments from the scenario files

### DIFF
--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -146,7 +146,7 @@ namespace C7Engine {
 				}
 			}
 		}
-	
+
 		private static void HandleCityResults(GameData gameData, Player player) {
 			log.Information($"\n*** City production for turn {gameData.turn}, player {player} ***");
 

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -394,6 +394,8 @@ namespace C7GameData {
 				player.taxRate = 5;
 				player.luxuryRate = 0;
 
+				player.governmentId = save.Governments[lead.Government].id;
+
 				// Add the starting techs for scenarios.
 				if (theBiq.LeadTech != null) {
 					for (int j = 0; j < theBiq.LeadTech[leadIndex].Length; ++j) {

--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -367,6 +367,8 @@ namespace C7GameData {
 		private void ImportBicLeaders() {
 			BiqData theBiq = biq.Race is null ? defaultBiq : biq;
 
+			Government defaultGovernment = save.Governments.Find(g => g.defaultType) ?? save.Governments[0];
+
 			// Make a player for each civ. The barbarians are always civ 0.
 			for (int i = 0; i < save.Civilizations.Count; ++i) {
 				save.Players.Add(MakeSavePlayerFromCiv(save.Civilizations[i],
@@ -374,6 +376,12 @@ namespace C7GameData {
 									   /*isHuman=*/false,
 									   /*cityNameIndex=*/0,
 									   /*era=*/""));
+
+				// Set a government for players not associated with LEAD.
+				// Usually, this applies only to barbarians, but in some scenarios
+				// it may also include civilizations that exist in the game files
+				// but are not actually part of the gameplay.
+				save.Players.Last().governmentId = defaultGovernment.id;
 			}
 
 			// Now fill in the rest of the data using the leader struct.

--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -220,7 +220,7 @@ namespace C7GameData {
 			foreach (City city in cities) {
 				result += city.CurrentCommerceYield().taxes;
 			}
-			
+
 			// Subtract unit support costs, if any.
 			var (_, _, unitSupportCost) = TotalUnitsAllowedUnitsAndSupportCost();
 			result -= unitSupportCost;


### PR DESCRIPTION
Recent changes to the government system broke local scenario-related tests because players weren't assigned governments when loading a scenario file. This PR fixes that.