### PR TITLE
Handle more food details - city size caps and adjusted growth rates 

### DIFF
--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -67462,7 +67462,10 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "iconRowIndex": 8
+      "iconRowIndex": 8,
+      "flags": [
+        "allowsCitySize2"
+      ]
     },
     {
       "name": "Bank",
@@ -67602,7 +67605,10 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "iconRowIndex": 19
+      "iconRowIndex": 19,
+      "flags": [
+        "allowsCitySize3"
+      ]
     },
     {
       "name": "Research Lab",
@@ -67869,7 +67875,10 @@
       "isSmallWonder": false,
       "culturePerTurn": 8,
       "contentFacesInCity": 8,
-      "iconRowIndex": 41
+      "iconRowIndex": 41,
+      "flags": [
+        "allowsCitySize3"
+      ]
     },
     {
       "name": "Leonardo\u0027s Workshop",
@@ -70399,7 +70408,12 @@
     "minimumResearchTime": 4,
     "shieldValueInGold": 4,
     "citizenValueInShields": 20,
-    "turnPenaltyForEachHurrySacrifice": 20
+    "turnPenaltyForEachHurrySacrifice": 20,
+    "maximumLevel1CitySize": 6,
+    "maximumLevel2CitySize": 12,
+    "foodNeededToGrowForLevel1Cities": 20,
+    "foodNeededToGrowForLevel2Cities": 40,
+    "foodNeededToGrowForLevel3Cities": 60
   },
   "techs": [
     {

--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -304,7 +304,17 @@ public partial class CityScreen : Control {
 	}
 
 	private void RenderFoodDetails(City city) {
-		foodDetails.Text = $"{city.CurrentFoodYield()} food/turn, {city.FoodGrowthPerTurn()} surplus. {city.foodStored} stored. Growth in {city.TurnsUntilGrowth()} turns.";
+		string growthStr;
+		int turnsUntilGrowth = city.TurnsUntilGrowth();
+		if (turnsUntilGrowth == int.MaxValue) {
+			growthStr = "Not growing.";
+		} else if (turnsUntilGrowth == int.MinValue) {
+			growthStr = "Starving!";
+		} else {
+			growthStr = $"Growth in {turnsUntilGrowth} turns.";
+		}
+
+		foodDetails.Text = $"{city.CurrentFoodYield()} food/turn, {city.FoodGrowthPerTurn()} surplus. {city.foodStored} stored. {growthStr}";
 	}
 
 	private void RenderCommerceDetails(City city) {

--- a/C7Engine/C7GameData/Building.cs
+++ b/C7Engine/C7GameData/Building.cs
@@ -79,6 +79,8 @@ namespace C7GameData {
 		public bool increasesLuxuryTrade;
 		public bool reducesCorruption;
 		public bool isForbiddenPalace;
+		public bool allowsCitySize2;
+		public bool allowsCitySize3;
 
 		public int culturePerTurn = 0;
 
@@ -115,6 +117,8 @@ namespace C7GameData {
 			increasesLuxuryTrade = building.flags.Contains(SaveBuilding.Flag.IncreasesLuxuryTrade);
 			reducesCorruption = building.flags.Contains(SaveBuilding.Flag.ReducesCorruption);
 			isForbiddenPalace = building.flags.Contains(SaveBuilding.Flag.ForbiddenPalace);
+			allowsCitySize2 = building.flags.Contains(SaveBuilding.Flag.AllowsCitySize2);
+			allowsCitySize3 = building.flags.Contains(SaveBuilding.Flag.AllowsCitySize3);
 			dataSource = building;
 
 			foreach (var kvp in BuildingRules.productionRules) {

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -50,7 +50,6 @@ namespace C7GameData {
 		public int shieldsStored = 0;
 
 		public int foodStored = 0;
-		public int foodNeededToGrow = 20;
 
 		public bool capital = false;
 		public Player owner { get; set; }
@@ -113,13 +112,29 @@ namespace C7GameData {
 						.ToHashSet();
 		}
 
-		public int TurnsUntilGrowth() {
-			if (FoodGrowthPerTurn() == 0) {
-				return int.MaxValue;
+		public int FoodNeededToGrow() {
+			Rules rules = owner.rules;
+			if (residents.Count <= rules.MaximumLevel1CitySize) {
+				return rules.FoodNeededToGrowForLevel1Cities;
+			} else if (residents.Count <= rules.MaximumLevel2CitySize) {
+				return rules.FoodNeededToGrowForLevel2Cities;
+			} else {
+				return rules.FoodNeededToGrowForLevel3Cities;
 			}
+		}
+
+		public int TurnsUntilGrowth() {
+			int foodGrowthPerTurn = FoodGrowthPerTurn();
+			int foodNeededToGrow = FoodNeededToGrow();
+			if (foodGrowthPerTurn == 0 || foodStored > foodNeededToGrow) {
+				return int.MaxValue;
+			} else if (foodGrowthPerTurn < 0) {
+				return int.MinValue;
+			}
+
 			int additionalFoodNeeded = foodNeededToGrow - foodStored;
-			int turnsRoundedDown = additionalFoodNeeded / FoodGrowthPerTurn();
-			if (additionalFoodNeeded % FoodGrowthPerTurn() != 0) {
+			int turnsRoundedDown = additionalFoodNeeded / foodGrowthPerTurn;
+			if (additionalFoodNeeded % foodGrowthPerTurn != 0) {
 				return turnsRoundedDown + 1;
 			}
 			return turnsRoundedDown;
@@ -222,8 +237,27 @@ namespace C7GameData {
 		}
 
 		public void HandleCityGrowth(GameData gameData) {
+			// Ensure borders expand before we assign the new citizen, so that
+			// the new citizen can go on one of our new tiles.
+			if (UpdateCultureAndCheckForExpansion()) {
+				gameData.UpdateTileOwners();
+			}
+
 			foodStored += FoodGrowthPerTurn();
-			if (foodStored >= foodNeededToGrow) {
+
+			// Handle the city starving.
+			if (foodStored < 0) {
+				RemoveCitizen();
+				foodStored = 0;
+				return;
+			}
+
+			// No growth necessary.
+			if (foodStored < FoodNeededToGrow()) {
+				return;
+			}
+
+			if (CanGrowPopulationByOne(gameData)) {
 				CityResident newResident = new CityResident();
 				newResident.nationality = owner.civilization;
 				newResident.city = this;
@@ -232,10 +266,47 @@ namespace C7GameData {
 				C7Engine.AI.CityTileAssignmentAI.AssignNewCitizenToTile(newResident);
 
 				foodStored = 0;
-			} else if (foodStored < 0) {
-				RemoveCitizen();
-				foodStored = 0;
 			}
+		}
+
+		private bool CanGrowPopulationByOne(GameData gD) {
+			// We can always grow up to size 6.
+			if (residents.Count + 1 <= gD.rules.MaximumLevel1CitySize) {
+				return true;
+			}
+
+			// If the city doesn't have fresh water and doesn't have an aqueduct
+			// then it can't grow into a city.
+			//
+			// TODO: lakes are bodies of water under 20 tiles (https://civilization.fandom.com/wiki/Fresh_Water_Lake_(Civ3))
+			bool hasFreshwaterAccess = location.BordersRiver();
+			bool canGrowIntoCity = hasFreshwaterAccess;
+			if (!hasFreshwaterAccess) {
+				foreach (CityBuilding cb in buildings) {
+					if (cb.building.allowsCitySize2 || cb.building.allowsCitySize3) {
+						canGrowIntoCity = true;
+						break;
+					}
+				}
+			}
+
+			if (!canGrowIntoCity) {
+				return false;
+			}
+
+			// With fresh water or an aqueduct we can grow to size 2.
+			if (residents.Count + 1 <= gD.rules.MaximumLevel2CitySize) {
+				return true;
+			}
+
+			// If we're a city trying to grow into a metropolis, we need a
+			// hospital.
+			foreach (CityBuilding cb in buildings) {
+				if (cb.building.allowsCitySize3) {
+					return true;
+				}
+			}
+			return false;
 		}
 
 		/**

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -237,12 +237,6 @@ namespace C7GameData {
 		}
 
 		public void HandleCityGrowth(GameData gameData) {
-			// Ensure borders expand before we assign the new citizen, so that
-			// the new citizen can go on one of our new tiles.
-			if (UpdateCultureAndCheckForExpansion()) {
-				gameData.UpdateTileOwners();
-			}
-
 			foodStored += FoodGrowthPerTurn();
 
 			// Handle the city starving.

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -571,7 +571,6 @@ namespace C7GameData {
 					shieldsStored = city.ShieldsCollected,
 					foodStored = city.TotalFood,
 					buildings = ImportCityBuildingsFromSav(i),
-					foodNeededToGrow = 20, // HACK: don't know where to find this
 					turnsOfUnhappinessDueToPopRushing = city.TurnsOfUnhappinessDueToPopRushing,
 				};
 
@@ -682,7 +681,6 @@ namespace C7GameData {
 					buildings = ImportCityBuildingsFromBiq(cityIndex, player.id),
 					shieldsStored = 0,
 					foodStored = 0,
-					foodNeededToGrow = 20, // HACK: don't know where to find this
 				};
 				saveCity.perPlayerCulture.Add(player.id.ToString(), city.Culture);
 
@@ -938,7 +936,9 @@ namespace C7GameData {
 				(bldg.ForbiddenPalace, SaveBuilding.Flag.ForbiddenPalace),
 				(bldg.IncreasesShieldsInWater, SaveBuilding.Flag.IncreasesShieldsInWater),
 				(bldg.IncreasesFoodInWater, SaveBuilding.Flag.IncreasesFoodInWater),
-				(bldg.IncreasesTradeInWater, SaveBuilding.Flag.IncreasesTradeInWater)
+				(bldg.IncreasesTradeInWater, SaveBuilding.Flag.IncreasesTradeInWater),
+				(bldg.AllowsCitySize2, SaveBuilding.Flag.AllowsCitySize2),
+				(bldg.AllowsCitySize3, SaveBuilding.Flag.AllowsCitySize3),
 			}
 			.Where(t => t.Item1)
 			.Select(t => t.Item2);
@@ -1235,6 +1235,8 @@ namespace C7GameData {
 
 			save.Rules.MaximumResearchTime = rule.MaximumResearchTime;
 			save.Rules.MinimumResearchTime = rule.MinimumResearchTime;
+			save.Rules.MaximumLevel1CitySize = rule.MaximumLevel1CitySize;
+			save.Rules.MaximumLevel2CitySize = rule.MaximumLevel2CitySize;
 			save.Rules.ShieldValueInGold = rule.ShieldValueInGold;
 			save.Rules.CitizenValueInShields = rule.CitizenValueInShields;
 			save.Rules.TurnPenaltyForEachHurrySacrifice = rule.TurnPenaltyForEachHurrySacrifice;

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -504,8 +504,14 @@ namespace C7GameData {
 			gold += CalculateGoldPerTurn();
 		}
 
-		public void HandleCityGrowth(GameData gameData) {
+		public void HandleCityUpdates(GameData gameData) {
 			foreach (City c in cities) {
+				// Ensure borders expand before we assign the new citizen, so that
+				// the new citizen can go on one of our new tiles.
+				if (c.UpdateCultureAndCheckForExpansion()) {
+					gameData.UpdateTileOwners();
+				}
+
 				c.HandleCityGrowth(gameData);
 			}
 		}

--- a/C7Engine/C7GameData/Rules.cs
+++ b/C7Engine/C7GameData/Rules.cs
@@ -5,5 +5,10 @@ namespace C7GameData {
 		public int ShieldValueInGold;
 		public int CitizenValueInShields;
 		public int TurnPenaltyForEachHurrySacrifice;
+		public int MaximumLevel1CitySize;
+		public int MaximumLevel2CitySize;
+		public int FoodNeededToGrowForLevel1Cities = 20;
+		public int FoodNeededToGrowForLevel2Cities = 40;
+		public int FoodNeededToGrowForLevel3Cities = 60;
 	}
 }

--- a/C7Engine/C7GameData/Save/SaveBuilding.cs
+++ b/C7Engine/C7GameData/Save/SaveBuilding.cs
@@ -15,6 +15,8 @@ namespace C7GameData.Save {
 			IncreasesShieldsInWater,
 			IncreasesFoodInWater,
 			IncreasesTradeInWater,
+			AllowsCitySize2,
+			AllowsCitySize3,
 		}
 		public string name;
 		public int shieldCost;

--- a/C7Engine/C7GameData/Save/SaveCity.cs
+++ b/C7Engine/C7GameData/Save/SaveCity.cs
@@ -49,7 +49,6 @@ namespace C7GameData.Save {
 		public Dictionary<string, int> perPlayerCulture = new();
 		public int shieldsStored;
 		public int foodStored;
-		public int foodNeededToGrow;
 		public int turnsOfUnhappinessDueToPopRushing;
 		public List<SaveCityResident> residents = new List<SaveCityResident>();
 		public List<SaveCityBuilding> buildings = [];
@@ -69,7 +68,6 @@ namespace C7GameData.Save {
 			};
 			shieldsStored = city.shieldsStored;
 			foodStored = city.foodStored;
-			foodNeededToGrow = city.foodNeededToGrow;
 			turnsOfUnhappinessDueToPopRushing = city.turnsOfUnhappinessDueToPopRushing;
 			residents = city.residents.ConvertAll(resident => {
 				return new SaveCityResident {
@@ -103,7 +101,6 @@ namespace C7GameData.Save {
 				},
 				shieldsStored = shieldsStored,
 				foodStored = foodStored,
-				foodNeededToGrow = foodNeededToGrow,
 				turnsOfUnhappinessDueToPopRushing = turnsOfUnhappinessDueToPopRushing,
 				capital = capital,
 				buildings = this.buildings.ConvertAll(building => building.ToCityBuilding(buildings, players)),

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -46,7 +46,7 @@ namespace C7Engine {
 					// Note that we do growth after calculating citizen moods,
 					// to ensure that the player has a chance to deal with the
 					// unhappiness of a new citizen during their turn.
-					player.HandleCityGrowth(gameData);
+					player.HandleCityUpdates(gameData);
 					HandleCityResults(gameData, player);
 
 					player.DoPerTurnFinanceUpdates(gameData);

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -145,10 +145,6 @@ namespace C7Engine {
 			log.Information($"\n*** City production for turn {gameData.turn}, player {player} ***");
 
 			foreach (City city in player.cities) {
-				if (city.UpdateCultureAndCheckForExpansion()) {
-					gameData.UpdateTileOwners();
-				}
-
 				IProducible producedItem = city.ComputeTurnProduction();
 				if (producedItem != null) {
 					log.Debug($"Produced {producedItem} in {city}");

--- a/EngineTests/GameData/CityTest.cs
+++ b/EngineTests/GameData/CityTest.cs
@@ -31,6 +31,7 @@ public class CityTest {
 	public void CityWith2ProductionPerTurn_ShouldReturn1TurnIf19_of_20FoodDone() {
 		Player player = new();
 		player.government = new Government();
+		player.rules = new() { MaximumLevel1CitySize = 6 };
 		TerrainType oneShield = new TerrainType();
 		oneShield.baseShieldProduction = 1;
 		Tile tile = new Tile(ID.None("tile"));


### PR DESCRIPTION
I put the food needed to grow values in the rules as the c# defaults because they don't seem to be present in the editor.
