### PR TITLE
Improve handling of civ destruction:

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -223,19 +223,12 @@ public partial class Game : Node2D {
 					break;
 				case MsgCityDestroyed mCD:
 					mapView.cityLayer.UpdateAfterCityDestruction(mCD.city);
+					break;
+				case MsgCivilizationDestroyed mCivD:
+					popupOverlay.ShowPopup(new CivilizationDestroyed(mCivD.civilization), PopupOverlay.PopupCategory.Advisor);
 
-					// If this was the last city of the civilization, display a popup
-					// noting that the civ is gone and destroy any remaining units.
-					//
-					// TODO: Implement the full set of conditions for destroying a civ;
-					// handling cases like 1 city elimination, regicide, settlers that
-					// are still alive, etc.
-					if (mCD.city.owner.RemainingCities() == 0) {
-						popupOverlay.ShowPopup(new CivilizationDestroyed(mCD.city.owner.civilization), PopupOverlay.PopupCategory.Advisor);
-						for (int i = 0; i < mCD.city.owner.units.Count; ++i) {
-							MapUnitExtensions.disband(mCD.city.owner.units[i]);
-						}
-					}
+					// Break out of fast forward mode after interesting events.
+					turnsLeftToFastForward = 0;
 					break;
 				case MsgUpdateUiAfterMove mUUAM:
 					// The unit finished moving and still has moves left, so we need to

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -67740,6 +67740,7 @@
       "barbarian": true,
       "human": false,
       "hasPlayedCurrentTurn": false,
+      "defeated": false,
       "civilization": "A Barbarian Chiefdom",
       "cityNameIndex": 0,
       "turnsUntilPriorityReevaluation": 0,
@@ -67758,6 +67759,7 @@
       "barbarian": false,
       "human": true,
       "hasPlayedCurrentTurn": false,
+      "defeated": false,
       "civilization": "Carthage",
       "cityNameIndex": 0,
       "tileKnowledge": [
@@ -67835,6 +67837,7 @@
       "barbarian": false,
       "human": false,
       "hasPlayedCurrentTurn": false,
+      "defeated": false,
       "civilization": "America",
       "cityNameIndex": 0,
       "tileKnowledge": [
@@ -67912,6 +67915,7 @@
       "barbarian": false,
       "human": false,
       "hasPlayedCurrentTurn": false,
+      "defeated": false,
       "civilization": "Aztecs",
       "cityNameIndex": 0,
       "tileKnowledge": [
@@ -67985,6 +67989,7 @@
       "barbarian": false,
       "human": false,
       "hasPlayedCurrentTurn": false,
+      "defeated": false,
       "civilization": "Inca",
       "cityNameIndex": 0,
       "tileKnowledge": [
@@ -68062,6 +68067,7 @@
       "barbarian": false,
       "human": false,
       "hasPlayedCurrentTurn": false,
+      "defeated": false,
       "civilization": "Persia",
       "cityNameIndex": 0,
       "tileKnowledge": [
@@ -68143,6 +68149,7 @@
       "barbarian": false,
       "human": false,
       "hasPlayedCurrentTurn": false,
+      "defeated": false,
       "civilization": "Maya",
       "cityNameIndex": 0,
       "tileKnowledge": [
@@ -68220,6 +68227,7 @@
       "barbarian": false,
       "human": false,
       "hasPlayedCurrentTurn": false,
+      "defeated": false,
       "civilization": "Iroquois",
       "cityNameIndex": 0,
       "tileKnowledge": [

--- a/C7Engine/AI/StrategicAI/WarPriority.cs
+++ b/C7Engine/AI/StrategicAI/WarPriority.cs
@@ -40,8 +40,6 @@ namespace C7GameData.AIData {
 			foreach (KeyValuePair<ID, PlayerRelationship> p in player.playerRelationships) {
 				// TODO: Make sure having seen barbarians doesn't prevent us from
 				// declaring new wars.
-				//
-				// TODO: Make sure we update this when a civ is destroyed.
 				if (p.Value.atWar) {
 					this.calculatedWeight = 1000;
 					return;

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -45,6 +45,10 @@ namespace C7Engine {
 			EngineStorage.gameData.cities.Remove(tile.cityAtTile);
 			EngineStorage.gameData.UpdateTileOwnersOnCityDestruction(tile.cityAtTile);
 			new MsgCityDestroyed(tile.cityAtTile).send();
+			if (EngineStorage.gameData.CheckForCivDestruction(tile.cityAtTile.owner)) {
+				// Let the UI know about the civ destruction.
+				new MsgCivilizationDestroyed(tile.cityAtTile.owner.civilization).send();
+			}
 			tile.cityAtTile = null;
 			tile.overlays.road = false;
 		}

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -62,6 +62,14 @@ namespace C7Engine {
 		}
 	}
 
+	public class MsgCivilizationDestroyed : MessageToUI {
+		public Civilization civilization;
+
+		public MsgCivilizationDestroyed(Civilization civ) {
+			this.civilization = civ;
+		}
+	}
+
 	public class MsgCityCreated : MessageToUI {
 		public City city;
 

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -79,7 +79,7 @@ namespace C7Engine {
 		/// <returns>true when it is time for the human to take control again</returns>
 		private static bool PlayPlayerTurns(GameData gameData, bool firstTurn) {
 			foreach (Player player in gameData.players) {
-				if (player.hasPlayedThisTurn) {
+				if (player.hasPlayedThisTurn || player.defeated) {
 					continue;
 				}
 

--- a/C7Engine/MapUnitExtensions.cs
+++ b/C7Engine/MapUnitExtensions.cs
@@ -471,26 +471,7 @@ namespace C7Engine {
 		}
 
 		public static void disband(this MapUnit unit) {
-			GameData gameData = EngineStorage.gameData;
-
-			// Set unit's hit points to zero to indicate that it's no longer alive. Ultimately we may not want to do this. I'm only doing it right
-			// now since this way all the UI needs to do to check if the selected unit has been destroyed is to check its hit points.
-			unit.hitPointsRemaining = 0;
-			unit.movementPoints.onConsumeAll();
-
-			if (unit.currentAI != null) {
-				unit.currentAI.UpdateOnDeath();
-				unit.currentAI = null;
-			}
-
-			// EngineStorage.animTracker.endAnimation(unit, false);   TODO: Must send message instead of call directly
-			unit.location.unitsOnTile.Remove(unit);
-			gameData.mapUnits.Remove(unit);
-			foreach (Player player in gameData.players) {
-				if (player.units.Contains(unit)) {
-					player.units.Remove(unit);
-				}
-			}
+			EngineStorage.gameData.DisbandUnit(unit);
 		}
 
 		public static bool canBuildCity(this MapUnit unit) {

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -124,6 +124,52 @@ namespace C7GameData {
 			UpdateTileOwners();
 		}
 
+		public bool CheckForCivDestruction(Player player) {
+			// TODO: Implement the full set of conditions for destroying a civ;
+			// handling cases like 1 city elimination, regicide, settlers that
+			// are still alive, etc.
+			if (player.RemainingCities() > 0) {
+				return false;
+			}
+
+			// This was the last city of the civilization, so destroy remaining
+			// units.
+			player.defeated = true;
+			for (int i = 0; i < player.units.Count; ++i) {
+				DisbandUnit(player.units[i]);
+			}
+
+			// Remove this civ from all other player's relationships.
+			foreach (Player p in players) {
+				p.playerRelationships.Remove(player.id);
+			}
+
+			return true;
+		}
+
+		public void DisbandUnit(MapUnit unit) {
+			// Set unit's hit points to zero to indicate that it's no longer alive. Ultimately we may not want to do this. I'm only doing it right
+			// now since this way all the UI needs to do to check if the selected unit has been destroyed is to check its hit points.
+			unit.hitPointsRemaining = 0;
+			unit.movementPoints.onConsumeAll();
+
+			if (unit.currentAI != null) {
+				unit.currentAI.UpdateOnDeath();
+				unit.currentAI = null;
+			}
+
+			// EngineStorage.animTracker.endAnimation(unit, false);   TODO: Must send message instead of call directly
+			unit.location.unitsOnTile.Remove(unit);
+			mapUnits.Remove(unit);
+
+			// TODO: why not just do Player p = unit.owner; p.units.Remove(unit);?	
+			foreach (Player player in players) {
+				if (player.units.Contains(unit)) {
+					player.units.Remove(unit);
+				}
+			}
+		}
+
 		// Rules taken from https://forums.civfanatics.com/threads/the-eight-laws-of-border-dynamics.106882/
 		private City ResolveTileOwnershipConflict(City a, City b, Tile t) {
 			int aRank = a.location.rankDistanceTo(t);

--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -17,6 +17,9 @@ namespace C7GameData {
 		public bool isHuman = false;
 		public bool hasPlayedThisTurn = false;
 
+		// Has this player been defeated?
+		public bool defeated = false;
+
 		public Civilization civilization;
 		internal int cityNameIndex = 0;
 

--- a/C7GameData/Save/SavePlayer.cs
+++ b/C7GameData/Save/SavePlayer.cs
@@ -24,6 +24,7 @@ namespace C7GameData.Save {
 		public bool barbarian;
 		public bool human = false;
 		public bool hasPlayedCurrentTurn = false;
+		public bool defeated = false;
 
 		public string civilization;
 		public int cityNameIndex = 0;
@@ -78,6 +79,7 @@ namespace C7GameData.Save {
 				isBarbarians = barbarian,
 				isHuman = human,
 				hasPlayedThisTurn = hasPlayedCurrentTurn,
+				defeated = defeated,
 				colorIndex = colorIndex,
 				civilization = civilization is not null ? civilizations.Find(civ => civ.name == civilization) : null,
 				cityNameIndex = cityNameIndex,
@@ -121,6 +123,7 @@ namespace C7GameData.Save {
 			barbarian = player.isBarbarians;
 			human = player.isHuman;
 			hasPlayedCurrentTurn = player.hasPlayedThisTurn;
+			defeated = player.defeated;
 			civilization = player.civilization?.name;
 			// TODO: this should be computed by looking at cities defined in the save
 			// so that adding cities in the save structure doesn't require updating this value


### PR DESCRIPTION
 - Move it to `GameData.cs` instead of in `Game.cs` - now it works in headless mode
 - Clear out player relationships when a civ is destroyed, allowing the other civs to exit war. We can now have civ's battle to the death with a single winner
 - Stop giving defeated players a turn

This required moving the logic for disbanding a unit into `GameData`, which probably makes more sense - it has to update several related fields.
