### PR TITLE
Add building-level mood modifications in a particular city

### DIFF
--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -67246,6 +67246,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 1,
+      "contentFacesInCity": 0,
       "flags": [
         "isCenterOfEmpire"
       ]
@@ -67257,6 +67258,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "flags": [
         "veteranGroundUnits"
       ]
@@ -67268,7 +67270,8 @@
       "requiredTech": "tech-4",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "contentFacesInCity": 0
     },
     {
       "name": "Temple",
@@ -67277,7 +67280,8 @@
       "requiredTech": "tech-7",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 2
+      "culturePerTurn": 2,
+      "contentFacesInCity": 1
     },
     {
       "name": "Marketplace",
@@ -67287,6 +67291,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "flags": [
         "increasesLuxuryTrade"
       ]
@@ -67298,7 +67303,8 @@
       "requiredTech": "tech-14",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 3
+      "culturePerTurn": 3,
+      "contentFacesInCity": 0
     },
     {
       "name": "Courthouse",
@@ -67308,6 +67314,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "flags": [
         "reducesCorruption"
       ]
@@ -67319,7 +67326,8 @@
       "requiredTech": "tech-2",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "contentFacesInCity": 0
     },
     {
       "name": "Aqueduct",
@@ -67328,7 +67336,8 @@
       "requiredTech": "tech-21",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "contentFacesInCity": 0
     },
     {
       "name": "Bank",
@@ -67338,7 +67347,8 @@
       "requiredBuilding": "Marketplace",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "contentFacesInCity": 0
     },
     {
       "name": "Cathedral",
@@ -67348,7 +67358,8 @@
       "requiredBuilding": "Temple",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 3
+      "culturePerTurn": 3,
+      "contentFacesInCity": 3
     },
     {
       "name": "University",
@@ -67358,7 +67369,8 @@
       "requiredBuilding": "Library",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 4
+      "culturePerTurn": 4,
+      "contentFacesInCity": 0
     },
     {
       "name": "Colosseum",
@@ -67367,7 +67379,8 @@
       "requiredTech": "tech-21",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 2
+      "culturePerTurn": 2,
+      "contentFacesInCity": 2
     },
     {
       "name": "Factory",
@@ -67377,6 +67390,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Iron"
       ]
@@ -67389,7 +67403,8 @@
       "requiredBuilding": "Factory",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "contentFacesInCity": 0
     },
     {
       "name": "Recycling Center",
@@ -67398,7 +67413,8 @@
       "requiredTech": "tech-68",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "contentFacesInCity": 0
     },
     {
       "name": "Coal Plant",
@@ -67409,6 +67425,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Coal"
       ]
@@ -67422,6 +67439,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "flags": [
         "mustBeNearRiver"
       ]
@@ -67435,6 +67453,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Uranium"
       ]
@@ -67446,7 +67465,8 @@
       "requiredTech": "tech-51",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "contentFacesInCity": 0
     },
     {
       "name": "Research Lab",
@@ -67456,7 +67476,8 @@
       "requiredBuilding": "University",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 2
+      "culturePerTurn": 2,
+      "contentFacesInCity": 0
     },
     {
       "name": "Mass Transit System",
@@ -67466,6 +67487,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Rubber"
       ]
@@ -67478,6 +67500,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Aluminum"
       ]
@@ -67490,6 +67513,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "flags": [
         "mustBeCoastal"
       ],
