### PR TITLE
Open city screen on double-click

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=16 format=3 uid="uid://cldl5nk4n61m2"]
+[gd_scene load_steps=18 format=3 uid="uid://cldl5nk4n61m2"]
 
 [ext_resource type="Script" path="res://Game.cs" id="1"]
+[ext_resource type="Script" path="res://DoubleClickHandler.cs" id="2_t735q"]
 [ext_resource type="Script" path="res://UIElements/Advisors/Advisors.cs" id="3"]
 [ext_resource type="Script" path="res://UIElements/UpperLeftNav/MenuButton.cs" id="4"]
 [ext_resource type="Script" path="res://UIElements/UpperLeftNav/CivilopediaButton.cs" id="5"]
@@ -61,7 +62,7 @@ _data = {
 "SlideOutAnimation": SubResource("1")
 }
 
-[node name="C7Game" type="Node2D" node_paths=PackedStringArray("Toolbar", "popupOverlay", "cityScreen", "advisor", "diplomacy", "slider", "animationPlayer")]
+[node name="C7Game" type="Node2D" node_paths=PackedStringArray("Toolbar", "popupOverlay", "cityScreen", "advisor", "diplomacy", "slider", "animationPlayer", "doubleClickHandler")]
 script = ExtResource("1")
 Toolbar = NodePath("CanvasLayer/Control/ToolBar/MarginContainer/HBoxContainer")
 popupOverlay = NodePath("CanvasLayer/PopupOverlay")
@@ -70,6 +71,10 @@ advisor = NodePath("CanvasLayer/Advisor")
 diplomacy = NodePath("CanvasLayer/Diplomacy")
 slider = NodePath("CanvasLayer/Control/SlideOutBar/VBoxContainer/Zoom")
 animationPlayer = NodePath("CanvasLayer/Control/SlideOutBar/AnimationPlayer")
+doubleClickHandler = NodePath("DoubleClickHandler")
+
+[node name="DoubleClickHandler" type="Node" parent="."]
+script = ExtResource("2_t735q")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 
@@ -255,10 +260,6 @@ grow_vertical = 2
 theme = ExtResource("10")
 script = ExtResource("13")
 
-[node name="LoadDialog" parent="." instance=ExtResource("12_yjlfl")]
-unique_name_in_owner = true
-visible = false
-
 [node name="Diplomacy" type="CenterContainer" parent="CanvasLayer" node_paths=PackedStringArray("popupOverlay")]
 anchors_preset = 15
 anchor_right = 1.0
@@ -282,19 +283,19 @@ control = NodePath("../Control")
 
 [node name="PopupSound" type="AudioStreamPlayer" parent="CanvasLayer/PopupOverlay"]
 
-[connection signal="NewAutoselectedUnit" from="." to="CanvasLayer/Control/GameStatus" method="OnNewUnitSelected"]
+[node name="LoadDialog" parent="." instance=ExtResource("12_yjlfl")]
+unique_name_in_owner = true
+visible = false
+
 [connection signal="NewAutoselectedUnit" from="." to="CanvasLayer/Control/UnitButtons" method="OnNewUnitSelected"]
-[connection signal="NoMoreAutoselectableUnits" from="." to="CanvasLayer/Control/GameStatus" method="OnNoMoreAutoselectableUnits"]
+[connection signal="NewAutoselectedUnit" from="." to="CanvasLayer/Control/GameStatus" method="OnNewUnitSelected"]
 [connection signal="NoMoreAutoselectableUnits" from="." to="CanvasLayer/Control/UnitButtons" method="OnNoMoreAutoselectableUnits"]
+[connection signal="NoMoreAutoselectableUnits" from="." to="CanvasLayer/Control/GameStatus" method="OnNoMoreAutoselectableUnits"]
 [connection signal="ShowCityScreen" from="." to="CanvasLayer/CityScreen" method="OnShowCityScreen"]
 [connection signal="ShowSpecificAdvisor" from="." to="CanvasLayer/Advisor" method="OnShowSpecificAdvisor"]
 [connection signal="TurnEnded" from="." to="CanvasLayer/Control/GameStatus" method="OnTurnEnded"]
