### PR TITLE
Allow unhappy cities to go into civil disorder

### DIFF
--- a/C7/AnimationManager.cs
+++ b/C7/AnimationManager.cs
@@ -122,10 +122,11 @@ public partial class AnimationManager {
 		}
 	}
 
-	public static void loadCursorAnimation(string path, ref SpriteFrames frames) {
+	// Used for loading animations that don't have a "tint", where the tint is
+	// the civ-specific coloring of a unit.
+	public static void loadNonTintedAnimation(string path, string name, ref SpriteFrames frames) {
 		Flic flic = Util.LoadFlic(path);
 		int row = 0;
-		string name = "cursor";
 		frames.AddAnimation(name);
 
 		for (int col = 0; col < flic.Images.GetLength(1); col++) {

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -452,15 +452,8 @@ public partial class Game : Node2D {
 			foreach (City city in controller.cities) {
 				if (!controller.isHuman) { continue; }
 
-				city.RecalculateCitizenMoods(gDA.gameData);
-				int happy = 0;
-				int unhappy = 0;
-				foreach (CityResident cr in city.residents) {
-					if (cr.mood == CityResident.Mood.Happy) { ++happy; }
-					if (cr.mood == CityResident.Mood.Unhappy) { ++unhappy; }
-				}
-
-				if (unhappy > happy) {
+				City.Mood cityMood = city.RecalculateCitizenMoods(gDA.gameData);
+				if (cityMood == City.Mood.Unhappy) {
 					popupOverlay.ShowPopup(
 						new ConfirmationPopup(
 							$"{city.name} will riot! Are you sure?",

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -442,13 +442,47 @@ public partial class Game : Node2D {
 	}
 
 	private void OnPlayerEndTurn() {
-		if (CurrentState == GameState.PlayerTurn) {
-			log.Information("Ending player turn");
-			EmitSignal(SignalName.TurnEnded);
-			log.Information("Starting computer turn");
-			CurrentState = GameState.ComputerTurn;
-			new MsgEndTurn().send(); // Triggers actual backend processing
+		if (CurrentState != GameState.PlayerTurn) {
+			return;
 		}
+
+		// Prompt the user if they would have a city riot when the turn ended.
+		{
+			using UIGameDataAccess gDA = new();
+			foreach (City city in controller.cities) {
+				if (!controller.isHuman) { continue; }
+
+				city.RecalculateCitizenMoods(gDA.gameData);
+				int happy = 0;
+				int unhappy = 0;
+				foreach (CityResident cr in city.residents) {
+					if (cr.mood == CityResident.Mood.Happy) { ++happy; }
+					if (cr.mood == CityResident.Mood.Unhappy) { ++unhappy; }
+				}
+
+				if (unhappy > happy) {
+					popupOverlay.ShowPopup(
+						new ConfirmationPopup(
+							$"{city.name} will riot! Are you sure?",
+							"Yes, let them riot!",
+							"No. Maybe you are right, advisor.",
+							() => {
+								DoActualEndTurn();
+							}),
+						PopupOverlay.PopupCategory.Advisor);
+					return;
+				}
+			}
+		}
+		DoActualEndTurn();
+	}
+
+	private void DoActualEndTurn() {
+		log.Information("Ending player turn");
+		EmitSignal(SignalName.TurnEnded);
+		log.Information("Starting computer turn");
+		CurrentState = GameState.ComputerTurn;
+		new MsgEndTurn().send(); // Triggers actual backend processing
 	}
 
 	public void _on_QuitButton_pressed() {

--- a/C7/Map/CityScene.cs
+++ b/C7/Map/CityScene.cs
@@ -2,6 +2,7 @@ using C7GameData;
 using ConvertCiv3Media;
 using Godot;
 using Serilog;
+using System;
 
 namespace C7.Map {
 	public partial class CityScene : Node2D {
@@ -12,9 +13,12 @@ namespace C7.Map {
 		private ImageTexture cityTexture;
 		private TextureRect cityGraphics = new TextureRect();
 		private CityLabelScene cityLabelScene;
+		private AnimatedSprite2D disorderSprite;
+		private City city;
 
 		public CityScene(City city, Vector2I tileCenter) {
 			cityLabelScene = new CityLabelScene(city, tileCenter);
+			this.city = city;
 
 			//TODO: Generalize, support multiple city types, etc.
 			Pcx pcx = TextureLoader.LoadPCX("Art/Cities/rMIDEAST.PCX");
@@ -30,11 +34,26 @@ namespace C7.Map {
 
 			AddChild(cityGraphics);
 			AddChild(cityLabelScene);
+
+			disorderSprite = new();
+			SpriteFrames frames = new();
+			disorderSprite.SpriteFrames = frames;
+			AnimationManager.loadNonTintedAnimation("Art/Animations/Disorder/DisorderDefault.flc", "disorder", ref frames);
+			disorderSprite.Animation = "disorder";
+			disorderSprite.Position = tileCenter + new Vector2(0, -32);
+			AddChild(disorderSprite);
+			disorderSprite.Play("disorder");
 		}
 
 		public override void _Draw() {
 			base._Draw();
 			cityLabelScene._Draw();
+
+			if (city.isInCivilDisorder) {
+				disorderSprite.Show();
+			} else {
+				disorderSprite.Hide();
+			}
 		}
 	}
 }

--- a/C7/Map/GotoLayer.cs
+++ b/C7/Map/GotoLayer.cs
@@ -40,8 +40,8 @@ public partial class GotoLayer : LooseLayer {
 			gotoCursorSprite = new AnimatedSprite2D();
 			SpriteFrames frames = new SpriteFrames();
 			gotoCursorSprite.SpriteFrames = frames;
-			AnimationManager.loadCursorAnimation("Art/Animations/Cursor/Cursor.flc", ref frames);
-			gotoCursorSprite.Animation = "cursor"; // hardcoded in loadCursorAnimation
+			AnimationManager.loadNonTintedAnimation("Art/Animations/Cursor/Cursor.flc", "cursor", ref frames);
+			gotoCursorSprite.Animation = "cursor";
 
 			gotoLabel = new() {
 				Theme = whiteFontTheme
@@ -49,22 +49,14 @@ public partial class GotoLayer : LooseLayer {
 
 			looseView.AddChild(gotoLabel);
 			looseView.AddChild(gotoCursorSprite);
+			gotoCursorSprite.Play("cursor");
 		}
 
 		gotoLabel.Theme = attackingMove ? redFontTheme : whiteFontTheme;
 		gotoLabel.Text = moves.ToString();
 		Vector2 labelSize = gotoLabelFont.GetStringSize(gotoLabel.Text);
 		gotoLabel.Position = position - labelSize / 2;
-
-		// This logic is copied from UnitLayer.cs
-		const double period = 2.5;
-		double repCount = (double)Time.GetTicksMsec() / 1000.0 / period;
-		float progress = (float)(repCount - Math.Floor(repCount));
 		gotoCursorSprite.Position = position;
-		int frameCount = gotoCursorSprite.SpriteFrames.GetFrameCount("cursor");
-		int nextFrame = (int)((float)frameCount * progress);
-		nextFrame = nextFrame >= frameCount ? frameCount - 1 : (nextFrame < 0 ? 0 : nextFrame);
-		gotoCursorSprite.Frame = nextFrame;
 
 		// Now that we're positioned our objects, we can display them again.
 		gotoCursorSprite.Show();

--- a/C7/Map/UnitLayer.cs
+++ b/C7/Map/UnitLayer.cs
@@ -170,19 +170,13 @@ public partial class UnitLayer : LooseLayer {
 			cursorSprite = new AnimatedSprite2D();
 			SpriteFrames frames = new SpriteFrames();
 			cursorSprite.SpriteFrames = frames;
-			AnimationManager.loadCursorAnimation("Art/Animations/Cursor/Cursor.flc", ref frames);
-			cursorSprite.Animation = "cursor"; // hardcoded in loadCursorAnimation
+			AnimationManager.loadNonTintedAnimation("Art/Animations/Cursor/Cursor.flc", "cursor", ref frames);
+			cursorSprite.Animation = "cursor";
 			looseView.AddChild(cursorSprite);
+			cursorSprite.Play("cursor");
 		}
 
-		const double period = 2.5; // TODO: Just eyeballing this for now. Read the actual period from the INI or something.
-		double repCount = (double)Time.GetTicksMsec() / 1000.0 / period;
-		float progress = (float)(repCount - Math.Floor(repCount));
 		cursorSprite.Position = position;
-		int frameCount = cursorSprite.SpriteFrames.GetFrameCount("cursor");
-		int nextFrame = (int)((float)frameCount * progress);
-		nextFrame = nextFrame >= frameCount ? frameCount - 1 : (nextFrame < 0 ? 0 : nextFrame);
-		cursorSprite.Frame = nextFrame;
 		cursorSprite.Show();
 	}
 

--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -141,13 +141,6 @@ public partial class CityScreen : Control {
 		}
 	}
 
-	// Returns a list of specialists that this player can use.
-	private List<CitizenType> GetKnownSpecialists(Player player) {
-		return citizenTypes.FindAll(x => {
-			return !x.IsDefaultCitizen && (x.PrerequisiteTech == null || player.knownTechs.Contains(x.PrerequisiteTech));
-		});
-	}
-
 	private void HandleReassignment(Tile tile) {
 		City city = tileAssignmentLayer.city;
 
@@ -172,7 +165,7 @@ public partial class CityScreen : Control {
 			CityResident resident = tile.personWorkingTile;
 			tile.personWorkingTile = null;
 			resident.tileWorked = Tile.NONE;
-			resident.citizenType = GetKnownSpecialists(city.owner)[0];
+			resident.citizenType = city.owner.GetKnownSpecialists()[0];
 			return;
 		}
 
@@ -202,7 +195,8 @@ public partial class CityScreen : Control {
 		}
 
 		// If we've clicked the city center, re-assign all the citizens using
-		// the basic AI.
+		// the basic AI, but specify that we want to manage moods by using
+		// entertainers if necessary.
 		//
 		// TODO: This throws away existing nationalities, fix that.
 		if (tile.cityAtTile == city) {
@@ -216,7 +210,7 @@ public partial class CityScreen : Control {
 					city = city
 				};
 				city.AddCitizen(newResident);
-				CityTileAssignmentAI.AssignNewCitizenToTile(newResident);
+				CityTileAssignmentAI.AssignNewCitizenToTile(newResident, manageMoods: true);
 			}
 		}
 	}
@@ -471,12 +465,15 @@ public partial class CityScreen : Control {
 			tb.TextureNormal = PopHeads.GetPopHead(cr, eraNum);
 			tb.SetPosition(new Vector2(xPos, 440));
 
-			List<CitizenType> specialistTypes = GetKnownSpecialists(city.owner);
+			List<CitizenType> specialistTypes = city.owner.GetKnownSpecialists();
 			int index = specialistTypes.FindIndex(x => x.Id == cr.citizenType.Id);
 			tb.Pressed += () => {
 				cr.citizenType = specialistTypes[(index + 1) % specialistTypes.Count];
 				++index;
 				RenderPopHeads(city);
+
+				using UIGameDataAccess gDa = new();
+				RenderCommerceDetails(city);
 			};
 
 			background.AddChild(tb);

--- a/C7Engine/AI/CityTileAssignmentAI.cs
+++ b/C7Engine/AI/CityTileAssignmentAI.cs
@@ -48,9 +48,9 @@ namespace C7Engine.AI {
 
 			// Check to see if this citizen working a tile would cause the city
 			// to be unhappy. If so, make them an entertainer.
-			city.RecalculateCitizenMoods(EngineStorage.gameData);
+			City.Mood cityMood = city.RecalculateCitizenMoods(EngineStorage.gameData);
 
-			if (city.isCityUnhappy() && manageMoods) {
+			if (cityMood == City.Mood.Unhappy && manageMoods) {
 				newResident.citizenType = city.owner.GetKnownSpecialists().MaxBy(x => x.Luxuries);
 				if (newResident.tileWorked != Tile.NONE) {
 					newResident.tileWorked = Tile.NONE;

--- a/C7Engine/AI/CityTileAssignmentAI.cs
+++ b/C7Engine/AI/CityTileAssignmentAI.cs
@@ -1,5 +1,6 @@
 using System;
 using C7GameData;
+using System.Linq;
 using Serilog;
 
 namespace C7Engine.AI {
@@ -15,7 +16,7 @@ namespace C7Engine.AI {
 		private static ILogger log = Log.ForContext<CityTileAssignmentAI>();
 
 		// Assigns a citizen, which is alredy part of a city, to a tile, if possible.
-		public static void AssignNewCitizenToTile(CityResident newResident) {
+		public static void AssignNewCitizenToTile(CityResident newResident, bool manageMoods = false) {
 			City city = newResident.city;
 			int foodYield = city.CurrentFoodYield();
 
@@ -38,10 +39,24 @@ namespace C7Engine.AI {
 			string yield = city.location.YieldString(city.owner);
 			log.Information($"Assigning new citizen of {city.name} to tile {preferredTile} with yield {yield}");
 
-			// TODO: if the preferred tile is NONE we should make them an
-			// entertainer.
-			newResident.tileWorked = preferredTile;
-			preferredTile.personWorkingTile = newResident;
+			if (preferredTile == Tile.NONE) {
+				newResident.citizenType = city.owner.GetKnownSpecialists()[0];
+			} else {
+				newResident.tileWorked = preferredTile;
+				preferredTile.personWorkingTile = newResident;
+			}
+
+			// Check to see if this citizen working a tile would cause the city
+			// to be unhappy. If so, make them an entertainer.
+			city.RecalculateCitizenMoods(EngineStorage.gameData);
+
+			if (city.isCityUnhappy() && manageMoods) {
+				newResident.citizenType = city.owner.GetKnownSpecialists().MaxBy(x => x.Luxuries);
+				if (newResident.tileWorked != Tile.NONE) {
+					newResident.tileWorked = Tile.NONE;
+					preferredTile.personWorkingTile = null;
+				}
+			}
 		}
 
 		public static double CalculateTileYieldScore(Tile t, int targetFoodAmount, Player player) {

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -26,6 +26,25 @@ namespace C7Engine {
 			stopwatch.Start();
 			log.Information("-> Begin " + player.civilization.cityNames[0] + " turn");
 
+			MaybeDoPriorityReevaluation(player);
+			MaybePickTechToResearch(player, techs);
+
+			// Roughly every 4 turns, see if there are trades to be made.
+			if (GameData.rng.Next(100) < 25) {
+				AttemptTrading(player);
+			}
+
+			DoUnitActions(player);
+
+			// Before ending the turn, adjust our sliders. We do this after unit
+			// moves so that any worker moves that finished during the unit moves
+			// will be usable (like if a luxury got hooked up).
+			AdjustSliders(player);
+
+			log.Information("-> End " + player.civilization.cityNames[0] + $" turn {stopwatch.ElapsedMilliseconds} milliseconds");
+		}
+
+		private static void MaybeDoPriorityReevaluation(Player player) {
 			if (player.turnsUntilPriorityReevaluation == 0) {
 				log.Information("Re-evaluating strategic priorities for " + player);
 				List<StrategicPriority> priorities = StrategicPriorityArbitrator.Arbitrate(player);
@@ -46,7 +65,9 @@ namespace C7Engine {
 			} else {
 				player.turnsUntilPriorityReevaluation--;
 			}
+		}
 
+		private static void MaybePickTechToResearch(Player player, List<Tech> techs) {
 			if (player.currentlyResearchedTech == null) {
 				Tech toResearch = PickTechToResearch(player, techs);
 				if (toResearch == null) {
@@ -57,12 +78,9 @@ namespace C7Engine {
 					player.SetCurrentlyResearchedTech(toResearch.id);
 				}
 			}
+		}
 
-			// Roughly every 4 turns, see if there are trades to be made.
-			if (GameData.rng.Next(100) < 25) {
-				AttemptTrading(player);
-			}
-
+		private static void DoUnitActions(Player player) {
 			// Reorder the list so that settlers are last, giving our escorts a
 			// chance to configure themselves without wasting a turn.
 			player.units.Sort((x, y) => (x.unitType.name == "Settler").CompareTo(y.unitType.name == "Settler"));
@@ -125,8 +143,6 @@ namespace C7Engine {
 
 				player.tileKnowledge.AddTilesToKnown(unit.location);
 			}
-
-			log.Information("-> End " + player.civilization.cityNames[0] + $" turn {stopwatch.ElapsedMilliseconds} milliseconds");
 		}
 
 		public static UnitAI GetAIForUnit(MapUnit unit, Player player) {
@@ -376,6 +392,70 @@ namespace C7Engine {
 					continue;
 				}
 				us.ExecuteDeal(gD, them, weWant, weGive);
+			}
+		}
+
+		private static void AdjustSliders(Player player) {
+			const int MAX_SLIDER_VALUE = 10;
+			const int MAX_AI_LUXURY_SLIDER = 5;
+
+			// Start by zeroing out the sliders.
+			player.luxuryRate = 0;
+			player.scienceRate = 0;
+			player.taxRate = 0;
+
+			// Increase the luxury slider until only a small handful of cities
+			// are unhappy (sometimes making all cities happy with the luxury
+			// slider is too expensive and it's easier to just use entertainers
+			// there).
+			while (MostCitiesUnhappy(player) && player.luxuryRate < MAX_AI_LUXURY_SLIDER) {
+				++player.luxuryRate;
+			}
+
+			// Fix up any remaining unhappy cities.
+			FixRemainingUnhappyCities(player);
+
+			// Now max out the science slider and then decrease it (increasing
+			// the tax rate) until we're not losing money.
+			player.scienceRate = MAX_SLIDER_VALUE - player.luxuryRate;
+			while (player.CalculateGoldPerTurn() < 0 && player.scienceRate > 0) {
+				player.scienceRate--;
+				player.taxRate++;
+			}
+
+			log.Information($"{player} slider values: Science: {player.scienceRate}, Luxury: {player.luxuryRate}, Tax: {player.taxRate}");
+		}
+
+		// Returns true if more than 10% of the player's cities are unhappy with
+		// current settings.
+		private static bool MostCitiesUnhappy(Player player) {
+			int unhappyCities = 0;
+			foreach (City city in player.cities) {
+				city.RecalculateCitizenMoods(EngineStorage.gameData);
+				if (city.isCityUnhappy()) {
+					++unhappyCities;
+				}
+			}
+			return unhappyCities / (double)player.cities.Count > .1;
+		}
+
+		// In each city, reassign citizens, managing moods, to ensure that we
+		// don't have any cities that will riot.
+		private static void FixRemainingUnhappyCities(Player player) {
+			foreach (City city in player.cities) {
+				// TODO: This throws away existing nationalities, fix that.
+				int numResidents = city.residents.Count;
+				city.RemoveAllCitizens();
+
+				for (int i = 0; i < numResidents; ++i) {
+					CityResident newResident = new() {
+						citizenType = EngineStorage.gameData.citizenTypes.Find(x => x.IsDefaultCitizen),
+						nationality = city.owner.civilization,
+						city = city
+					};
+					city.AddCitizen(newResident);
+					CityTileAssignmentAI.AssignNewCitizenToTile(newResident, manageMoods: true);
+				}
 			}
 		}
 	}

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -431,8 +431,8 @@ namespace C7Engine {
 		private static bool MostCitiesUnhappy(Player player) {
 			int unhappyCities = 0;
 			foreach (City city in player.cities) {
-				city.RecalculateCitizenMoods(EngineStorage.gameData);
-				if (city.isCityUnhappy()) {
+				City.Mood cityMood = city.RecalculateCitizenMoods(EngineStorage.gameData);
+				if (cityMood == City.Mood.Unhappy) {
 					++unhappyCities;
 				}
 			}

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -38,6 +38,8 @@ namespace C7GameData {
 	}
 
 	public class City {
+		private static ILogger log = Log.ForContext<City>();
+
 		public ID id { get; set; }
 		public Tile location { get; internal set; }
 		public string name;
@@ -69,6 +71,8 @@ namespace C7GameData {
 		// pop rushing. Larger values result in larger numbers of citizens being
 		// unhappy as well, in addition to the time penalty.
 		public int turnsOfUnhappinessDueToPopRushing = 0;
+
+		public bool isInCivilDisorder = false;
 
 		public static City NONE = new City(Tile.NONE, null, "Dummy City", ID.None("city"));
 
@@ -158,6 +162,10 @@ namespace C7GameData {
 		public HurryProductionDetails GetHurryProductionDetails() {
 			Rules rules = EngineStorage.gameData.rules;
 			int shieldCost = ShieldCostForHurrying();
+
+			if (isInCivilDisorder) {
+				return new HurryProductionDetails() { errorMessage = "The city is in disorder and cannot hurry production." };
+			}
 
 			switch (owner.government.hurryingType) {
 				case Government.HurryProductionType.CannotHurry:
@@ -266,12 +274,15 @@ namespace C7GameData {
 			// useful production is available. We do this here rather than 
 			// setting corruption to 100% because CorruptableValue would give us
 			// one useful commerce in that situation.
-			if (owner.government.transitionType) {
+			//
+			// The same is true for civil disorder.
+			if (owner.government.transitionType || isInCivilDisorder) {
 				result.useful = 0;
 				result.corrupt = yield;
 			}
 
-			// TODO: add specialist shields here.
+			// TODO: add specialist shields here. Do specialists still work in
+			// civil disorder?
 
 			return result;
 		}
@@ -287,18 +298,25 @@ namespace C7GameData {
 			// useful commerce is available. We do this here rather than setting
 			// corruption to 100% because CorruptableValue would give us one
 			// useful commerce in that situation.
+			//
+			// The same is true in civil disorder.
 			CorruptableValue commerce = new CorruptableValue(uncorruptedCommerce, corruption);
-			if (owner.government.transitionType) {
+			if (owner.government.transitionType || isInCivilDisorder) {
 				commerce.useful = 0;
 				commerce.corrupt = uncorruptedCommerce;
 			}
 
-			// TODO: Add specialist income, which is unaffected by corruption.
 			CommerceBreakdown result = new();
 			result.corrupted = commerce.corrupt;
 			result.beakers = (int)Math.Floor(commerce.useful * owner.scienceRate / 10.0);
 			result.happiness = (int)Math.Floor(commerce.useful * owner.luxuryRate / 10.0);
 			result.taxes = commerce.useful - result.beakers - result.happiness;
+
+			foreach (CityResident cr in residents) {
+				result.beakers += cr.citizenType.Research;
+				result.happiness += cr.citizenType.Luxuries;
+				result.taxes += cr.citizenType.Taxes;
+			}
 
 			return result;
 		}
@@ -606,7 +624,7 @@ namespace C7GameData {
 		//  - https://forums.civfanatics.com/threads/how-is-happiness-calculated.74966/
 		//  - https://codehappy.net/apolyton/threads/83368-1.htm
 		//
-		public void RecalculateCitizenMoods(GameData gameData) {
+		public void RecalculateCitizenMoods(GameData gameData, bool goIntoDisorderIfUnhappy = false) {
 			CityResident.Mood happy = CityResident.Mood.Happy;
 			CityResident.Mood content = CityResident.Mood.Content;
 			CityResident.Mood unhappy = CityResident.Mood.Unhappy;
@@ -703,6 +721,24 @@ namespace C7GameData {
 					ApplyMoodChange(sadPoints, content, unhappy);
 				}
 			}
+
+			if (goIntoDisorderIfUnhappy) {
+				isInCivilDisorder = isCityUnhappy();
+				if (isInCivilDisorder) {
+					log.Information($"City {this} for player {owner} is in civil disorder.");
+				}
+			}
+		}
+
+		// Required: RecalculateCitizenMoods must be called first.
+		public bool isCityUnhappy() {
+			int happyCount = 0;
+			int unhappyCount = 0;
+			foreach (CityResident cr in residents) {
+				if (cr.mood == CityResident.Mood.Happy) { ++happyCount; }
+				if (cr.mood == CityResident.Mood.Unhappy) { ++unhappyCount; }
+			}
+			return unhappyCount > 0 && unhappyCount > happyCount;
 		}
 
 		private Dictionary<Resource, int> ListResourceAccess(ResourceCategory category) {

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -617,6 +617,11 @@ namespace C7GameData {
 			ApplyMoodChange(contentToHappyMoves, unhappy, content);
 		}
 
+		public enum Mood {
+			Unhappy,
+			Happy
+		};
+
 		// This function does the heavy lifting of happiness calculations,
 		// combining the various bonuses and penalties that affect citizen moods.
 		//
@@ -624,7 +629,7 @@ namespace C7GameData {
 		//  - https://forums.civfanatics.com/threads/how-is-happiness-calculated.74966/
 		//  - https://codehappy.net/apolyton/threads/83368-1.htm
 		//
-		public void RecalculateCitizenMoods(GameData gameData, bool goIntoDisorderIfUnhappy = false) {
+		public Mood RecalculateCitizenMoods(GameData gameData) {
 			CityResident.Mood happy = CityResident.Mood.Happy;
 			CityResident.Mood content = CityResident.Mood.Content;
 			CityResident.Mood unhappy = CityResident.Mood.Unhappy;
@@ -722,23 +727,17 @@ namespace C7GameData {
 				}
 			}
 
-			if (goIntoDisorderIfUnhappy) {
-				isInCivilDisorder = isCityUnhappy();
-				if (isInCivilDisorder) {
-					log.Information($"City {this} for player {owner} is in civil disorder.");
-				}
-			}
-		}
-
-		// Required: RecalculateCitizenMoods must be called first.
-		public bool isCityUnhappy() {
 			int happyCount = 0;
 			int unhappyCount = 0;
 			foreach (CityResident cr in residents) {
 				if (cr.mood == CityResident.Mood.Happy) { ++happyCount; }
 				if (cr.mood == CityResident.Mood.Unhappy) { ++unhappyCount; }
 			}
-			return unhappyCount > 0 && unhappyCount > happyCount;
+			if (unhappyCount > 0 && unhappyCount > happyCount) {
+				return Mood.Unhappy;
+			} else {
+				return Mood.Happy;
+			}
 		}
 
 		private Dictionary<Resource, int> ListResourceAccess(ResourceCategory category) {

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -654,10 +654,17 @@ namespace C7GameData {
 			}
 		}
 
-		public void RecalculateCitizenMoods(GameData gameData) {
+		public void RecalculateCitizenMoods(GameData gameData, bool goIntoDisorderIfUnhappy = false) {
 			foreach (City c in cities) {
-				c.RecalculateCitizenMoods(gameData);
+				c.RecalculateCitizenMoods(gameData, goIntoDisorderIfUnhappy);
 			}
+		}
+
+		// Returns a list of specialists that this player can use.
+		public List<CitizenType> GetKnownSpecialists() {
+			return C7Engine.EngineStorage.gameData.citizenTypes.FindAll(x => {
+				return !x.IsDefaultCitizen && (x.PrerequisiteTech == null || knownTechs.Contains(x.PrerequisiteTech));
+			});
 		}
 
 		public void UpdateResourcesInBorders(IEnumerable<Tile> ownedTiles) {

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -656,7 +656,10 @@ namespace C7GameData {
 
 		public void RecalculateCitizenMoods(GameData gameData, bool goIntoDisorderIfUnhappy = false) {
 			foreach (City c in cities) {
-				c.RecalculateCitizenMoods(gameData, goIntoDisorderIfUnhappy);
+				City.Mood cityMood = c.RecalculateCitizenMoods(gameData);
+				if (cityMood == City.Mood.Unhappy && goIntoDisorderIfUnhappy) {
+					c.isInCivilDisorder = true;
+				}
 			}
 		}
 

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -40,7 +40,7 @@ namespace C7Engine {
 
 				gameData.turn++;
 				foreach (Player player in gameData.players) {
-					player.RecalculateCitizenMoods(gameData);
+					player.RecalculateCitizenMoods(gameData, goIntoDisorderIfUnhappy: true);
 					player.DoCorruptionCalculations(gameData);
 
 					// Note that we do growth after calculating citizen moods,


### PR DESCRIPTION
This requires a number of things:
 - The AI needs to know how to use the luxury slider (it seems like the AI doesn't usually do this in civ3, but a crude algorithm for this is pretty easy)
 - Entertainers need to be functional
 - We need to be able to reassign citizens so that moods are dealt with

I also significantly simplified how we dealt with some types of animated sprites - we can just call `Play()` instead of doing the frame math ourselves.

Size 3 warning: 
![image](https://github.com/user-attachments/assets/60543617-6c71-4134-89e4-944797f6f0d0)

After ignoring it: 
![image](https://github.com/user-attachments/assets/2fdf8a81-a5c1-42e4-8c68-5b6045571bf2)

Fixing via entertainer: 
![image](https://github.com/user-attachments/assets/f6748fba-ce6e-43f0-9724-ff3a38412cbc)
![image](https://github.com/user-attachments/assets/cfaf73f9-910a-4179-8b47-3893df7ce33d)

Fixing via luxury slider:
![image](https://github.com/user-attachments/assets/67914d6b-1f88-47ff-8e2e-2c5f3e01f855)
