### PR TITLE
Refactor: replace comment annotations with named arguments

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -953,7 +953,7 @@ public partial class Game : Node2D {
 			// declare war with the move) mark the path.
 			if (result.moveCost == -1
 					&& unit.location.distanceTo(tile) == 1
-					&& unit.CanEnterTile(tile, /*allowCombat=*/true, /*allowWarDeclaration=*/true)) {
+					&& unit.CanEnterTile(tile, allowCombat: true, allowWarDeclaration: true)) {
 				Queue<Tile> pathQueue = new();
 				pathQueue.Enqueue(tile);
 
@@ -964,7 +964,7 @@ public partial class Game : Node2D {
 
 				// If we couldn't enter this tile without a war declaration,
 				// record which civ we need to declare war on.
-				if (!unit.CanEnterTile(tile, /*allowCombat=*/true, /*allowWarDeclaration=*/false)) {
+				if (!unit.CanEnterTile(tile, allowCombat: true, allowWarDeclaration: false)) {
 					if (tile.cityAtTile != null) {
 						result.requiresWarDeclarationOnPlayer = tile.cityAtTile.owner;
 					} else {

--- a/C7/Map/TileAssignmentLayer.cs
+++ b/C7/Map/TileAssignmentLayer.cs
@@ -96,25 +96,25 @@ namespace C7.Map {
 			if (!workableTiles.Contains(tile.neighbors[TileDirection.NORTHWEST])) {
 				looseView.DrawLine(tileCenter + new Vector2(-tileWidth / 2, 0),
 									tileCenter + new Vector2(0, -tileHeight / 2),
-									Colors.White, /*width=*/2);
+									Colors.White, width: 2);
 			}
 
 			if (!workableTiles.Contains(tile.neighbors[TileDirection.NORTHEAST])) {
 				looseView.DrawLine(tileCenter + new Vector2(tileWidth / 2, 0),
 									tileCenter + new Vector2(0, -tileHeight / 2),
-									Colors.White, /*width=*/2);
+									Colors.White, width: 2);
 			}
 
 			if (!workableTiles.Contains(tile.neighbors[TileDirection.SOUTHWEST])) {
 				looseView.DrawLine(tileCenter + new Vector2(-tileWidth / 2, 0),
 									tileCenter + new Vector2(0, tileHeight / 2),
-									Colors.White, /*width=*/2);
+									Colors.White, width: 2);
 			}
 
 			if (!workableTiles.Contains(tile.neighbors[TileDirection.SOUTHEAST])) {
 				looseView.DrawLine(tileCenter + new Vector2(tileWidth / 2, 0),
 									tileCenter + new Vector2(0, tileHeight / 2),
-									Colors.White, /*width=*/2);
+									Colors.White, width: 2);
 			}
 		}
 

--- a/C7/UIElements/Advisors/DomesticAdvisor.cs
+++ b/C7/UIElements/Advisors/DomesticAdvisor.cs
@@ -53,7 +53,7 @@ public partial class DomesticAdvisor : Control {
 		ImageTexture DomesticBackground = Util.LoadTextureFromPCX("Art/Advisors/domestic.pcx");
 		background.Texture = DomesticBackground;
 
-		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Domestic, AdvisorHead.Mood.Happy, /*eraIndex=*/0);
+		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Domestic, AdvisorHead.Mood.Happy, eraIndex: 0);
 		advisorHead.SetPosition(new Vector2(851, 0));
 		background.AddChild(advisorHead);
 

--- a/C7/UIElements/Advisors/ScienceAdvisor.cs
+++ b/C7/UIElements/Advisors/ScienceAdvisor.cs
@@ -36,7 +36,7 @@ public partial class ScienceAdvisor : TextureRect {
 		IndustrialBackground = Util.LoadTextureFromPCX("Art/Advisors/science_industrial_new.pcx");
 		ModernBackground = Util.LoadTextureFromPCX("Art/Advisors/science_modern.pcx");
 
-		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Science, AdvisorHead.Mood.Happy, /*eraIndex=*/0);
+		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Science, AdvisorHead.Mood.Happy, eraIndex: 0);
 		advisorHead.SetPosition(new Vector2(851, 0));
 		AddChild(advisorHead);
 
