### PR TITLE
Basic production of buildings

### DIFF
--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -67256,7 +67256,10 @@
       "populationCost": 0,
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "flags": [
+        "veteranGroundUnits"
+      ]
     },
     {
       "name": "Granary",
@@ -67412,7 +67415,10 @@
       "requiredBuilding": "Factory",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "flags": [
+        "mustBeNearRiver"
+      ]
     },
     {
       "name": "Nuclear Plant",
@@ -67478,6 +67484,9 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "flags": [
+        "mustBeCoastal"
+      ],
       "requiredResources": [
         "Iron",
         "Saltpeter"
@@ -67500,7 +67509,11 @@
       "requiredTech": "tech-15",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "flags": [
+        "mustBeCoastal",
+        "veteranSeaUnits"
+      ]
     },
     {
       "name": "Offshore Platform",
@@ -67509,7 +67522,10 @@
       "requiredTech": "tech-72",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "flags": [
+        "mustBeCoastal"
+      ]
     },
     {
       "name": "Airport",
@@ -67525,14 +67541,6 @@
       "shieldCost": 160,
       "populationCost": 0,
       "requiredTech": "tech-47",
-      "isGreatWonder": false,
-      "isSmallWonder": false,
-      "culturePerTurn": 0
-    },
-    {
-      "name": "Wealth",
-      "shieldCost": 0,
-      "populationCost": 0,
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0
@@ -67562,7 +67570,10 @@
       "requiredTech": "tech-1",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 3
+      "culturePerTurn": 3,
+      "flags": [
+        "mustBeCoastal"
+      ]
     },
     {
       "name": "The Great Lighthouse",
@@ -67571,7 +67582,10 @@
       "requiredTech": "tech-15",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 2
+      "culturePerTurn": 2,
+      "flags": [
+        "mustBeCoastal"
+      ]
     },
     {
       "name": "The Great Library",
@@ -67625,7 +67639,10 @@
       "requiredTech": "tech-37",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 3
+      "culturePerTurn": 3,
+      "flags": [
+        "mustBeCoastal"
+      ]
     },
     {
       "name": "Copernicus\u0027 Observatory",
@@ -67697,7 +67714,10 @@
       "requiredTech": "tech-62",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 2
+      "culturePerTurn": 2,
+      "flags": [
+        "mustBeNearRiver"
+      ]
     },
     {
       "name": "Theory of Evolution",

--- a/C7Engine/AI/CityProductionAI.cs
+++ b/C7Engine/AI/CityProductionAI.cs
@@ -30,7 +30,7 @@ namespace C7Engine {
 		 */
 		public static IProducible GetNextItemToBeProduced(City city, IProducible lastProduced) {
 			List<StrategicPriority> priorities = city.owner.strategicPriorityData;
-			IEnumerable<IProducible> unitPrototypes = city.ListProductionOptions();
+			IEnumerable<IProducible> producibles = city.ListProductionOptions();
 
 			log.Debug($"Choosing what to produce next in {city.name}");
 
@@ -39,7 +39,7 @@ namespace C7Engine {
 
 			//N.B. This implicitly casts to UnitPrototype.  For now this is fine but once we add buildings, this (or the source of the list)
 			//will have to get smarter.
-			foreach (UnitPrototype unitPrototype in unitPrototypes) {
+			foreach (UnitPrototype unitPrototype in producibles.Where(p => p is UnitPrototype)) {
 				float baseScore = GetItemScore(unitPrototype);
 				log.Debug($" Base score for {unitPrototype} is {baseScore}");
 				// There may eventually be some additive adjusters (or that may play into the previous)

--- a/C7Engine/C7GameData/Building.cs
+++ b/C7Engine/C7GameData/Building.cs
@@ -25,5 +25,9 @@ namespace C7GameData {
 			culturePerTurn = building.culturePerTurn;
 			isCenterOfEmpire = building.flags.Contains(SaveBuilding.IS_CENTER_OF_EMPIRE);
 		}
+
+		public bool CanProduce(City city, HashSet<Resource> accessibleResources) {
+			return false;
+		}
 	}
 }

--- a/C7Engine/C7GameData/Building.cs
+++ b/C7Engine/C7GameData/Building.cs
@@ -11,6 +11,24 @@ namespace C7GameData {
 			{ SaveBuilding.Flag.MustBeNearRiver, MustBeNearRiver }
 		};
 
+		public static Dictionary<SaveBuilding.Flag, Action<MapUnit>> unitProductionEffects = new()
+		{
+			{ SaveBuilding.Flag.VeteranGroundUnits, VeteranGroundUnits },
+			{ SaveBuilding.Flag.VeteranSeaUnits, VeteranSeaUnits }
+		};
+
+		private static void VeteranGroundUnits(MapUnit unit) {
+			if (unit.unitType.categories.Contains("Land")) {
+				unit.Promote();
+			}
+		}
+
+		private static void VeteranSeaUnits(MapUnit unit) {
+			if (unit.unitType.categories.Contains("Sea")) {
+				unit.Promote();
+			}
+		}
+
 		private static bool MustBeCoastal(City city) {
 			return city.location.NeighborsWater();
 		}
@@ -28,6 +46,8 @@ namespace C7GameData {
 		public Building requiredBuilding;
 
 		List<Func<City, bool>> productionPrerequisites = [];
+		public Action<MapUnit> onFinishedUnitProduction;
+
 		public bool isGreatWonder;
 		public bool isSmallWonder;
 		public bool isCenterOfEmpire;
@@ -54,6 +74,11 @@ namespace C7GameData {
 				}
 			}
 
+			foreach (var kvp in BuildingRules.unitProductionEffects) {
+				if (building.flags.Contains(kvp.Key)) {
+					onFinishedUnitProduction += kvp.Value;
+				}
+			}
 		}
 
 		public bool CanProduce(City city, HashSet<Resource> accessibleResources) {

--- a/C7Engine/C7GameData/Building.cs
+++ b/C7Engine/C7GameData/Building.cs
@@ -1,13 +1,33 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using C7GameData.Save;
 
 namespace C7GameData {
+	public static class BuildingRules {
+		public static Dictionary<SaveBuilding.Flag, Func<City, bool>> productionRules = new()
+		{
+			{ SaveBuilding.Flag.MustBeCoastal, MustBeCoastal },
+			{ SaveBuilding.Flag.MustBeNearRiver, MustBeNearRiver }
+		};
+
+		private static bool MustBeCoastal(City city) {
+			return city.location.NeighborsWater();
+		}
+
+		private static bool MustBeNearRiver(City city) {
+			return city.location.BordersRiver();
+		}
+	}
+
 	public class Building : IProducible {
 		public string name { get; set; }
 		public int shieldCost { get; set; }
 		public int populationCost { get; set; } // Will always be equal to 0 in the Civ3 rule set
 		public Tech requiredTech { get; set; }
 		public Building requiredBuilding;
+
+		List<Func<City, bool>> productionPrerequisites = [];
 		public bool isGreatWonder;
 		public bool isSmallWonder;
 		public bool isCenterOfEmpire;
@@ -16,6 +36,8 @@ namespace C7GameData {
 
 		public HashSet<Resource> requiredResources { get; set; } = [];
 
+		SaveBuilding dataSource;
+
 		public Building(SaveBuilding building) {
 			name = building.name;
 			shieldCost = building.shieldCost;
@@ -23,11 +45,49 @@ namespace C7GameData {
 			isGreatWonder = building.isGreatWonder;
 			isSmallWonder = building.isSmallWonder;
 			culturePerTurn = building.culturePerTurn;
-			isCenterOfEmpire = building.flags.Contains(SaveBuilding.IS_CENTER_OF_EMPIRE);
+			isCenterOfEmpire = building.flags.Contains(SaveBuilding.Flag.IsCenterOfEmpire);
+			dataSource = building;
+
+			foreach (var kvp in BuildingRules.productionRules) {
+				if (building.flags.Contains(kvp.Key)) {
+					productionPrerequisites.Add(kvp.Value);
+				}
+			}
+
 		}
 
 		public bool CanProduce(City city, HashSet<Resource> accessibleResources) {
-			return false;
+			if (!city.owner.HasRequiredTechnology(this)) {
+				return false;
+			}
+
+			if (city.buildings.Exists(cityBuilding => cityBuilding.building == this)) {
+				return false;
+			}
+
+			// TODO: Add logic for wonders and the palace
+			if (isGreatWonder || isSmallWonder || isCenterOfEmpire) {
+				return false;
+			}
+
+			if (requiredBuilding != null &&
+				!city.buildings.Exists(cityBuilding => cityBuilding.building == this)) {
+				return false;
+			}
+
+			if (!requiredResources.All(accessibleResources.Contains)) {
+				return false;
+			}
+
+			if (!productionPrerequisites.All(func => func(city))) {
+				return false;
+			}
+
+			return true;
+		}
+
+		public SaveBuilding ToSaveBuilding() {
+			return dataSource;
 		}
 	}
 }

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -89,38 +89,23 @@ namespace C7GameData {
 			return capital;
 		}
 
-		public bool CanBuildUnit(UnitPrototype proto) {
-			return MeetsProductionRequirements(proto) && !IsUnitObsolete(proto);
+		public IEnumerable<IProducible> ListProductionOptions() {
+			HashSet<Resource> accessibleResources = GetAccessibleResources();
+
+			IEnumerable<IProducible> producibles = EngineStorage.gameData.unitPrototypes.Cast<IProducible>()
+													.Concat(EngineStorage.gameData.Buildings.Cast<IProducible>());
+
+			return producibles.Where(p => p.CanProduce(this, accessibleResources));
 		}
 
-		// TODO: Consider golden ages when determining whether a unit is obsolete.
-		// If a golden age has not yet been triggered and a unit can trigger one,  
-		// it shouldn't be marked as obsolete, even if its upgrade is available.
-		private bool IsUnitObsolete(UnitPrototype proto) {
-			List<UnitPrototype> upgradeChain = owner.civilization.GetUpgradeChain(proto);
+		private HashSet<Resource> GetAccessibleResources() {
+			PathingAlgorithm pathing = PathingAlgorithmChooser.GetTradeNetworkAlgorithm();
 
-			return upgradeChain.Any(MeetsProductionRequirements);
-		}
-
-		private bool HasRequiredTechnology(IProducible producible) {
-			return producible.requiredTech == null ||
-				   owner.knownTechs.Contains(producible.requiredTech.id);
-		}
-
-		private bool MeetsProductionRequirements(UnitPrototype proto) {
-			if (!owner.civilization.IsUnitAvailable(proto)) {
-				return false;
-			}
-
-			if (!HasRequiredTechnology(proto)) {
-				return false;
-			}
-
-			if (proto.categories.Contains("Sea") && !location.NeighborsWater()) {
-				return false;
-			}
-
-			return true;
+			return owner.resourcesInBorders
+						.Where(kv => owner.KnowsAboutResource(kv.Key))
+						.Where(kv => kv.Value.Any(t => HasTradeAccess(t, pathing)))
+						.Select(kv => kv.Key)
+						.ToHashSet();
 		}
 
 		public int TurnsUntilGrowth() {
@@ -423,10 +408,6 @@ namespace C7GameData {
 				perPlayerCulture[owner] += cb.building.culturePerTurn;
 			}
 			return start != GetBorderExpansionLevel();
-		}
-
-		public IEnumerable<IProducible> ListProductionOptions() {
-			return EngineStorage.gameData.unitPrototypes.Where(CanBuildUnit);
 		}
 
 		private Dictionary<Resource, int> ListResourceAccess(ResourceCategory category) {

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -257,6 +257,21 @@ namespace C7GameData {
 			});
 		}
 
+		public void AddUnit(UnitPrototype prototype, GameData gameData) {
+			MapUnit newUnit = prototype.GetInstance(gameData);
+			newUnit.owner = owner;
+			newUnit.location = location;
+			newUnit.experienceLevelKey = gameData.defaultExperienceLevelKey;
+			newUnit.experienceLevel = gameData.defaultExperienceLevel;
+			newUnit.facingDirection = TileDirection.SOUTHWEST;
+
+			location.unitsOnTile.Add(newUnit);
+			gameData.mapUnits.Add(newUnit);
+			owner.AddUnit(newUnit);
+
+			buildings.ForEach(b => b.building.onFinishedUnitProduction?.Invoke(newUnit));
+		}
+
 		// The list of tiles that could be worked by this city.
 		// This isn't necessarily a subset of our borders, because we're allowed
 		// to work tiles owned by our civ in our big fat cross, even if our

--- a/C7Engine/C7GameData/IProducible.cs
+++ b/C7Engine/C7GameData/IProducible.cs
@@ -11,5 +11,7 @@ namespace C7GameData {
 		int populationCost { get; set; }
 		Tech requiredTech { get; set; }
 		HashSet<Resource> requiredResources { get; set; }
+
+		bool CanProduce(City city, HashSet<Resource> accessibleResources);
 	}
 }

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -883,6 +883,10 @@ namespace C7GameData {
 			BLDG[] Bldg = biq.Bldg ?? defaultBiq.Bldg;
 
 			foreach (BLDG bldg in Bldg) {
+				if (bldg.Name == "Wealth") {
+					continue; // We don't consider Wealth as a building
+				}
+
 				SaveBuilding building = new() {
 					name=bldg.Name,
 					shieldCost=bldg.Cost * 10, // In Civ3 files, building costs are stored at 1/10th of their actual value
@@ -908,12 +912,22 @@ namespace C7GameData {
 					building.requiredResources.Add(save.Resources[bldg.RequiredResource2].Key);
 				}
 
-				if (bldg.CenterOfEmpire) {
-					building.flags.Add(SaveBuilding.IS_CENTER_OF_EMPIRE);
-				}
+				building.flags = LoadBuildingFlags(bldg).ToHashSet();
 
 				save.Buildings.Add(building);
 			}
+		}
+
+		private static IEnumerable<SaveBuilding.Flag> LoadBuildingFlags(BLDG bldg) {
+			return new[] {
+				(bldg.CenterOfEmpire, SaveBuilding.Flag.IsCenterOfEmpire),
+				(bldg.CoastalInstallation, SaveBuilding.Flag.MustBeCoastal),
+				(bldg.MustBeNearRiver, SaveBuilding.Flag.MustBeNearRiver),
+				(bldg.VeteranGroundUnits, SaveBuilding.Flag.VeteranGroundUnits),
+				(bldg.VeteranSeaUnits, SaveBuilding.Flag.VeteranSeaUnits),
+			}
+			.Where(t => t.Item1)
+			.Select(t => t.Item2);
 		}
 
 		private void ImportCiv3TerrainTypes() {

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -234,13 +234,17 @@ namespace C7GameData {
 			// TODO: Double promotionChance if unit is owned by a militaristic civ
 
 			if (GameData.rng.NextDouble() < promotionChance) {
-				ExperienceLevel nextLevel = EngineStorage.gameData.GetExperienceLevelAfter(experienceLevel);
-				if (nextLevel != null) {
-					experienceLevelKey = nextLevel.key;
-					experienceLevel = nextLevel;
-					hitPointsRemaining++;
-					animate(MapUnit.AnimatedAction.VICTORY, waitForAnimation);
-				}
+				Promote();
+				animate(MapUnit.AnimatedAction.VICTORY, waitForAnimation);
+			}
+		}
+
+		public void Promote() {
+			ExperienceLevel nextLevel = EngineStorage.gameData.GetExperienceLevelAfter(experienceLevel);
+			if (nextLevel != null) {
+				experienceLevelKey = nextLevel.key;
+				experienceLevel = nextLevel;
+				hitPointsRemaining++;
 			}
 		}
 

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -543,6 +543,12 @@ namespace C7GameData {
 								.GroupBy(t => t.Resource)
 								.ToDictionary(g => g.Key, g => g.ToList());
 		}
+
+		public bool HasRequiredTechnology(IProducible producible) {
+			return producible.requiredTech == null ||
+				   knownTechs.Contains(producible.requiredTech.id);
+		}
+
 	}
 
 }

--- a/C7Engine/C7GameData/Save/SaveBuilding.cs
+++ b/C7Engine/C7GameData/Save/SaveBuilding.cs
@@ -3,7 +3,13 @@ using System.Linq;
 
 namespace C7GameData.Save {
 	public class SaveBuilding {
-		public const string IS_CENTER_OF_EMPIRE = "isCenterOfEmpire";
+		public enum Flag {
+			IsCenterOfEmpire,
+			VeteranGroundUnits,
+			VeteranSeaUnits,
+			MustBeCoastal,
+			MustBeNearRiver
+		}
 
 		public string name;
 		public int shieldCost;
@@ -16,27 +22,10 @@ namespace C7GameData.Save {
 
 		// Assorted boolean flags for the building. They're stored in this set
 		// rather than as booleans to avoid bloating the json file.
-		public HashSet<string> flags = new();
+		public HashSet<Flag> flags = new();
 
 		public HashSet<string> requiredResources = [];
 
 		public SaveBuilding() { }
-
-		public SaveBuilding(Building b) {
-			(name, shieldCost, populationCost, isGreatWonder, isSmallWonder, culturePerTurn) =
-			(b.name, b.shieldCost, b.populationCost, b.isGreatWonder, b.isSmallWonder, b.culturePerTurn);
-
-			if (b.isCenterOfEmpire) {
-				flags.Add(IS_CENTER_OF_EMPIRE);
-			}
-
-			if (b.requiredTech != null)
-				requiredTech = b.requiredTech.id;
-
-			if (b.requiredBuilding != null)
-				requiredBuilding = b.requiredBuilding.name;
-
-			requiredResources = b.requiredResources.Select(r => r.Key).ToHashSet();
-		}
 	}
 }

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -55,7 +55,7 @@ namespace C7GameData.Save {
 				Map = new SaveMap(data.map),
 				TerrainTypes = data.terrainTypes,
 				Resources = data.Resources,
-				Buildings = data.Buildings.ConvertAll(building => new SaveBuilding(building)),
+				Buildings = data.Buildings.ConvertAll(building => building.ToSaveBuilding()),
 				BarbarianInfo = data.barbarianInfo,
 				Units = data.mapUnits.ConvertAll(unit => new SaveUnit(unit, data.map)),
 				UnitPrototypes = data.unitPrototypes.ConvertAll(proto => new SaveUnitPrototype(proto)),

--- a/C7Engine/C7GameData/UnitPrototype.cs
+++ b/C7Engine/C7GameData/UnitPrototype.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 
 namespace C7GameData {
 	using System;
+	using System.Linq;
 	using C7GameData.Save;
 
 	/**
@@ -72,5 +73,40 @@ namespace C7GameData {
 			instance.movementPoints.reset(movement);
 			return instance;
 		}
+
+		public bool CanProduce(City city, HashSet<Resource> accessibleResources) {
+			return MeetsProductionRequirements(city, accessibleResources) && !IsUnitObsolete(city, accessibleResources);
+		}
+
+		// TODO: Consider golden ages when determining whether a unit is obsolete.
+		// If a golden age has not yet been triggered and a unit can trigger one,  
+		// it shouldn't be marked as obsolete, even if its upgrade is available.
+		private bool IsUnitObsolete(City city, HashSet<Resource> accessibleResources) {
+			List<UnitPrototype> upgradeChain = city.owner.civilization.GetUpgradeChain(this);
+
+			return upgradeChain.Any(upgrade => upgrade.MeetsProductionRequirements(city, accessibleResources));
+		}
+
+		private bool MeetsProductionRequirements(City city, HashSet<Resource> accessibleResources) {
+			if (!city.owner.civilization.IsUnitAvailable(this)) {
+				return false;
+			}
+
+			if (!city.owner.HasRequiredTechnology(this)) {
+				return false;
+			}
+
+			if (categories.Contains("Sea") && !city.location.NeighborsWater()) {
+				return false;
+			}
+
+			if (!requiredResources.All(accessibleResources.Contains)) {
+				return false;
+			}
+
+			return true;
+		}
+
+
 	}
 }

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -164,16 +164,7 @@ namespace C7Engine {
 				if (producedItem != null) {
 					log.Debug($"Produced {producedItem} in {city}");
 					if (producedItem is UnitPrototype prototype) {
-						MapUnit newUnit = prototype.GetInstance(gameData);
-						newUnit.owner = city.owner;
-						newUnit.location = city.location;
-						newUnit.experienceLevelKey = gameData.defaultExperienceLevelKey;
-						newUnit.experienceLevel = gameData.defaultExperienceLevel;
-						newUnit.facingDirection = TileDirection.SOUTHWEST;
-
-						city.location.unitsOnTile.Add(newUnit);
-						gameData.mapUnits.Add(newUnit);
-						city.owner.AddUnit(newUnit);
+						city.AddUnit(prototype, gameData);
 					} else if (producedItem is Building building) {
 						city.AddBuilding(building);
 					}


### PR DESCRIPTION
This PR:
- Adds resource requirements for unit production
- Adds requirements for building production, including:
  - basic checks (mainly resources and technology) 
  - building-specific requirements (currently implemented: river and coastal placement requirements)
- Implements promotion effects of barracks and harbors a a proof of concept

**Notes on the implementation**
The code is written with future moddability in mind. Instead of hard-coding specific requirements and effects as parts of the Building class, this PR introduces a delegate-based approach. Requirements are stored as a collection of predicate functions, and the promotion effects are attached to the generic "onUnitProduction" action.

Currently, these delegates are generated from SaveBuildings tags, but once we implement user scripting, the functional behavior of buildings could be moved into moddable scripts.