### PR TITLE
Add a list of all cities to the domestic advisor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Godot-specific ignores
 .import/
+*.import
 export.cfg
 logs/
 .godot

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -240,6 +240,9 @@ public partial class Game : Node2D {
 				case MsgStartTurn mST:
 					OnPlayerStartTurn();
 					break;
+				case MsgShowCityScreen mSCS:
+					ShowCityScreenForCity(mSCS.city);
+					break;
 				case MsgCityCreated mCC:
 					ShowCityScreenForCity(mCC.city);
 					break;

--- a/C7/UIElements/Advisors/DomesticAdvisor.cs
+++ b/C7/UIElements/Advisors/DomesticAdvisor.cs
@@ -18,6 +18,17 @@ public partial class DomesticAdvisor : Control {
 	[Export] Label expenseSummary;
 	[Export] Label sumSummary;
 	[Export] Label growth;
+	[Export] VBoxContainer cityListContainer;
+	[Export] TextureButton eatenFood;
+	[Export] TextureButton fullFood;
+	[Export] TextureButton wastedShield;
+	[Export] TextureButton goodShield;
+	[Export] TextureButton wastedGold;
+	[Export] TextureButton goodGold;
+	[Export] TextureButton happyFace;
+	[Export] TextureButton contentFace;
+	[Export] TextureButton beaker;
+	[Export] TextureButton treasuryIcon;
 	PopupOverlay popupOverlay;
 
 	TextureRect scienceSliderIcon = new();
@@ -115,6 +126,18 @@ public partial class DomesticAdvisor : Control {
 		lessLuxury.SetPosition(new Vector2(575, luxurySliderY - 5));
 		lessLuxury.Pressed += () => { new MsgChangeSliders(false, false, false, true).send(); };
 		background.AddChild(lessLuxury);
+
+		// Column header icons.
+		eatenFood.TextureNormal = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 218, 2, 29, 29);
+		fullFood.TextureNormal = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 188, 2, 29, 29);
+		wastedShield.TextureNormal = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 157, 2, 29, 29);
+		goodShield.TextureNormal = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 125, 2, 29, 29);
+		wastedGold.TextureNormal = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 95, 2, 29, 29);
+		goodGold.TextureNormal = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 64, 2, 29, 29);
+		happyFace.TextureNormal = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 373, 2, 29, 29);
+		contentFace.TextureNormal = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 591, 2, 29, 29);
+		beaker.TextureNormal = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 34, 2, 29, 29);
+		treasuryIcon.TextureNormal = Util.LoadTextureFromPCX("Art/city screen/CityIcons.pcx", 746, 2, 29, 29);
 	}
 
 	public void ShowAdvisor() {
@@ -163,6 +186,15 @@ public partial class DomesticAdvisor : Control {
 		if (player.government.transitionType && player.inAnarchyUntilTurn > gameDataAccess.gameData.turn) {
 			DialogBoxAdvise.Text = $"{player.inAnarchyUntilTurn - gameDataAccess.gameData.turn} turns of anarchy left";
 		}
+
+		foreach (var node in cityListContainer.GetChildren()) {
+			cityListContainer.RemoveChild(node);
+			node.QueueFree();
+		}
+
+		foreach (City city in player.cities) {
+			cityListContainer.AddChild(MakeCityRow(city));
+		}
 	}
 
 	private int CalculateSliderXPos(int sliderRate) {
@@ -196,5 +228,139 @@ public partial class DomesticAdvisor : Control {
 						new StartGovernmentTransitionMsg(player).send();
 					}),
 				PopupOverlay.PopupCategory.Advisor);