@@ -134,7 +134,7 @@ public partial class ScienceAdvisor : TextureRect {
 			TechBox techButton = new(tech, techState);
 			techButton.SetPosition(new Vector2(tech.X, tech.Y));
 			techButton.Pressed += () => {
-				new MsgChooseResearch(tech.id, /*showAdvisor=*/true).send();
+				new MsgChooseResearch(tech.id, showAdvisor: true).send();
 			};
 			AddChild(techButton);
 			techBoxes.Add(techButton);

--- a/C7/UIElements/Popups/BuildCityDialog.cs
+++ b/C7/UIElements/Popups/BuildCityDialog.cs
@@ -25,7 +25,7 @@ public partial class BuildCityDialog : Popup {
 		AddTexture(530, 260);
 
 		TextureRect advisorHead = new();
-		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Culture, AdvisorHead.Mood.Happy, /*eraIndex=*/0);
+		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Culture, AdvisorHead.Mood.Happy, eraIndex: 0);
 		//Appears at 400, 110 in game, but leftmost 25px are transparent with default graphics
 		advisorHead.SetPosition(new Vector2(375, 0));
 		AddChild(advisorHead);

--- a/C7/UIElements/Popups/CivilizationDestroyed.cs
+++ b/C7/UIElements/Popups/CivilizationDestroyed.cs
@@ -21,7 +21,7 @@ public partial class CivilizationDestroyed : Popup {
 		AddTexture(530, 260);
 
 		TextureRect advisorHead = new() {
-			Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Military, AdvisorHead.Mood.Happy, /*eraIndex=*/0),
+			Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Military, AdvisorHead.Mood.Happy, eraIndex: 0),
 		};
 		//Appears at 400, 110 in game, but leftmost 25px are transparent with default graphics
 		advisorHead.SetPosition(new Vector2(375, 0));

--- a/C7/UIElements/Popups/ConfirmationPopup.cs
+++ b/C7/UIElements/Popups/ConfirmationPopup.cs
@@ -39,7 +39,7 @@ public partial class ConfirmationPopup : Popup {
 		AddTexture(530, 320);
 
 		TextureRect advisorHead = new TextureRect();
-		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Domestic, AdvisorHead.Mood.Surprised, /*eraIndex=*/0);
+		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Domestic, AdvisorHead.Mood.Surprised, eraIndex: 0);
 		//Appears at 400, 110 in game, but leftmost 25px are transparent with default graphics
 		advisorHead.SetPosition(new Vector2(375, 0));
 		AddChild(advisorHead);

--- a/C7/UIElements/Popups/InformationalPopup.cs
+++ b/C7/UIElements/Popups/InformationalPopup.cs
@@ -23,7 +23,7 @@ public partial class InformationalPopup : Popup {
 		int height = 230;
 
 		TextureRect advisorHead = new();
-		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Foreign, AdvisorHead.Mood.Happy, /*eraIndex=*/0);
+		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Foreign, AdvisorHead.Mood.Happy, eraIndex: 0);
 		advisorHead.SetPosition(new Vector2(275, 0));
 		AddChild(advisorHead);
 

