### PR TITLE
Allow changing governments!

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using C7Engine.AI;
 
 public partial class Game : Node2D {
-	[Signal] public delegate void TurnStartedEventHandler();
 	[Signal] public delegate void TurnEndedEventHandler();
 	[Signal] public delegate void ShowSpecificAdvisorEventHandler();
 	[Signal] public delegate void NewAutoselectedUnitEventHandler();
@@ -201,6 +200,9 @@ public partial class Game : Node2D {
 		cityScreen.tileAssignmentLayer = mapView.tileAssignmentLayer;
 		cityScreen.mapView = mapView;
 		cityScreen.citizenTypes = gameDataAccess.gameData.citizenTypes;
+
+		// Allow the domestic advisor to trigger popups.
+		advisor.domesticAdvisor.SetPopupOverlay(popupOverlay);
 	}
 
 	// Must only be called while holding the game data mutex
@@ -210,7 +212,7 @@ public partial class Game : Node2D {
 			switch (msg) {
 				case MsgStartUnitAnimation mSUA:
 					MapUnit unit = gameData.GetUnit(mSUA.unitID);
-					if (unit != null && (controller.tileKnowledge.isTileKnown(unit.location) || controller.tileKnowledge.isTileKnown(unit.previousLocation))) {
+					if (unit != null && (controller.tileKnowledge.isActiveTile(unit.location) || controller.tileKnowledge.isActiveTile(unit.previousLocation))) {
 						// TODO: This needs to be extended so that the player is shown when AIs found cities, when they move units
 						// (optionally, depending on preferences) and generalized so that modders can specify whether custom
 						// animations should be shown to the player.
@@ -228,7 +230,7 @@ public partial class Game : Node2D {
 					int X, Y;
 					gameData.map.tileIndexToCoords(mSEA.tileIndex, out X, out Y);
 					Tile tile = gameData.map.tileAt(X, Y);
-					if (tile != Tile.NONE && controller.tileKnowledge.isTileKnown(tile))
+					if (tile != Tile.NONE && controller.tileKnowledge.isActiveTile(tile))
 						animTracker.startAnimation(tile, mSEA.effect, mSEA.completionEvent, mSEA.ending);
 					else {
 						if (mSEA.completionEvent != null)
@@ -265,7 +267,7 @@ public partial class Game : Node2D {
 					// TODO: Move the F* key strings to a set of constants/enum.
 					EmitSignal(SignalName.ShowSpecificAdvisor, "F6");
 					break;
-				case MsgUpdateUiAfterSliderChange mUUASC:
+				case MsgUpdateUiAfterDomesticChange mUUASC:
 					// F1 is the science advisor.
 					// TODO: Move the F* key strings to a set of constants/enum.
 					EmitSignal(SignalName.ShowSpecificAdvisor, "F1");
@@ -391,23 +393,28 @@ public partial class Game : Node2D {
 	}
 
 	private void OnPlayerStartTurn() {
+		using UIGameDataAccess gameDataAccess = new();
 		log.Information("Starting player turn");
-		using (var gameDataAccess = new UIGameDataAccess()) {
-			int turnNumber = TurnHandling.GetTurnNumber();
-			Player player = controller;
 
-			// Allow fast forwarding in observer mode.
-			if (gameDataAccess.gameData.observerMode && turnsLeftToFastForward > 0) {
-				--turnsLeftToFastForward;
-				new MsgEndTurn().send();
-				return;
-			}
-
-			EmitSignal(SignalName.TurnStarted, turnNumber, player.gold, /*goldPerTurn=*/0);
-			CurrentState = GameState.PlayerTurn;
-
-			GetNextAutoselectedUnit(gameDataAccess.gameData);
+		// If the player can now pick a new government, force them to do so.
+		// When the popup is closed we call OnPlayerStartTurn again. This isn't
+		// ideal, but we don't yet have a general purpose "show a popup and
+		// wait for the player to acknowledge it" system.
+		if (controller.government.transitionType && TurnHandling.GetTurnNumber() >= controller.inAnarchyUntilTurn) {
+			popupOverlay.ShowPopup(
+				new GovernmentSelection(controller, controller.GetAvailableGovernments(gameDataAccess.gameData)),
+				PopupOverlay.PopupCategory.Info);
 		}
+
+		// Allow fast forwarding in observer mode.
+		if (gameDataAccess.gameData.observerMode && turnsLeftToFastForward > 0) {
+			--turnsLeftToFastForward;
+			new MsgEndTurn().send();
+			return;
+		}
+
+		CurrentState = GameState.PlayerTurn;
+		GetNextAutoselectedUnit(gameDataAccess.gameData);
 	}
 
 	private void OnPlayerEndTurn() {
@@ -466,7 +473,7 @@ public partial class Game : Node2D {
 
 	public override void _UnhandledInput(InputEvent @event) {
 		// Don't handle mouse actions if UI elements are visible
-		if (popupOverlay.Visible || cityScreen.Visible || advisor.Visible || diplomacy.Visible) {
+		if (popupOverlay.Visible || cityScreen.Visible || advisor.Visible || diplomacy.Visible || palaceScreen.Visible) {
 			IsMovingCamera = false;
 			return;
 		}

--- a/C7/UIElements/Advisors/Advisors.cs
+++ b/C7/UIElements/Advisors/Advisors.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 public partial class Advisors : CenterContainer {
 	private ILogger log = LogManager.ForContext<Advisors>();
 
-	[Export] private DomesticAdvisor domesticAdvisor;
+	[Export] public DomesticAdvisor domesticAdvisor;
 	private MilitaryAdvisor militaryAdvisor;
 	private ScienceAdvisor scienceAdvisor;
 

--- a/C7/UIElements/Advisors/DomesticAdvisor.cs
+++ b/C7/UIElements/Advisors/DomesticAdvisor.cs
@@ -18,6 +18,7 @@ public partial class DomesticAdvisor : Control {
 	[Export] Label expenseSummary;
 	[Export] Label sumSummary;
 	[Export] Label growth;
+	PopupOverlay popupOverlay;
 
 	TextureRect scienceSliderIcon = new();
 	Label scienceSliderLabel = new();
@@ -25,6 +26,7 @@ public partial class DomesticAdvisor : Control {
 	Label luxurySliderLabel = new();
 
 	TextureRect advisorHead = new();
+	Label DialogBoxAdvise = new();
 
 	// The Y position of the two sliders.
 	private int scienceSliderY = 84;
@@ -50,7 +52,6 @@ public partial class DomesticAdvisor : Control {
 		background.AddChild(DialogBox);
 
 		//TODO: Multi-line capabilities
-		Label DialogBoxAdvise = new Label();
 		DialogBoxAdvise.Text = "You are running C7!";
 		DialogBoxAdvise.SetPosition(new Vector2(815, 119));
 		background.AddChild(DialogBoxAdvise);
@@ -63,7 +64,7 @@ public partial class DomesticAdvisor : Control {
 		changeGovernment.TextureNormal = Util.LoadTextureFromPCX("Art/Advisors/domesticBUTTON.pcx", 1, 1, 145, 24);
 		changeGovernment.TextureHover = Util.LoadTextureFromPCX("Art/Advisors/domesticBUTTON.pcx", 1, 26, 145, 24);
 		changeGovernment.TexturePressed = Util.LoadTextureFromPCX("Art/Advisors/domesticBUTTON.pcx", 1, 52, 145, 24);
-		// TODO: implement changing governments
+		changeGovernment.Pressed += ChangeGovernments;
 
 		ImageTexture scienceSliderTexture = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 34, 2, 30, 30);
 		ImageTexture luxurySliderTexture = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 376, 2, 30, 30);
@@ -154,6 +155,14 @@ public partial class DomesticAdvisor : Control {
 
 		//TODO: Randomize or set logically
 		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Domestic, AdvisorHead.Mood.Happy, player.EraIndex());
+
+		// Disable the change government button unless we have a government to
+		// switch to.
+		changeGovernment.Disabled = player.GetAvailableGovernments(gameDataAccess.gameData).Count == 1;
+
+		if (player.government.transitionType && player.inAnarchyUntilTurn > gameDataAccess.gameData.turn) {
+			DialogBoxAdvise.Text = $"{player.inAnarchyUntilTurn - gameDataAccess.gameData.turn} turns of anarchy left";
+		}
 	}
 
 	private int CalculateSliderXPos(int sliderRate) {
@@ -161,5 +170,31 @@ public partial class DomesticAdvisor : Control {
 		int maxX = 725;
 
 		return minX + (int)((maxX - minX) * (sliderRate / 10.0));
+	}
+
+	public void SetPopupOverlay(PopupOverlay po) {
+		popupOverlay = po;
+	}
+
+	private void ChangeGovernments() {
+		using UIGameDataAccess gameDataAccess = new();
+		Player player = gameDataAccess.gameData.GetHumanPlayers()[0];
+
+		if (player.government.transitionType) {
+			popupOverlay.ShowPopup(
+				new InformationalPopup("You already started a revolution. Remember?"),
+				PopupOverlay.PopupCategory.Advisor);
+			return;
+		}
+
+		popupOverlay.ShowPopup(
+				new ConfirmationPopup(
+					"You say you want a revolution?",
+					"Yes, you know it's gonna be alright.",
+					"No. You can count me out.",
+					() => {
+						new StartGovernmentTransitionMsg(player).send();
+					}),
+				PopupOverlay.PopupCategory.Advisor);
 	}
 }

--- a/C7/UIElements/Diplomacy/DealScreen.cs
+++ b/C7/UIElements/Diplomacy/DealScreen.cs
@@ -163,8 +163,11 @@ public partial class DealScreen : TextureRect {
 	}
 
 	private void AttemptDeal() {
+		// TODO: This seems to be only usage of UIGameDataAccess that mutates
+		// state - can this be a message instead?
 		using UIGameDataAccess gameDataAccess = new();
 		GameData gD = gameDataAccess.gameData;
+
 		Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
 		Player humanPlayer = gD.players.Find(x => x.id == humanPlayerId);
 

--- a/C7/UIElements/Popups/GovernmentSelection.cs
+++ b/C7/UIElements/Popups/GovernmentSelection.cs
@@ -1,0 +1,47 @@
+using Godot;
+using System;
+using System.Diagnostics;
+using C7GameData;
+using C7Engine;
+using C7GameData.Save;
+using System.Collections.Generic;
+using Serilog;
+
+// The popup for selecting which other civilization to contact.
+public partial class GovernmentSelection : Popup {
+	private Player player;
+	private List<Government> governments;
+
+	public GovernmentSelection(Player player, List<Government> governments) {
+		alignment = BoxContainer.AlignmentMode.Center;
+		margins = new Margins(top: 200);
+		this.player = player;
+		this.governments = governments;
+	}
+
+	public override void _Ready() {
+		base._Ready();
+
+		int width = 530;
+		int height = 115 + 25 * governments.Count;
+		AddTexture(width, height);
+		AddBackground(width, height);
+		AddHeader("Select a new government type", 10);
+
+		int vOffset = 65;
+		foreach (Government g in governments) {
+			AddButton($"{g.name}", vOffset, () => {
+				Node parent = GetParent();
+				new SelectGovernmentMsg(player, g).send();
+				parent.EmitSignal(PopupOverlay.SignalName.HidePopup);
+			});
+			vOffset += 25;
+		}
+	}
+
+	public override void _ExitTree() {
+		// Restart the turn once a selection has been made.
+		new MsgStartTurn().send();
+	}
+
+}

--- a/C7Engine/C7GameData/AIData/TileKnowledge.cs
+++ b/C7Engine/C7GameData/AIData/TileKnowledge.cs
@@ -70,6 +70,9 @@ namespace C7GameData {
 		}
 
 		public bool isActiveTile(Tile t) {
+			if (t == Tile.NONE) {
+				return false;
+			}
 			return activeTiles.Contains(t);
 		}
 

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -330,6 +330,22 @@ namespace C7GameData {
 			return $"{tech.Name} ({EstimateTurnsToResearch(gD, tech)} turns)";
 		}
 
+		public List<Government> GetAvailableGovernments(GameData gameData) {
+			List<Government> result = new();
+			foreach (Government g in gameData.governments) {
+				// You can't deliberately switch into the transition type, you
+				// have to switch from one non-transitional type to another.
+				if (g.transitionType) {
+					continue;
+				}
+
+				if (g.prerequisiteTech == null || knownTechs.Contains(g.prerequisiteTech)) {
+					result.Add(g);
+				}
+			}
+			return result;
+		}
+
 		// See https://forums.civfanatics.com/threads/everything-about-corruption-c3c-edition.76619/
 		//
 		// This is the empire-wide information factored out of the rank corruption
@@ -361,6 +377,45 @@ namespace C7GameData {
 			float result = mapOptimalCityNumber * percentOptimalCitiesForDifficultyLevel / 100.0f
 				  * (1 + commercialCivFactor + govtFactor + communalCorruptionFactor * numCorruptionReducingSmallWondersInEmpire);
 			return (int)result;
+		}
+
+		// Notes:
+		//  - see https://www.civforum.de/showthread.php?3153-Anarchie-Wieviel-Runden-welche-Strategie&p=67682&viewfull=1#post67682 (in German)
+		//    This claims Soren Johnson said the time is 
+		//    1-5 years, random + 0-3 years, depending on the number of cities.
+		//    I think the 1-5 is actually 2 to 6, since the min is 2.
+		//
+		//  - https://forums.civfanatics.com/threads/frequently-asked-questions-civ3-play-the-world-conquests.170282/
+		//    For Religious civilizations, anarchy only lasts 1 turn in Vanilla 
+		//    and Play the World, and 2 turns in Conquests. For non-Religious 
+		//    civilizations, the formula is: 1 (2 for Conquests) + random number
+		//    between 1-4 + number between 0-3 depending on size of your empire.
+		public int GetTurnsOfAnarchyForTransition(GameData gameData) {
+			// TODO: if religious, return 2.
+
+			// We add Next(3)+Next(3) to roughly approximate a normal 
+			// distribution. With the base of 2, this gets us a random value 
+			// between 2 and 6.
+			int randomPortion = 2 + GameData.rng.Next(3) + GameData.rng.Next(3);
+
+			// Now we use the OCN to determine the city factor, which is between
+			// 0 and 3. This means that sprawling empires will have longer
+			// anarchy, but this will scale with map size.
+			float numCities = cities.Count;
+			int cityPortion = (int)Math.Min(3f, 3f * numCities / GetAdjustedOptimalCityNumber(gameData));
+
+			// The result is the sume of the random portion and the city portion,
+			// with the AI cap applied if relevant for this difficulty.
+			//
+			// Note that this AI transition time is applied after the early
+			// return for religious civs. There is a known strategy on higher
+			// difficulty levels of using religious civs to help cut down on the
+			// AI advantage due to this fact.
+			int result = randomPortion + cityPortion;
+			if (!isHuman && gameData.gameDifficulty.MaxAiGovernmentTransitionTime > 0) {
+				result = Math.Min(result, gameData.gameDifficulty.MaxAiGovernmentTransitionTime);
+			}
+			return result;
 		}
 
 		public void DoPerTurnFinanceUpdates(GameData gameData) {

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -102,6 +102,40 @@ namespace C7Engine {
 		}
 	}
 
+	// Switches the player government to anarchy and determines when the player
+	// can exit anarchy.
+	public class StartGovernmentTransitionMsg : MessageToEngine {
+		private Player player;
+
+		public StartGovernmentTransitionMsg(Player p) {
+			player = p;
+		}
+
+		public override void process() {
+			GameData gD = EngineStorage.gameData;
+			Government transitionGovt = gD.governments.Find(x => x.transitionType);
+			player.government = transitionGovt;
+			player.inAnarchyUntilTurn = gD.turn + player.GetTurnsOfAnarchyForTransition(gD);
+
+			// Update the domestic advisor once we know how long the anarchy is.
+			new MsgUpdateUiAfterDomesticChange().send();
+		}
+	}
+
+	public class SelectGovernmentMsg : MessageToEngine {
+		private Player player;
+		private Government government;
+
+		public SelectGovernmentMsg(Player player, Government government) {
+			this.player = player;
+			this.government = government;
+		}
+
+		public override void process() {
+			player.government = government;
+		}
+	}
+
 	// A Class that allows the UI to have the game engine run some
 	// terraform action.
 	public class MsgStartWorkerJob : MessageToEngine {
@@ -225,7 +259,7 @@ namespace C7Engine {
 			}
 
 			// Update the ui to reflect our changes.
-			new MsgUpdateUiAfterSliderChange().send();
+			new MsgUpdateUiAfterDomesticChange().send();
 		}
 	}
 

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -42,7 +42,7 @@ namespace C7Engine {
 
 	public class MsgUpdateUiAfterTechSelection : MessageToUI { }
 
-	public class MsgUpdateUiAfterSliderChange : MessageToUI { }
+	public class MsgUpdateUiAfterDomesticChange : MessageToUI { }
 
 	public class MsgWarDeclaration : MessageToUI {
 		public Player aggressor;


### PR DESCRIPTION
Once the despotism penalty PR is in, this will allow getting out of despotism. This PR handles hooking up the button, figuring out how many turns of anarchy there are, prompting the user to select a government when anarchy is over, and actually using the new government.

It doesn't handle:
 - AI government switching
 - Religious civs
 - Anarchy's negative effects
 - Prompting the user that a government change is possible once researched

Other miscellaneous fixes:
 - Some issues with capturing keyboard shortcuts when the domestic advisor was present
 - Ensuring animations aren't shown when they're covered by the fog of war (though I think this still might need a bit more work)
 - Removing some dead code from `Game.cs`

Screenshots:

![image](https://github.com/user-attachments/assets/208f55d9-3efd-4418-af1f-20916dde0674)

![image](https://github.com/user-attachments/assets/e6fbc6e5-ef0a-4327-b167-8abfb9bc043b)

![image](https://github.com/user-attachments/assets/bad5bcc9-1304-4070-8500-f9470a6f677f)

![image](https://github.com/user-attachments/assets/a4ee9f6b-ac16-4290-8799-bd87c1ecb0c6)

