### PR TITLE
Display luxury icons in the city screen

### DIFF
--- a/C7/Map/ResourceLayer.cs
+++ b/C7/Map/ResourceLayer.cs
@@ -19,7 +19,7 @@ namespace C7.Map {
 				return;
 			}
 
-			var texture = TextureLoader.Load("resources", resource, useCache: true);
+			var texture = TextureLoader.Load("resources.large", resource, useCache: true);
 
 			looseView.DrawTexture(texture, tileCenter - 0.5f * texture.GetSize());
 		}

--- a/C7/Text/TextureConfigs/civ3/resources.lua
+++ b/C7/Text/TextureConfigs/civ3/resources.lua
@@ -1,12 +1,15 @@
 local RESOURCE_SIZE = 50
+local LUXURY_SMALL_SIZE = 22
 
-local resources = {
+local resources = {}
+
+resources.large = {
   extra_data = {
     path = "Art/resources.pcx",
   },
 }
 
-function resources:map_object_to_sprite(resource)
+function resources.large:map_object_to_sprite(resource)
   if resource:GetType().Name ~= "Resource" then
     error "Expected a Resource object"
   end
@@ -18,6 +21,31 @@ function resources:map_object_to_sprite(resource)
   return {
     path = self.extra_data.path,
     crop_region = { col * RESOURCE_SIZE, row * RESOURCE_SIZE, RESOURCE_SIZE, RESOURCE_SIZE },
+    shadows = false,
+  }
+end
+
+resources.small = {
+  extra_data = {
+    path = "Art/city screen/luxuryicons_small.pcx",
+  },
+}
+
+function resources.small:map_object_to_sprite(resource)
+  if resource:GetType().Name ~= "Resource" then
+    error "Expected a Resource object"
+  end
+
+  local icon = resource.Icon
+  local col = icon - 8
+
+  if col < 0 then
+    error "Invalid resource icon index"
+  end
+
+  return {
+    path = self.extra_data.path,
+    crop_region = { col * LUXURY_SMALL_SIZE, 0, LUXURY_SMALL_SIZE, LUXURY_SMALL_SIZE },
     shadows = false,
   }
 end

--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -280,7 +280,7 @@ public partial class CityScreen : Control {
 			VBoxContainer resourceContainer = new();
 			resourceContainer.AddThemeConstantOverride("separation", 0);
 
-			var texture = (ImageTexture)TextureLoader.Load("resources", resource, useCache: true).Duplicate();
+			var texture = (ImageTexture)TextureLoader.Load("resources.large", resource, useCache: true).Duplicate();
 			texture.SetSizeOverride(new(45, 45));
 
 			TextureRect resourceRect = new() {
@@ -313,12 +313,14 @@ public partial class CityScreen : Control {
 				Text = "(" + count.ToString() + ")"
 			};
 
-			Label resourceName = new() {
-				Text = resource.Name
+			var texture = TextureLoader.Load("resources.small", resource, useCache: true);
+
+			TextureRect resourceRect = new() {
+				Texture = texture,
 			};
 
 			resourceContainer.AddChild(resourceCount);
-			resourceContainer.AddChild(resourceName);
+			resourceContainer.AddChild(resourceRect);
 
 			luxuriesContainer.AddChild(resourceContainer);
 		}


### PR DESCRIPTION
This PR adds logic for loading small luxury icons and displaying them in the city screen.

![image](https://github.com/user-attachments/assets/724a02f4-4712-4e2b-b743-c0ef7dc5b126)
