### PR TITLE
Speed up tests by avoiding expensive tile calculations

### DIFF
--- a/C7GameData/AIData/TileKnowledge.cs
+++ b/C7GameData/AIData/TileKnowledge.cs
@@ -20,7 +20,7 @@ namespace C7GameData {
 		// The set of tiles this player currently has explorers headed towards.
 		public HashSet<Tile> aiExplorationTargets = new();
 
-		public void AddTilesToKnown(Tile unitLocation) {
+		public void AddTilesToKnown(Tile unitLocation, bool recomputeActiveTiles = true) {
 			knownTiles.Add(unitLocation);
 			borderTiles.Remove(unitLocation);
 
@@ -42,7 +42,9 @@ namespace C7GameData {
 				}
 			}
 
-			RecomputeActiveTiles();
+			if (recomputeActiveTiles) {
+				RecomputeActiveTiles();
+			}
 		}
 
 		// neighboring tiles should not be added when loading tile knowledge

--- a/C7GameData/GameData.cs
+++ b/C7GameData/GameData.cs
@@ -91,6 +91,10 @@ namespace C7GameData {
 		// TODO: This is a placeholder method for calculating tile owners.
 		// Currently, it marks a tile as owned only if it is a city tile or adjacent to a city.
 		public void UpdateTileOwners() {
+			// We do this at the end of the method - we don't need to do this
+			// for each tile we add in the loop below.
+			bool recomputeActiveTiles = false;
+
 			foreach (City city in cities) {
 				if (city.size == 0) {
 					continue; // skip destroyed cities
@@ -103,12 +107,12 @@ namespace C7GameData {
 					// that conflict.
 					if (t.owningCity != null) {
 						t.owningCity = ResolveTileOwnershipConflict(t.owningCity, city, t);
-						t.owningCity.owner.tileKnowledge.AddTilesToKnown(t);
+						t.owningCity.owner.tileKnowledge.AddTilesToKnown(t, recomputeActiveTiles);
 						continue;
 					}
 
 					t.owningCity = city;
-					t.owningCity.owner.tileKnowledge.AddTilesToKnown(t);
+					t.owningCity.owner.tileKnowledge.AddTilesToKnown(t, recomputeActiveTiles);
 				}
 			}
 


### PR DESCRIPTION
We don't need to repeatedly recalculate active tiles in a loop, when at the end of the loop we recalculate active tiles again.
