### PR TITLE
Store city population in only one way, not 2

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -123,17 +123,6 @@ public partial class Game : Node2D {
 				Util.setModPath(scenarioSearchPath);
 				log.Debug("RelativeModPath ", scenarioSearchPath);
 				return Util.Civ3MediaPath("Text/PediaIcons.txt");
-			}, (City city, CitizenType ct) => {
-				// Provide tile assignments for scenarios, which don't specify
-				// this in the BIC file.
-				for (int i = 0; i < city.size; ++i) {
-					CityResident newResident = new() {
-						citizenType = ct,
-						nationality = city.owner.civilization,
-						city = city
-					};
-					CityTileAssignmentAI.AssignNewCitizenToTile(newResident);
-				}
 			}); // Spawns engine thread
 			Global.ResetLoadGamePath();
 

--- a/C7/Map/CityLabelScene.cs
+++ b/C7/Map/CityLabelScene.cs
@@ -202,7 +202,7 @@ namespace C7.Map {
 			if (city.TurnsUntilProductionFinished() == int.MaxValue) {
 				productionLabel.Text = $"{city.itemBeingProduced.name} : --";
 			}
-			popSizeLabel.Text = city.size.ToString();
+			popSizeLabel.Text = city.residents.Count.ToString();
 
 			// Update population label color based on growth
 			if (city.TurnsUntilGrowth() < 0) {

--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -225,6 +225,7 @@ public partial class CityScreen : Control {
 					nationality = city.owner.civilization,
 					city = city
 				};
+				city.AddCitizen(newResident);
 				CityTileAssignmentAI.AssignNewCitizenToTile(newResident);
 			}
 		}

