### PR TITLE
Show built improvements, refactor the city scene

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -10,9 +10,9 @@
 [ext_resource type="Script" path="res://UIElements/UnitButtons/RenameButton.cs" id="8"]
 [ext_resource type="Script" path="res://UIElements/Popups/PopupOverlay.cs" id="9"]
 [ext_resource type="Theme" uid="uid://c1jpmssnhvodi" path="res://C7Theme.tres" id="10"]
+[ext_resource type="PackedScene" uid="uid://bo4yg85jcbgdx" path="res://UIElements/CityScreen/city_screen.tscn" id="11_12lt4"]
 [ext_resource type="Script" path="res://UIElements/UnitButtons/UnitButtons.cs" id="12"]
 [ext_resource type="PackedScene" uid="uid://bvncm1bgcii5e" path="res://UIElements/civ3_file_dialog.tscn" id="12_yjlfl"]
-[ext_resource type="Script" path="res://UIElements/CityScreen/CityScreen.cs" id="13"]
 [ext_resource type="Script" path="res://UIElements/Diplomacy/Diplomacy.cs" id="14"]
 
 [sub_resource type="Animation" id="2"]
@@ -251,14 +251,8 @@ grow_vertical = 2
 theme = ExtResource("10")
 script = ExtResource("3")
 
-[node name="CityScreen" type="CenterContainer" parent="CanvasLayer"]
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme = ExtResource("10")
-script = ExtResource("13")
+[node name="CityScreen" parent="CanvasLayer" instance=ExtResource("11_12lt4")]
+visible = false
 
 [node name="Diplomacy" type="CenterContainer" parent="CanvasLayer" node_paths=PackedStringArray("popupOverlay")]
 anchors_preset = 15

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -298,24 +298,6 @@ public partial class Game : Node2D {
 		}
 	}
 
