### PR TITLE
city screen: fix the Y offsets of the shields and food 

### DIFF
--- a/C7/UIElements/CityScreen/city_screen.tscn
+++ b/C7/UIElements/CityScreen/city_screen.tscn
@@ -193,9 +193,9 @@ theme_override_constants/separation = 0
 [node name="ProductionLabel" type="Label" parent="HBoxContainer/Background" index="15"]
 layout_mode = 0
 offset_left = 284.0
-offset_top = 511.0
+offset_top = 509.0
 offset_right = 505.0
-offset_bottom = 531.0
+offset_bottom = 529.0
 theme_override_font_sizes/font_size = 12
 text = "PRODUCTION: 10 per turn"
 
@@ -222,9 +222,9 @@ horizontal_alignment = 1
 [node name="FoodLabel" type="Label" parent="HBoxContainer/Background" index="18"]
 layout_mode = 0
 offset_left = 285.0
-offset_top = 559.0
+offset_top = 557.0
 offset_right = 506.0
-offset_bottom = 579.0
+offset_bottom = 577.0
 theme_override_font_sizes/font_size = 12
 text = "FOOD: 3 per turn"
 
@@ -250,8 +250,6 @@ offset_bottom = 761.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="HBoxContainer/Background/CenterContainer2" index="0"]
 layout_mode = 2
-theme_override_constants/h_separation = 0
-theme_override_constants/v_separation = 0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="HBoxContainer/Background/CenterContainer2/VBoxContainer" index="0"]
 layout_mode = 2
@@ -263,7 +261,6 @@ theme_override_constants/v_separation = 0
 columns = 2
 
 [node name="Label" type="Label" parent="HBoxContainer/Background/CenterContainer2/VBoxContainer" index="1"]
-visible = false
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
 text = "GRANARY"
@@ -272,21 +269,21 @@ text = "GRANARY"
 layout_mode = 2
 
 [node name="FoodInGranaryContainer" type="GridContainer" parent="HBoxContainer/Background/CenterContainer2/VBoxContainer/HBoxContainer2" index="0"]
-visible = false
 layout_mode = 2
 theme_override_constants/h_separation = 0
 theme_override_constants/v_separation = 0
+columns = 2
 
 [node name="ShieldRowContainer" type="Control" parent="HBoxContainer/Background" index="21"]
 anchors_preset = 0
 offset_left = 288.0
-offset_top = 527.0
+offset_top = 522.0
 offset_right = 835.0
-offset_bottom = 554.0
+offset_bottom = 549.0
 
 [node name="FoodRowContainer" type="Control" parent="HBoxContainer/Background" index="22"]
 anchors_preset = 0
 offset_left = 287.0
-offset_top = 577.0
+offset_top = 571.0
 offset_right = 767.0
-offset_bottom = 604.0
+offset_bottom = 598.0


### PR DESCRIPTION
This was misaligned for the civ3 textures

Now:

![image](https://github.com/user-attachments/assets/1599ccc5-8c54-403b-a780-52f15a8d2188)
