### PR TITLE
Centralize the logic for advisor popup heads

### DIFF
--- a/C7/UIElements/Advisors/DomesticAdvisor.cs
+++ b/C7/UIElements/Advisors/DomesticAdvisor.cs
@@ -24,6 +24,8 @@ public partial class DomesticAdvisor : Control {
 	TextureRect luxurySliderIcon = new();
 	Label luxurySliderLabel = new();
 
+	TextureRect advisorHead = new();
+
 	// The Y position of the two sliders.
 	private int scienceSliderY = 84;
 	private int luxurySliderY = 130;
@@ -37,17 +39,9 @@ public partial class DomesticAdvisor : Control {
 		ImageTexture DomesticBackground = Util.LoadTextureFromPCX("Art/Advisors/domestic.pcx");
 		background.Texture = DomesticBackground;
 
-		//TODO: Age-based background.  Only use Ancient for now.
-		ImageTexture AdvisorHappy = Util.LoadTextureFromPCX("Art/SmallHeads/popupDOMESTIC.pcx", 1, 40, 149, 110);
-		ImageTexture AdvisorAngry = Util.LoadTextureFromPCX("Art/SmallHeads/popupDOMESTIC.pcx", 151, 40, 149, 110);
-		ImageTexture AdvisorSad = Util.LoadTextureFromPCX("Art/SmallHeads/popupDOMESTIC.pcx", 301, 40, 149, 110);
-		ImageTexture AdvisorSurprised = Util.LoadTextureFromPCX("Art/SmallHeads/popupDOMESTIC.pcx", 451, 40, 149, 110);
-
-		TextureRect AdvisorHead = new TextureRect();
-		//TODO: Randomize or set logically
-		AdvisorHead.Texture = AdvisorSurprised;
-		AdvisorHead.SetPosition(new Vector2(851, 0));
-		background.AddChild(AdvisorHead);
+		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Domestic, AdvisorHead.Mood.Happy, /*eraIndex=*/0);
+		advisorHead.SetPosition(new Vector2(851, 0));
+		background.AddChild(advisorHead);
 
 		ImageTexture DialogBoxTexture = Util.LoadTextureFromPCX("Art/Advisors/dialogbox.pcx");
 		TextureButton DialogBox = new TextureButton();
@@ -157,6 +151,9 @@ public partial class DomesticAdvisor : Control {
 			sumSummary.Text = $"Neutral: {goldPerTurn}";
 			growth.Text = "Balanced";
 		}
+
+		//TODO: Randomize or set logically
+		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Domestic, AdvisorHead.Mood.Happy, player.EraIndex());
 	}
 
 	private int CalculateSliderXPos(int sliderRate) {

--- a/C7/UIElements/Advisors/MilitaryAdvisor.cs
+++ b/C7/UIElements/Advisors/MilitaryAdvisor.cs
@@ -15,18 +15,6 @@ public partial class MilitaryAdvisor : TextureRect {
 	private void CreateUI() {
 		this.Texture = Util.LoadTextureFromPCX("Art/Advisors/military.pcx");
 
-		//TODO: Age-based background.  Only use Ancient for now.
-		ImageTexture AdvisorHappy = Util.LoadTextureFromPCX("Art/SmallHeads/popupMILITARY.pcx", 1, 40, 149, 110);
-		ImageTexture AdvisorAngry = Util.LoadTextureFromPCX("Art/SmallHeads/popupMILITARY.pcx", 151, 40, 149, 110);
-		ImageTexture AdvisorSad = Util.LoadTextureFromPCX("Art/SmallHeads/popupMILITARY.pcx", 301, 40, 149, 110);
-		ImageTexture AdvisorSurprised = Util.LoadTextureFromPCX("Art/SmallHeads/popupMILITARY.pcx", 451, 40, 149, 110);
-
-		TextureRect AdvisorHead = new TextureRect();
-		//TODO: Randomize or set logically
-		AdvisorHead.Texture = AdvisorSurprised;
-		AdvisorHead.SetPosition(new Vector2(851, 0));
-		AddChild(AdvisorHead);
-
 		ImageTexture DialogBoxTexture = Util.LoadTextureFromPCX("Art/Advisors/dialogbox.pcx");
 		TextureButton DialogBox = new TextureButton();
 		DialogBox.TextureNormal = DialogBoxTexture;
@@ -64,6 +52,12 @@ public partial class MilitaryAdvisor : TextureRect {
 			unitSupportCostLabel.SetPosition(new Vector2(0, 188));
 			unitSupportCostLabel.SetTextAndCenterLabel($"Unit Support Cost\n{unitSupportCost} gold/turn");
 			unitSupportCostLabel.Position += new Vector2(-50, 0);
+
+			TextureRect advisorHead = new();
+			//TODO: Randomize or set logically
+			advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Military, AdvisorHead.Mood.Happy, player.EraIndex());
+			advisorHead.SetPosition(new Vector2(851, 0));
+			AddChild(advisorHead);
 		}
 
 	}

--- a/C7/UIElements/Advisors/ScienceAdvisor.cs
+++ b/C7/UIElements/Advisors/ScienceAdvisor.cs
@@ -12,6 +12,7 @@ public partial class ScienceAdvisor : TextureRect {
 	private TextureButton nextEra;
 	private TextureButton previousEra;
 	private List<TechBox> techBoxes = new();
+	private TextureRect advisorHead = new();
 
 	// Stored separately so we can modify this without mutating the player.
 	private string eraName;
@@ -35,19 +36,9 @@ public partial class ScienceAdvisor : TextureRect {
 		IndustrialBackground = Util.LoadTextureFromPCX("Art/Advisors/science_industrial_new.pcx");
 		ModernBackground = Util.LoadTextureFromPCX("Art/Advisors/science_modern.pcx");
 
-		// TODO: Age-based background.  Only use Ancient for now.
-		// TODO: Consider moving this to an advisor utility, since we're copying
-		// these X,Y coordinates in multiple places.
-		ImageTexture AdvisorHappy = Util.LoadTextureFromPCX("Art/SmallHeads/popupSCIENCE.pcx", 1, 40, 149, 110);
-		ImageTexture AdvisorAngry = Util.LoadTextureFromPCX("Art/SmallHeads/popupSCIENCE.pcx", 151, 40, 149, 110);
-		ImageTexture AdvisorSad = Util.LoadTextureFromPCX("Art/SmallHeads/popupSCIENCE.pcx", 301, 40, 149, 110);
-		ImageTexture AdvisorSurprised = Util.LoadTextureFromPCX("Art/SmallHeads/popupSCIENCE.pcx", 451, 40, 149, 110);
-
-		TextureRect AdvisorHead = new();
-		//TODO: Randomize or set logically
-		AdvisorHead.Texture = AdvisorSurprised;
-		AdvisorHead.SetPosition(new Vector2(851, 0));
-		AddChild(AdvisorHead);
+		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Science, AdvisorHead.Mood.Happy, /*eraIndex=*/0);
+		advisorHead.SetPosition(new Vector2(851, 0));
+		AddChild(advisorHead);
 
 		ImageTexture DialogBoxTexture = Util.LoadTextureFromPCX("Art/Advisors/dialogbox.pcx");
 		TextureButton DialogBox = new TextureButton();
@@ -122,6 +113,7 @@ public partial class ScienceAdvisor : TextureRect {
 			this.Texture = ModernBackground;
 			nextEra.Hide();
 		}
+		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Science, AdvisorHead.Mood.Happy, player.EraIndex());
 
 		foreach (Tech tech in allTechs) {
 			if (tech.EraCivilopediaName != eraName) {

--- a/C7/UIElements/Popups/AdvisorHead.cs
+++ b/C7/UIElements/Popups/AdvisorHead.cs
@@ -1,0 +1,36 @@
+using Godot;
+using System;
+
+public class AdvisorHead {
+	public enum Mood {
+		Happy,
+		Angry,
+		Sad,
+		Surprised
+	};
+
+	public enum Advisor {
+		Domestic,
+		Trade,
+		Military,
+		Foreign,
+		Culture,
+		Science
+	};
+
+	public static ImageTexture GetPopupImage(Advisor advisor, Mood mood, int eraIndex) {
+		return Util.LoadTextureFromPCX(GetFilename(advisor), 1 + (int)mood * 150, 150 * (eraIndex + 1) - 110, 149, 110, false);
+	}
+
+	private static string GetFilename(Advisor advisor) {
+		switch (advisor) {
+			case Advisor.Domestic: return "Art/SmallHeads/popupDOMESTIC.pcx";
+			case Advisor.Trade: return "Art/SmallHeads/popupTRADE.pcx";
+			case Advisor.Military: return "Art/SmallHeads/popupMILITARY.pcx";
+			case Advisor.Foreign: return "Art/SmallHeads/popupFOREIGN.pcx";
+			case Advisor.Culture: return "Art/SmallHeads/popupCULTURE.pcx";
+			case Advisor.Science: return "Art/SmallHeads/popupSCIENCE.pcx";
+		}
+		throw new Exception($"Unknown advisor type: {advisor}");
+	}
+}

--- a/C7/UIElements/Popups/BuildCityDialog.cs
+++ b/C7/UIElements/Popups/BuildCityDialog.cs
@@ -24,12 +24,11 @@ public partial class BuildCityDialog : Popup {
 
 		AddTexture(530, 260);
 
-		ImageTexture AdvisorHappy = Util.LoadTextureFromPCX("Art/SmallHeads/popupCULTURE.pcx", 1, 40, 149, 110, false);
-		TextureRect AdvisorHead = new TextureRect();
-		AdvisorHead.Texture = AdvisorHappy;
+		TextureRect advisorHead = new();
+		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Culture, AdvisorHead.Mood.Happy, /*eraIndex=*/0);
 		//Appears at 400, 110 in game, but leftmost 25px are transparent with default graphics
-		AdvisorHead.SetPosition(new Vector2(375, 0));
-		AddChild(AdvisorHead);
+		advisorHead.SetPosition(new Vector2(375, 0));
+		AddChild(advisorHead);
 
 		AddBackground(530, 150, 110);
 

--- a/C7/UIElements/Popups/CivilizationDestroyed.cs
+++ b/C7/UIElements/Popups/CivilizationDestroyed.cs
@@ -20,13 +20,12 @@ public partial class CivilizationDestroyed : Popup {
 		//The top 110 px are for the advisor.
 		AddTexture(530, 260);
 
-		ImageTexture AdvisorHappy = Util.LoadTextureFromPCX("Art/SmallHeads/popupMILITARY.pcx", 1, 40, 149, 110, false);
-		TextureRect AdvisorHead = new() {
-			Texture = AdvisorHappy
+		TextureRect advisorHead = new() {
+			Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Military, AdvisorHead.Mood.Happy, /*eraIndex=*/0),
 		};
 		//Appears at 400, 110 in game, but leftmost 25px are transparent with default graphics
-		AdvisorHead.SetPosition(new Vector2(375, 0));
-		AddChild(AdvisorHead);
+		advisorHead.SetPosition(new Vector2(375, 0));
+		AddChild(advisorHead);
 
 		AddBackground(530, 150, 110);
 		AddHeader("Military Advisor", 120);

--- a/C7/UIElements/Popups/DisbandConfirmation.cs
+++ b/C7/UIElements/Popups/DisbandConfirmation.cs
@@ -37,12 +37,11 @@ public partial class DisbandConfirmation : Popup {
 		// out the size of this TextureRect, and it won't be able to align it properly.
 		AddTexture(530, 320);
 
-		ImageTexture AdvisorHappy = Util.LoadTextureFromPCX("Art/SmallHeads/popupDOMESTIC.pcx", 1, 40, 149, 110, false);
-		TextureRect AdvisorHead = new TextureRect();
-		AdvisorHead.Texture = AdvisorHappy;
+		TextureRect advisorHead = new TextureRect();
+		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Domestic, AdvisorHead.Mood.Surprised, /*eraIndex=*/0);
 		//Appears at 400, 110 in game, but leftmost 25px are transparent with default graphics
-		AdvisorHead.SetPosition(new Vector2(375, 0));
-		AddChild(AdvisorHead);
+		advisorHead.SetPosition(new Vector2(375, 0));
+		AddChild(advisorHead);
 
 		//TODO: Almost all (135 ms) of the disband confirmation creation, after the first time, is in the
 		//background creation.  90 ms or so on the first time is before this point (and is well-cached later on).

--- a/C7/UIElements/Popups/InformationalPopup.cs
+++ b/C7/UIElements/Popups/InformationalPopup.cs
@@ -22,11 +22,10 @@ public partial class InformationalPopup : Popup {
 		int width = 430;
 		int height = 230;
 
-		ImageTexture AdvisorHappy = Util.LoadTextureFromPCX("Art/SmallHeads/popupFOREIGN.pcx", 1, 40, 149, 110, false);
-		TextureRect AdvisorHead = new TextureRect();
-		AdvisorHead.Texture = AdvisorHappy;
-		AdvisorHead.SetPosition(new Vector2(275, 0));
-		AddChild(AdvisorHead);
+		TextureRect advisorHead = new();
+		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Foreign, AdvisorHead.Mood.Happy, /*eraIndex=*/0);
+		advisorHead.SetPosition(new Vector2(275, 0));
+		AddChild(advisorHead);
 
 		AddTexture(width, height);
 		AddBackground(width, height - 110, 110);

--- a/C7/UIElements/Popups/WarConfirmation.cs
+++ b/C7/UIElements/Popups/WarConfirmation.cs
@@ -20,12 +20,11 @@ public partial class WarConfirmation : Popup {
 
 		AddTexture(530, 320);
 
-		ImageTexture AdvisorHappy = Util.LoadTextureFromPCX("Art/SmallHeads/popupFOREIGN.pcx", 1, 40, 149, 110, false);
-		TextureRect AdvisorHead = new TextureRect();
-		AdvisorHead.Texture = AdvisorHappy;
+		TextureRect advisorHead = new();
+		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Foreign, AdvisorHead.Mood.Surprised, /*eraIndex=*/0);
 		//Appears at 400, 110 in game, but leftmost 25px are transparent with default graphics
-		AdvisorHead.SetPosition(new Vector2(375, 0));
-		AddChild(AdvisorHead);
+		advisorHead.SetPosition(new Vector2(375, 0));
+		AddChild(advisorHead);
 
 		AddBackground(530, 210, 110);
 		AddHeader("Foreign Advisor", 120);


### PR DESCRIPTION
This reduces a lot of duplicate code and allows us to easily add mood and era support.