--- a/C7/UIElements/Popups/ScienceSelection.cs
+++ b/C7/UIElements/Popups/ScienceSelection.cs
@@ -41,7 +41,7 @@ public partial class ScienceSelection : Popup {
 		optionButton.SetPosition(new Vector2(25, 190));
 
 		AddButton("OK. Sounds good.", 235, () => {
-			new MsgChooseResearch(options[optionButton.Selected].id, /*showAdvisor=*/false).send();
+			new MsgChooseResearch(options[optionButton.Selected].id, showAdvisor: false).send();
 			GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
 		});
 		AddButton("What's the big picture?", 265, () => {
@@ -50,7 +50,7 @@ public partial class ScienceSelection : Popup {
 		});
 
 		AddConfirmButton(new Vector2(width - 40, height - 40), () => {
-			new MsgChooseResearch(options[optionButton.Selected].id, /*showAdvisor=*/false).send();
+			new MsgChooseResearch(options[optionButton.Selected].id, showAdvisor: false).send();
 			GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
 		});
 	}

--- a/C7/UIElements/Popups/WarConfirmation.cs
+++ b/C7/UIElements/Popups/WarConfirmation.cs
@@ -21,7 +21,7 @@ public partial class WarConfirmation : Popup {
 		AddTexture(530, 320);
 
 		TextureRect advisorHead = new();
-		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Foreign, AdvisorHead.Mood.Surprised, /*eraIndex=*/0);
+		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Foreign, AdvisorHead.Mood.Surprised, eraIndex: 0);
 		//Appears at 400, 110 in game, but leftmost 25px are transparent with default graphics
 		advisorHead.SetPosition(new Vector2(375, 0));
 		AddChild(advisorHead);

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -166,7 +166,7 @@ namespace C7Engine {
 				}
 
 				// Priority 3: defend our cities.
-				return new DefenderAI(DefenderAI.MakeAiDataForDefendAtRiskCity(unit, player, /*minDefenders=*/int.MaxValue));
+				return new DefenderAI(DefenderAI.MakeAiDataForDefendAtRiskCity(unit, player, minDefenders: int.MaxValue));
 			}
 
 			// If there's an unescorted settler, escort it.
@@ -204,7 +204,7 @@ namespace C7Engine {
 
 			//As of today (4/7/2022), let's tackle just one of those - adequate defense of cities.  The AI is really good at losing cities to barbs right now,
 			//and that's a problem.
-			return new DefenderAI(DefenderAI.MakeAiDataForDefendAtRiskCity(unit, player, /*minDefenders=*/int.MaxValue));
+			return new DefenderAI(DefenderAI.MakeAiDataForDefendAtRiskCity(unit, player, minDefenders: int.MaxValue));
 		}
 
 		private static bool PlayerIsAtWarWithOtherPlayer(Player player) {

--- a/C7Engine/AI/UnitAI/CombatAI.cs
+++ b/C7Engine/AI/UnitAI/CombatAI.cs
@@ -79,7 +79,7 @@ namespace C7Engine.AI.UnitAI {
 			}
 
 			// Move along the path, initiating combat if we reach our target.
-			return this.TryToMoveAlongPath(unit, ref data.path, /*allowCombat=*/true);
+			return this.TryToMoveAlongPath(unit, ref data.path, allowCombat: true);
 		}
 
 		public string SummarizePlan() {

--- a/C7Engine/AI/UnitAI/DefenderAI.cs
+++ b/C7Engine/AI/UnitAI/DefenderAI.cs
@@ -53,7 +53,7 @@ namespace C7Engine.AI.UnitAI {
 				return C7GameData.UnitAI.Result.Done;
 			} else {
 				log.Debug("Moving defender towards " + data.destination);
-				return this.TryToMoveAlongPath(unit, ref data.pathToDestination, /*allowCombat=*/false);
+				return this.TryToMoveAlongPath(unit, ref data.pathToDestination, allowCombat: false);
 			}
 		}
 

--- a/C7Engine/AI/UnitAI/EscortAI.cs
+++ b/C7Engine/AI/UnitAI/EscortAI.cs
@@ -80,7 +80,7 @@ namespace C7Engine {
 
 			// Move to the unit we're escorting.
 			TilePath path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, data.unitToEscort.location);
-			result = this.TryToMoveAlongPath(unit, ref path, /*allowCombat=*/false);
+			result = this.TryToMoveAlongPath(unit, ref path, allowCombat: false);
 			if (result != UnitAI.Result.InProgress) {
 				return result;
 			}

--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -51,7 +51,7 @@ namespace C7Engine {
 				return UnitAI.Result.Done;
 			}
 
