### PR TITLE
Implement clearing forests and wetlands

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -881,15 +881,9 @@ public partial class Game : Node2D {
 			}
 		}
 
-		if (currentAction == C7Action.UnitBuildRoad && CurrentlySelectedUnit != MapUnit.NONE && (CurrentlySelectedUnit?.canBuildRoad() ?? false)) {
-			new MsgStartWorkerJob(CurrentlySelectedUnit?.id, currentAction).send();
-		}
-
-		if (currentAction == C7Action.UnitBuildMine && CurrentlySelectedUnit != MapUnit.NONE && (CurrentlySelectedUnit?.canBuildMine() ?? false)) {
-			new MsgStartWorkerJob(CurrentlySelectedUnit?.id, currentAction).send();
-		}
-
-		if (currentAction == C7Action.UnitIrrigate && CurrentlySelectedUnit != MapUnit.NONE && (CurrentlySelectedUnit?.canIrrigate() ?? false)) {
+		if (C7Action.terraformActions.Contains(currentAction)
+			&& CurrentlySelectedUnit != MapUnit.NONE
+			&& CurrentlySelectedUnit.canPerformTerraformAction(currentAction)) {
 			new MsgStartWorkerJob(CurrentlySelectedUnit?.id, currentAction).send();
 		}
 	}

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -63133,6 +63133,9 @@
       "miningBonus": 1,
       "irrigationBonus": 1,
       "roadBonus": 1,
