### PR TITLE
Clear the texture cache between games

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -96,6 +96,10 @@ public partial class Game : Node2D {
 		Global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
 
 		try {
+			// Ensure we clear out our image caches, as scenarios and games will
+			// use the same filenames but have different content for them.
+			Util.ClearCaches();
+
 			var animSoundPlayer = new AudioStreamPlayer();
 			AddChild(animSoundPlayer);
 			civ3AnimData = new AnimationManager(animSoundPlayer);

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -419,4 +419,13 @@ public partial class Util {
 			property["usage"] = (int)PropertyUsageFlags.NoInstanceState;
 		}
 	}
+
+	// Allow clearing the caches, so that scenarios with different files that
+	// have the same name can be loaded independently.
+	public static void ClearCaches() {
+		PcxCache.Clear();
+		ColorCache.Clear();
+		textureCache.Clear();
+		flicCache.Clear();
+	}
 }


### PR DESCRIPTION
This fixes the issue where scenarios would display the wrong science arrows, since scenario and regular games use the same names for textures.