-	// This is the terrain generator that used to be part of TerrainAsTileMap. Now it gets passed to and called from generateDummyGameMap so that
-	// function can be more in charge of terrain generation. Eventually we'll want generation to be part of the engine not the UI but we can't
-	// simply move this function there right now since we don't want the engine to depend on Godot.
-	public int[,] genBasicTerrainNoiseMap(int seed, int mapWidth, int mapHeight) {
-		var tr = new int[mapWidth,mapHeight];
-		Godot.FastNoiseLite noise = new Godot.FastNoiseLite();
-		noise.Seed = seed;
-		// Populate map values
-		for (int Y = 0; Y < mapHeight; Y++) {
-			for (int X = 0; X < mapWidth; X++) {
-				// Multiplying X & Y for noise coordinate sampling
-				float n = noise.GetNoise2D(X*2,Y*2);
-				tr[X, Y] = n < 0.1 ? 2 : n < 0.4 ? 1 : 0;
-			}
-		}
-		return tr;
-	}
-
 	// If "location" is not already near the center of the screen, moves the camera to bring it into view.
 	public void ensureLocationIsInView(Tile location) {
 		if (controller.tileKnowledge.isTileKnown(location) && location != Tile.NONE) {
@@ -708,7 +690,7 @@ public partial class Game : Node2D {
 		}
 
 		if (currentAction == C7Action.Escape && cityScreen.Visible) {
-			cityScreen.HideScreen();
+			cityScreen.Hide();
 			return;
 		}
 

--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -26,7 +26,7 @@ public partial class CityScreen : Control {
 	[Export] private TextureButton productionButton;
 	[Export] private TextureButton close;
 
-	private ProductionMenu productionMenu;
+	[Export] private ProductionMenu productionMenu;
 
 	Theme yieldDetailsFontTheme = new();
 	FontFile yieldDetailsFont = new();
@@ -225,11 +225,7 @@ public partial class CityScreen : Control {
 	}
 
 	private void OnExit() {
-		if (productionMenu != null) {
-			productionMenu.QueueFree();
-			productionMenu = null;
-		}
-
+		productionMenu.Hide();
 		tileAssignmentLayer.city = null;
 	}
 
@@ -304,20 +300,11 @@ public partial class CityScreen : Control {
 			productionButtonLabel.SetTextAndCenterLabel($"{city.itemBeingProduced.name}");
 		}
 
-		bool wasVisible = false;
-		if (productionMenu != null) {
-			wasVisible = productionMenu.Visible;
-			productionMenu.QueueFree();
-			productionMenu = null;
-		}
-		productionMenu = new ProductionMenu(city, (IProducible p) => {
+		productionMenu.AddItems(city, (IProducible p) => {
 			using UIGameDataAccess gameDataAccess = new();
 			city.SetItemBeingProduced(p);
 			RenderProductionDetails(city);
 		});
-		background.AddChild(productionMenu);
-		productionMenu.SetPosition(new Vector2(814, 135));
-		productionMenu.Visible = wasVisible;
 	}
 
 	private void RenderCulture(City city) {

--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -10,15 +10,23 @@ using C7Engine.AI;
 
 // Handles the city screen, where citizens can be assigned and other details of
 // the city can bee seen.
-public partial class CityScreen : CenterContainer {
+[Tool]
+public partial class CityScreen : Control {
 	private ILogger log = LogManager.ForContext<CityScreen>();
 	public TileAssignmentLayer tileAssignmentLayer;
 	public MapView mapView;
 	public List<CitizenType> citizenTypes;
-	private TextureRect background;
 	private List<TextureButton> popHeads = new();
-	private Label culturePerTurn;
-	private Label totalCulture;
+
+	[Export] private TextureRect background;
+	[Export] private VBoxContainer existingBuildings;
+	[Export] private Label culturePerTurn;
+	[Export] private Label totalCulture;
+
+	[Export] private TextureButton productionButton;
+	[Export] private TextureButton close;
+
+	private ProductionMenu productionMenu;
 
 	Theme yieldDetailsFontTheme = new();
 	FontFile yieldDetailsFont = new();
@@ -29,51 +37,16 @@ public partial class CityScreen : CenterContainer {
 	private Label commerceScienceDetails;
 	private Label commerceHappinessDetails;
 
-	private TextureButton productionButton;
-	private ProductionMenu productionMenu;
-
-	private ColorRect leftSidebar = new();
-	private ColorRect rightSidebar = new();
-	private ColorRect topSidebar = new();
-	private ColorRect bottomSidebar = new();
-
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
-		background = new() {
-			Texture = Util.LoadTextureFromPCX("Art/city screen/background.pcx")
-		};
-		AddChild(background);
-
-		// The sidebars.
-		background.AddChild(leftSidebar);
-		background.AddChild(rightSidebar);
-		background.AddChild(topSidebar);
-		background.AddChild(bottomSidebar);
-
-		leftSidebar.Color = Colors.Black;
-		rightSidebar.Color = Colors.Black;
-		topSidebar.Color = Colors.Black;
-		bottomSidebar.Color = Colors.Black;
-
-		UpdateSidebars();
-		GetViewport().SizeChanged += UpdateSidebars; // Update on resize
+		background.Texture = Util.LoadTextureFromPCX("Art/city screen/background.pcx");
 
 		// The close button.
-		TextureButton close = new() {
-			TextureNormal = Util.LoadTextureFromPCX("Art/city screen/cityMgmtButtons.pcx", 155, 1, 32, 48),
-			TextureHover = Util.LoadTextureFromPCX("Art/city screen/cityMgmtButtons.pcx", 155, 50, 32, 48),
-			TexturePressed = Util.LoadTextureFromPCX("Art/city screen/cityMgmtButtons.pcx", 155, 99, 32, 48)
-		};
-		close.SetPosition(new Vector2(950, 20));
-		close.Pressed += () => { HideScreen(); };
-		background.AddChild(close);
+		close.TextureNormal = Util.LoadTextureFromPCX("Art/city screen/cityMgmtButtons.pcx", 155, 1, 32, 48);
+		close.TextureHover = Util.LoadTextureFromPCX("Art/city screen/cityMgmtButtons.pcx", 155, 50, 32, 48);
+		close.TexturePressed = Util.LoadTextureFromPCX("Art/city screen/cityMgmtButtons.pcx", 155, 99, 32, 48);
 
-		background.AddChild(new Label() {
-			Text = "CULTURE",
-			OffsetLeft = 714,
-			OffsetTop = 4
-		});
-
+		close.Pressed += Hide;
 
 		// Load the font we'll use for the details.
 		//
@@ -121,16 +94,13 @@ public partial class CityScreen : CenterContainer {
 		};
 		background.AddChild(commerceHappinessDetails);
 
-		productionButton = new() {
-			TextureNormal = Util.LoadTextureFromPCX("Art/city screen/ProdButton.pcx", 1, 0, 114, 95),
-			TextureHover = Util.LoadTextureFromPCX("Art/city screen/ProdButton.pcx", 116, 0, 115, 95),
-			TexturePressed = Util.LoadTextureFromPCX("Art/city screen/ProdButton.pcx", 231, 0, 115, 95)
-		};
-		productionButton.SetPosition(new Vector2(905, 515));
-		background.AddChild(productionButton);
+		productionButton.TextureNormal = Util.LoadTextureFromPCX("Art/city screen/ProdButton.pcx", 1, 0, 114, 95);
+		productionButton.TextureHover = Util.LoadTextureFromPCX("Art/city screen/ProdButton.pcx", 116, 0, 115, 95);
+		productionButton.TexturePressed = Util.LoadTextureFromPCX("Art/city screen/ProdButton.pcx", 231, 0, 115, 95);
+
 		productionButton.Pressed += () => { this.productionMenu.Visible = !this.productionMenu.Visible; };
 
-		this.Hide();
+		Hidden += OnExit;
 	}
 
 	public override void _UnhandledInput(InputEvent @event) {
@@ -242,11 +212,6 @@ public partial class CityScreen : CenterContainer {
 		}
 	}
 
-	public void HideScreen() {
-		this.Hide();
-		tileAssignmentLayer.city = null;
-	}
-
 	private void OnShowCityScreen(ParameterWrapper<City> city) {
 		this.Show();
 		mapView.centerCameraOnTile(city.Value.location.neighbors[TileDirection.SOUTH]);
@@ -256,6 +221,29 @@ public partial class CityScreen : CenterContainer {
 		RenderFoodDetails(city.Value);
 		RenderCommerceDetails(city.Value);
 		RenderProductionDetails(city.Value);
+		RenderExistingBuildings(city.Value.buildings);
+	}
+
+	private void OnExit() {
+		if (productionMenu != null) {
+			productionMenu.QueueFree();
+			productionMenu = null;
+		}
+
+		tileAssignmentLayer.city = null;
+	}
+
+	private void RenderExistingBuildings(List<CityBuilding> buildings) {
+		foreach (var node in existingBuildings.GetChildren()) {
+			existingBuildings.RemoveChild(node);
+		}
+
+		foreach (CityBuilding building in buildings) {
+			Label label = new() {
+				Text = building.building.name
+			};
+			existingBuildings.AddChild(label);
+		}
 	}
 
 	private void RenderFoodDetails(City city) {
@@ -333,22 +321,8 @@ public partial class CityScreen : CenterContainer {
 	}
 
 	private void RenderCulture(City city) {
-		if (culturePerTurn == null) {
-			culturePerTurn = new Label() {
-				OffsetLeft = 790,
-				OffsetTop = 4
-			};
-			background.AddChild(culturePerTurn);
-		}
 		culturePerTurn.Text = "0/turn";  // TODO: fill this in
 
-		if (totalCulture == null) {
-			totalCulture = new Label() {
-				OffsetLeft = 714,
-				OffsetTop = 55
-			};
-			background.AddChild(totalCulture);
-		}
 		int nextCultureExpansion = (int)Math.Pow(10, city.GetBorderExpansionLevel());
 		totalCulture.Text = $"Total: {city.GetCulture()}/{nextCultureExpansion}";
 	}
@@ -433,31 +407,5 @@ public partial class CityScreen : CenterContainer {
 			popHeads.Add(tb);
 			xPos += 48;
 		}
-	}
-
-	private void UpdateSidebars() {
-		Vector2 viewportSize = GetViewport().GetVisibleRect().Size;
-
-		float sidebarWidth = (viewportSize.X - background.Texture.GetWidth()) / 2;
-		float sidebarHeight = viewportSize.Y;
-
-		float topBottomBarHeight = (viewportSize.Y - background.Texture.GetHeight()) / 2;
-		float topBottomBarWidth = viewportSize.X;
-
-		// Left Sidebar
-		leftSidebar.Position = new Vector2(-sidebarWidth, 0);
-		leftSidebar.Size = new Vector2(sidebarWidth, sidebarHeight);
-
-		// Right Sidebar
-		rightSidebar.Position = new Vector2(background.Texture.GetWidth(), 0);
-		rightSidebar.Size = new Vector2(sidebarWidth, sidebarHeight);
-
-		// Top Sidebar
-		topSidebar.Position = new Vector2(0, -topBottomBarHeight);
-		topSidebar.Size = new Vector2(topBottomBarWidth, topBottomBarHeight);
-
-		// Bottom Sidebar
-		bottomSidebar.Position = new Vector2(0, background.Texture.GetHeight());
-		bottomSidebar.Size = new Vector2(topBottomBarWidth, topBottomBarHeight);
 	}
 }

--- a/C7/UIElements/CityScreen/ProductionMenu.cs
+++ b/C7/UIElements/CityScreen/ProductionMenu.cs
@@ -4,28 +4,37 @@ using C7GameData;
 using C7Engine;
 using System;
 
-public partial class ProductionMenu : TextureRect {
+[Tool]
+[GlobalClass]
+public partial class ProductionMenu : Civ3TextureRect {
 	private Dictionary<TreeItem, IProducible> itemMapping = new();
 
-	public ProductionMenu(City city, Action<IProducible> chooseProduction) {
+	Tree tree = new();
+	Theme fontTheme = new();
+
+	public ProductionMenu() {
 		this.Texture = Util.LoadTextureFromPCX("Art/city screen/ProductionQueueBox.pcx");
 
 		// Load the font we'll use.
 		FontFile font = ResourceLoader.Load<FontFile>("res://Fonts/NotoSans-Regular.ttf", null, ResourceLoader.CacheMode.Ignore);
 		font.FixedSize = 12;
-		Theme fontTheme = new();
 		fontTheme.DefaultFont = font;
 
 		// Set up the tree of items. We use a tree so we get a scroll bar and
 		// other niceties.
-		Tree tree = new();
 		AddChild(tree);
-
 		tree.Columns = 2;
-		TreeItem root = TradingTree.ConfigureTreeTheme(tree, fontTheme);
 
 		// Match the size of the texture used in the deal screen.
 		tree.Size = new Vector2(203, 360);
+
+		TradingTree.ConfigureTreeTheme(tree, fontTheme);
+	}
+
+	public void AddItems(City city, Action<IProducible> chooseProduction) {
+		tree.Clear();
+
+		TreeItem root = TradingTree.CreateTreeRoot(tree);
 
 		foreach (IProducible option in city.ListProductionOptions()) {
 			int buildTime = city.TurnsToProduce(option);

--- a/C7/UIElements/CityScreen/city_screen.tscn
+++ b/C7/UIElements/CityScreen/city_screen.tscn
@@ -1,0 +1,105 @@
+[gd_scene load_steps=2 format=3 uid="uid://bo4yg85jcbgdx"]
+
+[ext_resource type="Script" path="res://UIElements/CityScreen/CityScreen.cs" id="1_e5kig"]
+
+[node name="CityScreen" type="VBoxContainer" node_paths=PackedStringArray("background", "existingBuildings", "culturePerTurn", "totalCulture", "productionButton", "close")]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 0
+script = ExtResource("1_e5kig")
+background = NodePath("HBoxContainer/Background")
+existingBuildings = NodePath("HBoxContainer/Background/ScrollContainer/ExistingBuildings")
+culturePerTurn = NodePath("HBoxContainer/Background/CulturePerTurn")
+totalCulture = NodePath("HBoxContainer/Background/TotalCulture")
+productionButton = NodePath("HBoxContainer/Background/ProductionButton")
+close = NodePath("HBoxContainer/Background/Close")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+layout_mode = 2
+size_flags_vertical = 3
+color = Color(0, 0, 0, 1)
+
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 0
+
+[node name="ColorRect" type="ColorRect" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+color = Color(0, 0, 0, 1)
+
+[node name="Background" type="TextureRect" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+
+[node name="Improvements" type="Label" parent="HBoxContainer/Background"]
+layout_mode = 2
+offset_left = 7.0
+offset_top = 514.0
+offset_right = 116.0
+offset_bottom = 534.0
+text = "IMPROVEMENTS"
+
+[node name="ScrollContainer" type="ScrollContainer" parent="HBoxContainer/Background"]
+layout_mode = 2
+offset_left = 7.0
+offset_top = 537.0
+offset_right = 153.0
+offset_bottom = 759.0
+
+[node name="ExistingBuildings" type="VBoxContainer" parent="HBoxContainer/Background/ScrollContainer"]
+layout_mode = 2
+
+[node name="Culture" type="Label" parent="HBoxContainer/Background"]
+layout_mode = 0
+offset_left = 714.0
+offset_top = 4.0
+offset_right = 775.0
+offset_bottom = 24.0
+text = "CULTURE"
+
+[node name="CulturePerTurn" type="Label" parent="HBoxContainer/Background"]
+layout_mode = 0
+offset_left = 790.0
+offset_top = 4.0
+offset_right = 830.0
+offset_bottom = 24.0
+text = "-1/turn"
+
+[node name="TotalCulture" type="Label" parent="HBoxContainer/Background"]
+layout_mode = 0
+offset_left = 714.0
+offset_top = 60.0
+offset_right = 815.0
+offset_bottom = 80.0
+text = "Total: 123/1234"
+
+[node name="ProductionButton" type="TextureButton" parent="HBoxContainer/Background"]
+layout_mode = 0
+offset_left = 906.0
+offset_top = 515.0
+offset_right = 1020.0
+offset_bottom = 610.0
+
+[node name="Close" type="TextureButton" parent="HBoxContainer/Background"]
+layout_mode = 0
+offset_left = 950.0
+offset_top = 20.0
+offset_right = 990.0
+offset_bottom = 60.0
+
+[node name="ColorRect2" type="ColorRect" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+color = Color(0, 0, 0, 1)
+
+[node name="ColorRect2" type="ColorRect" parent="."]
+layout_mode = 2
+size_flags_vertical = 3
+color = Color(0, 0, 0, 1)

--- a/C7/UIElements/CityScreen/city_screen.tscn
+++ b/C7/UIElements/CityScreen/city_screen.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=4 format=3 uid="uid://bo4yg85jcbgdx"]
+[gd_scene load_steps=5 format=3 uid="uid://bo4yg85jcbgdx"]
 
 [ext_resource type="Script" path="res://UIElements/CityScreen/CityScreen.cs" id="1_e5kig"]
 [ext_resource type="Script" path="res://UIElements/Civ3TextureRect.cs" id="2_0mao8"]
 [ext_resource type="Script" path="res://UIElements/Civ3TextureButton.cs" id="3_3cdyr"]
+[ext_resource type="Script" path="res://UIElements/CityScreen/ProductionMenu.cs" id="4_xfbtv"]
 
-[node name="CityScreen" type="VBoxContainer" node_paths=PackedStringArray("background", "existingBuildings", "culturePerTurn", "totalCulture", "productionButton", "close")]
+[node name="CityScreen" type="VBoxContainer" node_paths=PackedStringArray("background", "existingBuildings", "culturePerTurn", "totalCulture", "productionButton", "close", "productionMenu")]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -18,6 +19,7 @@ culturePerTurn = NodePath("HBoxContainer/Background/CulturePerTurn")
 totalCulture = NodePath("HBoxContainer/Background/TotalCulture")
 productionButton = NodePath("HBoxContainer/Background/ProductionButton")
 close = NodePath("HBoxContainer/Background/Close")
+productionMenu = NodePath("HBoxContainer/Background/ProductionMenu")
 
 [node name="ColorRect" type="ColorRect" parent="."]
 layout_mode = 2
@@ -97,6 +99,15 @@ offset_top = 20.0
 offset_right = 990.0
 offset_bottom = 60.0
 script = ExtResource("3_3cdyr")
+
+[node name="ProductionMenu" type="TextureRect" parent="HBoxContainer/Background"]
+visible = false
+layout_mode = 0
+offset_left = 814.0
+offset_top = 135.0
+offset_right = 1017.0
+offset_bottom = 495.0
+script = ExtResource("4_xfbtv")
 
 [node name="ColorRect2" type="ColorRect" parent="HBoxContainer"]
 layout_mode = 2

--- a/C7/UIElements/CityScreen/city_screen.tscn
+++ b/C7/UIElements/CityScreen/city_screen.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=2 format=3 uid="uid://bo4yg85jcbgdx"]
+[gd_scene load_steps=4 format=3 uid="uid://bo4yg85jcbgdx"]
 
 [ext_resource type="Script" path="res://UIElements/CityScreen/CityScreen.cs" id="1_e5kig"]
+[ext_resource type="Script" path="res://UIElements/Civ3TextureRect.cs" id="2_0mao8"]
+[ext_resource type="Script" path="res://UIElements/Civ3TextureButton.cs" id="3_3cdyr"]
 
 [node name="CityScreen" type="VBoxContainer" node_paths=PackedStringArray("background", "existingBuildings", "culturePerTurn", "totalCulture", "productionButton", "close")]
 anchors_preset = 15
@@ -36,6 +38,7 @@ color = Color(0, 0, 0, 1)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
+script = ExtResource("2_0mao8")
 
 [node name="Improvements" type="Label" parent="HBoxContainer/Background"]
 layout_mode = 2
@@ -85,6 +88,7 @@ offset_left = 906.0
 offset_top = 515.0
 offset_right = 1020.0
 offset_bottom = 610.0
+script = ExtResource("3_3cdyr")
 
 [node name="Close" type="TextureButton" parent="HBoxContainer/Background"]
 layout_mode = 0
@@ -92,6 +96,7 @@ offset_left = 950.0
 offset_top = 20.0
 offset_right = 990.0
 offset_bottom = 60.0
+script = ExtResource("3_3cdyr")
 
 [node name="ColorRect2" type="ColorRect" parent="HBoxContainer"]
 layout_mode = 2

--- a/C7/UIElements/Civ3TextureButton.cs
+++ b/C7/UIElements/Civ3TextureButton.cs
@@ -1,0 +1,10 @@
+using Godot;
+using System.Collections.Generic;
+
+[GlobalClass]
+[Tool]
+public partial class Civ3TextureButton : TextureButton {
+	public override void _ValidateProperty(Godot.Collections.Dictionary property) {
+		Util.ApplyNoSaveFlag(property, [PropertyName.TextureNormal, PropertyName.TextureHover, PropertyName.TexturePressed]);
+	}
+}

--- a/C7/UIElements/Civ3TextureRect.cs
+++ b/C7/UIElements/Civ3TextureRect.cs
@@ -1,0 +1,10 @@
+using Godot;
+using System.Collections.Generic;
+
+[GlobalClass]
+[Tool]
+public partial class Civ3TextureRect : TextureRect {
+	public override void _ValidateProperty(Godot.Collections.Dictionary property) {
+		Util.ApplyNoSaveFlag(property, [PropertyName.Texture]);
+	}
+}

--- a/C7/UIElements/Diplomacy/TradeOfferUi.cs
+++ b/C7/UIElements/Diplomacy/TradeOfferUi.cs
@@ -22,7 +22,8 @@ public partial class TradeOfferUi : Tree {
 		this.playerGold = playerGold;
 		this.Columns = 1;
 		this.AllowRmbSelect = true;
-		TreeItem root = TradingTree.ConfigureTreeTheme(this, fontTheme);
+		TradingTree.ConfigureTreeTheme(this, fontTheme);
+		TreeItem root = TradingTree.CreateTreeRoot(this);
 
 		// Match the size of the texture used in the deal screen.
 		this.Size = new Vector2(190, 100);

--- a/C7/UIElements/Diplomacy/TradingTree.cs
+++ b/C7/UIElements/Diplomacy/TradingTree.cs
@@ -26,7 +26,9 @@ public partial class TradingTree : Tree {
 		this.currentOffer = currentOffer;
 		this.playerGold = playerGold;
 		this.Columns = 1;
-		TreeItem root = ConfigureTreeTheme(this, fontTheme);
+
+		ConfigureTreeTheme(this, fontTheme);
+		TreeItem root = CreateTreeRoot(this);
 
 		// Match the size of the texture used in the deal screen.
 		this.Size = new Vector2(190, 400);
@@ -154,13 +156,17 @@ public partial class TradingTree : Tree {
 		}
 	}
 
-	// The central styling for the trading tree and trade offer ui trees.
-	public static TreeItem ConfigureTreeTheme(Tree tree, Theme fontTheme) {
+	public static TreeItem CreateTreeRoot(Tree tree) {
 		// All trees have one root, but we don't want a single root, so hide it.
 		TreeItem root = tree.CreateItem();
 		tree.HideRoot = true;
 		tree.HideFolding = true;
 
+		return root;
+	}
+
+	// The central styling for the trading tree and trade offer ui trees.
+	public static void ConfigureTreeTheme(Tree tree, Theme fontTheme) {
 		// Configure the tree to look like we expect it to in civ - a transparent
 		// background with no lines between items.
 		Color transparent = new Color(0, 0, 0, 0);
@@ -179,7 +185,5 @@ public partial class TradingTree : Tree {
 		tree.AddThemeColorOverride("relationship_line_color", transparent);
 		tree.AddThemeColorOverride("guide_color", transparent);
 		tree.AddThemeConstantOverride("v_separation", 1);
-
-		return root;
 	}
 }

--- a/C7/UIElements/Diplomacy/TradingTree.cs
+++ b/C7/UIElements/Diplomacy/TradingTree.cs
@@ -139,12 +139,18 @@ public partial class TradingTree : Tree {
 
 		if (needsPeaceTreaty) {
 			goldHeader.Visible = false;
-			techHeader.Visible = false;
 			peaceTreaty.Visible = true;
+
+			if (techHeader != null) {
+				techHeader.Visible = false;
+			}
 		} else {
 			goldHeader.Visible = true;
-			techHeader.Visible = true;
 			lumpSum.Visible = !currentOffer.gold.HasValue;
+
+			if (techHeader != null) {
+				techHeader.Visible = true;
+			}
 
 			foreach (TreeItem ti in techItems) {
 				ti.Visible = !currentOffer.techs.Any(x => x.Name == ti.GetText(0));

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -403,4 +403,20 @@ public partial class Util {
 
 		return wav;
 	}
+
+	// This method is intended for use within overrides of Godot object _ValidateProperty method.
+	// Its purpose is to prevent values of properties listed in validProperties from being saved as
+	// part of the scene.  It's useful when using [Tool] scripts to execute code in editor. It
+	// allows to load Civ3 textures as part of such scripts, but prevents these textures from being
+	// saved into the scene.
+	//
+	// See Godot docs on _ValidateProperty:
+	// https://docs.godotengine.org/en/4.2/classes/class_object.html#class-object-private-method-validate-property
+	public static void ApplyNoSaveFlag(Godot.Collections.Dictionary property, HashSet<StringName> validProperties) {
+		StringName propertyName = property["name"].AsStringName();
+
+		if (validProperties.Contains(propertyName)) {
+			property["usage"] = (int)PropertyUsageFlags.NoInstanceState;
+		}
+	}
 }


### PR DESCRIPTION
This PR adds a list of built improvements to the city screen.

It also overhauls the city screen scene, utilizing [Godot's ability](https://docs.godotengine.org/en/stable/tutorials/plugins/running_code_in_the_editor.html) to execute code in the editor. Now, all Civ3 assets necessary for the city screen are loaded directly into the editor, and logic for positioning the nodes is moved from the C# class to the scene file.

Additionally, this PR fixes two bugs:
- A graphical bug where black sidebars in the city scene sometimes didn't cover the entire screen.
- An issue with the trading screen where it didn't load properly when there were no tradable techs.

![image](https://github.com/user-attachments/assets/d5a4ec8b-1325-4faf-9740-6f185bf27a38)
![image](https://github.com/user-attachments/assets/e66df0b4-95a6-4af9-b7c3-b0477eb22262)