+	}
+
+	private HBoxContainer MakeCityRow(City city) {
+		HBoxContainer hboxContainer = new();
+
+		// Use an empty pany container to make it blank, unlike an HSeparator
+		PanelContainer hSeparator1 = new();
+		hSeparator1.CustomMinimumSize = new Vector2(30, 50);
+		hSeparator1.AddThemeStyleboxOverride("panel", new StyleBoxEmpty());
+		hboxContainer.AddChild(hSeparator1);
+
+		Button cityName = new();
+		cityName.CustomMinimumSize = new Vector2(127, 0);
+		cityName.Text = city.name;
+		cityName.ClipText = true;
+		cityName.TextOverrunBehavior = TextServer.OverrunBehavior.TrimEllipsis;
+		cityName.Pressed += () => {
+			this.Hide();
+			new MsgShowCityScreen(city).send();
+		};
+		hboxContainer.AddChild(cityName);
+
+		Label foodLabel = new();
+		foodLabel.CustomMinimumSize = new Vector2(40, 0);
+		foodLabel.Text = SpaceAlignedDotFormat(city.FoodConsumedPerTurn(), city.FoodGrowthPerTurn());
+		foodLabel.HorizontalAlignment = HorizontalAlignment.Center;
+		hboxContainer.AddChild(foodLabel);
+
+		Label shieldsLabel = new();
+		shieldsLabel.CustomMinimumSize = new Vector2(40, 0);
+		{
+			CorruptableValue prod = city.CurrentProductionYield();
+			shieldsLabel.Text = SpaceAlignedDotFormat(prod.corrupt, prod.useful);
+		}
+		shieldsLabel.HorizontalAlignment = HorizontalAlignment.Center;
+		hboxContainer.AddChild(shieldsLabel);
+
+		Label commerceLabel = new();
+		commerceLabel.CustomMinimumSize = new Vector2(40, 0);
+		CommerceBreakdown commerce = city.CurrentCommerceYield();
+		commerceLabel.Text = SpaceAlignedDotFormat(commerce.corrupted, commerce.taxes + commerce.beakers + commerce.happiness);
+		commerceLabel.HorizontalAlignment = HorizontalAlignment.Center;
+		hboxContainer.AddChild(commerceLabel);
+
+		// Use an empty pany container to make it blank, unlike an HSeparator
+		PanelContainer hSeparator2 = new();
+		hSeparator2.CustomMinimumSize = new Vector2(25, 0);
+		hSeparator2.AddThemeStyleboxOverride("panel", new StyleBoxEmpty());
+		hboxContainer.AddChild(hSeparator2);
+
+		Label maintenanceLabel = new();
+		maintenanceLabel.CustomMinimumSize = new Vector2(40, 0);
+		maintenanceLabel.Text = "0";  // TODO: track maintenance
+		maintenanceLabel.HorizontalAlignment = HorizontalAlignment.Center;
+		maintenanceLabel.VerticalAlignment = VerticalAlignment.Center;
+		maintenanceLabel.ClipText = true;
+		hboxContainer.AddChild(maintenanceLabel);
+
+		Label happinessLabel = new();
+		happinessLabel.CustomMinimumSize = new Vector2(40, 0);
+		{
+			int happy = 0;
+			int content = 0;
+			foreach (CityResident cr in city.residents) {
+				if (cr.citizenType.IsDefaultCitizen && cr.mood == CityResident.Mood.Happy) {
+					++happy;
+				}
+				if (cr.citizenType.IsDefaultCitizen && cr.mood == CityResident.Mood.Content) {
+					++content;
+				}
+			}
+			happinessLabel.Text = SpaceAlignedDotFormat(happy, content);
+		}
+		happinessLabel.HorizontalAlignment = HorizontalAlignment.Center;
+		happinessLabel.VerticalAlignment = VerticalAlignment.Center;
+		happinessLabel.ClipText = true;
+		hboxContainer.AddChild(happinessLabel);
+
+		Label scienceLabel = new();
+		scienceLabel.CustomMinimumSize = new Vector2(40, 0);
+		scienceLabel.Text = $"{commerce.beakers}"; ;
+		scienceLabel.HorizontalAlignment = HorizontalAlignment.Center;
+		scienceLabel.VerticalAlignment = VerticalAlignment.Center;
+		scienceLabel.ClipText = true;
+		hboxContainer.AddChild(scienceLabel);
+
+		Label taxesLabel = new();
+		taxesLabel.CustomMinimumSize = new Vector2(40, 0);
+		taxesLabel.Text = $"{commerce.taxes}"; ;
+		taxesLabel.HorizontalAlignment = HorizontalAlignment.Center;
+		taxesLabel.VerticalAlignment = VerticalAlignment.Center;
+		taxesLabel.ClipText = true;
+		hboxContainer.AddChild(taxesLabel);
+
+		// Use an empty pany container to make it blank, unlike an HSeparator
+		PanelContainer hSeparator3 = new();
+		hSeparator3.CustomMinimumSize = new Vector2(25, 0);
+		hSeparator3.AddThemeStyleboxOverride("panel", new StyleBoxEmpty());
+		hboxContainer.AddChild(hSeparator3);
+
+		PanelContainer popuplationContainer = new();
+		popuplationContainer.CustomMinimumSize = new Vector2(220, 0);
+		popuplationContainer.AddThemeStyleboxOverride("panel", new StyleBoxEmpty());
+		hboxContainer.AddChild(popuplationContainer);
+
+		PanelContainer productionContainer = new();
+		productionContainer.CustomMinimumSize = new Vector2(50, 0);
+		productionContainer.AddThemeStyleboxOverride("panel", new StyleBoxEmpty());
+		hboxContainer.AddChild(productionContainer);
+
+		Label productionLabel = new();
+		productionLabel.CustomMinimumSize = new Vector2(75, 0);
+		string turnsLeft = city.TurnsUntilProductionFinished() == int.MaxValue ? "(9999999 turns)" : $"({city.TurnsUntilProductionFinished()} turns)";
+		productionLabel.Text = $"{city.itemBeingProduced.name}\n{turnsLeft}";
+		productionLabel.VerticalAlignment = VerticalAlignment.Center;
+		productionLabel.ClipText = true;
+		productionLabel.TextOverrunBehavior = TextServer.OverrunBehavior.TrimEllipsis;
+		hboxContainer.AddChild(productionLabel);
+
+		return hboxContainer;
+	}
+
+	// Returns a.b, always taking up 5 characters as long as a and b are less
+	// than 100, adding leading or trailing spaces if necessary.
+	string SpaceAlignedDotFormat(int a, int b) {
+		string result = "";
+		if (a < 10) {
+			result += " ";
+		}
+		result += $"{a}.{b}";
+		if (b < 10) {
+			result += " ";
+		}
+		return result;
 	}
 }

