### PR TITLE
Add more labels to the domestic advisor

### DIFF
--- a/C7/UIElements/Advisors/DomesticAdvisor.cs
+++ b/C7/UIElements/Advisors/DomesticAdvisor.cs
@@ -8,6 +8,16 @@ using System;
 public partial class DomesticAdvisor : Control {
 	[Export] TextureRect background;
 	[Export] TextureButton close;
+	[Export] TextureButton changeGovernment;
+	[Export] Label governmentLabel;
+	[Export] Label scienceStatus;
+	[Export] Label treasury;
+	[Export] Label incomeDetails;
+	[Export] Label expenseDetails;
+	[Export] Label incomeSummary;
+	[Export] Label expenseSummary;
+	[Export] Label sumSummary;
+	[Export] Label growth;
 
 	TextureRect scienceSliderIcon = new();
 	Label scienceSliderLabel = new();
@@ -55,6 +65,11 @@ public partial class DomesticAdvisor : Control {
 		close.TextureHover = Util.LoadTextureFromPCX("Art/exitBox-backgroundStates.pcx", 72, 0, 72, 48);
 		close.TexturePressed = Util.LoadTextureFromPCX("Art/exitBox-backgroundStates.pcx", 144, 0, 72, 48);
 		close.Pressed += Hide;
+
+		changeGovernment.TextureNormal = Util.LoadTextureFromPCX("Art/Advisors/domesticBUTTON.pcx", 1, 1, 145, 24);
+		changeGovernment.TextureHover = Util.LoadTextureFromPCX("Art/Advisors/domesticBUTTON.pcx", 1, 26, 145, 24);
+		changeGovernment.TexturePressed = Util.LoadTextureFromPCX("Art/Advisors/domesticBUTTON.pcx", 1, 52, 145, 24);
+		// TODO: implement changing governments
 
 		ImageTexture scienceSliderTexture = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 34, 2, 30, 30);
 		ImageTexture luxurySliderTexture = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 376, 2, 30, 30);