@@ -67506,7 +67530,8 @@
       "requiredBuilding": "Factory",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "contentFacesInCity": 0
     },
     {
       "name": "Harbor",
@@ -67516,6 +67541,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "flags": [
         "mustBeCoastal",
         "veteranSeaUnits",
@@ -67530,6 +67556,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "flags": [
         "mustBeCoastal",
         "increasesShieldsInWater"
@@ -67542,7 +67569,8 @@
       "requiredTech": "tech-59",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "contentFacesInCity": 0
     },
     {
       "name": "Police Station",
@@ -67552,6 +67580,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "flags": [
         "reducesCorruption"
       ]
@@ -67563,7 +67592,8 @@
       "requiredTech": "tech-2",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 4
+      "culturePerTurn": 4,
+      "contentFacesInCity": 0
     },
     {
       "name": "The Hanging Gardens",
@@ -67572,7 +67602,8 @@
       "requiredTech": "tech-20",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 4
+      "culturePerTurn": 4,
+      "contentFacesInCity": 3
     },
     {
       "name": "The Colossus",
@@ -67582,6 +67613,7 @@
       "isGreatWonder": true,
       "isSmallWonder": false,
       "culturePerTurn": 3,
+      "contentFacesInCity": 0,
       "flags": [
         "mustBeCoastal"
       ]
@@ -67594,6 +67626,7 @@
       "isGreatWonder": true,
       "isSmallWonder": false,
       "culturePerTurn": 2,
+      "contentFacesInCity": 0,
       "flags": [
         "mustBeCoastal"
       ]
@@ -67605,7 +67638,8 @@
       "requiredTech": "tech-14",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 6
+      "culturePerTurn": 6,
+      "contentFacesInCity": 0
     },
     {
       "name": "The Oracle",
@@ -67614,7 +67648,8 @@
       "requiredTech": "tech-10",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 4
+      "culturePerTurn": 4,
+      "contentFacesInCity": 0
     },
     {
       "name": "The Great Wall",
@@ -67623,7 +67658,8 @@
       "requiredTech": "tech-21",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 2
+      "culturePerTurn": 2,
+      "contentFacesInCity": 0
     },
     {
       "name": "Sun Tzu\u0027s Art of War",
@@ -67632,7 +67668,8 @@
       "requiredTech": "tech-23",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 2
+      "culturePerTurn": 2,
+      "contentFacesInCity": 0
     },
     {
       "name": "Sistine Chapel",
@@ -67641,7 +67678,8 @@
       "requiredTech": "tech-25",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 6
+      "culturePerTurn": 6,
+      "contentFacesInCity": 0
     },
     {
       "name": "Magellan\u0027s Voyage",
@@ -67651,6 +67689,7 @@
       "isGreatWonder": true,
       "isSmallWonder": false,
       "culturePerTurn": 3,
+      "contentFacesInCity": 0,
       "flags": [
         "mustBeCoastal"
       ]
@@ -67662,7 +67701,8 @@
       "requiredTech": "tech-33",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 4
+      "culturePerTurn": 4,
+      "contentFacesInCity": 0
     },
     {
       "name": "Shakespeare\u0027s Theater",
@@ -67671,7 +67711,8 @@
       "requiredTech": "tech-40",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 8
+      "culturePerTurn": 8,
+      "contentFacesInCity": 8
     },
     {
       "name": "Leonardo\u0027s Workshop",
@@ -67680,7 +67721,8 @@
       "requiredTech": "tech-27",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 2
+      "culturePerTurn": 2,
+      "contentFacesInCity": 0
     },
     {
       "name": "JS Bach\u0027s Cathedral",
@@ -67689,7 +67731,8 @@
       "requiredTech": "tech-29",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 6
+      "culturePerTurn": 6,
+      "contentFacesInCity": 2
     },
     {
       "name": "Newton\u0027s University",
@@ -67698,7 +67741,8 @@
       "requiredTech": "tech-41",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 6
+      "culturePerTurn": 6,
+      "contentFacesInCity": 0
     },
     {
       "name": "Smith\u0027s Trading Company",
@@ -67707,7 +67751,8 @@
       "requiredTech": "tech-36",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 3
+      "culturePerTurn": 3,
+      "contentFacesInCity": 0
     },
     {
       "name": "Universal Suffrage",
@@ -67716,7 +67761,8 @@
       "requiredTech": "tech-48",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 4
+      "culturePerTurn": 4,
+      "contentFacesInCity": 0
     },
     {
       "name": "Hoover Dam",
@@ -67726,6 +67772,7 @@
       "isGreatWonder": true,
       "isSmallWonder": false,
       "culturePerTurn": 2,
+      "contentFacesInCity": 0,
       "flags": [
         "mustBeNearRiver"
       ]
@@ -67737,7 +67784,8 @@
       "requiredTech": "tech-50",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 3
+      "culturePerTurn": 3,
+      "contentFacesInCity": 0
     },
     {
       "name": "The United Nations",
@@ -67746,7 +67794,8 @@
       "requiredTech": "tech-66",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 4
+      "culturePerTurn": 4,
+      "contentFacesInCity": 0
     },
     {
       "name": "The Manhattan Project",
@@ -67756,6 +67805,7 @@
       "isGreatWonder": true,
       "isSmallWonder": false,
       "culturePerTurn": 2,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Uranium"
       ]
@@ -67767,7 +67817,8 @@
       "requiredTech": "tech-77",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 3
+      "culturePerTurn": 3,
+      "contentFacesInCity": 1
     },
     {
       "name": "Longevity",
@@ -67776,7 +67827,8 @@
       "requiredTech": "tech-77",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 3
+      "culturePerTurn": 3,
+      "contentFacesInCity": 0
     },
     {
       "name": "SETI program",
@@ -67785,7 +67837,8 @@
       "requiredTech": "tech-67",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 3
+      "culturePerTurn": 3,
+      "contentFacesInCity": 0
     },
     {
       "name": "Heroic Epic",
@@ -67793,7 +67846,8 @@
       "populationCost": 0,
       "isGreatWonder": false,
       "isSmallWonder": true,
-      "culturePerTurn": 4
+      "culturePerTurn": 4,
+      "contentFacesInCity": 0
     },
     {
       "name": "Iron Works",
@@ -67802,6 +67856,7 @@
       "isGreatWonder": false,
       "isSmallWonder": true,
       "culturePerTurn": 2,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Iron",
         "Coal"
@@ -67814,6 +67869,7 @@
       "isGreatWonder": false,
       "isSmallWonder": true,
       "culturePerTurn": 2,
+      "contentFacesInCity": 0,
       "flags": [
         "forbiddenPalace"
       ]
@@ -67825,7 +67881,8 @@
       "requiredTech": "tech-43",
       "isGreatWonder": false,
       "isSmallWonder": true,
-      "culturePerTurn": 1
+      "culturePerTurn": 1,
+      "contentFacesInCity": 0
     },
     {
       "name": "The Pentagon",
@@ -67833,7 +67890,8 @@
       "populationCost": 0,
       "isGreatWonder": false,
       "isSmallWonder": true,
-      "culturePerTurn": 1
+      "culturePerTurn": 1,
+      "contentFacesInCity": 0
     },
     {
       "name": "Wall Street",
@@ -67842,7 +67900,8 @@
       "requiredBuilding": "Stock Exchange",
       "isGreatWonder": false,
       "isSmallWonder": true,
-      "culturePerTurn": 2
+      "culturePerTurn": 2,
+      "contentFacesInCity": 0
     },
     {
       "name": "Apollo Program",
@@ -67852,6 +67911,7 @@
       "isGreatWonder": false,
       "isSmallWonder": true,
       "culturePerTurn": 2,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Aluminum"
       ]
@@ -67864,7 +67924,8 @@
       "requiredBuilding": "SAM Missile Battery",
       "isGreatWonder": false,
       "isSmallWonder": true,
-      "culturePerTurn": 1
+      "culturePerTurn": 1,
+      "contentFacesInCity": 0
     },
     {
       "name": "Intelligence Agency",
@@ -67873,7 +67934,8 @@
       "requiredTech": "tech-52",
       "isGreatWonder": false,
       "isSmallWonder": true,
-      "culturePerTurn": 1
+      "culturePerTurn": 1,
+      "contentFacesInCity": 0
     },
     {
       "name": "Battlefield Medicine",
@@ -67882,7 +67944,8 @@
       "requiredBuilding": "Hospital",
       "isGreatWonder": false,
       "isSmallWonder": true,
-      "culturePerTurn": 1
+      "culturePerTurn": 1,
+      "contentFacesInCity": 0
     },
     {
       "name": "SS Thrusters",
@@ -67892,6 +67955,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Aluminum"
       ]