--- a/C7/UIElements/Advisors/domestic_advisor.tscn
+++ b/C7/UIElements/Advisors/domestic_advisor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://da7hbbufyfllg"]
+[gd_scene load_steps=7 format=3 uid="uid://da7hbbufyfllg"]
 
 [ext_resource type="Script" path="res://UIElements/Advisors/DomesticAdvisor.cs" id="1"]
 [ext_resource type="Script" path="res://UIElements/Civ3TextureRect.cs" id="2"]
@@ -13,7 +13,9 @@ line_spacing = 0.0
 font_size = 11
 font_color = Color(0, 0, 0, 1)
 
-[node name="DomesticAdvisor" type="CenterContainer" node_paths=PackedStringArray("background", "close", "changeGovernment", "governmentLabel", "scienceStatus", "treasury", "incomeDetails", "expenseDetails", "incomeSummary", "expenseSummary", "sumSummary", "growth")]
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_5hkgh"]
+
+[node name="DomesticAdvisor" type="CenterContainer" node_paths=PackedStringArray("background", "close", "changeGovernment", "governmentLabel", "scienceStatus", "treasury", "incomeDetails", "expenseDetails", "incomeSummary", "expenseSummary", "sumSummary", "growth", "cityListContainer", "eatenFood", "fullFood", "wastedShield", "goodShield", "wastedGold", "goodGold", "happyFace", "contentFace", "beaker", "treasuryIcon")]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -32,6 +34,17 @@ incomeSummary = NodePath("Background/IncomeSummary")
 expenseSummary = NodePath("Background/ExpenseSummary")
 sumSummary = NodePath("Background/SumSummary")
 growth = NodePath("Background/Growth")