+      "allowedWorkerActions": [
+        "unit_plant_forest"
+      ],
       "defenseBonus": {
         "description": "Plains",
         "amount": 0.1
@@ -63149,6 +63152,9 @@
       "miningBonus": 1,
       "irrigationBonus": 1,
       "roadBonus": 1,
+      "allowedWorkerActions": [
+        "unit_plant_forest"
+      ],
       "defenseBonus": {
         "description": "Grassland",
         "amount": 0.1
@@ -63165,6 +63171,9 @@
       "miningBonus": 1,
       "irrigationBonus": 0,
       "roadBonus": 1,
+      "allowedWorkerActions": [
+        "unit_plant_forest"
+      ],
       "defenseBonus": {
         "description": "Tundra",
         "amount": 0.1
@@ -63229,6 +63238,9 @@
       "miningBonus": 0,
       "irrigationBonus": 0,
       "roadBonus": 1,
+      "allowedWorkerActions": [
+        "unit_clear_forest"
+      ],
       "defenseBonus": {
         "description": "Forest",
         "amount": 0.25
@@ -63245,6 +63257,9 @@
       "miningBonus": 0,
       "irrigationBonus": 0,
       "roadBonus": 1,
+      "allowedWorkerActions": [
+        "unit_clear_wetlands"
+      ],
       "defenseBonus": {
         "description": "Jungle",
         "amount": 0.25
@@ -63261,6 +63276,9 @@
       "miningBonus": 0,
       "irrigationBonus": 0,
       "roadBonus": 1,
+      "allowedWorkerActions": [
+        "unit_clear_wetlands"
+      ],
       "defenseBonus": {
         "description": "Marsh",
         "amount": 0.2
@@ -64002,6 +64020,8 @@
         "unit_build_road",
         "unit_build_mine",
         "unit_irrigate",
+        "unit_clear_wetlands",
+        "unit_clear_forest",
         "unit_hold",
         "unit_wait",
         "unit_fortify",

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -63,8 +63,8 @@ public partial class UnitButtons : VBoxContainer {
 		AddNewButton(specializedControls, new UnitControlButton("barricade", 4, 4, onButtonPressed));
 		AddNewButton(specializedControls, new UnitControlButton(C7Action.UnitBuildMine, 1, 3, onButtonPressed));
 		AddNewButton(specializedControls, new UnitControlButton(C7Action.UnitIrrigate, 2, 3, onButtonPressed));
-		AddNewButton(specializedControls, new UnitControlButton("chopForest", 3, 3, onButtonPressed));
-		AddNewButton(specializedControls, new UnitControlButton("chopJungle", 4, 3, onButtonPressed));
+		AddNewButton(specializedControls, new UnitControlButton(C7Action.UnitClearForest, 3, 3, onButtonPressed));
+		AddNewButton(specializedControls, new UnitControlButton(C7Action.UnitClearWetlands, 4, 3, onButtonPressed));
 		AddNewButton(specializedControls, new UnitControlButton("plantForest", 5, 3, onButtonPressed));
 		AddNewButton(specializedControls, new UnitControlButton("clearDamage", 6, 3, onButtonPressed));
 		AddNewButton(specializedControls, new UnitControlButton(C7Action.UnitAutomate, 7, 3, onButtonPressed));

--- a/C7Engine/C7GameData/Actions.cs
+++ b/C7Engine/C7GameData/Actions.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace C7GameData {
 	// The strings for each action correspond to values in project.godot for keyboard shortcuts
 	public static class C7Action {
@@ -38,6 +41,23 @@ namespace C7GameData {
 		public const string UnitSentry = "unit_sentry";
 		public const string UnitSentryEnemyOnly = "unit_sentry_enemy_only";
 		public const string UnitWait = "unit_wait";
+
+		public static HashSet<string> terraformActions = [
+			UnitBuildMine,
+			UnitIrrigate,
+			UnitBuildRoad,
+			UnitBuildRailroad,
+			UnitClearForest,
+			UnitClearWetlands,
+			UnitPlantForest,
+			UnitClearDamage,
+			UnitBuildBarricade,
+			UnitBuildFortress,
+			UnitBuildOutpost,
+			UnitBuildAirfield,
+			UnitClearDamage,
+			UnitBuildRadarTower
+		];
 
 		// This method transforms an action string into a TileDirection.
 		// A null value will be returned if the conversion is unsuccessful.

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -695,6 +695,8 @@ namespace C7GameData {
 			if (prto.BuildRoad) yield return C7Action.UnitBuildRoad;
 			if (prto.BuildMine) yield return C7Action.UnitBuildMine;
 			if (prto.Irrigate) yield return C7Action.UnitIrrigate;
+			if (prto.ClearJungle) yield return C7Action.UnitClearWetlands;
+			if (prto.ClearForest) yield return C7Action.UnitClearForest;
 			if (prto.Bombard) yield return C7Action.UnitBombard;
 			if (prto.SkipTurn) yield return C7Action.UnitHold;
 			if (prto.Wait) yield return C7Action.UnitWait;

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -636,16 +636,8 @@ namespace C7GameData {
 		}
 
 		public bool canPerformTerraformAction(string action) {
-			switch (action) {
-				case C7Action.UnitIrrigate:
-					return canIrrigate();
-				case C7Action.UnitBuildMine:
-					return canBuildMine();
-				case C7Action.UnitBuildRoad:
-					return canBuildRoad();
-				default:
-					return true;
-			}
+			Terraform terraform = EngineStorage.gameData.Terraforms.Find(t => t.Action == action);
+			return unitType.actions.Contains(action) && terraform.MeetsRequirements(owner, location);
 		}
 
 		public bool canBuildRoad() {
@@ -695,6 +687,12 @@ namespace C7GameData {
 					return;
 				case C7Action.UnitBuildRoad:
 					animate(MapUnit.AnimatedAction.ROAD, false, AnimationEnding.Repeat);
+					return;
+				case C7Action.UnitClearForest:
+					animate(MapUnit.AnimatedAction.FOREST, false, AnimationEnding.Repeat);
+					return;
+				case C7Action.UnitClearWetlands:
+					animate(MapUnit.AnimatedAction.JUNGLE, false, AnimationEnding.Repeat);
 					return;
 				default:
 					// do nothing;

--- a/C7Engine/C7GameData/Terraform.cs
+++ b/C7Engine/C7GameData/Terraform.cs
@@ -1,6 +1,27 @@
+using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace C7GameData;
+
+public static class TerraformRules {
+	public static readonly Dictionary<string, Action<Tile>> OnCompleteActions = new() {
+		{C7Action.UnitBuildMine, tile => tile.overlays.mine = true},
+		{C7Action.UnitIrrigate, tile => tile.overlays.irrigation = true},
+		{C7Action.UnitBuildRoad, tile => tile.overlays.road = true},
+		{C7Action.UnitClearWetlands, tile => tile.ClearTerrainOverlay()},
+		// TODO: add bonus shields to the nearest city - should only happen the first time a forest is cleared
+		{C7Action.UnitClearForest, tile => tile.ClearTerrainOverlay()},
+	};
+
+	public static readonly Dictionary<string, Func<Player, Tile, bool>> ActionValidators = new() {
+		{C7Action.UnitBuildMine, (_, tile) => tile.CanBeMined()},
+		{C7Action.UnitIrrigate, (player, tile) => tile.CanBeIrrigated(player)},
+		{C7Action.UnitBuildRoad, (_, tile) => tile.CanBeRoaded()},
+		{C7Action.UnitClearWetlands, (_, tile) => tile.overlayTerrainType.allowedWorkerActions.Contains(C7Action.UnitClearWetlands)},
+		{C7Action.UnitClearForest, (_, tile) =>  tile.overlayTerrainType.allowedWorkerActions.Contains(C7Action.UnitClearForest)}
+	};
+}
 
 public class Terraform {
 	public ID Id;
@@ -15,5 +36,31 @@ public class Terraform {
 
 	public List<ID> RequiredResources = new();
 
-	public string Action;
+	[JsonIgnore]
+	public Action<Tile> OnComplete;
+
+	[JsonIgnore]
+	public Func<Player, Tile, bool> MeetsRequirements;
+
+	public string Action {
+		get => _action;
+		set {
+			_action = value;
+
+			if (value == null) {
+				return;
+			}
+
+			if (TerraformRules.OnCompleteActions.TryGetValue(value, out var onComplete)) {
+				OnComplete = onComplete;
+			}
+
+			if (TerraformRules.ActionValidators.TryGetValue(value, out var prerequisite)) {
+				MeetsRequirements = prerequisite;
+			} else {
+				MeetsRequirements = (_, _) => false;
+			}
+		}
+	}
+	private string _action;
 }

--- a/C7Engine/C7GameData/TerrainType.cs
+++ b/C7Engine/C7GameData/TerrainType.cs
@@ -2,6 +2,7 @@ namespace C7GameData {
 	using QueryCiv3;
 	using QueryCiv3.Biq;
 	using System.Collections.Generic;
+	using System.Linq;
 
 	public class TerrainType {
 		//The "key" is a language-independent name for the terrain.  Civ3 relies on their index in the list to know
@@ -19,6 +20,7 @@ namespace C7GameData {
 		public int miningBonus { get; set; }
 		public int irrigationBonus { get; set; }
 		public int roadBonus { get; set; }
+		public HashSet<string> allowedWorkerActions;
 		public StrengthBonus defenseBonus;
 
 		//some stuff about graphics would probably make sense, too
@@ -48,22 +50,31 @@ namespace C7GameData {
 
 
 		public static TerrainType ImportFromCiv3(int civ3Index, TERR civ3Terrain) {
-			TerrainType c7Terrain = new TerrainType();
-			c7Terrain.Key = civTerrainKeyLookup[civ3Index];
-			c7Terrain.DisplayName = civ3Terrain.Name;
-			c7Terrain.baseFoodProduction = civ3Terrain.Food;
-			c7Terrain.baseShieldProduction = civ3Terrain.Shields;
-			c7Terrain.baseCommerceProduction = civ3Terrain.Commerce;
-			c7Terrain.movementCost = civ3Terrain.MovementCost;
-			c7Terrain.allowCities = civ3Terrain.AllowCities != 0;
-			c7Terrain.defenseBonus = new StrengthBonus {
-				description = civ3Terrain.Name,
-				amount = civ3Terrain.DefenseBonus / 100.0
+			TerrainType c7Terrain = new() {
+				Key = civTerrainKeyLookup[civ3Index],
+				DisplayName = civ3Terrain.Name,
+				baseFoodProduction = civ3Terrain.Food,
+				baseShieldProduction = civ3Terrain.Shields,
+				baseCommerceProduction = civ3Terrain.Commerce,
+				movementCost = civ3Terrain.MovementCost,
+				allowCities = civ3Terrain.AllowCities != 0,
+				defenseBonus = new StrengthBonus {
+					description = civ3Terrain.Name,
+					amount = civ3Terrain.DefenseBonus / 100.0
+				},
+				miningBonus = civ3Terrain.MiningBonus,
+				roadBonus = civ3Terrain.RoadBonus,
+				irrigationBonus = civ3Terrain.IrrigationBonus,
+				allowedWorkerActions = LoadWorkerActions(civ3Terrain).ToHashSet(),
 			};
-			c7Terrain.miningBonus = civ3Terrain.MiningBonus;
-			c7Terrain.roadBonus = civ3Terrain.RoadBonus;
-			c7Terrain.irrigationBonus = civ3Terrain.IrrigationBonus;
+
 			return c7Terrain;
+		}
+
+		private static IEnumerable<string> LoadWorkerActions(TERR civ3Terrain) {
+			if (civ3Terrain.CanChopForest) yield return C7Action.UnitClearForest;
+			if (civ3Terrain.CanClearWetlands) yield return C7Action.UnitClearWetlands;
+			if (civ3Terrain.CanPlantForest) yield return C7Action.UnitPlantForest;
 		}
 
 		//This only works for Conquests due to the new terrains being added in the middle of the list.

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -534,21 +534,7 @@ namespace C7GameData {
 				}
 			}
 
-			SetTerraformOverlay(currentWorkerJob);
-		}
-
-		private void SetTerraformOverlay(Terraform currentWorkerJob) {
-			switch (currentWorkerJob.Action) {
-				case C7Action.UnitIrrigate:
-					overlays.irrigation = true;
-					break;
-				case C7Action.UnitBuildMine:
-					overlays.mine = true;
-					break;
-				case C7Action.UnitBuildRoad:
-					overlays.road = true;
-					break;
-			}
+			currentWorkerJob.OnComplete(this);
 		}
 
 		public void Animate(AnimatedEffect effect, bool wait) {
@@ -560,6 +546,11 @@ namespace C7GameData {
 					EngineStorage.gameDataMutex.WaitOne();
 				}
 			}
+		}
+
+		public void ClearTerrainOverlay() {
+			overlayTerrainType = baseTerrainType;
+			overlayTerrainTypeKey = baseTerrainTypeKey;
 		}
 	}
 

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -51,22 +51,11 @@ namespace C7Engine {
 				}
 			}
 
+			result.AddRange(C7Action.terraformActions.Where(unit.canPerformTerraformAction));
+
 			if (unit.canBuildCity()) {
 				result.Add(C7Action.UnitBuildCity);
 			}
-
-			if (unit.canBuildRoad()) {
-				result.Add(C7Action.UnitBuildRoad);
-			}
-
-			if (unit.canBuildMine()) {
-				result.Add(C7Action.UnitBuildMine);
-			}
-
-			if (unit.canIrrigate()) {
-				result.Add(C7Action.UnitIrrigate);
-			}
-
 			if (unit.canExplore()) {
 				result.Add(C7Action.UnitExplore);
 			}

--- a/QueryCiv3/BiqSections/Terr.cs
+++ b/QueryCiv3/BiqSections/Terr.cs
@@ -25,7 +25,10 @@ namespace QueryCiv3.Biq {
 		public int Shields;
 		public int Commerce;
 		// Which worker job (TFRM) can be performed on this terrain type
-		public int WorkerJobAllowed;
+		private int WorkerJobAllowed;
+		public readonly bool CanPlantForest { get => WorkerJobAllowed == 5; }
+		public readonly bool CanChopForest { get => WorkerJobAllowed == 6; }
+		public readonly bool CanClearWetlands { get => WorkerJobAllowed == 7; }
 		// Which Terrain this Terrain becomes if affected by pollution.  -1 = not affected.  14 = Base Terrain Type (probably 12 in Vanilla/PTW)
 		public int PollutionEffect;
 		public byte AllowCities;


### PR DESCRIPTION
This PR allows player-controlled workers to clear wetlands and forests. It also refactors the Terraform system by implementing the requirements and effects as delegates (similar to #697 and #695).