### PR TITLE
Handle happiness levels from luxury spending and default unhappiness

### DIFF
--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -43,6 +43,8 @@ public partial class CityScreen : Control {
 	private Label commerceScienceDetails;
 	private Label commerceHappinessDetails;
 
+	private const int HEAD_SIZE = 48;
+
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
 		background.Texture = Util.LoadTextureFromPCX("Art/city screen/background.pcx");
@@ -411,20 +413,30 @@ public partial class CityScreen : Control {
 		// type, and again 10 columns per row. This time they are
 		// (ancient, middle, industrial, modern, blank) for male and female heads
 		//
-		// TODO: handle citizen moods
 		// TODO: handle per-civ regions
 		// TODO: handle male/female citizens
 
 		// Start by splitting the default residents from the specialists, since
 		// they are spaced apart in the UI.
-		List<CityResident> defaultResidents = city.residents.FindAll(x => x.citizenType.IsDefaultCitizen);
+		List<CityResident> happyResidents =
+			city.residents.FindAll(x => x.citizenType.IsDefaultCitizen && x.mood == CityResident.Mood.Happy);
+		List<CityResident> contentResidents =
+			city.residents.FindAll(x => x.citizenType.IsDefaultCitizen && x.mood == CityResident.Mood.Content);
+		List<CityResident> unhappyResidents =
+			city.residents.FindAll(x => x.citizenType.IsDefaultCitizen && x.mood == CityResident.Mood.Unhappy);
 		List<CityResident> specialists = city.residents.FindAll(x => !x.citizenType.IsDefaultCitizen);
 
-		// Each head is 48px, so leave a 1 head gap if we have specialists.
-		int width = city.residents.Count * 48;
+		// Leave a 1 head gap if we have specialists.
+		int width = city.residents.Count * HEAD_SIZE;
 		if (specialists.Count > 0) {
-			width += 48;
+			width += HEAD_SIZE;
 		}
+
+		// Leave a 1 head gap between each section of moods.
+		int numMoodsPresent = (happyResidents.Count > 0 ? 1 : 0)
+			+ (contentResidents.Count > 0 ? 1: 0)
+			+ (unhappyResidents.Count > 0 ? 1: 0);
+		width += (numMoodsPresent - 1) * HEAD_SIZE;
 
 		// Track the x position of each head so that we're centered in the screen
 		int xPos = background.Texture.GetWidth() / 2 + -width / 2;
@@ -432,14 +444,20 @@ public partial class CityScreen : Control {
 		// Add each of the default citizens. These are buttons with the idea that
 		// we can eventually support clicking on the heads to view details, such
 		// as the reason for unhappiness.
-		foreach (CityResident cr in defaultResidents) {
-			TextureButton tb = new();
-			tb.TextureNormal = Util.LoadTextureFromPCX("Art/SmallHeads/popHeads.pcx",
-														0 + 1, 200 * eraNum + 1, 48, 48);
-			tb.SetPosition(new Vector2(xPos, 440));
-			background.AddChild(tb);
-			popHeads.Add(tb);
-			xPos += 48;
+		foreach (CityResident cr in happyResidents) {
+			xPos = AddDefaultCitizen(cr, xPos, eraNum);
+		}
+		if (happyResidents.Count > 0 && (contentResidents.Count > 0 || unhappyResidents.Count > 0)) {
+			xPos += HEAD_SIZE;
+		}
+		foreach (CityResident cr in contentResidents) {
+			xPos = AddDefaultCitizen(cr, xPos, eraNum);
+		}
+		if (contentResidents.Count > 0 && unhappyResidents.Count > 0) {
+			xPos += HEAD_SIZE;
+		}
+		foreach (CityResident cr in unhappyResidents) {
+			xPos = AddDefaultCitizen(cr, xPos, eraNum);
 		}
 
 		// Add space before specialists.
@@ -455,7 +473,7 @@ public partial class CityScreen : Control {
 			int numRowsOfLaborers = 16;
 			int textY = 50 * numRowsOfLaborers + 50 * (cr.citizenType.SpecialistIndex - 1);
 			tb.TextureNormal = Util.LoadTextureFromPCX("Art/SmallHeads/popHeads.pcx",
-														textX + 1, textY + 1, 48, 48);
+														textX + 1, textY + 1, HEAD_SIZE, HEAD_SIZE);
 			tb.SetPosition(new Vector2(xPos, 440));
 
 			List<CitizenType> specialistTypes = GetKnownSpecialists(city.owner);
@@ -468,7 +486,7 @@ public partial class CityScreen : Control {
 
 			background.AddChild(tb);
 			popHeads.Add(tb);
-			xPos += 48;
+			xPos += HEAD_SIZE;
 		}
 	}
 
@@ -484,5 +502,24 @@ public partial class CityScreen : Control {
 		List<City> cities = currentCity.owner.cities;
 		City previousCity = cities[(cities.IndexOf(currentCity) + cities.Count - 1) % cities.Count];
 		OnShowCityScreen(new ParameterWrapper<City>(previousCity));
+	}
+
+	private int AddDefaultCitizen(CityResident cr, int xPos, int eraNum) {
+		int column = cr.mood switch {
+			CityResident.Mood.Content => 0,
+			CityResident.Mood.Happy => 1,
+			CityResident.Mood.Unhappy => 3,
+		};
+		int headWithBorderSize = HEAD_SIZE + 2;
+
+		TextureButton tb = new();
+		tb.TextureNormal = Util.LoadTextureFromPCX("Art/SmallHeads/popHeads.pcx",
+													0 + 1,
+													200 * eraNum + headWithBorderSize * column + 1,
+													HEAD_SIZE, HEAD_SIZE);
+		tb.SetPosition(new Vector2(xPos, 440));
+		background.AddChild(tb);
+		popHeads.Add(tb);
+		return xPos + 48;
 	}
 }

--- a/C7Engine/AI/CityTileAssignmentAI.cs
+++ b/C7Engine/AI/CityTileAssignmentAI.cs
@@ -40,7 +40,7 @@ namespace C7Engine.AI {
 			newResident.tileWorked = preferredTile;
 			preferredTile.personWorkingTile = newResident;
 
-			city.residents.Add(newResident);
+			city.AddCitizen(newResident);
 		}
 
 		public static double CalculateTileYieldScore(Tile t, int targetFoodAmount, Player player) {

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -229,6 +229,18 @@ namespace C7GameData {
 		private void RemoveCitizen() {
 			residents[residents.Count - 1].tileWorked.personWorkingTile = null;
 			residents.RemoveAt(residents.Count - 1);
+
+			// We changed citizens, which may have changed yields, so 
+			// recalculate happiness.
+			RecalculateCitizenMoods(EngineStorage.gameData);
+		}
+
+		public void AddCitizen(CityResident cr) {
+			residents.Add(cr);
+
+			// We changed citizens, which may have changed yields, so 
+			// recalculate happiness.
+			RecalculateCitizenMoods(EngineStorage.gameData);
 		}
 
 		public void RemoveCitizens(int number) {
@@ -451,6 +463,110 @@ namespace C7GameData {
 				perPlayerCulture[owner] += cb.building.culturePerTurn;
 			}
 			return start != GetBorderExpansionLevel();
+		}
+
+		// Initializes the citizen moods, before positive and negative
+		// influcences are added. A fixed number of citizens are born content,
+		// based on the difficulty level, and after that all citizens are born
+		// unhappy. Specialists and resisters are excluded from this.
+		private void InitializeMoodsForDifficulty(Difficulty gameDifficulty) {
+			int numLaborers = residents.Count(x => x.citizenType.IsDefaultCitizen);
+			int content = Math.Min(gameDifficulty.NumberOfCitizensBornContent, numLaborers);
+
+			foreach (CityResident r in residents) {
+				if (!r.citizenType.IsDefaultCitizen) {
+					continue;
+				}
+
+				if (content > 0) {
+					--content;
+					r.mood = CityResident.Mood.Content;
+				} else {
+					r.mood = CityResident.Mood.Unhappy;
+				}
+			}
+		}
+
+		// Attemps to move the specified number of citizens that have mood `from`
+		// to mood `to`, returning the actual number changed.
+		private int ApplyMoodChange(int count, CityResident.Mood from, CityResident.Mood to) {
+			int result = 0;
+
+			foreach (CityResident r in residents) {
+				if (!r.citizenType.IsDefaultCitizen) {
+					continue;
+				}
+
+				if (count <= 0) {
+					break;
+				}
+
+				if (r.mood == from) {
+					--count;
+					++result;
+					r.mood = to;
+				}
+			}
+
+			return result;
+		}
+
+		// This function does the heavy lifting of happiness calculations,
+		// combining the various bonuses and penalties that affect citizen moods.
+		//
+		// Some references:
+		//  - https://forums.civfanatics.com/threads/how-is-happiness-calculated.74966/
+		//  - https://codehappy.net/apolyton/threads/83368-1.htm
+		//
+		public void RecalculateCitizenMoods(GameData gameData) {
+			CityResident.Mood happy = CityResident.Mood.Happy;
+			CityResident.Mood content = CityResident.Mood.Content;
+			CityResident.Mood unhappy = CityResident.Mood.Unhappy;
+			InitializeMoodsForDifficulty(gameData.gameDifficulty);
+
+			// We want to track the move deltas from content to happy and unhappy
+			// to content. We can also move from unhappy straight to content,
+			// but it costs 2 "points" from the contentToHappy counter, and is
+			// only applied if there are no content faces.
+			int contentToHappyMoves = 0;
+			int unhappyToContentMoves = 0;
+
+			// TODO: add penalty for poprushing
+			// TODO: add penalty for drafting
+			// TODO: add penalty for building with unhappiness (in city and global)
+			// TODO: add penalty for war weariness
+			// TODO: add penalty for aggression against home country
+
+			// Luxuries move content faces to happy faces.
+			contentToHappyMoves += CurrentCommerceYield().happiness;
+
+			// TODO: count luxuries
+			// TODO: account for marketplaces
+			// TODO: account for building happiness (wonders, non wonders, and global/continent)
+
+			if (contentToHappyMoves >= 0) {
+				if (unhappyToContentMoves >= 0) {
+					// First apply all the unhappy->content moves. If there are
+					// left over content faces that's ok, they can't be used to
+					// get a citizen to happy.
+					ApplyMoodChange(unhappyToContentMoves, unhappy, content);
+
+					// Now move content faces to happy faces.
+					contentToHappyMoves -= ApplyMoodChange(contentToHappyMoves, content, happy);
+
+					// If there are moves left over we can try moving unhappy
+					// faces to happy, but it takes two "points".
+					contentToHappyMoves -= 2 * ApplyMoodChange(contentToHappyMoves / 2, unhappy, happy);
+
+					// Account for the remainder of the integer division
+					// (ApplyMoodChange ignores a negative input). 
+					ApplyMoodChange(contentToHappyMoves, unhappy, content);
+				} else {
+					// TODO: handle this once we support penalties
+				}
+			} else {
+				// TODO: handle this once we support penalties.
+			}
 		}
 
 		private Dictionary<Resource, int> ListResourceAccess(ResourceCategory category) {

--- a/C7Engine/C7GameData/CityResident.cs
+++ b/C7Engine/C7GameData/CityResident.cs
@@ -6,6 +6,13 @@ namespace C7GameData {
 		public Tile tileWorked = Tile.NONE;
 		public Civilization nationality;
 		public City city;
-		//Eventually more things like happiness
+
+		// Only relevant if citizenType.IsDefaultCitizen == true
+		public enum Mood {
+			Happy,
+			Content,
+			Unhappy
+		};
+		public Mood mood;
 	}
 }

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -620,6 +620,12 @@ namespace C7GameData {
 			}
 		}
 
+		public void RecalculateCitizenMoods(GameData gameData) {
+			foreach (City c in cities) {
+				c.RecalculateCitizenMoods(gameData);
+			}
+		}
+
 		public void UpdateResourcesInBorders(IEnumerable<Tile> ownedTiles) {
 			resourcesInBorders = ownedTiles
 								.Where(t => t.Resource != null)

--- a/C7Engine/C7GameData/Save/SaveCity.cs
+++ b/C7Engine/C7GameData/Save/SaveCity.cs
@@ -75,6 +75,7 @@ namespace C7GameData.Save {
 					nationality = resident.nationality?.name,
 					city = resident.city.id,
 					tileWorked = new TileLocation(resident.tileWorked),
+					citizenType = resident.citizenType.Id,
 				};
 			});
 			buildings = city.buildings.ConvertAll(building => new SaveCityBuilding(building));

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -107,6 +107,7 @@ namespace C7GameData.Save {
 
 			data.UpdateTileOwners();
 			foreach (Player p in data.players) {
+				p.RecalculateCitizenMoods(data);
 				p.DoCorruptionCalculations(data);
 			}
 

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -262,6 +262,12 @@ namespace C7Engine {
 				player.taxRate++;
 			}
 
+			// Update citizen moods in all cities, as changing the sliders can
+			// change moods.
+			foreach (City city in player.cities) {
+				city.RecalculateCitizenMoods(EngineStorage.gameData);
+			}
+
 			// Update the ui to reflect our changes.
 			new MsgUpdateUiAfterDomesticChange().send();
 		}

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -40,6 +40,7 @@ namespace C7Engine {
 
 				gameData.turn++;
 				foreach (Player player in gameData.players) {
+					player.RecalculateCitizenMoods(gameData);
 					player.DoCorruptionCalculations(gameData);
 					HandleCityResults(gameData, player);
 					player.DoPerTurnFinanceUpdates(gameData);


### PR DESCRIPTION
This is just the start to the rather complex world of happiness calculations, but it gives us a place to start with many other fancier things:
 - Making hooking up luxuries do something
 - Making marketplaces functional
 - Being able to add civil disorder
 - Making the domestic advisor show city populations and moods
 - Implementing pop rushing/drafting and the penalties
 - Implementing entertainers and other specialists

Now when a city in the default game hits size 3, one of the citizens will be unhappy, since only two citizens are born content on regent difficulty. We can fix this with the luxury slider (note the 1 gpt of luxury spending in the second screenshot).

![image](https://github.com/user-attachments/assets/af3c8be9-3e12-4dc6-a699-1287360e7b01)

![image](https://github.com/user-attachments/assets/4220f1bb-a680-443c-b8d7-a171d9413d35)