+cityListContainer = NodePath("Background/ScrollContainer/VBoxContainer")
+eatenFood = NodePath("Background/EatenFood")
+fullFood = NodePath("Background/FullFood")
+wastedShield = NodePath("Background/WastedShield")
+goodShield = NodePath("Background/GoodShield")
+wastedGold = NodePath("Background/WastedGold")
+goodGold = NodePath("Background/GoodGold")
+happyFace = NodePath("Background/HappyFace")
+contentFace = NodePath("Background/ContentFace")
+beaker = NodePath("Background/Beaker")
+treasuryIcon = NodePath("Background/TreasuryIcon")
 
 [node name="Background" type="TextureRect" parent="."]
 layout_mode = 2
@@ -45,7 +58,7 @@ offset_right = 1024.0
 offset_bottom = 768.0
 script = ExtResource("3")
 
-[node name="ChangeGovernment" type="TextureButton" parent="Background" index="1"]
+[node name="ChangeGovernment" type="TextureButton" parent="Background"]
 layout_mode = 0
 offset_left = 650.0
 offset_top = 186.0
@@ -53,7 +66,7 @@ offset_right = 795.0
 offset_bottom = 210.0
 script = ExtResource("3")
 
-[node name="GovernmentLabel" type="Label" parent="Background/ChangeGovernment" index="0"]
+[node name="GovernmentLabel" type="Label" parent="Background/ChangeGovernment"]
 layout_mode = 0
 offset_left = 6.0
 offset_top = 2.0
@@ -61,7 +74,7 @@ offset_right = 139.0
 offset_bottom = 22.0
 text = "Despotism"
 
-[node name="Label" type="Label" parent="Background" index="2"]
+[node name="Label" type="Label" parent="Background"]
 layout_mode = 0
 offset_left = 559.0
 offset_top = 189.0
@@ -70,7 +83,7 @@ offset_bottom = 209.0
 text = "Government"
 label_settings = SubResource("LabelSettings_0b8py")
 
-[node name="ScienceStatus" type="Label" parent="Background" index="3"]
+[node name="ScienceStatus" type="Label" parent="Background"]
 layout_mode = 0
 offset_left = 565.0
 offset_top = 165.0
@@ -78,7 +91,7 @@ offset_right = 711.0
 offset_bottom = 185.0
 text = "Placeholder (25 turns)"
 
-[node name="Treasury" type="Label" parent="Background" index="4"]
+[node name="Treasury" type="Label" parent="Background"]
 layout_mode = 0
 offset_left = 83.0
 offset_top = 193.0
@@ -86,7 +99,7 @@ offset_right = 237.0
 offset_bottom = 213.0
 text = "Treasury: 12345 gold"
 
-[node name="IncomeDetails" type="Label" parent="Background" index="5"]
+[node name="IncomeDetails" type="Label" parent="Background"]
 layout_mode = 0
 offset_left = 84.0
 offset_top = 98.0
@@ -99,7 +112,7 @@ From interest: +0"
 label_settings = SubResource("LabelSettings_61gj0")
 horizontal_alignment = 2
 
-[node name="ExpenseDetails" type="Label" parent="Background" index="6"]
+[node name="ExpenseDetails" type="Label" parent="Background"]
 layout_mode = 0
 offset_left = 379.0
 offset_top = 87.0
@@ -113,7 +126,7 @@ text = "-123: Science
 -8: To other civs"
 label_settings = SubResource("LabelSettings_61gj0")
 
-[node name="IncomeSummary" type="Label" parent="Background" index="7"]
+[node name="IncomeSummary" type="Label" parent="Background"]
 layout_mode = 0
 offset_left = 254.0
 offset_top = 102.0
@@ -121,7 +134,7 @@ offset_right = 294.0
 offset_bottom = 122.0
 text = "Income: 1234"
 
