### PR TITLE
Fix the import of what building is being constructed in sav files

### DIFF
--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -649,10 +649,11 @@ namespace C7GameData {
 
 		private (string, ProducibleType) CityToProducible(QueryCiv3.Sav.CITY city) {
 			PRTO[] unitPrototypes = biq.Prto ?? defaultBiq.Prto;
+			BiqData theBiq = biq.Bldg is null ? defaultBiq : biq;
 
 			return city.ConstructingType switch {
 				0 => ("Worker", ProducibleType.UNIT), // TODO: Wealth production is not implemented yet
-				1 => (save.Buildings[city.Constructing].name, ProducibleType.BUILDING),
+				1 => (theBiq.Bldg[city.Constructing].Name, ProducibleType.BUILDING),
 				2 => (unitPrototypes[city.Constructing].Name, ProducibleType.UNIT),
 				_ => throw new NotImplementedException()
 			};


### PR DESCRIPTION
This was fixed for loading building [here](https://github.com/C7-Game/Prototype/pull/697/files#diff-5b1d272ad07723413554fc5a64f60c1032e66dfaae37a3e72929dd9d08b2f2a8R620) when wealth was removed from the list of buildings but missed here.