### PR TITLE
Change the disband confirmation to a general confirmation popup 

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -372,4 +372,3 @@ visible = false
 [connection signal="HidePopup" from="CanvasLayer/PopupOverlay" to="CanvasLayer/PopupOverlay" method="OnHidePopup"]
 [connection signal="Quit" from="CanvasLayer/PopupOverlay" to="." method="OnQuitTheGame"]
 [connection signal="Retire" from="CanvasLayer/PopupOverlay" to="." method="_on_QuitButton_pressed"]
-[connection signal="UnitDisbanded" from="CanvasLayer/PopupOverlay" to="." method="OnUnitDisbanded"]

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -788,7 +788,15 @@ public partial class Game : Node2D {
 		}
 
 		if (currentAction == C7Action.UnitDisband) {
-			popupOverlay.ShowPopup(new DisbandConfirmation(CurrentlySelectedUnit), PopupOverlay.PopupCategory.Advisor);
+			popupOverlay.ShowPopup(
+				new ConfirmationPopup(
+					$"Disband {CurrentlySelectedUnit.unitType.name}? Pardon me but these are OUR people. Do \nyou really want to disband them?",
+					"Yes, we need to!",
+					"No. Maybe you are right, advisor.",
+					() => {
+						new ActionToEngineMsg(() => CurrentlySelectedUnit?.disband()).send();
+					}),
+				PopupOverlay.PopupCategory.Advisor);
 		}
 
 		// unit_goto's behavior is more complicated than other actions - it
@@ -928,11 +936,6 @@ public partial class Game : Node2D {
 		} else {
 			animationPlayer.Play("SlideOutAnimation");
 		}
-	}
-
-	// Called by the disband popup
-	private void OnUnitDisbanded() {
-		new ActionToEngineMsg(() => CurrentlySelectedUnit?.disband()).send();
 	}
 
 	/**

--- a/C7/UIElements/Popups/ConfirmationPopup.cs
+++ b/C7/UIElements/Popups/ConfirmationPopup.cs
@@ -4,21 +4,22 @@ using System.Diagnostics;
 using C7GameData;
 using Serilog;
 
-public partial class DisbandConfirmation : Popup {
-	private ILogger log = LogManager.ForContext<DisbandConfirmation>();
-
-	string unitType = "";
+public partial class ConfirmationPopup : Popup {
+	private ILogger log = LogManager.ForContext<ConfirmationPopup>();
 
 	Stopwatch loadTimer = new Stopwatch();
+	string message;
+	string yesText;
+	string noText;
+	Action yesAction;
 
-	//So Godot doesn't print error " Cannot construct temporary MonoObject because the class does not define a parameterless constructor"
-	//Not sure how important that is *shrug*
-	public DisbandConfirmation() { }
-
-	public DisbandConfirmation(MapUnit unit) {
+	public ConfirmationPopup(string message, string yesText, string noText, Action yesAction) {
 		alignment = BoxContainer.AlignmentMode.End;
 		margins = new Margins(right: 10);
-		unitType = unit.unitType.name;
+		this.message = message;
+		this.yesText = yesText;
+		this.noText = noText;
+		this.yesAction = yesAction;
 	}
 
 	public override void _EnterTree() {
@@ -51,26 +52,25 @@ public partial class DisbandConfirmation : Popup {
 
 		AddHeader("Domestic Advisor", 120);
 
-		Label warningMessage = new Label();
+		Label warningMessage = new();
 		//TODO: General-purpose text breaking up util.  Instead of \n
 		//This appears to be the way to do multi line labels, see: https://godotengine.org/qa/11126/how-to-break-line-on-the-label-using-gdscript
 		//Maybe there's an awesomer control we can user instead
-		warningMessage.Text = "Disband " + unitType + "?  Pardon me but these are OUR people. Do \nyou really want to disband them?";
+		warningMessage.Text = message; //"Disband " + unitType + "?  Pardon me but these are OUR people. Do \nyou really want to disband them?";
 
 		warningMessage.SetPosition(new Vector2(25, 170));
 		AddChild(warningMessage);
 
-		AddButton("Yes, we need to!", 215, disband);
-		AddButton("No. Maybe you are right, advisor.", 245, cancel);
+		AddButton(yesText, 215, confirmed);
+		AddButton(noText, 245, cancel);
 
 		loadTimer.Stop();
 		TimeSpan stopwatchElapsed = loadTimer.Elapsed;
-		log.Verbose("Disband popup load time: " + Convert.ToInt32(stopwatchElapsed.TotalMilliseconds) + " ms");
+		log.Verbose("Confirmation popup load time: " + Convert.ToInt32(stopwatchElapsed.TotalMilliseconds) + " ms");
 	}
 
-	private void disband() {
-		//tell the game to disband it.  right now we're doing that first, which is WRONG!
-		GetParent().EmitSignal(PopupOverlay.SignalName.UnitDisbanded);
+	private void confirmed() {
+		yesAction();
 		GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
 	}
 

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -8,7 +8,6 @@ public partial class PopupOverlay : HBoxContainer {
 
 	private ILogger log = LogManager.ForContext<PopupOverlay>();
 
-	[Signal] public delegate void UnitDisbandedEventHandler();
 	[Signal] public delegate void QuitEventHandler();
 	[Signal] public delegate void RetireEventHandler();
 	[Signal] public delegate void BuildCityEventHandler(string name);


### PR DESCRIPTION
... and use a plain old C# `Action` to avoid some complex godot wiring we don't need. We just want to run a callback.

The popup still works:

![image](https://github.com/user-attachments/assets/3c8f650c-0dcf-4e81-ace8-54d38a9c4211)
