### PR TITLE
Allow buildings to modify tile yields

### DIFF
--- a/C7/Map/TileAssignmentLayer.cs
+++ b/C7/Map/TileAssignmentLayer.cs
@@ -51,9 +51,9 @@ namespace C7.Map {
 				return;
 			}
 
-			Tile.TileYield food = tile.foodYield(city.owner);
-			Tile.TileYield shields = tile.productionYield(city.owner);
-			Tile.TileYield gold = tile.commerceYield(city.owner);
+			Tile.Yield food = tile.foodYield(city);
+			Tile.Yield shields = tile.productionYield(city);
+			Tile.Yield gold = tile.commerceYield(city);
 
 			int totalWidth = ((food.penalty + food.yield) * foodTexture.GetWidth()) +
 						((shields.penalty + shields.yield) * shieldTexture.GetWidth()) +

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -67518,7 +67518,8 @@
       "culturePerTurn": 0,
       "flags": [
         "mustBeCoastal",
-        "veteranSeaUnits"
+        "veteranSeaUnits",
+        "increasesFoodInWater"
       ]
     },
     {
@@ -67530,7 +67531,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "flags": [
-        "mustBeCoastal"
+        "mustBeCoastal",
+        "increasesShieldsInWater"
       ]
     },
     {
@@ -68041,7 +68043,10 @@
       "requiredBuilding": "Harbor",
       "isGreatWonder": false,
       "isSmallWonder": false,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "flags": [
+        "increasesTradeInWater"
+      ]
     },
     {
       "name": "The Temple of Artemis",
@@ -68089,7 +68094,10 @@
       "requiredTech": "tech-52",
       "isGreatWonder": false,
       "isSmallWonder": true,
-      "culturePerTurn": 0
+      "culturePerTurn": 0,
+      "flags": [
+        "forbiddenPalace"
+      ]
     }
   ],
   "players": [

--- a/C7Engine/C7GameData/Building.cs
+++ b/C7Engine/C7GameData/Building.cs
@@ -47,6 +47,7 @@ namespace C7GameData {
 
 		List<Func<City, bool>> productionPrerequisites = [];
 		public Action<MapUnit> onFinishedUnitProduction;
+		public Action<Tile.Yield, Tile.YieldType> tileModifier;
 
 		public bool isGreatWonder;
 		public bool isSmallWonder;

--- a/C7Engine/C7GameData/Building.cs
+++ b/C7Engine/C7GameData/Building.cs
@@ -17,6 +17,30 @@ namespace C7GameData {
 			{ SaveBuilding.Flag.VeteranSeaUnits, VeteranSeaUnits }
 		};
 
+		public static Dictionary<SaveBuilding.Flag, Action<Tile.Yield>> tileModifiers = new(){
+			{ SaveBuilding.Flag.IncreasesFoodInWater, IncreaseFoodInWater },
+			{ SaveBuilding.Flag.IncreasesShieldsInWater, IncreaseShieldInWater},
+			{ SaveBuilding.Flag.IncreasesTradeInWater, IncreaseTradeInWater}
+		};
+
+		private static void IncreaseTradeInWater(Tile.Yield yield) {
+			if (yield.type == Tile.YieldType.Commerce && yield.tile.IsWater() && yield.baseYield > 0) {
+				yield.bonus += 1;
+			}
+		}
+
+		private static void IncreaseShieldInWater(Tile.Yield yield) {
+			if (yield.type == Tile.YieldType.Production && yield.tile.IsWater()) {
+				yield.bonus += 1;
+			}
+		}
+
+		private static void IncreaseFoodInWater(Tile.Yield yield) {
+			if (yield.type == Tile.YieldType.Food && yield.tile.IsWater()) {
+				yield.bonus += 1;
+			}
+		}
+
 		private static void VeteranGroundUnits(MapUnit unit) {
 			if (unit.unitType.categories.Contains("Land")) {
 				unit.Promote();
@@ -47,7 +71,7 @@ namespace C7GameData {
 
 		List<Func<City, bool>> productionPrerequisites = [];
 		public Action<MapUnit> onFinishedUnitProduction;
-		public Action<Tile.Yield, Tile.YieldType> tileModifier;
+		public Action<Tile.Yield> tileModifier;
 
 		public bool isGreatWonder;
 		public bool isSmallWonder;
@@ -84,6 +108,12 @@ namespace C7GameData {
 			foreach (var kvp in BuildingRules.unitProductionEffects) {
 				if (building.flags.Contains(kvp.Key)) {
 					onFinishedUnitProduction += kvp.Value;
+				}
+			}
+
+			foreach (var kvp in BuildingRules.tileModifiers) {
+				if (building.flags.Contains(kvp.Key)) {
+					tileModifier += kvp.Value;
 				}
 			}
 		}

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -166,17 +166,17 @@ namespace C7GameData {
 		}
 
 		public int CurrentFoodYield() {
-			int yield = location.foodYield(owner).yield;
+			int yield = location.foodYield(this).yield;
 			foreach (CityResident r in residents) {
-				yield += r.tileWorked.foodYield(owner).yield;
+				yield += r.tileWorked.foodYield(this).yield;
 			}
 			return yield;
 		}
 
 		public CorruptableValue CurrentProductionYield() {
-			int yield = location.productionYield(owner).yield;
+			int yield = location.productionYield(this).yield;
 			foreach (CityResident r in residents) {
-				yield += r.tileWorked.productionYield(owner).yield;
+				yield += r.tileWorked.productionYield(this).yield;
 			}
 			CorruptableValue result = new(yield, corruption);
 
@@ -196,9 +196,9 @@ namespace C7GameData {
 		}
 
 		public CommerceBreakdown CurrentCommerceYield() {
-			int uncorruptedCommerce = location.commerceYield(owner).yield;
+			int uncorruptedCommerce = location.commerceYield(this).yield;
 			foreach (CityResident r in residents) {
-				uncorruptedCommerce += r.tileWorked.commerceYield(owner).yield;
+				uncorruptedCommerce += r.tileWorked.commerceYield(this).yield;
 			}
 
 			// Using our value of corruption, figure out how much useful

--- a/C7Engine/C7GameData/Government.cs
+++ b/C7Engine/C7GameData/Government.cs
@@ -43,7 +43,7 @@ namespace C7GameData {
 		private bool _hasTradeBonus;
 
 		[JsonIgnore]
-		public Action<Tile.Yield, Tile.YieldType> tileModifier;
+		public Action<Tile.Yield> tileModifier;
 
 		// See https://codehappy.net/apolyton/threads/46801-1.htm and
 		// https://forums.civfanatics.com/threads/everything-about-corruption-c3c-edition.76619/.
@@ -75,14 +75,14 @@ namespace C7GameData {
 		public int freeUnitsPerMetropolis;
 		public int unitCost;
 
-		private static void TradeBonus(Tile.Yield yield, Tile.YieldType yieldType) {
-			if (yieldType == Tile.YieldType.Commerce && yield.yield > 0) {
+		private static void TradeBonus(Tile.Yield yield) {
+			if (yield.type == Tile.YieldType.Commerce && yield.baseYield > 0) {
 				yield.bonus += 1;
 			}
 		}
 
-		private static void TilePenalty(Tile.Yield yield, Tile.YieldType yieldType) {
-			yield.penalty += yield.yield > 2 ? 1 : 0;
+		private static void TilePenalty(Tile.Yield yield) {
+			yield.penalty += yield.baseYield > 2 ? 1 : 0;
 		}
 	}
 }

--- a/C7Engine/C7GameData/Government.cs
+++ b/C7Engine/C7GameData/Government.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Text.Json.Serialization;
 
 namespace C7GameData {
 	public class Government {
@@ -17,10 +19,31 @@ namespace C7GameData {
 		// The "despotism penalty" applies for this goverment; reduces all 
 		// commerce, production and food output done by citizen laborers by -1 
 		// when they produce more than 2.
-		public bool hasTilePenalty;
+		public bool hasTilePenalty {
+			get => _hasTilePenalty;
+			set {
+				_hasTilePenalty = value;
+				if (value) {
+					tileModifier += TilePenalty;
+				}
+			}
+		}
+		private bool _hasTilePenalty;
 
 		// +1 commerce any tile with at least 1 commerce.
-		public bool hasTradeBonus;
+		public bool hasTradeBonus {
+			get => _hasTradeBonus;
+			set {
+				_hasTradeBonus = value;
+				if (value) {
+					tileModifier += TradeBonus;
+				}
+			}
+		}
+		private bool _hasTradeBonus;
+
+		[JsonIgnore]
+		public Action<Tile.Yield, Tile.YieldType> tileModifier;
 
 		// See https://codehappy.net/apolyton/threads/46801-1.htm and
 		// https://forums.civfanatics.com/threads/everything-about-corruption-c3c-edition.76619/.
@@ -51,5 +74,15 @@ namespace C7GameData {
 		public int freeUnitsPerCity;
 		public int freeUnitsPerMetropolis;
 		public int unitCost;
+
+		private static void TradeBonus(Tile.Yield yield, Tile.YieldType yieldType) {
+			if (yieldType == Tile.YieldType.Commerce && yield.yield > 0) {
+				yield.bonus += 1;
+			}
+		}
+
+		private static void TilePenalty(Tile.Yield yield, Tile.YieldType yieldType) {
+			yield.penalty += yield.yield > 2 ? 1 : 0;
+		}
 	}
 }

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -928,6 +928,9 @@ namespace C7GameData {
 				(bldg.IncreasesLuxuryTrade, SaveBuilding.Flag.IncreasesLuxuryTrade),
 				(bldg.ReducesCorruption, SaveBuilding.Flag.ReducesCorruption),
 				(bldg.ForbiddenPalace, SaveBuilding.Flag.ForbiddenPalace),
+				(bldg.IncreasesShieldsInWater, SaveBuilding.Flag.IncreasesShieldsInWater),
+				(bldg.IncreasesFoodInWater, SaveBuilding.Flag.IncreasesFoodInWater),
+				(bldg.IncreasesTradeInWater, SaveBuilding.Flag.IncreasesTradeInWater)
 			}
 			.Where(t => t.Item1)
 			.Select(t => t.Item2);

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -610,12 +610,14 @@ namespace C7GameData {
 			var city = savData.City[cityIndex];
 			var cityBuildings = savData.CityBuilding[cityIndex];
 
+			BiqData theBiq = biq.Bldg is null ? defaultBiq : biq;
+
 			for (int buildingIndex = 0; buildingIndex < cityBuildings.Length; ++buildingIndex) {
 				var building = cityBuildings[buildingIndex];
 
 				if (building.BuiltByPlayer != -1 && city.Bitm.IsBuildingUsable(buildingIndex)) {
 					res.Add(new SaveCityBuilding {
-						building = save.Buildings[buildingIndex].name,
+						building = theBiq.Bldg[buildingIndex].Name,
 						builtByPlayer = save.Players[building.BuiltByPlayer].id,
 						year = building.Year,
 						totalCulture = building.Culture,

--- a/C7Engine/C7GameData/Save/SaveBuilding.cs
+++ b/C7Engine/C7GameData/Save/SaveBuilding.cs
@@ -11,9 +11,11 @@ namespace C7GameData.Save {
 			MustBeNearRiver,
 			IncreasesLuxuryTrade,
 			ReducesCorruption,
-			ForbiddenPalace
+			ForbiddenPalace,
+			IncreasesShieldsInWater,
+			IncreasesFoodInWater,
+			IncreasesTradeInWater,
 		}
-
 		public string name;
 		public int shieldCost;
 		public int populationCost;

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -14,31 +14,36 @@ namespace C7GameData {
 		}
 
 		public class Yield {
-			public static Yield GetYield(int yield, YieldType type, City city) {
-				Yield res = new(yield);
-
-				city.owner.government.tileModifier?.Invoke(res, type);
-				city.buildings.ForEach(b => b.building.tileModifier?.Invoke(res, type));
-
-				return res;
+			public static Yield CalculateForCity(Tile tile, int yield, YieldType type, City city) {
+				return new Yield(tile, yield, type).ApplyPlayerModifiers(city.owner).ApplyCityModifiers(city);
 			}
 
-			public static Yield GetYield(int yield, YieldType type, Player player) {
-				Yield res = new(yield);
-
-				player.government.tileModifier?.Invoke(res, type);
-
-				return res;
+			public static Yield CalculateForPlayer(Tile tile, int yield, YieldType type, Player player) {
+				return new Yield(tile, yield, type).ApplyPlayerModifiers(player);
 			}
 
-			public Yield(int yield) {
-				_yield = yield;
+			public Yield(Tile tile, int baseYield, YieldType type) {
+				this.tile = tile;
+				this.baseYield = baseYield;
+				this.type = type;
 			}
 
+			private Yield ApplyPlayerModifiers(Player player) {
+				player.government.tileModifier?.Invoke(this);
+				return this;
+			}
+
+			private Yield ApplyCityModifiers(City city) {
+				city.buildings.ForEach(b => b.building.tileModifier?.Invoke(this));
+				return this;
+			}
+
+			public readonly Tile tile;
+			public readonly YieldType type;
 			public int penalty = 0;
 			public int bonus = 0;
-			public int yield { get => _yield + bonus - penalty; }
-			private int _yield = 0;
+			public readonly int baseYield = 0;
+			public int yield { get => baseYield + bonus - penalty; }
 		}
 
 		public ID Id { get; internal set; }
@@ -268,12 +273,12 @@ namespace C7GameData {
 
 		public Yield foodYield(Player player) {
 			int yield = baseFoodYield(player);
-			return Yield.GetYield(yield, YieldType.Food, player);
+			return Yield.CalculateForPlayer(this, yield, YieldType.Food, player);
 		}
 
 		public Yield foodYield(City city) {
 			int yield = baseFoodYield(city.owner);
-			return Yield.GetYield(yield, YieldType.Food, city);
+			return Yield.CalculateForCity(this, yield, YieldType.Food, city);
 		}
 
 		private int baseProductionYield(Player player) {
@@ -316,12 +321,12 @@ namespace C7GameData {
 
 		public Yield productionYield(Player player) {
 			int yield = baseProductionYield(player);
-			return Yield.GetYield(yield, YieldType.Production, player);
+			return Yield.CalculateForPlayer(this, yield, YieldType.Production, player);
 		}
 
 		public Yield productionYield(City city) {
 			int yield = baseProductionYield(city.owner);
-			return Yield.GetYield(yield, YieldType.Production, city);
+			return Yield.CalculateForCity(this, yield, YieldType.Production, city);
 		}
 
 		private int baseCommerceYield(Player player) {
@@ -369,13 +374,13 @@ namespace C7GameData {
 
 			// TODO: handle the commerce bonus for costal cities+seafaring
 			// TODO: handle the commerce bonus for commerial civs
-			return Yield.GetYield(yield, YieldType.Commerce, player);
+			return Yield.CalculateForPlayer(this, yield, YieldType.Commerce, player);
 		}
 
 		public Yield commerceYield(City city) {
 			int yield = baseCommerceYield(city.owner);
 
-			return Yield.GetYield(yield, YieldType.Commerce, city);
+			return Yield.CalculateForCity(this, yield, YieldType.Commerce, city);
 		}
 
 		public bool BordersRiver() {

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -7,15 +7,38 @@ namespace C7GameData {
 	using C7Engine;
 
 	public class Tile {
-		public class TileYield {
-			public TileYield(int yield, Player player) {
-				bool despotismPenalty = player.government.hasTilePenalty;
-				this.penalty = yield > 2 && despotismPenalty ? 1 : 0;
-				this.yield = yield - penalty;
+		public enum YieldType {
+			Commerce,
+			Food,
+			Production
+		}
+
+		public class Yield {
+			public static Yield GetYield(int yield, YieldType type, City city) {
+				Yield res = new(yield);
+
+				city.owner.government.tileModifier?.Invoke(res, type);
+				city.buildings.ForEach(b => b.building.tileModifier?.Invoke(res, type));
+
+				return res;
+			}
+
+			public static Yield GetYield(int yield, YieldType type, Player player) {
+				Yield res = new(yield);
+
+				player.government.tileModifier?.Invoke(res, type);
+
+				return res;
+			}
+
+			public Yield(int yield) {
+				_yield = yield;
 			}
 
 			public int penalty = 0;
-			public int yield = 0;
+			public int bonus = 0;
+			public int yield { get => _yield + bonus - penalty; }
+			private int _yield = 0;
 		}
 
 		public ID Id { get; internal set; }
@@ -216,7 +239,7 @@ namespace C7GameData {
 			return (dx + dy) / 2 + Math.Abs(dx - dy) / 4;
 		}
 
-		public TileYield foodYield(Player player) {
+		private int baseFoodYield(Player player) {
 			int yield = overlayTerrainType.baseFoodProduction;
 			if (this.Resource != Resource.NONE && player.KnowsAboutResource(Resource)) {
 				yield += this.Resource.FoodBonus;
@@ -240,10 +263,20 @@ namespace C7GameData {
 				// water source or has already reached city size (≥ 7)
 			}
 
-			return new TileYield(yield, player);
+			return yield;
 		}
 
-		public TileYield productionYield(Player player) {
+		public Yield foodYield(Player player) {
+			int yield = baseFoodYield(player);
+			return Yield.GetYield(yield, YieldType.Food, player);
+		}
+
+		public Yield foodYield(City city) {
+			int yield = baseFoodYield(city.owner);
+			return Yield.GetYield(yield, YieldType.Food, city);
+		}
+
+		private int baseProductionYield(Player player) {
 			int yield = overlayTerrainType.baseShieldProduction;
 			if (overlayTerrainType.Key == "grassland" && this.isBonusShield) {
 				yield++;
@@ -278,10 +311,20 @@ namespace C7GameData {
 				}
 			}
 
-			return new TileYield(yield, player);
+			return yield;
 		}
 
-		public TileYield commerceYield(Player player) {
+		public Yield productionYield(Player player) {
+			int yield = baseProductionYield(player);
+			return Yield.GetYield(yield, YieldType.Production, player);
+		}
+
+		public Yield productionYield(City city) {
+			int yield = baseProductionYield(city.owner);
+			return Yield.GetYield(yield, YieldType.Production, city);
+		}
+
+		private int baseCommerceYield(Player player) {
 			int yield = overlayTerrainType.baseCommerceProduction;
 			if (this.Resource != Resource.NONE && player.KnowsAboutResource(Resource)) {
 				yield += this.Resource.CommerceBonus;
@@ -318,10 +361,21 @@ namespace C7GameData {
 				yield = Math.Max(regularCityYield, capitalCityYield);
 			}
 
+			return yield;
+		}
+
+		public Yield commerceYield(Player player) {
+			int yield = baseCommerceYield(player);
+
 			// TODO: handle the commerce bonus for costal cities+seafaring
 			// TODO: handle the commerce bonus for commerial civs
-			// TODO: handle the commerce bonus from Republic/Democracy.
-			return new TileYield(yield, player);
+			return Yield.GetYield(yield, YieldType.Commerce, player);
+		}
+
+		public Yield commerceYield(City city) {
+			int yield = baseCommerceYield(city.owner);
+
+			return Yield.GetYield(yield, YieldType.Commerce, city);
 		}
 
 		public bool BordersRiver() {

--- a/C7GameDataTests/.gitignore
+++ b/C7GameDataTests/.gitignore
@@ -1,1 +1,0 @@
-data/output

--- a/EngineTests/EngineTests.csproj
+++ b/EngineTests/EngineTests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/EngineTests/GameData/SaveTest.cs
+++ b/EngineTests/GameData/SaveTest.cs
@@ -12,7 +12,7 @@ using C7Engine;
 using C7GameData.Save;
 using QueryCiv3;
 using System.Runtime.InteropServices;
-using C7Engine.Pathing;
+using Newtonsoft.Json.Linq;
 
 public class SaveTests {
 
@@ -75,9 +75,17 @@ public class SaveTests {
 		Assert.NotEmpty(savedNeverGameData);
 		Assert.NotEmpty(savedWasGameData);
 
+		string originalText = File.ReadAllText(developerSave);
+		string neverGameDataText = File.ReadAllText(outputNeverGameDataPath);
+		string wasGameDataText = File.ReadAllText(outputWasGameDataPath);
+
+		JObject originalJson = JObject.Parse(originalText);
+		JObject neverGameDataJson = JObject.Parse(neverGameDataText);
+		JObject wasGameDataJson = JObject.Parse(wasGameDataText);
+
 		// saved files should be the same as the original
-		Assert.Equal(original, savedNeverGameData);
-		Assert.Equal(original, savedWasGameData);
+		Assert.True(JToken.DeepEquals(originalJson, neverGameDataJson));
+		Assert.True(JToken.DeepEquals(originalJson, wasGameDataJson));
 	}
 
 	private void WaitForStartTurnMessage() {


### PR DESCRIPTION
This PR:
- Allows buildings to modify tile yields. Implements the effects of Harbor, Commercial Dock, and Offshore Platform.
- Implements the Republic commerce bonus.
- Improve the save test. Now it compares the JSON files semantically. It will prevent test fails on reordering of the fields.

The implementation of tile modifiers is similar to the #695. Yield bonuses and penalties are implemented via action fields in Government and Building classes. These actions are invoked during yield calculation in the Tile.Yield class. In the future, the same approach can be used for the civilization traits (yield bonuses of seafaring, commercial, agricultural civs). 