-[connection signal="BuildCity" from="CanvasLayer/PopupOverlay" to="." method="OnBuildCity"]
-[connection signal="HidePopup" from="CanvasLayer/PopupOverlay" to="CanvasLayer/PopupOverlay" method="OnHidePopup"]
-[connection signal="Quit" from="CanvasLayer/PopupOverlay" to="." method="OnQuitTheGame"]
-[connection signal="Retire" from="CanvasLayer/PopupOverlay" to="." method="_on_QuitButton_pressed"]
-[connection signal="UnitDisbanded" from="CanvasLayer/PopupOverlay" to="." method="OnUnitDisbanded"]
-[connection signal="DiplomacySelection" from="CanvasLayer/PopupOverlay" to="." method="OnDiplomacySelected"]
+[connection signal="DoubleClick" from="DoubleClickHandler" to="." method="OnDoubleLeftMouseButtonClick"]
+[connection signal="SingleClick" from="DoubleClickHandler" to="." method="OnSingleLeftMouseButtonClick"]
 [connection signal="ActionRequested" from="CanvasLayer/Control/UnitButtons" to="." method="ProcessAction"]
 [connection signal="BlinkyEndTurnButtonPressed" from="CanvasLayer/Control/GameStatus" to="." method="OnPlayerEndTurn"]
 [connection signal="pressed" from="CanvasLayer/Control/ToolBar/MarginContainer/HBoxContainer/AdvisorButton" to="CanvasLayer/Advisor" method="ShowLatestAdvisor"]
@@ -306,3 +307,9 @@ control = NodePath("../Control")
 [connection signal="pressed" from="CanvasLayer/Control/SlideOutBar/VBoxContainer/UpButton" to="." method="_on_UpButton_pressed"]
 [connection signal="value_changed" from="CanvasLayer/Control/SlideOutBar/VBoxContainer/Zoom" to="." method="_on_Zoom_value_changed"]
 [connection signal="pressed" from="CanvasLayer/Control/SlideOutBar/VBoxContainer/QuitButton" to="." method="_on_QuitButton_pressed"]
+[connection signal="BuildCity" from="CanvasLayer/PopupOverlay" to="." method="OnBuildCity"]
+[connection signal="DiplomacySelection" from="CanvasLayer/PopupOverlay" to="." method="OnDiplomacySelected"]
+[connection signal="HidePopup" from="CanvasLayer/PopupOverlay" to="CanvasLayer/PopupOverlay" method="OnHidePopup"]
+[connection signal="Quit" from="CanvasLayer/PopupOverlay" to="." method="OnQuitTheGame"]
+[connection signal="Retire" from="CanvasLayer/PopupOverlay" to="." method="_on_QuitButton_pressed"]
+[connection signal="UnitDisbanded" from="CanvasLayer/PopupOverlay" to="." method="OnUnitDisbanded"]

--- a/C7/DoubleClickHandler.cs
+++ b/C7/DoubleClickHandler.cs
@@ -1,5 +1,19 @@
 using Godot;
 
+/// <summary>
+/// A class for detecting double-clicks.
+///
+/// To differentiate between single and double clicks, this class uses
+/// a timer-based detection mechanism. When a click occurs, it waits
+/// for a short period (DOUBLE_CLICK_DELAY) to check if another click
+/// follows. If a second click happens, it emits a double-click
+/// signal; otherwise, it emits a single-click signal.
+///
+/// Although Godot provides built-in double-click detection, it does
+/// not allow handling single clicks separately. For example, with
+/// Godot’s built-in detection, clicking on a city that contains a
+/// unit would both zoom to the city and select the unit.
+/// </summary>
 [GlobalClass]
 public partial class DoubleClickHandler : Node {
 	int leftMouseButtonClickCount = 0;

--- a/C7/DoubleClickHandler.cs
+++ b/C7/DoubleClickHandler.cs
@@ -1,0 +1,38 @@
+using Godot;
+
+[GlobalClass]
+public partial class DoubleClickHandler : Node {
+	int leftMouseButtonClickCount = 0;
+	InputEventMouseButton lastEventMouseButton;
+	const double DOUBLE_CLICK_DELAY = 0.2;
+
+	Timer timer = new();
+
+	[Signal] public delegate void SingleClickEventHandler(InputEventMouseButton eventMouseButton);
+	[Signal] public delegate void DoubleClickEventHandler(InputEventMouseButton eventMouseButton);
+
+	public override void _Ready() {
+		AddChild(timer);
+		timer.OneShot = true;
+		timer.Timeout += OnTimeout;
+	}
+
+	public void Accept(InputEventMouseButton eventMouseButton) {
+		lastEventMouseButton = eventMouseButton;
+		++leftMouseButtonClickCount;
+
+		timer.Stop();
+
+		if (leftMouseButtonClickCount >= 2) {
+			EmitSignal(SignalName.DoubleClick, lastEventMouseButton);
+			leftMouseButtonClickCount = 0;
+		} else {
+			timer.Start(DOUBLE_CLICK_DELAY);
+		}
+	}
+
+	private void OnTimeout() {
+		EmitSignal(SignalName.SingleClick, lastEventMouseButton);
+		leftMouseButtonClickCount = 0;
+	}
+}

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -292,18 +292,6 @@ public partial class Game : Node2D {
 						 CurrentlySelectedUnit.isAutomated))
 						GetNextAutoselectedUnit(gameData);
 				}