--- a/C7Engine/AI/CityProductionAI.cs
+++ b/C7Engine/AI/CityProductionAI.cs
@@ -192,7 +192,7 @@ namespace C7Engine {
 		public static float AdjustScoreByPopCost(City city, UnitPrototype unitPrototype, float baseScore) {
 			//If the city isn't going to grow in time, return 0
 			if (unitPrototype.populationCost > 0) {
-				int size = city.size;
+				int size = city.residents.Count;
 				//Don't allow starting on something that costs more pop than we have
 				if (unitPrototype.populationCost > size) {
 					return 0.0f;

--- a/C7Engine/AI/CityTileAssignmentAI.cs
+++ b/C7Engine/AI/CityTileAssignmentAI.cs
@@ -14,11 +14,12 @@ namespace C7Engine.AI {
 
 		private static ILogger log = Log.ForContext<CityTileAssignmentAI>();
 
+		// Assigns a citizen, which is alredy part of a city, to a tile, if possible.
 		public static void AssignNewCitizenToTile(CityResident newResident) {
 			City city = newResident.city;
 			int foodYield = city.CurrentFoodYield();
 
-			int desiredFoodRate = city.size * FOOD_PER_CITIZEN + DesiredFoodSurplusPerTurn;
+			int desiredFoodRate = city.residents.Count * FOOD_PER_CITIZEN + DesiredFoodSurplusPerTurn;
 			int targetTileFoodAmount = desiredFoodRate - foodYield;
 
 			double maxScore = 0;
@@ -37,10 +38,10 @@ namespace C7Engine.AI {
 			string yield = city.location.YieldString(city.owner);
 			log.Information($"Assigning new citizen of {city.name} to tile {preferredTile} with yield {yield}");
 
+			// TODO: if the preferred tile is NONE we should make them an
+			// entertainer.
 			newResident.tileWorked = preferredTile;
 			preferredTile.personWorkingTile = newResident;
-
-			city.AddCitizen(newResident);
 		}
 
 		public static double CalculateTileYieldScore(Tile t, int targetFoodAmount, Player player) {

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -42,7 +42,6 @@ namespace C7GameData {
 		public ID id { get; set; }
 		public Tile location { get; internal set; }
 		public string name;
-		public int size = 1;
 		public Dictionary<Player, int> perPlayerCulture = new();
 
 		//Temporary production code because production is fun.
@@ -138,13 +137,19 @@ namespace C7GameData {
 			return TurnsToProduce(itemBeingProduced);
 		}
 
-		public void ComputeCityGrowth() {
+		public void HandleCityGrowth(GameData gameData) {
 			foodStored += FoodGrowthPerTurn();
 			if (foodStored >= foodNeededToGrow) {
-				size++;
+				CityResident newResident = new CityResident();
+				newResident.nationality = owner.civilization;
+				newResident.city = this;
+				newResident.citizenType = gameData.citizenTypes.Find(x => x.IsDefaultCitizen);
+				AddCitizen(newResident);
+				C7Engine.AI.CityTileAssignmentAI.AssignNewCitizenToTile(newResident);
+
 				foodStored = 0;
 			} else if (foodStored < 0) {
-				size--;
+				RemoveCitizen();
 				foodStored = 0;
 			}
 		}
@@ -155,9 +160,9 @@ namespace C7GameData {
 		 */
 		public IProducible ComputeTurnProduction() {
 			shieldsStored += CurrentProductionYield().useful;
-			if (shieldsStored >= itemBeingProduced.shieldCost && size > itemBeingProduced.populationCost) {
+			if (shieldsStored >= itemBeingProduced.shieldCost && residents.Count > itemBeingProduced.populationCost) {
 				shieldsStored = 0;
-				size -= itemBeingProduced.populationCost;
+				RemoveCitizens(itemBeingProduced.populationCost);
 				return itemBeingProduced;
 			}
 
@@ -228,7 +233,7 @@ namespace C7GameData {
 
 		public int FoodConsumedPerTurn() {
 			// TODO: exclude resisters in the future.
-			return size * 2;
+			return residents.Count * 2;
 		}
 
 		private void RemoveCitizen() {
@@ -258,7 +263,7 @@ namespace C7GameData {
 		}
 
 		public override string ToString() {
-			return $"{name} ({size})";
+			return $"{name} ({residents.Count})";
 		}
 
 		public int GetCulture() {

--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -95,7 +95,7 @@ namespace C7GameData {
 			bool recomputeActiveTiles = false;
 
 			foreach (City city in cities) {
-				if (city.size == 0) {
+				if (city.residents.Count == 0) {
 					continue; // skip destroyed cities
 				}
 

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -238,7 +238,7 @@ namespace C7GameData {
 			int result = 0;
 			foreach (City city in cities) {
 				// Destroyed cities have a size of zero.
-				if (city.size > 0) {
+				if (city.residents.Count > 0) {
 					++result;
 				}
 			}
@@ -503,6 +503,12 @@ namespace C7GameData {
 			gold += CalculateGoldPerTurn();
 		}
 
+		public void HandleCityGrowth(GameData gameData) {
+			foreach (City c in cities) {
+				c.HandleCityGrowth(gameData);
+			}
+		}
+
 		public void DoPerTurnScienceUpdates(GameData gameData) {
 			if (currentlyResearchedTech == null) {
 				return;
@@ -554,9 +560,9 @@ namespace C7GameData {
 			foreach (City city in cities) {
 				// TODO: Import these sizes from Rule.cs in the biq. Maybe have
 				// them live in the city class?
-				if (city.size <= 6) {
+				if (city.residents.Count <= 6) {
 					freeUnits += government.freeUnitsPerTown;
-				} else if (city.size <= 12) {
+				} else if (city.residents.Count <= 12) {
 					freeUnits += government.freeUnitsPerCity;
 				} else {
 					freeUnits += government.freeUnitsPerMetropolis;

--- a/C7Engine/C7GameData/Save/SaveCity.cs
+++ b/C7Engine/C7GameData/Save/SaveCity.cs
@@ -61,7 +61,6 @@ namespace C7GameData.Save {
 			capital = city.capital;
 			location = new TileLocation(city.location);
 			name = city.name;
-			size = city.size;
 			producible = city.itemBeingProduced.name;
 			producibleType = city.itemBeingProduced switch {
 				UnitPrototype => ProducibleType.UNIT,
@@ -90,14 +89,12 @@ namespace C7GameData.Save {
 							List<UnitPrototype> unitPrototypes,
 							List<Civilization> civilizations,
 							List<Building> buildings,
-							List<CitizenType> citizenTypes,
-							Action<City, CitizenType> assignScenarioResidents) {
+							List<CitizenType> citizenTypes) {
 			City city = new City{
 				id = id,
 				location = gameMap.tileAt(location.X, location.Y),
 				owner = players.Find(p => p.id == owner),
 				name = name,
-				size = size,
 				itemBeingProduced = producibleType switch {
 					ProducibleType.UNIT => unitPrototypes.Find(proto => proto.name == producible),
 					ProducibleType.BUILDING => buildings.Find(building => building.name == producible),
@@ -128,11 +125,20 @@ namespace C7GameData.Save {
 			}
 
 			// Scenarios don't specify the citizens of each city, only the city
-			// size. So we need to do that assignment now. This requires using
-			// the tile assignment AI, which due to dependency reasons we can't
-			// access directly, so we do this via a lambda.
+			// size. So we need to add the appropriate residents here.
+			//
+			// We wait to assign them to tiles until after tile ownership has
+			// been established in SaveGame.cs.
 			if (city.residents.Count == 0) {
-				assignScenarioResidents(city, citizenTypes.Find(x => x.IsDefaultCitizen));
+				CitizenType ct = citizenTypes.Find(x => x.IsDefaultCitizen);
+				for (int i = 0; i < size; ++i) {
+					CityResident newResident = new() {
+						citizenType = ct,
+						nationality = city.owner.civilization,
+						city = city
+					};
+					city.residents.Add(newResident);
+				}
 			}
 
 			return city;

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -91,13 +91,13 @@ namespace C7GameData.Save {
 			}
 		}
 
-		public GameData ToGameData(Action<City, CitizenType> assignScenarioResidents) {
+		public GameData ToGameData() {
 			GameData data = InitializeGameData();
 			ConvertMapAndPlayers(data);
 			ConvertTechnologies(data);
 			ConvertBuildings(data);
 			ConvertUnits(data);
-			ConvertCities(data, assignScenarioResidents);
+			ConvertCities(data);
 			ConvertBarbarianInfo(data);
 			ConvertStrengthBonuses(data);
 			ConvertHealRates(data);
@@ -107,6 +107,15 @@ namespace C7GameData.Save {
 
 			data.UpdateTileOwners();
 			foreach (Player p in data.players) {
+				// Backfill citizen assignments for scenarios that don't specify
+				// them.
+				foreach (City c in p.cities) {
+					foreach (CityResident cr in c.residents) {
+						if (cr.citizenType.IsDefaultCitizen && cr.tileWorked == Tile.NONE) {
+							C7Engine.AI.CityTileAssignmentAI.AssignNewCitizenToTile(cr);
+						}
+					}
+				}
 				// TODO: this may require more than one loop, because if all the
 				// citizens are happy it reduces wasted shields via we love the
 				// king day.
@@ -230,10 +239,10 @@ namespace C7GameData.Save {
 			});
 		}
 
-		private void ConvertCities(GameData data, Action<City, CitizenType> assignScenarioResidents) {
+		private void ConvertCities(GameData data) {
 			// cities require game map for location and players for city owner
 			data.cities = Cities.ConvertAll(city =>
-				city.ToCity(data.map, data.players, data.unitPrototypes, Civilizations, data.Buildings, CitizenTypes, assignScenarioResidents)
+				city.ToCity(data.map, data.players, data.unitPrototypes, Civilizations, data.Buildings, CitizenTypes)
 			);
 
 			// add references to map tiles after units and cities are defined

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -294,9 +294,9 @@ namespace C7GameData {
 				yield = 1;
 
 				// There is a size bonus for larger cities.
-				if (cityAtTile.size >= 7 && cityAtTile.size < 13) {
+				if (cityAtTile.residents.Count >= 7 && cityAtTile.residents.Count < 13) {
 					yield += 1;
-				} else if (cityAtTile.size >= 13) {
+				} else if (cityAtTile.residents.Count >= 13) {
 					yield += 2;
 
 					// TODO: +1 more for industrial civs.
@@ -344,9 +344,9 @@ namespace C7GameData {
 			// See https://wiki.civforum.de/wiki/Stadtfeldertrag_(Civ3)
 			if (HasCity) {
 				int regularCityYield;
-				if (cityAtTile.size < 7) {
+				if (cityAtTile.residents.Count < 7) {
 					regularCityYield = 1;
-				} else if (cityAtTile.size < 13) {
+				} else if (cityAtTile.residents.Count < 13) {
 					regularCityYield = 2;
 				} else {
 					regularCityYield = 3;

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -19,14 +19,17 @@ namespace C7Engine {
 			owner.cities.Add(newCity);
 			tileWithNewCity.cityAtTile = newCity;
 
-			// Update owners before we assign the citizen so the tile owners are
-			// accurate.
-			gameData.UpdateTileOwners();
-
 			CityResident firstResident = new CityResident();
 			firstResident.city = newCity;
 			firstResident.citizenType = gameData.citizenTypes.Find(x => x.IsDefaultCitizen);
+			newCity.AddCitizen(firstResident);
+
+			// Update owners before we assign the citizen so the tile owners are
+			// accurate. We do this after adding the resident though, because
+			// cities with zero residents are considered destroyed.
+			gameData.UpdateTileOwners();
 			CityTileAssignmentAI.AssignNewCitizenToTile(firstResident);
+
 			newCity.SetItemBeingProduced(CityProductionAI.GetNextItemToBeProduced(newCity, null));
 
 			// Cities are treated as though they have a road, but if

--- a/C7Engine/EntryPoints/CreateGame.cs
+++ b/C7Engine/EntryPoints/CreateGame.cs
@@ -13,13 +13,12 @@ namespace C7Engine {
 		 * hopefully it won't be too much of a goose hunt to refactor it later if we decide to do so.
 		 **/
 		public static Player createGame(string loadFilePath, string defaultBicPath,
-										Func<string, string> getPediaIconsPath,
-										Action<City, CitizenType> assignScenarioResidents) {
+										Func<string, string> getPediaIconsPath) {
 			EngineStorage.createThread();
 			EngineStorage.gameDataMutex.WaitOne();
 
 			SaveGame save = SaveManager.LoadSave(loadFilePath, defaultBicPath, getPediaIconsPath);
-			GameData gameData = save.ToGameData(assignScenarioResidents);
+			GameData gameData = save.ToGameData();
 
 			EngineStorage.gameData = gameData;
 

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -42,7 +42,13 @@ namespace C7Engine {
 				foreach (Player player in gameData.players) {
 					player.RecalculateCitizenMoods(gameData);
 					player.DoCorruptionCalculations(gameData);
+
+					// Note that we do growth after calculating citizen moods,
+					// to ensure that the player has a chance to deal with the
+					// unhappiness of a new citizen during their turn.
+					player.HandleCityGrowth(gameData);
 					HandleCityResults(gameData, player);
+
 					player.DoPerTurnFinanceUpdates(gameData);
 					player.DoPerTurnScienceUpdates(gameData);
 				}
@@ -139,24 +145,6 @@ namespace C7Engine {
 			log.Information($"\n*** City production for turn {gameData.turn}, player {player} ***");
 
 			foreach (City city in player.cities) {
-				int initialSize = city.size;
-				city.ComputeCityGrowth();
-				int newSize = city.size;
-				if (newSize > initialSize) {
-					CityResident newResident = new CityResident();
-					newResident.nationality = city.owner.civilization;
-					newResident.city = city;
-					newResident.citizenType = gameData.citizenTypes.Find(x => x.IsDefaultCitizen);
-					CityTileAssignmentAI.AssignNewCitizenToTile(newResident);
-				} else if (newSize < initialSize) {
-					int diff = initialSize - newSize;
-					if (newSize <= 0) {
-						log.Error($"Attempting to remove the last resident from {city}");
-					} else {
-						city.RemoveCitizens(diff);
-					}
-				}
-
 				if (city.UpdateCultureAndCheckForExpansion()) {
 					gameData.UpdateTileOwners();
 				}
@@ -168,10 +156,6 @@ namespace C7Engine {
 						city.AddUnit(prototype, gameData);
 					} else if (producedItem is Building building) {
 						city.AddBuilding(building);
-					}
-
-					if (producedItem.populationCost > 0) {
-						city.RemoveCitizens(producedItem.populationCost);
 					}
 
 					city.SetItemBeingProduced(CityProductionAI.GetNextItemToBeProduced(city, producedItem));

--- a/EngineTests/GameData/CityTest.cs
+++ b/EngineTests/GameData/CityTest.cs
@@ -37,7 +37,6 @@ public class CityTest {
 
 		City city = new City(tile, player, "Gotham", ID.None("city"));
 		city.foodStored = 19;
-		city.size = 1;
 		tile.cityAtTile = city;
 
 		TerrainType grassland = new TerrainType();

--- a/EngineTests/GameData/SaveTest.cs
+++ b/EngineTests/GameData/SaveTest.cs
@@ -113,17 +113,11 @@ public class SaveTests {
 			getPediaIconsPath = (string unused) => { return unused; };
 		}
 
-		return CreateGame.createGame(path, biqPath,
-			getPediaIconsPath,
-			(City c, CitizenType ct) => {
-				// We don't care about scenario tile assignment here.
-			});
+		return CreateGame.createGame(path, biqPath, getPediaIconsPath);
 	}
 
 	private GameData ToGameData(SaveGame game) {
-		return game.ToGameData((City c, CitizenType ct) => {
-			// We don't care about scenario tile assignment here.
-		});
+		return game.ToGameData();
 	}
 
 	private void CheckAiInvariants() {


### PR DESCRIPTION
This avoids weird mistakes in accounting, as I accidentally introduced while trying to add pop rushing. Simplifying this will make adding pop rushing easier.

While here I also fixed the issue with scenario loading where none of the tile assignments were valid.