@@ -67904,6 +67968,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Aluminum"
       ]
@@ -67916,6 +67981,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Aluminum"
       ]
@@ -67928,6 +67994,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Aluminum"
       ]
@@ -67940,6 +68007,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Uranium"
       ]
@@ -67952,6 +68020,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Aluminum"
       ]
@@ -67964,6 +68033,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Aluminum",
         "Uranium"
@@ -67977,6 +68047,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Aluminum"
       ]
@@ -67989,6 +68060,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Aluminum"
       ]
@@ -68001,6 +68073,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Aluminum",
         "Rubber"
@@ -68013,7 +68086,8 @@
       "requiredTech": "tech-72",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 4
+      "culturePerTurn": 4,
+      "contentFacesInCity": 0
     },
     {
       "name": "Civil Defense",
@@ -68023,7 +68097,8 @@
       "requiredBuilding": "Barracks",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "contentFacesInCity": 0
     },
     {
       "name": "Stock Exchange",
@@ -68033,7 +68108,8 @@
       "requiredBuilding": "Bank",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "contentFacesInCity": 0
     },
     {
       "name": "Commercial Dock",
@@ -68044,6 +68120,7 @@
       "isGreatWonder": false,
       "isSmallWonder": false,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "flags": [
         "increasesTradeInWater"
       ]
@@ -68055,7 +68132,8 @@
       "requiredTech": "tech-17",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 4
+      "culturePerTurn": 4,
+      "contentFacesInCity": 0
     },
     {
       "name": "The Statue of Zeus",
@@ -68065,6 +68143,7 @@
       "isGreatWonder": true,
       "isSmallWonder": false,
       "culturePerTurn": 4,
+      "contentFacesInCity": 0,
       "requiredResources": [
         "Ivory"
       ]
@@ -68076,7 +68155,8 @@
       "requiredTech": "tech-12",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 2
+      "culturePerTurn": 2,
+      "contentFacesInCity": 3
     },
     {
       "name": "Knights Templar",
@@ -68085,7 +68165,8 @@
       "requiredTech": "tech-26",
       "isGreatWonder": true,
       "isSmallWonder": false,
-      "culturePerTurn": 2
+      "culturePerTurn": 2,
+      "contentFacesInCity": 0
     },
     {
       "name": "Secret Police HQ",
@@ -68095,6 +68176,7 @@
       "isGreatWonder": false,
       "isSmallWonder": true,
       "culturePerTurn": 0,
+      "contentFacesInCity": 0,
       "flags": [
         "forbiddenPalace"
       ]

--- a/C7Engine/C7GameData/Building.cs
+++ b/C7Engine/C7GameData/Building.cs
@@ -82,6 +82,16 @@ namespace C7GameData {
 
 		public int culturePerTurn = 0;
 
+		// The number of unhappy faces that become content in the city with this
+		// building.
+		public int contentFacesInCity = 0;
+
+		// The number of happy faces that become content in the city with this
+		// building. Note that this is less powerful than other sources of
+		// unhappiness, like drafting or poprushing, which converts happy faces
+		// to sad faces.
+		public int unhappyFacesInCity = 0;
+
 		public HashSet<Resource> requiredResources { get; set; } = [];
 
 		SaveBuilding dataSource;
@@ -93,6 +103,11 @@ namespace C7GameData {
 			isGreatWonder = building.isGreatWonder;
 			isSmallWonder = building.isSmallWonder;
 			culturePerTurn = building.culturePerTurn;
+			if (building.contentFacesInCity < 0) {
+				unhappyFacesInCity = -building.contentFacesInCity;
+			} else {
+				contentFacesInCity = building.contentFacesInCity;
+			}
 			isCenterOfEmpire = building.flags.Contains(SaveBuilding.Flag.IsCenterOfEmpire);
 			increasesLuxuryTrade = building.flags.Contains(SaveBuilding.Flag.IncreasesLuxuryTrade);
 			reducesCorruption = building.flags.Contains(SaveBuilding.Flag.ReducesCorruption);

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -300,6 +300,10 @@ namespace C7GameData {
 				year = 1, // TODO: Implement in-game year tracking
 				totalCulture = 0
 			});
+
+			// Recalculate moods after adding a building, since buildings can
+			// affect moods.
+			RecalculateCitizenMoods(EngineStorage.gameData);
 		}
 
 		public void AddUnit(UnitPrototype prototype, GameData gameData) {
@@ -506,6 +510,26 @@ namespace C7GameData {
 			return result;
 		}
 
+		// Handles the process of consuming content to happy moves, first making
+		// content faces happy, then unhappy to happy at 1/2 the rate, and then
+		// applying the remainder of unhappy->content, if any.
+		private void ConsumeContentToHappyMoves(int contentToHappyMoves) {
+			CityResident.Mood happy = CityResident.Mood.Happy;
+			CityResident.Mood content = CityResident.Mood.Content;
+			CityResident.Mood unhappy = CityResident.Mood.Unhappy;
+
+			// Now move content faces to happy faces.
+			contentToHappyMoves -= ApplyMoodChange(contentToHappyMoves, content, happy);
+
+			// If there are moves left over we can try moving unhappy
+			// faces to happy, but it takes two "points".
+			contentToHappyMoves -= 2 * ApplyMoodChange(contentToHappyMoves / 2, unhappy, happy);
+
+			// Account for the remainder of the integer division
+			// (ApplyMoodChange ignores a negative input). 
+			ApplyMoodChange(contentToHappyMoves, unhappy, content);
+		}
+
 		// This function does the heavy lifting of happiness calculations,
 		// combining the various bonuses and penalties that affect citizen moods.
 		//
@@ -528,9 +552,16 @@ namespace C7GameData {
 
 			// TODO: add penalty for poprushing
 			// TODO: add penalty for drafting
-			// TODO: add penalty for building with unhappiness (in city and global)
+			// TODO: add penalty for building with unhappiness (global/continental)
 			// TODO: add penalty for war weariness
 			// TODO: add penalty for aggression against home country
+
+			// Building happiness/unhappiness, which only affects the unhappy to
+			// content transition, nothing with happy faces.
+			foreach (CityBuilding cb in buildings) {
+				unhappyToContentMoves -= cb.building.unhappyFacesInCity;
+				unhappyToContentMoves += cb.building.contentFacesInCity;
+			}
 
 			// Luxury spending moves content faces to happy faces.
 			contentToHappyMoves += CurrentCommerceYield().happiness;
@@ -551,18 +582,24 @@ namespace C7GameData {
 					// get a citizen to happy.
 					ApplyMoodChange(unhappyToContentMoves, unhappy, content);
 
-					// Now move content faces to happy faces.
-					contentToHappyMoves -= ApplyMoodChange(contentToHappyMoves, content, happy);
-
-					// If there are moves left over we can try moving unhappy
-					// faces to happy, but it takes two "points".
-					contentToHappyMoves -= 2 * ApplyMoodChange(contentToHappyMoves / 2, unhappy, happy);
-
-					// Account for the remainder of the integer division
-					// (ApplyMoodChange ignores a negative input). 
-					ApplyMoodChange(contentToHappyMoves, unhappy, content);
+					// Then do the same for content->happy moves, which can also
+					// make unhappy->happy moves.
+					ConsumeContentToHappyMoves(contentToHappyMoves);
 				} else {
-					// TODO: handle this once we support penalties
+					int happyPoints = contentToHappyMoves;
+					int sadPoints = -unhappyToContentMoves; // Deal with positive numbers
+
+					// Each "sadness point" wipes away a content->happy move,
+					// so netralize things out.
+					contentToHappyMoves = Math.Max(0, happyPoints - sadPoints);
+					sadPoints = Math.Max(0, sadPoints - happyPoints);
+
+					// Use up all our content to happy moves.
+					ConsumeContentToHappyMoves(contentToHappyMoves);
+
+					// Now apply any remaining "sadness points", moving happy
+					// faces back to content.
+					ApplyMoodChange(sadPoints, happy, content);
 				}
 			} else {
 				// TODO: handle this once we support penalties.

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -896,6 +896,7 @@ namespace C7GameData {
 					isSmallWonder=bldg.SmallWonder,
 					isGreatWonder=bldg.Wonder,
 					culturePerTurn=bldg.Culture,
+					contentFacesInCity=bldg.ContentFaces - bldg.UnhappyFaces,
 				};
 
 				if (bldg.RequiredAdvance != -1) {

--- a/C7Engine/C7GameData/Save/SaveBuilding.cs
+++ b/C7Engine/C7GameData/Save/SaveBuilding.cs
@@ -24,6 +24,7 @@ namespace C7GameData.Save {
 		public bool isGreatWonder;
 		public bool isSmallWonder;
 		public int culturePerTurn;
+		public int contentFacesInCity;
 
 		// Assorted boolean flags for the building. They're stored in this set
 		// rather than as booleans to avoid bloating the json file.

--- a/QueryCiv3/BiqSections/Bldg.cs
+++ b/QueryCiv3/BiqSections/Bldg.cs
@@ -22,8 +22,8 @@ namespace QueryCiv3.Biq {
 		public int DefenseBonus;
 		public int NavalDefenseBonus;
 		public int MaintenanceCost;
-		public int HappyFacesAllCities;
-		public int HappyFaces;
+		public int ContentFacesAllCities;
+		public int ContentFaces;
 		public int UnhappyFacesAllCities;
 		public int UnhappyFaces;
 		public int NumberOfRequiredBuildings;


### PR DESCRIPTION
This only applies to city-level effects, not global or continent-level effects, but means that temples will start to be functional.

Interestingly there's an "unhappiness" modifier for buildings available in the editor, though the base game doesn't actually use this. I did some testing with a modified scenario and found that it moves happy faces back to content.