-[node name="ExpenseSummary" type="Label" parent="Background" index="8"]
+[node name="ExpenseSummary" type="Label" parent="Background"]
 layout_mode = 0
 offset_left = 254.0
 offset_top = 152.0
@@ -129,7 +142,7 @@ offset_right = 294.0
 offset_bottom = 172.0
 text = "Expenses: 4567"
 
-[node name="SumSummary" type="Label" parent="Background" index="9"]
+[node name="SumSummary" type="Label" parent="Background"]
 layout_mode = 0
 offset_left = 254.0
 offset_top = 193.0
@@ -137,10 +150,220 @@ offset_right = 294.0
 offset_bottom = 213.0
 text = "Net loss: -18"
 
-[node name="Growth" type="Label" parent="Background" index="10"]
+[node name="Growth" type="Label" parent="Background"]
 layout_mode = 0
 offset_left = 390.0
 offset_top = 195.0
 offset_right = 459.0
 offset_bottom = 215.0
 text = "Shrinking!"
+
+[node name="Label2" type="Label" parent="Background"]
+layout_mode = 2
+offset_left = 122.0
+offset_top = 253.0
+offset_right = 158.0
+offset_bottom = 273.0
+text = "Cities"
+
+[node name="Label3" type="Label" parent="Background"]
+layout_mode = 0
+offset_left = 707.0
+offset_top = 253.0
+offset_right = 779.0
+offset_bottom = 273.0
+text = "Population"
+
+[node name="Label4" type="Label" parent="Background"]
+layout_mode = 0
+offset_left = 899.0
+offset_top = 252.0
+offset_right = 967.0
+offset_bottom = 272.0
+text = "Producing"
+
+[node name="ScrollContainer" type="ScrollContainer" parent="Background"]
+layout_mode = 0
+offset_left = 72.0
+offset_top = 298.0
+offset_right = 986.0
+offset_bottom = 676.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Background/ScrollContainer"]
+layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Background/ScrollContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="HSeparator" type="HSeparator" parent="Background/ScrollContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(30, 50)
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Background/ScrollContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(127, 0)
+layout_mode = 2
+text = "Placeholder that gets "
+vertical_alignment = 1
+clip_text = true
+text_overrun_behavior = 3
+
+[node name="Label2" type="Label" parent="Background/ScrollContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(40, 0)
+layout_mode = 2
+text = "10.20"
+horizontal_alignment = 1
+
+[node name="Label3" type="Label" parent="Background/ScrollContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(40, 0)
+layout_mode = 2
+text = "10.20"
+horizontal_alignment = 1
+
+[node name="Label4" type="Label" parent="Background/ScrollContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(40, 0)
+layout_mode = 2
+text = "10.20"
+horizontal_alignment = 1
+
+[node name="HSeparator2" type="HSeparator" parent="Background/ScrollContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(25, 0)
+layout_mode = 2
+
+[node name="Label5" type="Label" parent="Background/ScrollContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(40, 0)
+layout_mode = 2
+text = "20"
+horizontal_alignment = 1
+vertical_alignment = 1
+clip_text = true
+text_overrun_behavior = 3
+
+[node name="Label6" type="Label" parent="Background/ScrollContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(40, 0)
+layout_mode = 2
+text = "20"
+horizontal_alignment = 1
+vertical_alignment = 1
+clip_text = true
+text_overrun_behavior = 3
+
+[node name="Label7" type="Label" parent="Background/ScrollContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(40, 0)
+layout_mode = 2
+text = "20"
+horizontal_alignment = 1
+vertical_alignment = 1
+clip_text = true
+text_overrun_behavior = 3
+
+[node name="Label8" type="Label" parent="Background/ScrollContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(40, 0)
+layout_mode = 2
+text = "20"
+horizontal_alignment = 1
+vertical_alignment = 1
+clip_text = true
+text_overrun_behavior = 3
+
+[node name="HSeparator3" type="HSeparator" parent="Background/ScrollContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(25, 0)
+layout_mode = 2
+
+[node name="PanelContainer" type="PanelContainer" parent="Background/ScrollContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(220, 0)
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxEmpty_5hkgh")
+
+[node name="PanelContainer2" type="PanelContainer" parent="Background/ScrollContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(50, 0)
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxEmpty_5hkgh")
+
+[node name="Label9" type="Label" parent="Background/ScrollContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(75, 0)
+layout_mode = 2
+text = "Statue of Ze
+(200 turns)"
+vertical_alignment = 1
+clip_text = true
+text_overrun_behavior = 3
+
+[node name="EatenFood" type="TextureButton" parent="Background"]
+layout_mode = 0
+offset_left = 241.0
+offset_top = 239.0
+offset_right = 270.0
+offset_bottom = 268.0
+script = ExtResource("3")
+
+[node name="FullFood" type="TextureButton" parent="Background"]
+layout_mode = 0
+offset_left = 251.0
+offset_top = 248.0
+offset_right = 280.0
+offset_bottom = 277.0
+script = ExtResource("3")
+
+[node name="WastedShield" type="TextureButton" parent="Background"]
+layout_mode = 0
+offset_left = 294.0
+offset_top = 241.0
+offset_right = 323.0
+offset_bottom = 270.0
+script = ExtResource("3")
+
+[node name="GoodShield" type="TextureButton" parent="Background"]
+layout_mode = 0
+offset_left = 298.0
+offset_top = 248.0
+offset_right = 327.0
+offset_bottom = 277.0
+script = ExtResource("3")
+
+[node name="WastedGold" type="TextureButton" parent="Background"]
+layout_mode = 0
+offset_left = 333.0
+offset_top = 246.0
+offset_right = 362.0
+offset_bottom = 275.0
+script = ExtResource("3")
+
+[node name="GoodGold" type="TextureButton" parent="Background"]
+layout_mode = 0
+offset_left = 342.0
+offset_top = 251.0
+offset_right = 371.0
+offset_bottom = 280.0
+script = ExtResource("3")
+
+[node name="ContentFace" type="TextureButton" parent="Background"]
+layout_mode = 0
+offset_left = 458.0
+offset_top = 251.0
+offset_right = 487.0
+offset_bottom = 280.0
+script = ExtResource("3")
+
+[node name="HappyFace" type="TextureButton" parent="Background"]
+layout_mode = 0
+offset_left = 443.0
+offset_top = 251.0
+offset_right = 472.0
+offset_bottom = 280.0
+script = ExtResource("3")
+
+[node name="Beaker" type="TextureButton" parent="Background"]
+layout_mode = 0
+offset_left = 493.0
+offset_top = 246.0
+offset_right = 522.0
+offset_bottom = 275.0
+script = ExtResource("3")
+
+[node name="TreasuryIcon" type="TextureButton" parent="Background"]
+layout_mode = 0
+offset_left = 537.0
+offset_top = 248.0
+offset_right = 566.0
+offset_bottom = 277.0
+script = ExtResource("3")

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -223,7 +223,12 @@ namespace C7GameData {
 		}
 
 		public int FoodGrowthPerTurn() {
-			return CurrentFoodYield() - size * 2;
+			return CurrentFoodYield() - FoodConsumedPerTurn();
+		}
+
+		public int FoodConsumedPerTurn() {
+			// TODO: exclude resisters in the future.
+			return size * 2;
 		}
 
 		private void RemoveCitizen() {

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -77,4 +77,12 @@ namespace C7Engine {
 			this.city = city;
 		}
 	}
+
+	public class MsgShowCityScreen : MessageToUI {
+		public City city;
+
+		public MsgShowCityScreen(City city) {
+			this.city = city;
+		}
+	}
 }


### PR DESCRIPTION
This allows zooming to a particular city by clicking on the name, but doesn't yet allow sorting.

I've kept the placeholder nodes in the scene since they make it easier to align things.

Pop heads and icons are next.

![image](https://github.com/user-attachments/assets/ff24c146-391f-49f7-bda4-7f3591cd9874)
