### PR TITLE
Refactor terrain improvement system

### DIFF
--- a/C7/Map/TileOverlayLayer.cs
+++ b/C7/Map/TileOverlayLayer.cs
@@ -166,7 +166,7 @@ namespace C7.Map {
 		}
 
 		private static bool hasRoad(Tile tile) {
-			return tile.overlays.HasImprovement(TerrainImprovement.road);
+			return tile.overlays.HasImprovement(TerrainImprovement.road) || tile.HasCity;
 		}
 
 		private static bool hasRailRoad(Tile tile) {

--- a/C7/Map/TileOverlayLayer.cs
+++ b/C7/Map/TileOverlayLayer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using C7GameData;
 using Godot;
 
@@ -45,12 +46,12 @@ namespace C7.Map {
 			Rect2 screenTarget = new Rect2(tileCenter - tileSize / 2, tileSize);
 
 			// Irrigation shows up under roads, so draw that first.
-			if (tile.overlays.irrigation) {
+			if (tile.overlays.HasImprovement(TerrainImprovement.irrigation)) {
 				// Figure out which index into the irrigation texture to use for
 				// this tile.
 				int irrigationIndex = 0;
 				foreach (KeyValuePair<TileDirection, Tile> dirToTile in tile.neighbors) {
-					if (dirToTile.Value.overlays.irrigation) {
+					if (dirToTile.Value.overlays.HasImprovement(TerrainImprovement.irrigation)) {
 						irrigationIndex |= getIrrigationFlag(dirToTile.Key);
 					}
 				}
@@ -72,7 +73,7 @@ namespace C7.Map {
 				looseView.DrawTextureRectRegion(texture, screenTarget, getIrrigationRect(irrigationIndex));
 			}
 
-			if (hasRoad(tile) && !hasRailRoad(tile)) {
+			if (hasRoad(tile)) {
 				int roadIndex = 0;
 				foreach (KeyValuePair<TileDirection, Tile> dirToTile in tile.neighbors) {
 					if (hasRoad(dirToTile.Value)) {
@@ -99,7 +100,7 @@ namespace C7.Map {
 			}
 
 			// Mines go over roads, so draw those last.
-			if (tile.overlays.mine) {
+			if (tile.overlays.HasImprovement(TerrainImprovement.mine)) {
 				looseView.DrawTexture(mineTexture, screenTarget.Position);
 			}
 		}
@@ -161,18 +162,15 @@ namespace C7.Map {
 		}
 
 		private static bool HasAnyOverlays(Tile tile) {
-			return tile.overlays.road ||
-				tile.overlays.railroad ||
-				tile.overlays.mine ||
-				tile.overlays.irrigation;
+			return tile.overlays.GetImprovements().Any();
 		}
 
 		private static bool hasRoad(Tile tile) {
-			return tile.overlays.road;
+			return tile.overlays.HasImprovement(TerrainImprovement.road);
 		}
 
 		private static bool hasRailRoad(Tile tile) {
-			return tile.overlays.railroad;
+			return tile.overlays.HasImprovement(TerrainImprovement.railroad);
 		}
 	}
 }

--- a/C7/Map/TileOverlayLayer.cs
+++ b/C7/Map/TileOverlayLayer.cs
@@ -76,7 +76,7 @@ namespace C7.Map {
 			if (hasRoad(tile)) {
 				int roadIndex = 0;
 				foreach (KeyValuePair<TileDirection, Tile> dirToTile in tile.neighbors) {
-					if (hasRoad(dirToTile.Value)) {
+					if (hasRoad(dirToTile.Value) || dirToTile.Value.HasCity) {
 						roadIndex |= getRoadFlag(dirToTile.Key);
 					}
 				}
@@ -87,7 +87,7 @@ namespace C7.Map {
 				int roadIndex = 0;
 				int railroadIndex = 0;
 				foreach (KeyValuePair<TileDirection, Tile> dirToTile in tile.neighbors) {
-					if (hasRailRoad(dirToTile.Value)) {
+					if (hasRailRoad(dirToTile.Value) || dirToTile.Value.HasCity) {
 						railroadIndex |= getRoadFlag(dirToTile.Key);
 					} else if (hasRoad(dirToTile.Value)) {
 						roadIndex |= getRoadFlag(dirToTile.Key);
@@ -166,7 +166,7 @@ namespace C7.Map {
 		}
 
 		private static bool hasRoad(Tile tile) {
-			return tile.overlays.HasImprovement(TerrainImprovement.road) || tile.HasCity;
+			return tile.overlays.HasImprovement(TerrainImprovement.road);
 		}
 
 		private static bool hasRailRoad(Tile tile) {

--- a/C7Engine/AI/Pathing/EdgeWalker.cs
+++ b/C7Engine/AI/Pathing/EdgeWalker.cs
@@ -66,7 +66,7 @@ namespace C7Engine.Pathing {
 
 			// TODO: When buildings are implemented, the logic for airports and harbors should also be included.
 			foreach (Tile neighbor in node.neighbors.Values) {
-				if (neighbor.overlays.road) {
+				if (neighbor.overlays.HasRoad()) {
 					result.Add(new Edge<Tile>(node, neighbor, 1));
 				}
 			}

--- a/C7Engine/AI/UnitAI/SettlerAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerAI.cs
@@ -59,7 +59,7 @@ namespace C7Engine {
 					if (unit.location == data.destination) {
 						log.Information("Building city with " + unit);
 						//TODO: This should use a message, and the message handler should cause the disbanding to happen.
-						CityInteractions.BuildCity(unit.location.XCoordinate, unit.location.YCoordinate, player.id, unit.owner.GetNextCityName());
+						CityInteractions.BuildCity(unit.location, player, unit.owner.GetNextCityName());
 						unit.disband();
 					} else if (data.escort == null) {
 						log.Information($"Settler {unit.id} is waiting for an escort");

--- a/C7Engine/AI/UnitAI/WorkerAI.cs
+++ b/C7Engine/AI/UnitAI/WorkerAI.cs
@@ -111,7 +111,7 @@ namespace C7Engine {
 			const int FoodPoints = 5;
 
 			foreach (Terraform terraform in accessibleTerraforms) {
-				Tile tAfterImprovement = t.ShallowCopy();
+				Tile tAfterImprovement = t.Copy();
 				terraform.OnComplete(tAfterImprovement);
 
 				int newCommerce = tAfterImprovement.commerceYield(player).yield;

--- a/C7Engine/C7GameData/AIData/TilePath.cs
+++ b/C7Engine/C7GameData/AIData/TilePath.cs
@@ -93,18 +93,18 @@ namespace C7GameData {
 			// River crossings disrupt roads, so check that first.
 			if (from.HasRiverCrossing(dir)) return newLocation.MovementCost();
 
-			// Travelling between two tiles with railroads is free.
-			if (from.overlays.railroad && newLocation.overlays.railroad) return 0;
-
-			// Traveling from a railroad/road to a road has the cost of a road; 1/3.
-			if ((from.overlays.railroad || from.overlays.road) && newLocation.overlays.road) return 1.0f / 3;
-
 			// Special case: if we are a water unit, traveling from the water into
 			// a city, it doesn't matter if the city is on hills or on grassland,
 			// the cost should always be 1.
 			if (from.IsWater() && newLocation.HasCity) return 1;
 
-			return newLocation.MovementCost();
+			// Movement costs of terrain improvements (roads and railroads)
+			float fromCost = from.overlays.MovementCost();
+			float toCost = newLocation.overlays.MovementCost();
+
+			return (fromCost == -1 || toCost == -1)
+				? newLocation.MovementCost() // terrrain movement cost
+				: Math.Max(fromCost, toCost);
 		}
 	}
 }

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -626,7 +626,7 @@ namespace C7GameData {
 
 			// TODO: Need to check somewhere that this unit is allowed to build a city on its current tile. Either do that here or in every caller
 			// (probably best to just do it here).
-			City city = CityInteractions.BuildCity(location.XCoordinate, location.YCoordinate, owner.id, cityName);
+			City city = CityInteractions.BuildCity(location, owner, cityName);
 
 			// TODO: Should directly delete the unit instead of disbanding it. Disbanding in a city will eventually award shields, which we
 			// obviously don't want to do here.

--- a/C7Engine/C7GameData/Save/SaveTile.cs
+++ b/C7Engine/C7GameData/Save/SaveTile.cs
@@ -37,24 +37,13 @@ namespace C7GameData.Save {
 			if (tile.hasBarbarianCamp) {
 				features.Add("barbarianCamp");
 			}
-			if (tile.overlays.road) {
-				overlays.Add("road");
-			}
-			if (tile.overlays.railroad) {
-				overlays.Add("railroad");
-			}
-			if (tile.overlays.mine) {
-				overlays.Add("mine");
-			}
-			if (tile.overlays.irrigation) {
-				overlays.Add("irrigation");
-			}
+
+			overlays.AddRange(tile.overlays.GetImprovements().Select(i => i.key));
 		}
 
 		// TODO: if this is slow, features can be read from JSON and then hashed so the Contains check is faster
 		public Tile ToTile(List<TerrainType> terrainTypes, List<Resource> resources) {
-			Tile tile = new Tile{
-				Id = id,
+			Tile tile = new Tile(id){
 				ExtraInfo = extraInfo,
 				XCoordinate = X,
 				YCoordinate = Y,
@@ -77,15 +66,10 @@ namespace C7GameData.Save {
 				isBonusShield = features.Contains("bonusShield"),
 				isSnowCapped = features.Contains("snowCapped"),
 				isPineForest = features.Contains("pineForest"),
-				overlays = new TileOverlays{
-					road = overlays.Contains("road"),
-					railroad = overlays.Contains("railroad"),
-					mine = overlays.Contains("mine"),
-					irrigation = overlays.Contains("irrigation"),
-				},
 			};
 
 			tile.Resource = tile.ResourceKey == Resource.NONE.Key ? Resource.NONE : resources.Find(r => r.Key == tile.ResourceKey);
+			overlays.ForEach(key => tile.overlays.Add(TerrainImprovement.FromKey(key)));
 
 			return tile;
 		}

--- a/C7Engine/C7GameData/StrengthBonus.cs
+++ b/C7Engine/C7GameData/StrengthBonus.cs
@@ -5,6 +5,11 @@ namespace C7GameData {
 		public string description;
 		public double amount; // e.g. 0.25 = +25% strength
 
+		public StrengthBonus(string description, double amount) {
+			this.description = description;
+			this.amount = amount;
+		}
+
 		// Converts a list of strength bonuses to a multiplier on strength. For example, a list of two bonuses of +10% and +25% would return a
 		// multiplier of 1.35. Multipliers cannot be less than zero.
 		public static double ListToMultiplier(IEnumerable<StrengthBonus> bonuses) {

--- a/C7Engine/C7GameData/Terraform.cs
+++ b/C7Engine/C7GameData/Terraform.cs
@@ -6,9 +6,10 @@ namespace C7GameData;
 
 public static class TerraformRules {
 	public static readonly Dictionary<string, Action<Tile>> OnCompleteActions = new() {
-		{C7Action.UnitBuildMine, tile => tile.overlays.mine = true},
-		{C7Action.UnitIrrigate, tile => tile.overlays.irrigation = true},
-		{C7Action.UnitBuildRoad, tile => tile.overlays.road = true},
+		{C7Action.UnitBuildMine, tile => tile.overlays.Add(TerrainImprovement.mine)},
+		{C7Action.UnitIrrigate, tile => tile.overlays.Add(TerrainImprovement.irrigation)},
+		{C7Action.UnitBuildRoad, tile => tile.overlays.Add(TerrainImprovement.road)},
+		{C7Action.UnitBuildRailroad, tile => tile.overlays.Add(TerrainImprovement.railroad)},
 		{C7Action.UnitClearWetlands, tile => tile.ClearTerrainOverlay()},
 		// TODO: add bonus shields to the nearest city - should only happen the first time a forest is cleared
 		{C7Action.UnitClearForest, tile => tile.ClearTerrainOverlay()},
@@ -17,7 +18,7 @@ public static class TerraformRules {
 	public static readonly Dictionary<string, Func<Player, Tile, bool>> ActionValidators = new() {
 		{C7Action.UnitBuildMine, (_, tile) => tile.CanBeMined()},
 		{C7Action.UnitIrrigate, (player, tile) => tile.CanBeIrrigated(player)},
-		{C7Action.UnitBuildRoad, (_, tile) => tile.CanBeRoaded()},
+		{C7Action.UnitBuildRoad, (_, tile) => tile.overlays.CanAdd(TerrainImprovement.road)},
 		{C7Action.UnitClearWetlands, (_, tile) => tile.overlayTerrainType.allowedWorkerActions.Contains(C7Action.UnitClearWetlands)},
 		{C7Action.UnitClearForest, (_, tile) =>  tile.overlayTerrainType.allowedWorkerActions.Contains(C7Action.UnitClearForest)}
 	};

--- a/C7Engine/C7GameData/TerrainImprovement.cs
+++ b/C7Engine/C7GameData/TerrainImprovement.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+
+namespace C7GameData {
+	public class TerrainImprovement {
+		public enum Layer {
+			Roads,
+			ResourceDevelopment, // mine, irrigation
+			Holdings, // outpost, radar tower, fortress, barricade
+		}
+
+		private static Dictionary<string, TerrainImprovement> improvementByKey = [];
+
+		public static readonly TerrainImprovement road = new(nameof(road), Layer.Roads, movementCost: 1.0f / 3);
+		public static readonly TerrainImprovement railroad = new(nameof(railroad), Layer.Roads, road, movementCost: 0);
+		public static readonly TerrainImprovement mine = new(nameof(mine), Layer.ResourceDevelopment);
+		public static readonly TerrainImprovement irrigation = new(nameof(irrigation), Layer.ResourceDevelopment);
+		public static readonly TerrainImprovement fortress = new(nameof(fortress), Layer.Holdings, defenseBonus: new(nameof(fortress), 0.5));
+		public static readonly TerrainImprovement barricade = new(nameof(barricade), Layer.Holdings, fortress, defenseBonus: new(nameof(barricade), 1));
+
+		public readonly string key;
+
+		public readonly Layer layer;
+		public readonly StrengthBonus? defenseBonus;
+
+		// A terrain improvement with negative movement cost shouldn't affect the tile movement cost
+		public readonly float movementCost = -1;
+
+		// In the default ruleset, Road upgrades to Railroad and Fortress upgrades to Barricade.
+		// The upgrade relationship affects:
+		// 1) confirmation dialog when replacing improvements (if an improvement is replaced with its upgrade, there is no need for a confirmation)
+		// 2) availability of an improvement (a player can't build an upgraded improvement without building a base improvement)
+		// 3) result of pillaging (after pillaging, an upgraded improvement will downgrade)
+		public readonly TerrainImprovement upgradesFrom;
+
+		public TerrainImprovement(
+			string key,
+			Layer layer,
+			TerrainImprovement upgradesFrom = null,
+			StrengthBonus? defenseBonus = null,
+			float movementCost = -1
+		) {
+			this.key = key;
+			this.layer = layer;
+			this.defenseBonus = defenseBonus;
+			this.upgradesFrom = upgradesFrom;
+			this.movementCost = movementCost;
+
+			improvementByKey[key] = this;
+		}
+
+		public static TerrainImprovement FromKey(string key) {
+			return improvementByKey[key];
+		}
+	}
+}

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -102,15 +102,14 @@ namespace C7GameData {
 		public bool riverWest;
 		public bool riverNorthwest;
 
-		public TileOverlays overlays = new TileOverlays();
+		public TileOverlays overlays;
 
 		public Tile(ID id) {
 			this.Id = id;
 			unitsOnTile = new List<MapUnit>();
 			Resource = Resource.NONE;
+			overlays = new(this);
 		}
-
-		internal Tile() { }
 
 		// TODO: this should be either an extension in C7Engine, or otherwise
 		// calculated somewhere else, but it's not obvious to someone unfamiliar
@@ -250,9 +249,9 @@ namespace C7GameData {
 				yield += this.Resource.FoodBonus;
 			}
 
-			if (this.overlays.irrigation) {
+			if (this.overlays.HasImprovement(TerrainImprovement.irrigation)) {
 				yield += this.overlayTerrainType.irrigationBonus;
-				if (this.overlays.railroad) {
+				if (this.overlays.HasImprovement(TerrainImprovement.railroad)) {
 					yield += 1;
 				}
 			}
@@ -309,9 +308,9 @@ namespace C7GameData {
 				yield += this.Resource.ShieldsBonus;
 			}
 
-			if (this.overlays.mine) {
+			if (this.overlays.HasImprovement(TerrainImprovement.mine)) {
 				yield += this.overlayTerrainType.miningBonus;
-				if (this.overlays.railroad) {
+				if (this.overlays.HasImprovement(TerrainImprovement.railroad)) {
 					yield += 1;
 				}
 			}
@@ -337,7 +336,7 @@ namespace C7GameData {
 			if (BordersRiver()) {
 				yield += 1;
 			}
-			if (overlays.road) {
+			if (overlays.HasRoad()) {
 				yield += overlayTerrainType.roadBonus;
 			}
 
@@ -388,11 +387,7 @@ namespace C7GameData {
 		}
 
 		public bool CanBeMined() {
-			return overlayTerrainType.miningBonus > 0 && !overlays.mine && !overlays.irrigation && cityAtTile == null;
-		}
-
-		public bool CanBeRoaded() {
-			return IsLand() && !overlays.road;
+			return overlayTerrainType.miningBonus > 0 && overlays.CanAdd(TerrainImprovement.mine);
 		}
 
 		// TODO: This method doesn't handle two important irrigation cases:
@@ -401,9 +396,8 @@ namespace C7GameData {
 		public bool CanBeIrrigated(Player player) {
 			// Irrigation can't be done if there is no irrigation bonus for the
 			// tile or if there's already an improvement or city on the tile.
-			if (overlayTerrainType.irrigationBonus == 0 ||
-				overlays.mine ||
-				overlays.irrigation ||
+			if (!overlays.CanAdd(TerrainImprovement.irrigation) ||
+				overlayTerrainType.irrigationBonus == 0 ||
 				cityAtTile != null) {
 				return false;
 			}
@@ -415,7 +409,7 @@ namespace C7GameData {
 
 			foreach (KeyValuePair<TileDirection, Tile> dirToTile in neighbors) {
 				// If a neighboring tile is irrigated, this tile has fresh water access.
-				if (dirToTile.Value.overlays.irrigation) {
+				if (dirToTile.Value.overlays.HasImprovement(TerrainImprovement.irrigation)) {
 					return true;
 				}
 
@@ -427,7 +421,7 @@ namespace C7GameData {
 					}
 
 					foreach (var (dir, tile) in dirToTile.Value.neighbors) {
-						if (tile.overlays.irrigation) {
+						if (tile.overlays.HasImprovement(TerrainImprovement.irrigation)) {
 							return true;
 						}
 					}
@@ -553,8 +547,10 @@ namespace C7GameData {
 			overlayTerrainTypeKey = baseTerrainTypeKey;
 		}
 
-		public Tile ShallowCopy() {
-			return (Tile)MemberwiseClone();
+		public Tile Copy() {
+			Tile clone = (Tile)MemberwiseClone();
+			clone.overlays = new TileOverlays(overlays);
+			return clone;
 		}
 	}
 
@@ -599,14 +595,62 @@ namespace C7GameData {
 		}
 	}
 
-	public struct TileOverlays {
-		public bool road = false;
-		// assume that railroad contains road too
-		public bool railroad = false;
-		public bool mine = false;
-		public bool irrigation = false;
+	public class TileOverlays {
+		private readonly Tile tile;
+		private Dictionary<TerrainImprovement.Layer, TerrainImprovement> terrainImprovementByLayer = [];
 
-		public TileOverlays() {
+		public TileOverlays(Tile tile) {
+			this.tile = tile;
+		}
+
+		public TileOverlays(TileOverlays other)
+			: this(other.tile) {
+			terrainImprovementByLayer = new(other.terrainImprovementByLayer);
+		}
+
+		public void Add(TerrainImprovement improvement) {
+			if (!CanAdd(improvement))
+				throw new InvalidOperationException($"Cannot add {improvement.key} to the tile");
+
+			terrainImprovementByLayer[improvement.layer] = improvement;
+		}
+
+		public bool HasImprovement(TerrainImprovement improvement) {
+			return terrainImprovementByLayer.TryGetValue(improvement.layer, out TerrainImprovement val) && val == improvement;
+		}
+
+		public IEnumerable<TerrainImprovement> GetImprovements() {
+			return terrainImprovementByLayer.Values;
+		}
+
+		public bool CanAdd(TerrainImprovement improvement) {
+			if (tile.HasCity)
+				return false;
+
+			if (!terrainImprovementByLayer.TryGetValue(improvement.layer, out var current))
+				return improvement.upgradesFrom == null;
+
+			if (current == improvement || current.upgradesFrom == improvement)
+				return false;
+
+			return improvement.upgradesFrom == current;
+		}
+
+		public bool HasRoad() {
+			return terrainImprovementByLayer.ContainsKey(TerrainImprovement.Layer.Roads) || tile.HasCity;
+		}
+
+		// Will return a -1 if the tile movement cost is unaffected by the improvements
+		public float MovementCost() {
+			if (terrainImprovementByLayer.TryGetValue(TerrainImprovement.Layer.Roads, out TerrainImprovement road)) {
+				return road.movementCost;
+			}
+
+			if (tile.HasCity) {
+				return TerrainImprovement.road.movementCost;
+			}
+
+			return -1;
 		}
 	}
 }

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -654,7 +654,7 @@ namespace C7GameData {
 			}
 
 			if (tile.HasCity) {
-				return TerrainImprovement.road.movementCost;
+				return 0;
 			}
 
 			return -1;

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -52,7 +52,6 @@ namespace C7GameData {
 		public int YCoordinate;
 
 		// Needed for coordinate wrapping.
-		[JsonIgnore]
 		public GameMap map;
 
 		// An arbitrary number indicating which landmass this tile is part of,
@@ -64,13 +63,22 @@ namespace C7GameData {
 
 		public City owningCity; // The city whose border contains this tile
 		public string baseTerrainTypeKey { get; set; }
-		[JsonIgnore]
 		public TerrainType baseTerrainType = TerrainType.NONE;
 		public string overlayTerrainTypeKey { get; set; }
-		[JsonIgnore]
 		public TerrainType overlayTerrainType = TerrainType.NONE;
-		public City cityAtTile;
-		[JsonIgnore]
+
+		private City _cityAtTile;
+		public City cityAtTile {
+			get { return _cityAtTile; }
+			set {
+				_cityAtTile = value;
+				if (value != null) {
+					ClearTerrainOverlay();
+					overlays.Clear();
+				}
+			}
+		}
+
 		public bool HasCity => cityAtTile != null && cityAtTile != City.NONE;
 		public CityResident personWorkingTile = null;   //allows us to see if another city is working this tile
 		public bool hasBarbarianCamp = false;
@@ -82,7 +90,6 @@ namespace C7GameData {
 		//has the best defense, or which tile a unit is on when viewing the Military Advisor.
 		public List<MapUnit> unitsOnTile = new List<MapUnit>();
 		public string ResourceKey { get; set; }
-		[JsonIgnore]
 		public Resource Resource { get; set; }
 
 		public Dictionary<TileDirection, Tile> neighbors { get; set; } = new Dictionary<TileDirection, Tile>();
@@ -651,6 +658,10 @@ namespace C7GameData {
 			}
 
 			return -1;
+		}
+
+		public void Clear() {
+			terrainImprovementByLayer.Clear();
 		}
 	}
 }

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -6,10 +6,8 @@ namespace C7Engine {
 	using C7GameData;
 
 	public class CityInteractions {
-		public static City BuildCity(int X, int Y, ID playerID, string name) {
+		public static City BuildCity(Tile tileWithNewCity, Player owner, string name) {
 			GameData gameData = EngineStorage.gameData;
-			Player owner = gameData.GetPlayer(playerID);
-			Tile tileWithNewCity = gameData.map.tileAt(X, Y);
 			City newCity = new City(tileWithNewCity, owner, name, gameData.ids.CreateID("city"));
 			if (owner.cities.Count == 0) {
 				newCity.capital = true;

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -32,12 +32,6 @@ namespace C7Engine {
 
 			newCity.SetItemBeingProduced(CityProductionAI.GetNextItemToBeProduced(newCity, null));
 
-			// Cities are treated as though they have a road, but if
-			// a city is build on a mine, the mine should be removed.
-			tileWithNewCity.overlays.road = true;
-			tileWithNewCity.overlays.mine = false;
-			tileWithNewCity.overlays.irrigation = false;
-
 			// Redo corruption calculations after a city is created, since it
 			// may change rank corruption values.
 			owner.DoCorruptionCalculations(EngineStorage.gameData);
@@ -59,7 +53,6 @@ namespace C7Engine {
 				new MsgCivilizationDestroyed(tile.cityAtTile.owner.civilization).send();
 			}
 			tile.cityAtTile = null;
-			tile.overlays.road = false;
 
 			// Redo corruption calculations after a city is destroyed, since it
 			// may change rank corruption values.

--- a/EngineTests/AI/Pathing/EdgeWalkerTest.cs
+++ b/EngineTests/AI/Pathing/EdgeWalkerTest.cs
@@ -77,7 +77,7 @@ namespace EngineTests {
 
 			// Set up a neighbor with a road.
 			Tile end = plains;
-			end.overlays.road = true;
+			end.overlays.Add(TerrainImprovement.road);
 			start.neighbors[TileDirection.NORTH] = end;
 
 			// The road shouldn't matter, since we don't have a road.
@@ -89,7 +89,7 @@ namespace EngineTests {
 		[Fact]
 		void testRoadOnStartNotOnDestination() {
 			Tile start = hill;
-			start.overlays.road = true;
+			start.overlays.Add(TerrainImprovement.road);
 
 			// Set up a neighbor without a road.
 			Tile end = plains;
@@ -104,11 +104,11 @@ namespace EngineTests {
 		[Fact]
 		void testRoadOnStartAndDestination() {
 			Tile start = hill;
-			start.overlays.road = true;
+			start.overlays.Add(TerrainImprovement.road);
 
 			// Set up a neighbor with a road.
 			Tile end = plains;
-			end.overlays.road = true;
+			end.overlays.Add(TerrainImprovement.road);
 			start.neighbors[TileDirection.NORTH] = end;
 
 			// The cost should be adjusted because we both have a road.


### PR DESCRIPTION
This PR introduces a new class, TerrainImprovement, which describes player-made improvements (roads, mines, irrigation, outposts...) Currently, it encapsulates the movement cost, the defense bonus (for barricades and fortresses), and the upgrade relationship (for example, the fact that the railroad is an upgrade from the regular road).

This PR groups the terrain improvements by layers
- Roads
- ResourceDevelopment - mines and irrigation
- Holdings - outpost, radar tower, fortress, barricade. 

The layer systems plays a limiting role when adding new improvements to the tile via the TileOverlays class: each tile can have only one type of improvement per layer.

Some of the Civ3 improvements doesn't fit well into this system: in the Civ3, there are irregularities with Colony (it can coexist with Fortress but not with Outpost or Radar Tower) and Airfield (it can't coexist with anything except roads). I think this can be addressed later by adding custom logic.

In the future, I want to move tile yield effects into the TerrainImprovement class. Also, it would be ideal to allow defining new improvements via scripting/JSON, but it would be tricky since it requires decoupling the improvement drawing logic from the TileOverlayLayer class.