-			return this.TryToMoveAlongPath(unit, ref data.pathToDestination, /*allowCombat=*/false);
+			return this.TryToMoveAlongPath(unit, ref data.pathToDestination, allowCombat: false);
 		}
 
 		public string SummarizePlan() {

--- a/C7Engine/AI/UnitAI/SettlerAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerAI.cs
@@ -66,7 +66,7 @@ namespace C7Engine {
 						unit.movementPoints.onConsumeAll();
 						return C7GameData.UnitAI.Result.InProgress;
 					} else {
-						return this.TryToMoveAlongPath(unit, ref data.pathToDestination, /*allowCombat=*/false);
+						return this.TryToMoveAlongPath(unit, ref data.pathToDestination, allowCombat: false);
 					}
 					break;
 				case SettlerAIData.SettlerGoal.JOIN_CITY:

--- a/C7Engine/AI/UnitAI/WorkerAI.cs
+++ b/C7Engine/AI/UnitAI/WorkerAI.cs
@@ -70,7 +70,7 @@ namespace C7Engine {
 				return PerformWorkerMove(unit, improvement);
 			}
 
-			return this.TryToMoveAlongPath(unit, ref data.pathToDestination, /*allowCombat=*/false);
+			return this.TryToMoveAlongPath(unit, ref data.pathToDestination, allowCombat: false);
 		}
 
 		private static string? GetTileImprovement(Tile t, Player player) {

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -367,10 +367,10 @@ namespace C7GameData {
 			// Make a player for each civ. The barbarians are always civ 0.
 			for (int i = 0; i < save.Civilizations.Count; ++i) {
 				save.Players.Add(MakeSavePlayerFromCiv(save.Civilizations[i],
-									   /*isBarbarian=*/i == 0,
-									   /*isHuman=*/false,
-									   /*cityNameIndex=*/0,
-									   /*era=*/""));
+									   isBarbarian: i == 0,
+									   isHuman: false,
+									   cityNameIndex: 0,
+									   era: ""));
 
 				// Set a government for players not associated with LEAD.
 				// Usually, this applies only to barbarians, but in some scenarios
@@ -425,10 +425,10 @@ namespace C7GameData {
 				}
 				Civilization civ = save.Civilizations[leader.RaceID];
 				SavePlayer player = MakeSavePlayerFromCiv(civ,
-										  /*isBarbarian=*/i == 0,
-										  /*isHuman=*/i == 1,
-										  /*cityNameIndex=*/leader.FoundedCities,
-										  /*era=*/theBiq.Eras[leader.Era].CivilopediaEntry);
+										  isBarbarian: i == 0,
+										  isHuman: i == 1,
+										  cityNameIndex: leader.FoundedCities,
+										  era: theBiq.Eras[leader.Era].CivilopediaEntry);
 
 				// Record what the player is currently researching.
 				if (leader.Researching > -1) {

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -445,7 +445,7 @@ namespace C7GameData {
 		}
 
 		public bool CanEnterTile(Tile tile, bool allowCombat) {
-			return CanEnterTile(tile, allowCombat, /*allowWarDeclaration=*/false);
+			return CanEnterTile(tile, allowCombat, allowWarDeclaration: false);
 		}
 
 		// Like above, but allows specifying that we want to handle the case

--- a/EngineTests/GameData/SaveTest.cs
+++ b/EngineTests/GameData/SaveTest.cs
@@ -280,8 +280,8 @@ public class SaveTests {
 
 		// Only bother running one turn of the newer scenarios, just to keep the
 		// tests faster.
-		CheckScenariosInCiv3Subfolder("Conquests/Conquests", /*runOneTurn=*/true);
-		CheckScenariosInCiv3Subfolder("Conquests/Scenarios", /*runOneTurn=*/false);
+		CheckScenariosInCiv3Subfolder("Conquests/Conquests", runOneTurn: true);
+		CheckScenariosInCiv3Subfolder("Conquests/Scenarios", runOneTurn: false);
 	}
 
 	private void CheckScenariosInCiv3Subfolder(string subfolder, bool runOneTurn) {


### PR DESCRIPTION
I've recently learned that C# has support for [named arguments](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/named-and-optional-arguments), so I went through the codebase and replaced comment annotations (/\*argument=\*/1) with named arguments.