### PR TITLE
Ignore destroyed and sold buildings when loading SAV files

### DIFF
--- a/C7GameData/ImportCiv3.cs
+++ b/C7GameData/ImportCiv3.cs
@@ -611,12 +611,14 @@ namespace C7GameData {
 
 		List<SaveCityBuilding> ImportCityBuildingsFromSav(int cityIndex) {
 			List<SaveCityBuilding> res = [];
+
+			var city = savData.City[cityIndex];
 			var cityBuildings = savData.CityBuilding[cityIndex];
 
 			for (int buildingIndex = 0; buildingIndex < cityBuildings.Length; ++buildingIndex) {
 				var building = cityBuildings[buildingIndex];
 
-				if (building.BuiltByPlayer != -1) {
+				if (building.BuiltByPlayer != -1 && city.Bitm.IsBuildingUsable(buildingIndex)) {
 					res.Add(new SaveCityBuilding {
 						building = save.Buildings[buildingIndex].name,
 						builtByPlayer = save.Players[building.BuiltByPlayer].id,

--- a/QueryCiv3/SavSections/Bitm.cs
+++ b/QueryCiv3/SavSections/Bitm.cs
@@ -9,5 +9,13 @@ namespace QueryCiv3.Sav {
 		private fixed byte UsableBuildingBits[32];
 		public int BuildingCount;
 		public int BuildingBytes;
+
+		public bool IsBuildingUsable(int buildingIndex) {
+			int byteIndex = buildingIndex / 8;
+			int bitIndex = buildingIndex % 8;
+			fixed (byte* ptr = UsableBuildingBits) {
+				return (ptr[byteIndex] & (1 << bitIndex)) != 0;
+			}
+		}
 	}
 }


### PR DESCRIPTION
Previously, sold and destroyed buildings were loaded as existing ones (see #580). This PR fixes that.