@@ -110,18 +125,38 @@ public partial class DomesticAdvisor : Control {
 	public void ShowAdvisor() {
 		Show();
 
-		int scienceRate = 5;
-		int luxuryRate = 5;
-		using (UIGameDataAccess gameDataAccess = new()) {
-			Player player = gameDataAccess.gameData.GetHumanPlayers()[0];
-			scienceRate = player.scienceRate;
-			luxuryRate = player.luxuryRate;
-		}
+		using UIGameDataAccess gameDataAccess = new();
+		Player player = gameDataAccess.gameData.GetHumanPlayers()[0];
+
+		int scienceRate = player.scienceRate;
+		int luxuryRate = player.luxuryRate;
 
 		scienceSliderIcon.SetPosition(new Vector2(CalculateSliderXPos(scienceRate), scienceSliderY));
 		luxurySliderIcon.SetPosition(new Vector2(CalculateSliderXPos(luxuryRate), luxurySliderY));
 		scienceSliderLabel.Text = $"{scienceRate * 10}%";
 		luxurySliderLabel.Text = $"{luxuryRate * 10}%";
+
+		governmentLabel.Text = $"{player.government.name}";
+		scienceStatus.Text = player.SummarizeScience(gameDataAccess.gameData);
+		treasury.Text = $"Treasury: {player.gold}";
+
+		// TODO: fill these in.
+		incomeDetails.Text = "From cities: +??\nFrom taxmen: +??\nFrom other civs: +??\nFrom interest: +??";
+		expenseDetails.Text = "-??: Science\n-??: Entertainment\n-??: Corruption\n-??: Maintenance\n-??: Unit costs\n-??: To other civs";
+		incomeSummary.Text = "??";
+		expenseSummary.Text = "??";
+
+		int goldPerTurn = player.CalculateGoldPerTurn();
+		if (goldPerTurn > 0) {
+			sumSummary.Text = $"Net gain: {goldPerTurn}";
+			growth.Text = "Growing!";
+		} else if (goldPerTurn < 0) {
+			sumSummary.Text = $"Net loss: {goldPerTurn}";
+			growth.Text = "Shrinking!";
+		} else {
+			sumSummary.Text = $"Neutral: {goldPerTurn}";
+			growth.Text = "Balanced";
+		}
 	}
 
 	private int CalculateSliderXPos(int sliderRate) {

--- a/C7/UIElements/Advisors/domestic_advisor.tscn
+++ b/C7/UIElements/Advisors/domestic_advisor.tscn
@@ -4,7 +4,16 @@
 [ext_resource type="Script" path="res://UIElements/Civ3TextureRect.cs" id="2"]
 [ext_resource type="Script" path="res://UIElements/Civ3TextureButton.cs" id="3"]
 
-[node name="DomesticAdvisor" type="CenterContainer" node_paths=PackedStringArray("background", "close")]
+[sub_resource type="LabelSettings" id="LabelSettings_0b8py"]
+font_size = 13
+font_color = Color(0, 0, 0, 1)
+
+[sub_resource type="LabelSettings" id="LabelSettings_61gj0"]
+line_spacing = 0.0
+font_size = 11
+font_color = Color(0, 0, 0, 1)
+
+[node name="DomesticAdvisor" type="CenterContainer" node_paths=PackedStringArray("background", "close", "changeGovernment", "governmentLabel", "scienceStatus", "treasury", "incomeDetails", "expenseDetails", "incomeSummary", "expenseSummary", "sumSummary", "growth")]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -13,6 +22,16 @@ grow_vertical = 2
 script = ExtResource("1")
 background = NodePath("Background")
 close = NodePath("Background/Close")
+changeGovernment = NodePath("Background/ChangeGovernment")
+governmentLabel = NodePath("Background/ChangeGovernment/GovernmentLabel")
+scienceStatus = NodePath("Background/ScienceStatus")
+treasury = NodePath("Background/Treasury")
+incomeDetails = NodePath("Background/IncomeDetails")
+expenseDetails = NodePath("Background/ExpenseDetails")
+incomeSummary = NodePath("Background/IncomeSummary")
+expenseSummary = NodePath("Background/ExpenseSummary")
+sumSummary = NodePath("Background/SumSummary")
+growth = NodePath("Background/Growth")
 
 [node name="Background" type="TextureRect" parent="."]
 layout_mode = 2
@@ -25,3 +44,103 @@ offset_top = 720.0
 offset_right = 1024.0
 offset_bottom = 768.0
 script = ExtResource("3")
+
+[node name="ChangeGovernment" type="TextureButton" parent="Background" index="1"]
+layout_mode = 0
+offset_left = 650.0
+offset_top = 186.0
+offset_right = 795.0
+offset_bottom = 210.0
+script = ExtResource("3")
+
+[node name="GovernmentLabel" type="Label" parent="Background/ChangeGovernment" index="0"]
+layout_mode = 0
+offset_left = 6.0
+offset_top = 2.0
+offset_right = 139.0
+offset_bottom = 22.0
+text = "Despotism"
+
+[node name="Label" type="Label" parent="Background" index="2"]
+layout_mode = 0
+offset_left = 559.0
+offset_top = 189.0
+offset_right = 642.0
+offset_bottom = 209.0
+text = "Government"
+label_settings = SubResource("LabelSettings_0b8py")
+
+[node name="ScienceStatus" type="Label" parent="Background" index="3"]
+layout_mode = 0
+offset_left = 565.0
+offset_top = 165.0
+offset_right = 711.0
+offset_bottom = 185.0
+text = "Placeholder (25 turns)"
+
+[node name="Treasury" type="Label" parent="Background" index="4"]
+layout_mode = 0
+offset_left = 83.0
+offset_top = 193.0
+offset_right = 237.0
+offset_bottom = 213.0
+text = "Treasury: 12345 gold"
+
+[node name="IncomeDetails" type="Label" parent="Background" index="5"]
+layout_mode = 0
+offset_left = 84.0
+offset_top = 98.0
+offset_right = 222.0
+offset_bottom = 165.0
+text = "From cities: + 1234
+From taxmen: +0
+From other civs: +0
+From interest: +0"
+label_settings = SubResource("LabelSettings_61gj0")
+horizontal_alignment = 2
+
+[node name="ExpenseDetails" type="Label" parent="Background" index="6"]
+layout_mode = 0
+offset_left = 379.0
+offset_top = 87.0
+offset_right = 537.0
+offset_bottom = 183.0
+text = "-123: Science
+-18: Entertainment
+-100: Corruption
+-19: Maintenance
+-5: Unit costs
+-8: To other civs"
+label_settings = SubResource("LabelSettings_61gj0")
+
+[node name="IncomeSummary" type="Label" parent="Background" index="7"]
+layout_mode = 0
+offset_left = 254.0
+offset_top = 102.0
+offset_right = 294.0
+offset_bottom = 122.0
+text = "Income: 1234"
+
+[node name="ExpenseSummary" type="Label" parent="Background" index="8"]
+layout_mode = 0
+offset_left = 254.0
+offset_top = 152.0
+offset_right = 294.0
+offset_bottom = 172.0
+text = "Expenses: 4567"
+
+[node name="SumSummary" type="Label" parent="Background" index="9"]
+layout_mode = 0
+offset_left = 254.0
+offset_top = 193.0
+offset_right = 294.0
+offset_bottom = 213.0
+text = "Net loss: -18"
+
+[node name="Growth" type="Label" parent="Background" index="10"]
+layout_mode = 0
+offset_left = 390.0
+offset_top = 195.0
+offset_right = 459.0
+offset_bottom = 215.0
+text = "Shrinking!"

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -171,17 +171,7 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 			}
 
 			// Tech progress.
-			{
-				Tech tech = gD.techs.Find(x => x.id == player.currentlyResearchedTech);
-				string techName = tech == null ? "Not selected" : tech.Name;
-				int turnsRemaining = tech == null ? int.MaxValue : player.EstimateTurnsToResearch(gD, tech);
-
-				if (turnsRemaining >= int.MaxValue) {
-					scienceProgress.SetTextAndCenterLabel($"{techName} (-- turns)");
-				} else {
-					scienceProgress.SetTextAndCenterLabel($"{techName} ({turnsRemaining} turns)");
-				}
-			}
+			scienceProgress.SetTextAndCenterLabel(player.SummarizeScience(gD));
 
 			// Civ and government.
 			civAndGovt.SetTextAndCenterLabel($"{player.civilization.name} - {player.government.name} (5.5.0)");

--- a/C7GameData/Player.cs
+++ b/C7GameData/Player.cs
@@ -321,6 +321,15 @@ namespace C7GameData {
 			return result;
 		}
 
+		public string SummarizeScience(GameData gD) {
+			Tech tech = gD.techs.Find(x => x.id == currentlyResearchedTech);
+			if (tech == null) {
+				return "Not selected (-- turns)";
+			}
+
+			return $"{tech.Name} ({EstimateTurnsToResearch(gD, tech)} turns)";
+		}
+
 		public void DoPerTurnFinanceUpdates(GameData gameData) {
 			if (isBarbarians) {
 				return;


### PR DESCRIPTION
Now that this is in the godot editor this is much easier to do, though I still don't know how to hook up the `[Export]` variables without editing the `tscn` text file.

![image](https://github.com/user-attachments/assets/fc4de3b5-e510-4571-b4f4-98c30567641c)
