### PR TITLE
Update tile knowledge to account for terrain heights

### DIFF
--- a/C7/MainMenu.cs
+++ b/C7/MainMenu.cs
@@ -163,10 +163,6 @@ public partial class MainMenu : Node2D {
 				}
 			}
 			player.tileKnowledge.Clear();
-			player.tileKnowledge.Add(startingLocation);
-			foreach (TileDirection direction in Enum.GetValues(typeof(TileDirection))) {
-				player.tileKnowledge.Add(Tile.NeighborCoordinate(startingLocation, direction));
-			}
 		}
 
 		log.Information("saving generated map");

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -63126,7 +63126,8 @@
         "Oil",
         "Incense",
         "Oasis"
-      ]
+      ],
+      "height": 0
     },
     {
       "key": "plains",
@@ -63153,7 +63154,8 @@
         "Cattle",
         "Wheat",
         "Sugar"
-      ]
+      ],
+      "height": 0
     },
     {
       "key": "grassland",
@@ -63179,7 +63181,8 @@
         "Cattle",
         "Wheat",
         "Tobacco"
-      ]
+      ],
+      "height": 0
     },
     {
       "key": "tundra",
@@ -63204,7 +63207,8 @@
         "Aluminum",
         "Furs",
         "Game"
-      ]
+      ],
+      "height": 0
     },
     {
       "key": "flood plain",
@@ -63223,7 +63227,8 @@
       },
       "allowedResources": [
         "Wheat"
-      ]
+      ],
+      "height": 0
     },
     {
       "key": "hills",
@@ -63251,7 +63256,8 @@
         "Gold",
         "Sugar",
         "Tobacco"
-      ]
+      ],
+      "height": 2
     },
     {
       "key": "mountains",
@@ -63275,7 +63281,8 @@
         "Uranium",
         "Gems",
         "Gold"
-      ]
+      ],
+      "height": 4
     },
     {
       "key": "forest",
@@ -63304,7 +63311,8 @@
         "Ivory",
         "Silks",
         "Game"
-      ]
+      ],
+      "height": 1
     },
     {
       "key": "jungle",
@@ -63332,7 +63340,8 @@
         "Silks",
         "Gems",
         "Tropical Fruit"
-      ]
+      ],
+      "height": 1
     },
     {
       "key": "marsh",
@@ -63357,7 +63366,8 @@
         "Rubber",
         "Game",
         "Fish"
-      ]
+      ],
+      "height": -2
     },
     {
       "key": "volcano",
@@ -63373,7 +63383,8 @@
       "defenseBonus": {
         "description": "Volcano",
         "amount": 0.8
-      }
+      },
+      "height": 4
     },
     {
       "key": "coast",
@@ -63392,7 +63403,8 @@
       },
       "allowedResources": [
         "Fish"
-      ]
+      ],
+      "height": -2
     },
     {
       "key": "sea",
@@ -63412,7 +63424,8 @@
       "allowedResources": [
         "Whales",
         "Fish"
-      ]
+      ],
+      "height": -2
     },
     {
       "key": "ocean",
@@ -63428,7 +63441,8 @@
       "defenseBonus": {
         "description": "Ocean",
         "amount": 0.1
-      }
+      },
+      "height": -2
     }
   ],
   "resources": [

--- a/C7Engine/C7GameData/AIData/TileKnowledge.cs
+++ b/C7Engine/C7GameData/AIData/TileKnowledge.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System;
 
 namespace C7GameData {
 	public class TileKnowledge {
@@ -24,11 +25,7 @@ namespace C7GameData {
 			knownTiles.Add(unitLocation);
 			borderTiles.Remove(unitLocation);
 
-			foreach (Tile t in unitLocation.neighbors.Values) {
-				if (t == Tile.NONE) {
-					continue;
-				}
-
+			foreach (Tile t in GetTilesVisibleToUnit(unitLocation)) {
 				knownTiles.Add(t);
 				borderTiles.Remove(t);
 
@@ -45,6 +42,66 @@ namespace C7GameData {
 			if (recomputeActiveTiles) {
 				RecomputeActiveTiles();
 			}
+		}
+
+		private HashSet<Tile> GetTilesVisibleToUnit(Tile unitLocation) {
+			HashSet<Tile> result = new();
+			result.Add(unitLocation);
+
+			foreach (TileDirection a in TileDirection.GetValues(typeof(TileDirection))) {
+				Tile innerRingNeighbor = unitLocation.neighbors[a];
+				if (innerRingNeighbor == Tile.NONE) {
+					continue;
+				}
+				result.Add(innerRingNeighbor);
+
+				foreach (TileDirection b in TileDirection.GetValues(typeof(TileDirection))) {
+					// Say we have the following. We are standing on the XX tile
+					// and need to figure out which tiles we can see. We can see
+					// the hill directly to our SW, because we're next to it.
+					// We can see the hill that is S+SW of us, because it's
+					// diagonal to us and we can see tiles of height 2 from 2
+					// tiles away. We can't see the hill that is SW+SW of us
+					// because we are blocked. To implement this we need to
+					// prevent 90 degree "turns", which we handle by ensuring
+					// the a+b combo is never a combination of two N/S/E/W dirs.
+					//
+					//                      <  ..  >
+					//                  <  ..  ><  XX  >
+					//              <  ..  >< Hill ><  gg  >
+					//                  < Hill ><  gg  >
+					//                      < Hill >
+					if (((int)a) % 2 == 0 && ((int)b) % 2 == 0) {
+						continue;
+					}
+
+					Tile outerRingNeighbor = innerRingNeighbor.neighbors[b];
+					if (outerRingNeighbor == Tile.NONE) {
+						continue;
+					}
+					int unitHeight = unitLocation.overlayTerrainType.height;
+					int innerHeight = innerRingNeighbor.overlayTerrainType.height;
+					int outerHeight = outerRingNeighbor.overlayTerrainType.height;
+
+					// Tiles with a height of at least 2 are visible from 2 tiles
+					// away as long as the tile in between is 2 less than the
+					// outer tile (so you can see mountains over hills, but
+					// not hills over forest).
+					if (outerHeight >= 2 && innerHeight + 2 <= outerHeight) {
+						result.Add(outerRingNeighbor);
+						continue;
+					}
+
+					// You can also see tiles whose height is 2 lower than where
+					// you are standing, as long as the tile in the middle has
+					// height at least 2 lower than you.
+					if (outerHeight + 1 <= unitHeight && innerHeight + 2 <= unitHeight) {
+						result.Add(outerRingNeighbor);
+						continue;
+					}
+				}
+			}
+			return result;
 		}
 
 		// neighboring tiles should not be added when loading tile knowledge
@@ -103,12 +160,9 @@ namespace C7GameData {
 
 				// A tile with a unit on it and all of its neighbors are active.
 				if (t.unitsOnTile.Count > 0 && t.unitsOnTile[0].owner == _player) {
-					activeTiles.Add(t);
-
-					foreach (Tile neighbor in t.neighbors.Values) {
-						activeTiles.Add(neighbor);
+					foreach (Tile x in GetTilesVisibleToUnit(t)) {
+						activeTiles.Add(x);
 					}
-					continue;
 				}
 			}
 		}

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -118,6 +118,12 @@ namespace C7GameData.Save {
 						}
 					}
 				}
+
+				// Backfill visibility.
+				foreach (MapUnit u in p.units) {
+					p.tileKnowledge.AddTilesToKnown(u.location);
+				}
+
 				// TODO: this may require more than one loop, because if all the
 				// citizens are happy it reduces wasted shields via we love the
 				// king day.

--- a/C7Engine/C7GameData/TerrainType.cs
+++ b/C7Engine/C7GameData/TerrainType.cs
@@ -23,6 +23,7 @@ namespace C7GameData {
 		public HashSet<UnitAction> allowedWorkerActions = [];
 		public StrengthBonus defenseBonus;
 		public HashSet<string> allowedResources = new();
+		public int height = -1;
 
 		//some stuff about graphics would probably make sense, too
 
@@ -68,6 +69,18 @@ namespace C7GameData {
 				irrigationBonus = civ3Terrain.IrrigationBonus,
 				allowedWorkerActions = LoadWorkerActions(civ3Terrain).ToHashSet(),
 			};
+
+			if (c7Terrain.Key == "mountains" || c7Terrain.Key == "volcano") {
+				c7Terrain.height = 4;
+			} else if (c7Terrain.Key == "hills") {
+				c7Terrain.height = 2;
+			} else if (c7Terrain.Key == "ocean" || c7Terrain.Key == "sea" || c7Terrain.Key == "coast" || c7Terrain.Key == "marsh") {
+				c7Terrain.height = -2;
+			} else if (c7Terrain.Key == "forest" || c7Terrain.Key == "jungle") {
+				c7Terrain.height = 1;
+			} else {
+				c7Terrain.height = 0;
+			}
 
 			return c7Terrain;
 		}

--- a/QueryCiv3/BiqSections/Terr.cs
+++ b/QueryCiv3/BiqSections/Terr.cs
@@ -39,7 +39,7 @@ namespace QueryCiv3.Biq {
 		public byte AllowForts;
 		public byte AllowOutposts;
 		public byte AllowRadarTowers;
-		private fixed byte Unknown[4];
+		private int Unknown;
 		public byte LandmarkEnabled;
 		public int LandmarkFood;
 		public int LandmarkShields;
@@ -54,7 +54,7 @@ namespace QueryCiv3.Biq {
 		public string LandmarkName { get => Util.GetString(ref this, 157, 32); }
 		public string LandmarkCivilopediaEntry { get => Util.GetString(ref this, 189, 32); }
 
-		private fixed byte Unknown2[4];
+		private int Unknown2;
 		public int TerrainFlags;
 		public int DiseaseStrength;
 	}


### PR DESCRIPTION
#103 helpfully had the details here.

This makes early game exploring much more interesting.

Example of seeing mountains at a distance: 
![image](https://github.com/user-attachments/assets/d6e9ecbf-7ec6-460c-b92d-2157c3e66b30)