-				//Listen to keys.  There is a C# Mono Godot bug where e.g. Godot.Key.F1 (etc.) doesn't work
-				//without a manual cast to int.
-				//https://github.com/godotengine/godot/issues/16388
-				if (Input.IsKeyPressed(Godot.Key.F1)) {
-					EmitSignal(SignalName.ShowSpecificAdvisor, "F1");
-				}
-				if (Input.IsKeyPressed(Godot.Key.F3)) {
-					EmitSignal(SignalName.ShowSpecificAdvisor, "F3");
-				}
-				if (Input.IsKeyPressed(Godot.Key.F6)) {
-					EmitSignal(SignalName.ShowSpecificAdvisor, "F6");
-				}
 			}
 		}
 	}
@@ -479,135 +467,202 @@ public partial class Game : Node2D {
 
 		// Control node must not be in the way and/or have mouse pass enabled
 		if (@event is InputEventMouseButton eventMouseButton) {
-			if (eventMouseButton.ButtonIndex == MouseButton.Left) {
-				GetViewport().SetInputAsHandled();
-				if (eventMouseButton.IsPressed()) {
-					if (gotoInfo != null) {
-						HandleGotoClick(gotoInfo);
-						setGotoMode(false);
-					} else {
-						// Select unit on tile at mouse location
-						using (var gameDataAccess = new UIGameDataAccess()) {
-							var tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
-							if (tile != null) {
-								// TODO: This should really be the top unit.
-								MapUnit to_select = tile.unitsOnTile.FirstOrDefault();
-								if (to_select != null && to_select.owner == controller) {
-									bool canMove = setSelectedUnit(to_select);
-									if (!canMove) {
-										TemporaryPopup popup = new("This unit has already moved.", 1);
-										popup.SetPosition(eventMouseButton.Position + new Vector2(0, -64));
-										AddChild(popup);
-										popup.ShowPopup();
-									}
-								}
-							}
-						}
-
-						OldPosition = eventMouseButton.Position;
-						IsMovingCamera = true;
-					}
-				} else {
-					IsMovingCamera = false;
-				}
-			} else if (eventMouseButton.ButtonIndex == MouseButton.WheelUp) {
-				GetViewport().SetInputAsHandled();
-				AdjustZoomSlider(1, GetViewport().GetMousePosition());
-			} else if (eventMouseButton.ButtonIndex == MouseButton.WheelDown) {
-				GetViewport().SetInputAsHandled();
-				AdjustZoomSlider(-1, GetViewport().GetMousePosition());
-			} else if ((eventMouseButton.ButtonIndex == MouseButton.Right) && (!eventMouseButton.IsPressed())) {
-				setGotoMode(false);
-				using (var gameDataAccess = new UIGameDataAccess()) {
-					var tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
-					if (tile != null) {
-						bool shiftDown = Input.IsKeyPressed(Godot.Key.Shift);
-
-						// Handle the shortcut of shift+right clicking a city to get the change production menu.
-						if (shiftDown && tile.cityAtTile?.owner == controller)
-							new RightClickChooseProductionMenu(this, tile.cityAtTile).Open(eventMouseButton.Position);
-						else if ((!shiftDown) && tile.unitsOnTile.Count > 0)
-							// There are units on this title, so open that menu.
-							new RightClickTileMenu(this, tile).Open(eventMouseButton.Position);
-						else if ((!shiftDown) && tile.cityAtTile?.owner == controller)
-							// There are no units, but this is the player's city.
-							new RightClickCityMenu(this, tile).Open(eventMouseButton.Position);
-
-						string yield = tile.YieldString(controller);
-						log.Debug($"({tile.XCoordinate}, {tile.YCoordinate}): {tile.overlayTerrainType.DisplayName} {yield}");
-
-						if (tile.cityAtTile != null) {
-							City city = tile.cityAtTile;
-							log.Debug($"  {city.name}, production {city.shieldsStored} of {city.itemBeingProduced.shieldCost}");
-							foreach (CityResident resident in city.residents) {
-								log.Debug($"  Resident working at {resident.tileWorked}");
-							}
-						}
-
-						if (tile.unitsOnTile.Count > 0) {
-							foreach (MapUnit unit in tile.unitsOnTile) {
-								log.Debug("  Unit on tile: " + unit);
-								if (unit.currentAI != null) {
-									log.Debug("  Strategy: " + unit.currentAI.SummarizePlan());
-								}
-							}
-						}
-					} else {
-						log.Debug("Didn't click on any tile");
-					}
-				}
-			}
+			HandleMouseButtonInput(eventMouseButton);
 		} else if (@event is InputEventMouseMotion eventMouseMotion) {
-			if (IsMovingCamera) {
-				GetViewport().SetInputAsHandled();
-				mapView.cameraLocation += OldPosition - eventMouseMotion.Position;
-				OldPosition = eventMouseMotion.Position;
-			} else if (gotoInfo != null) {
-				gotoInfo = GetGotoInfo(eventMouseMotion.Position);
-			}
+			HandleMouseMotionInput(eventMouseMotion);
 		} else if (@event is InputEventKey eventKeyDown && eventKeyDown.Pressed) {
-			if (eventKeyDown.Keycode == Godot.Key.O && eventKeyDown.ShiftPressed && eventKeyDown.IsCommandOrControlPressed() && eventKeyDown.AltPressed) {
-				using (UIGameDataAccess gameDataAccess = new UIGameDataAccess()) {
-					gameDataAccess.gameData.observerMode = !gameDataAccess.gameData.observerMode;
-					if (gameDataAccess.gameData.observerMode) {
-						foreach (Player player in gameDataAccess.gameData.players) {
-							player.isHuman = false;
-						}
-						SetAnimationsEnabled(false);
-						popupOverlay.ShowPopup(
-							new TextDialog("How many turns to fast forward through?",
-											"Turns: ", "100",
-											BoxContainer.AlignmentMode.Begin,
-											(string turns) => { turnsLeftToFastForward = int.Parse(turns); }),
-								PopupOverlay.PopupCategory.Advisor);
-					} else {
-						foreach (Player player in gameDataAccess.gameData.players) {
-							if (player.id == EngineStorage.uiControllerID) {
-								player.isHuman = true;
-							}
-						}
-					}
-				}
-			}
-			if (eventKeyDown.Keycode == Godot.Key.G && eventKeyDown.ShiftPressed && eventKeyDown.IsCommandOrControlPressed() && eventKeyDown.AltPressed) {
-				using (UIGameDataAccess gameDataAccess = new UIGameDataAccess()) {
-					gameDataAccess.gameData.showGridCoordinates = !gameDataAccess.gameData.showGridCoordinates;
-				}
-			}
+			HandleKeyboardInput(eventKeyDown);
 		} else if (@event is InputEventMagnifyGesture magnifyGesture) {
-			// UI slider has the min/max zoom settings for now
-			double newScale = mapView.cameraZoom * magnifyGesture.Factor;
-			if (newScale < slider.MinValue)
-				newScale = slider.MinValue;
-			else if (newScale > slider.MaxValue)
-				newScale = slider.MaxValue;
-			mapView.setCameraZoom((float)newScale, magnifyGesture.Position);
-			// Update the UI slider
-			slider.Value = newScale;
+			HandleMagnifyGesture(magnifyGesture);
 		}
 	}
 
