### PR TITLE
SaveTest: Fix a flaky assertion

### DIFF
--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -323,7 +323,7 @@ namespace C7GameData {
 				if (unitSupportCost > 0) {
 					for (int i = 0; i < unitSupportCost / government.unitCost; ++i) {
 						MapUnit unitToDisband = units[GameData.rng.Next(units.Count)];
-						log.Information($"{this} is out of gold, disbanding {unitToDisband} to being unit support costs under control");
+						log.Information($"{this} is out of gold, disbanding {unitToDisband} at {unitToDisband.location} to being unit support costs under control");
 						gameData.DisbandUnit(unitToDisband);
 					}
 					continue;

--- a/C7GameDataTests/SaveTest.cs
+++ b/C7GameDataTests/SaveTest.cs
@@ -138,7 +138,10 @@ public class SaveTests {
 					if (settlerAi.data.escort != null) {
 						Assert.Equal(settlerAi.data.escort.location, u.location);
 					} else {
-						Assert.True(u.location.unitsOnTile.Count > 1);
+						// This assertion is tempting, but will sometimes fire
+						// if the escort is disbanded due to unit support costs.
+						//
+						// Assert.True(u.location.unitsOnTile.Count > 1, $"{u} {u.location}");
 					}
 				}
 			}


### PR DESCRIPTION
This can fire if the escorting unit is disbanded due to unit support costs.

This has been flaking for a couple of PRs I have out.