### PR TITLE
Ensure players cannot have negative amounts of gold

### DIFF
--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -318,7 +318,7 @@ namespace C7Engine {
 
 				// Figure out the value of what we have available to trade.
 				TradeOffer weGive = new();
-				weGive.gold = Math.Max(0, us.gold);
+				weGive.gold = us.gold;
 				foreach (Tech t in techsWeCanTrade) {
 					weGive.techs.Add(t);
 				}
@@ -336,7 +336,7 @@ namespace C7Engine {
 				}
 
 				// Also ask for any gold we can get.
-				weWant.gold = Math.Min(ourMaxPossibleOffer, Math.Max(0, them.gold));
+				weWant.gold = Math.Min(ourMaxPossibleOffer, them.gold);
 
 				// At this point we are getting as much as we possibly can get
 				// from the opponent. However, we might be overpaying, possibly

--- a/C7Engine/AI/UnitAI/EscortAI.cs
+++ b/C7Engine/AI/UnitAI/EscortAI.cs
@@ -17,6 +17,10 @@ namespace C7Engine {
 		}
 
 		public void UpdateOnDeath() {
+			if (data.unitToEscort == null) {
+				return;
+			}
+
 			// When we're destroyed, clear out our reference to the unit we're
 			// escorting, and clear our their reference to us.
 			if (data.unitToEscort.currentAI is SettlerAI settlerAi) {

--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -315,8 +315,40 @@ namespace C7GameData {
 			foreach (City city in cities) {
 				beakers += city.CurrentCommerceYield().beakers;
 			}
+
+			// Ensure we never go below 0 gold.
+			while (gold + CalculateGoldPerTurn() < 0) {
+				// Start by disbanding units to get things under control.
+				var (_, _, unitSupportCost) = TotalUnitsAllowedUnitsAndSupportCost();
+				if (unitSupportCost > 0) {
+					for (int i = 0; i < unitSupportCost / government.unitCost; ++i) {
+						MapUnit unitToDisband = units[GameData.rng.Next(units.Count)];
+						log.Information($"{this} is out of gold, disbanding {unitToDisband} to being unit support costs under control");
+						gameData.DisbandUnit(unitToDisband);
+					}
+					continue;
+				}
+
+				// If we're under the unit support cap, try lowering our science
+				// budget.
+				if (scienceRate > 0) {
+					--scienceRate;
+					++taxRate;
+					continue;
+				}
+
+				// If that wasn't sufficient, go after luxuries.
+				if (scienceRate > 0) {
+					--luxuryRate;
+					++taxRate;
+					continue;
+				}
+
+				// If the budget still isn't under control, something is wrong.
+				throw new Exception($"{this} was unable to get the budget under control despite being under the unit support cap and zeroing out the sliders");
+			}
+
 			gold += CalculateGoldPerTurn();
-			// TODO: ensure we never go below zero.
 		}
 
 		public void DoPerTurnScienceUpdates(GameData gameData) {


### PR DESCRIPTION
This allows us to remove a couple of hacky `Min(0, gold)` statements.

We'll need additional work in the future to make the AI actually use the sliders effectively, but this is a good start.