-	// Handle Godot keybind actions
+	private void HandleMouseButtonInput(InputEventMouseButton eventMouseButton) {
+		if (eventMouseButton.ButtonIndex == MouseButton.Left) {
+			HandleLeftMouseButton(eventMouseButton);
+		} else if (eventMouseButton.ButtonIndex == MouseButton.Right && !eventMouseButton.IsPressed()) {
+			HandleRightMouseButton(eventMouseButton);
+		} else if (eventMouseButton.ButtonIndex == MouseButton.WheelUp) {
+			GetViewport().SetInputAsHandled();
+			AdjustZoomSlider(1, GetViewport().GetMousePosition());
+		} else if (eventMouseButton.ButtonIndex == MouseButton.WheelDown) {
+			GetViewport().SetInputAsHandled();
+			AdjustZoomSlider(-1, GetViewport().GetMousePosition());
+		}
+	}
+
+	private void HandleLeftMouseButton(InputEventMouseButton eventMouseButton) {
+		GetViewport().SetInputAsHandled();
+		if (eventMouseButton.IsPressed()) {
+			if (gotoInfo != null) {
+				HandleGotoClick(gotoInfo);
+				setGotoMode(false);
+			} else {
+				// Select unit on tile at mouse location
+				HandleUnitSelection(eventMouseButton);
+				OldPosition = eventMouseButton.Position;
+				IsMovingCamera = true;
+			}
+		} else {
+			IsMovingCamera = false;
+		}
+	}
+
+	private void HandleUnitSelection(InputEventMouseButton eventMouseButton) {
+		using var gameDataAccess = new UIGameDataAccess();
+
+		var tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
+		if (tile == null) {
+			return;
+		}
+
+		// TODO: This should really be the top unit.
+		MapUnit to_select = tile.unitsOnTile.FirstOrDefault();
+		if (to_select == null || to_select.owner != controller) {
+			return;
+		}
+
+		bool canMove = setSelectedUnit(to_select);
+		if (!canMove) {
+			TemporaryPopup popup = new("This unit has already moved.", 1);
+			popup.SetPosition(eventMouseButton.Position + new Vector2(0, -64));
+			AddChild(popup);
+			popup.ShowPopup();
+		}
+	}
+
+	private void HandleRightMouseButton(InputEventMouseButton eventMouseButton) {
+		setGotoMode(false);
+		using var gameDataAccess = new UIGameDataAccess();
+		var tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
+		if (tile != null) {
+			HandleRightClickOnTile(tile, eventMouseButton);
+		} else {
+			log.Debug("Didn't click on any tile");
+		}
+	}
+
+	private void HandleRightClickOnTile(Tile tile, InputEventMouseButton eventMouseButton) {
+		bool shiftDown = Input.IsKeyPressed(Godot.Key.Shift);
+
+		// Handle the shortcut of shift+right clicking a city to get the change production menu.
+		if (shiftDown && tile.cityAtTile?.owner == controller)
+			new RightClickChooseProductionMenu(this, tile.cityAtTile).Open(eventMouseButton.Position);
+		else if ((!shiftDown) && tile.unitsOnTile.Count > 0)
+			// There are units on this title, so open that menu.
+			new RightClickTileMenu(this, tile).Open(eventMouseButton.Position);
+		else if ((!shiftDown) && tile.cityAtTile?.owner == controller)
+			// There are no units, but this is the player's city.
+			new RightClickCityMenu(this, tile).Open(eventMouseButton.Position);
+
+		LogTileDetails(tile);
+	}
+
+	private void LogTileDetails(Tile tile) {
+		string yield = tile.YieldString(controller);
+		log.Debug($"({tile.XCoordinate}, {tile.YCoordinate}): {tile.overlayTerrainType.DisplayName} {yield}");
+
+		if (tile.cityAtTile != null) {
+			LogCityDetails(tile.cityAtTile);
+		}
+
+		if (tile.unitsOnTile.Count > 0) {
+			LogUnitDetails(tile.unitsOnTile);
+		}
+	}
+
+	private void LogCityDetails(City city) {
+		log.Debug($"  {city.name}, production {city.shieldsStored} of {city.itemBeingProduced.shieldCost}");
+		foreach (CityResident resident in city.residents) {
+			log.Debug($"  Resident working at {resident.tileWorked}");
+		}
+	}
+
+	private void LogUnitDetails(List<MapUnit> unitsOnTile) {
+		foreach (MapUnit unit in unitsOnTile) {
+			log.Debug("  Unit on tile: " + unit);
+			if (unit.currentAI != null) {
+				log.Debug("  Strategy: " + unit.currentAI.SummarizePlan());
+			}
+		}
+	}
+
+	private void HandleMouseMotionInput(InputEventMouseMotion eventMouseMotion) {
+		if (IsMovingCamera) {
+			GetViewport().SetInputAsHandled();
+			mapView.cameraLocation += OldPosition - eventMouseMotion.Position;
+			OldPosition = eventMouseMotion.Position;
+		} else if (gotoInfo != null) {
+			gotoInfo = GetGotoInfo(eventMouseMotion.Position);
+		}
+	}
+
+	private void HandleKeyboardInput(InputEventKey eventKeyDown) {
+		if (eventKeyDown.Keycode == Godot.Key.O && eventKeyDown.ShiftPressed && eventKeyDown.IsCommandOrControlPressed() && eventKeyDown.AltPressed) {
+			ToggleObserverMode();
+		}
+		if (eventKeyDown.Keycode == Godot.Key.G && eventKeyDown.ShiftPressed && eventKeyDown.IsCommandOrControlPressed() && eventKeyDown.AltPressed) {
+			ToggleGridCoordinates();
+		}
+		if (eventKeyDown.Keycode == Godot.Key.F1) {
+			EmitSignal(SignalName.ShowSpecificAdvisor, "F1");
+		}
+		if (eventKeyDown.Keycode == Godot.Key.F3) {
+			EmitSignal(SignalName.ShowSpecificAdvisor, "F3");
+		}
+		if (eventKeyDown.Keycode == Godot.Key.F6) {
+			EmitSignal(SignalName.ShowSpecificAdvisor, "F6");
+		}
+	}
+
+	private void ToggleObserverMode() {
+		using UIGameDataAccess gameDataAccess = new UIGameDataAccess();
+		gameDataAccess.gameData.observerMode = !gameDataAccess.gameData.observerMode;
+		if (gameDataAccess.gameData.observerMode) {
+			SetObserverModeOn(gameDataAccess);
+		} else {
+			SetObserverModeOff(gameDataAccess);
+		}
+	}
+
+	private void SetObserverModeOn(UIGameDataAccess gameDataAccess) {
+		foreach (Player player in gameDataAccess.gameData.players) {
+			player.isHuman = false;
+		}
+		SetAnimationsEnabled(false);
+		popupOverlay.ShowPopup(
+			new TextDialog("How many turns to fast forward through?",
+							"Turns: ", "100",
+							BoxContainer.AlignmentMode.Begin,
+							(string turns) => { turnsLeftToFastForward = int.Parse(turns); }),
+				PopupOverlay.PopupCategory.Advisor);
+	}
+
+	private void SetObserverModeOff(UIGameDataAccess gameDataAccess) {
+		foreach (Player player in gameDataAccess.gameData.players) {
+			if (player.id == EngineStorage.uiControllerID) {
+				player.isHuman = true;
+			}
+		}
+	}
+
+	private void ToggleGridCoordinates() {
+		using UIGameDataAccess gameDataAccess = new UIGameDataAccess();
+		gameDataAccess.gameData.showGridCoordinates = !gameDataAccess.gameData.showGridCoordinates;
+	}
+
+	private void HandleMagnifyGesture(InputEventMagnifyGesture magnifyGesture) {
+		// UI slider has the min/max zoom settings for now
+		double newScale = mapView.cameraZoom * magnifyGesture.Factor;
+		if (newScale < slider.MinValue)
+			newScale = slider.MinValue;
+		else if (newScale > slider.MaxValue)
+			newScale = slider.MaxValue;
+		mapView.setCameraZoom((float)newScale, magnifyGesture.Position);
+		// Update the UI slider
+		slider.Value = newScale;
+	}
+
 	private void ProcessActions() {
 		Godot.Collections.Array<StringName> actions = InputMap.GetActions();
 
@@ -688,10 +743,9 @@ public partial class Game : Node2D {
 		}
 
 		if (currentAction == C7Action.UnitWait) {
-			using (var gameDataAccess = new UIGameDataAccess()) {
-				UnitInteractions.waitUnit(gameDataAccess.gameData, CurrentlySelectedUnit.id);
-				GetNextAutoselectedUnit(gameDataAccess.gameData);
-			}
+			using var gameDataAccess = new UIGameDataAccess();
+			UnitInteractions.waitUnit(gameDataAccess.gameData, CurrentlySelectedUnit.id);
+			GetNextAutoselectedUnit(gameDataAccess.gameData);
 		}
 
 		if (currentAction == C7Action.UnitFortify) {
@@ -726,12 +780,11 @@ public partial class Game : Node2D {
 		}
 
 		if (currentAction == C7Action.UnitBuildCity && CurrentlySelectedUnit != MapUnit.NONE && (CurrentlySelectedUnit?.canBuildCity() ?? false)) {
-			using (var gameDataAccess = new UIGameDataAccess()) {
-				MapUnit currentUnit = gameDataAccess.gameData.GetUnit(CurrentlySelectedUnit.id);
-				log.Debug(currentUnit.Describe());
-				if (currentUnit.canBuildCity()) {
-					popupOverlay.ShowPopup(new BuildCityDialog(controller.GetNextCityName()), PopupOverlay.PopupCategory.Advisor);
-				}
+			using var gameDataAccess = new UIGameDataAccess();
+			MapUnit currentUnit = gameDataAccess.gameData.GetUnit(CurrentlySelectedUnit.id);
+			log.Debug(currentUnit.Describe());
+			if (currentUnit.canBuildCity()) {
+				popupOverlay.ShowPopup(new BuildCityDialog(controller.GetNextCityName()), PopupOverlay.PopupCategory.Advisor);
 			}
 		}
 

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -501,8 +501,7 @@ public partial class Game : Node2D {
 
 			if (CanDoubleClick(eventMouseButton)) {
 				doubleClickHandler.Accept(eventMouseButton);
-			}
-			else {
+			} else {
 				OnSingleLeftMouseButtonClick(eventMouseButton);
 			}
 		} else {
@@ -519,7 +518,7 @@ public partial class Game : Node2D {
 	private bool CanDoubleClick(InputEventMouseButton eventMouseButton) {
 		Tile tile = PositionToTile(eventMouseButton.Position);
 
-		return gotoInfo == null && tile != null && tile.cityAtTile != null;
+		return gotoInfo == null && tile?.cityAtTile?.owner == controller;
 	}
 
 	private void OnSingleLeftMouseButtonClick(InputEventMouseButton eventMouseButton) {
@@ -535,9 +534,9 @@ public partial class Game : Node2D {
 	private void OnDoubleLeftMouseButtonClick(InputEventMouseButton eventMouseButton) {
 		using var gameDataAccess = new UIGameDataAccess();
 		Tile tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
-		if (tile == null || tile.cityAtTile == null) { return; }
-
-		ShowCityScreenForCity(tile.cityAtTile);
+		if (tile?.cityAtTile?.owner == controller) {
+			ShowCityScreenForCity(tile.cityAtTile);
+		}
 	}
 
 	private void HandleUnitSelection(InputEventMouseButton eventMouseButton) {

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -576,10 +576,10 @@ public partial class Game : Node2D {
 		// Handle the shortcut of shift+right clicking a city to get the change production menu.
 		if (shiftDown && tile.cityAtTile?.owner == controller)
 			new RightClickChooseProductionMenu(this, tile.cityAtTile).Open(eventMouseButton.Position);
-		else if ((!shiftDown) && tile.unitsOnTile.Count > 0)
+		else if (!shiftDown && tile.unitsOnTile.Count > 0)
 			// There are units on this title, so open that menu.
 			new RightClickTileMenu(this, tile).Open(eventMouseButton.Position);
-		else if ((!shiftDown) && tile.cityAtTile?.owner == controller)
+		else if (!shiftDown && tile.cityAtTile?.owner == controller)
 			// There are no units, but this is the player's city.
 			new RightClickCityMenu(this, tile).Open(eventMouseButton.Position);
 

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -532,17 +532,14 @@ public partial class Game : Node2D {
 	}
 
 	private void OnDoubleLeftMouseButtonClick(InputEventMouseButton eventMouseButton) {
-		using var gameDataAccess = new UIGameDataAccess();
-		Tile tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
+		Tile tile = PositionToTile(eventMouseButton.Position);
 		if (tile?.cityAtTile?.owner == controller) {
 			ShowCityScreenForCity(tile.cityAtTile);
 		}
 	}
 
 	private void HandleUnitSelection(InputEventMouseButton eventMouseButton) {
-		using var gameDataAccess = new UIGameDataAccess();
-
-		var tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
+		Tile tile = PositionToTile(eventMouseButton.Position);
 		if (tile == null) {
 			return;
 		}
@@ -564,8 +561,8 @@ public partial class Game : Node2D {
 
 	private void HandleRightMouseButton(InputEventMouseButton eventMouseButton) {
 		setGotoMode(false);
-		using var gameDataAccess = new UIGameDataAccess();
-		var tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
+
+		Tile tile = PositionToTile(eventMouseButton.Position);
 		if (tile != null) {
 			HandleRightClickOnTile(tile, eventMouseButton);
 		} else {

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -80,6 +80,8 @@ public partial class Game : Node2D {
 	private VSlider slider;
 	[Export]
 	private AnimationPlayer animationPlayer;
+	[Export]
+	private DoubleClickHandler doubleClickHandler;
 
 	bool errorOnLoad = false;
 
@@ -494,18 +496,48 @@ public partial class Game : Node2D {
 	private void HandleLeftMouseButton(InputEventMouseButton eventMouseButton) {
 		GetViewport().SetInputAsHandled();
 		if (eventMouseButton.IsPressed()) {
-			if (gotoInfo != null) {
-				HandleGotoClick(gotoInfo);
-				setGotoMode(false);
-			} else {
-				// Select unit on tile at mouse location
-				HandleUnitSelection(eventMouseButton);
-				OldPosition = eventMouseButton.Position;
-				IsMovingCamera = true;
+			OldPosition = eventMouseButton.Position;
+			IsMovingCamera = true;
+
+			if (CanDoubleClick(eventMouseButton)) {
+				doubleClickHandler.Accept(eventMouseButton);
+			}
+			else {
+				OnSingleLeftMouseButtonClick(eventMouseButton);
 			}
 		} else {
 			IsMovingCamera = false;
 		}
+	}
+
+	private Tile PositionToTile(Vector2 position) {
+		using var gameDataAccess = new UIGameDataAccess();
+		Tile tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, position);
+		return tile;
+	}
+
+	private bool CanDoubleClick(InputEventMouseButton eventMouseButton) {
+		Tile tile = PositionToTile(eventMouseButton.Position);
+
+		return gotoInfo == null && tile != null && tile.cityAtTile != null;
+	}
+
+	private void OnSingleLeftMouseButtonClick(InputEventMouseButton eventMouseButton) {
+		if (gotoInfo != null) {
+			HandleGotoClick(gotoInfo);
+			setGotoMode(false);
+		} else {
+			// Select unit on tile at mouse location
+			HandleUnitSelection(eventMouseButton);
+		}
+	}
+
+	private void OnDoubleLeftMouseButtonClick(InputEventMouseButton eventMouseButton) {
+		using var gameDataAccess = new UIGameDataAccess();
+		Tile tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
+		if (tile == null || tile.cityAtTile == null) { return; }
+
+		ShowCityScreenForCity(tile.cityAtTile);
 	}
 
 	private void HandleUnitSelection(InputEventMouseButton eventMouseButton) {


### PR DESCRIPTION
This PR makes it possible to open the city screen by double-clicking on a city. 

It introduces a new class for detecting double-clicks. This new class was necessary because, although Godot provides built-in double-click detection, it does not allow handling single clicks separately. With Godot’s built-in detection, clicking on a city that contains a unit would both zoom to the city and select the unit.

To differentiate between single and double clicks the new class uses a timer-based detection. When a click occurs, the class waits for a short period (0.2 seconds) to check if another click follows. If a second click happens, it emits a double-click signal; otherwise, it emits a single-click signal. The only downside of using it is a small delay when single-clicking on a city to select a unit.

Additionally, this PR includes a refactor of the `_UnhandledInput` method in the `Game` class, splitting it into multiple smaller methods.