### PR TITLE
Support great wonders that add buildings to other cities

### DIFF
--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -67748,7 +67748,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
-      "iconRowIndex": 30
+      "iconRowIndex": 30,
+      "buildingGainedInEveryCityOnContinent": "Granary"
     },
     {
       "name": "The Hanging Gardens",
@@ -67826,7 +67827,8 @@
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
       "iconRowIndex": 36,
-      "renderedObsoleteBy": "tech-21"
+      "renderedObsoleteBy": "tech-21",
+      "buildingGainedInEveryCityOnContinent": "Walls"
     },
     {
       "name": "Sun Tzu\u0027s Art of War",
@@ -67837,7 +67839,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
-      "iconRowIndex": 37
+      "iconRowIndex": 37,
+      "buildingGainedInEveryCityOnContinent": "Barracks"
     },
     {
       "name": "Sistine Chapel",
@@ -67954,6 +67957,7 @@
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
       "iconRowIndex": 47,
+      "buildingGainedInEveryCityOnContinent": "Hydro Plant",
       "flags": [
         "mustBeNearRiver"
       ]
@@ -68295,7 +68299,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
-      "iconRowIndex": 74
+      "iconRowIndex": 74,
+      "buildingGainedInEveryCityOnContinent": "Research Lab"
     },
     {
       "name": "Civil Defense",
@@ -68346,7 +68351,8 @@
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
       "iconRowIndex": 78,
-      "renderedObsoleteBy": "tech-17"
+      "renderedObsoleteBy": "tech-17",
+      "buildingGainedInEveryCityOnContinent": "Temple"
     },
     {
       "name": "The Statue of Zeus",

--- a/C7Engine/C7GameData/Building.cs
+++ b/C7Engine/C7GameData/Building.cs
@@ -196,6 +196,57 @@ namespace C7GameData {
 			return true;
 		}
 
+		public void CreationEffects(City owningCity) {
+			if (dataSource.buildingGainedInEveryCity != null) {
+				Building b = EngineStorage.gameData.Buildings.Find(x => x.name == dataSource.buildingGainedInEveryCity);
+				foreach (City c in owningCity.owner.cities) {
+					c.AddBuilding(b, CityBuilding.Source.ProvidedByWonder);
+				}
+			}
+			if (dataSource.buildingGainedInEveryCityOnContinent != null) {
+				Building b = EngineStorage.gameData.Buildings.Find(x => x.name == dataSource.buildingGainedInEveryCityOnContinent);
+				foreach (City c in owningCity.owner.cities) {
+					if (c.location.continent != owningCity.location.continent) {
+						continue;
+					}
+
+					c.AddBuilding(b, CityBuilding.Source.ProvidedByWonder);
+				}
+			}
+		}
+
+		public void EffectsOnNewCities(City owningCity, City newCity) {
+			if (dataSource.buildingGainedInEveryCity != null) {
+				Building b = EngineStorage.gameData.Buildings.Find(x => x.name == dataSource.buildingGainedInEveryCity);
+				newCity.AddBuilding(b, CityBuilding.Source.ProvidedByWonder);
+			}
+			if (dataSource.buildingGainedInEveryCityOnContinent != null) {
+				Building b = EngineStorage.gameData.Buildings.Find(x => x.name == dataSource.buildingGainedInEveryCityOnContinent);
+				if (newCity.location.continent == owningCity.location.continent) {
+					newCity.AddBuilding(b, CityBuilding.Source.ProvidedByWonder);
+				}
+			}
+		}
+
+		public void DestructionEffects(City previouslyOwningCity) {
+			if (dataSource.buildingGainedInEveryCity != null) {
+				Building b = EngineStorage.gameData.Buildings.Find(x => x.name == dataSource.buildingGainedInEveryCity);
+				foreach (City c in previouslyOwningCity.owner.cities) {
+					c.RemoveBuilding(b, CityBuilding.Source.ProvidedByWonder);
+				}
+			}
+			if (dataSource.buildingGainedInEveryCityOnContinent != null) {
+				Building b = EngineStorage.gameData.Buildings.Find(x => x.name == dataSource.buildingGainedInEveryCityOnContinent);
+				foreach (City c in previouslyOwningCity.owner.cities) {
+					if (c.location.continent != previouslyOwningCity.location.continent) {
+						continue;
+					}
+
+					c.RemoveBuilding(b, CityBuilding.Source.ProvidedByWonder);
+				}
+			}
+		}
+
 		public SaveBuilding ToSaveBuilding() {
 			return dataSource;
 		}

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -11,6 +11,18 @@ namespace C7GameData {
 		public int year;
 		public int totalCulture; // This represents the total culture produced by the building. 
 								 // In Civ3, this value is displayed in the cultural advisor tab
+
+		public enum Source {
+			Built,
+
+			// Options other than Built have no maintenance costs.
+			ProvidedByWonder,
+
+			// This option allows selling the building and downgrading to just
+			// Built.
+			BuiltAndThenProvidedByWonder,
+		}
+		public Source source = Source.Built;
 	}
 
 	public struct CommerceBreakdown {
@@ -54,6 +66,7 @@ namespace C7GameData {
 		public bool capital = false;
 		public Player owner { get; set; }
 		public List<CityResident> residents = new List<CityResident>();
+
 		public List<CityBuilding> buildings = [];
 
 		// The order of this city within all the cities of a player for the
@@ -246,7 +259,7 @@ namespace C7GameData {
 			if (producedItem is UnitPrototype prototype) {
 				AddUnit(prototype, gameData);
 			} else if (producedItem is Building building) {
-				AddBuilding(building);
+				AddBuilding(building, CityBuilding.Source.Built);
 
 				// If we completed a great wonder, mark it as completed so no
 				// other civ can build it. If any other cities are building the
@@ -517,13 +530,48 @@ namespace C7GameData {
 			return (int)Math.Floor(Math.Log10(culture)) + 1;
 		}
 
-		public void AddBuilding(Building building) {
+		public void AddBuilding(Building building, CityBuilding.Source source) {
+			// If we already have this building, then as long as we didn't
+			// somehow build it twice this is a case where we built a building
+			// and then a wonder provided it. Update the building.
+			foreach (CityBuilding cb in buildings) {
+				if (cb.building.name == building.name) {
+					if (cb.source == source) {
+						throw new Exception($"Built a building twice or it was awarded by two wonders: {source}");
+					}
+					cb.source = CityBuilding.Source.BuiltAndThenProvidedByWonder;
+					return;
+				}
+			}
+
+			// Otherwise add the building.
 			buildings.Add(new CityBuilding {
 				building = building,
 				builtByPlayer = owner,
 				year = 1, // TODO: Implement in-game year tracking
-				totalCulture = 0
+				totalCulture = 0,
+				source = source,
 			});
+			building.CreationEffects(this);
+		}
+
+		public void RemoveBuilding(Building building, CityBuilding.Source source) {
+			// Remove this building unless it was provided by a wonder and was
+			// built. In that case just downgrade the source.
+			for (int i = 0; i < buildings.Count;) {
+				CityBuilding cb = buildings[i];
+				if (cb.building.name == building.name) {
+					if (cb.source != CityBuilding.Source.BuiltAndThenProvidedByWonder) {
+						buildings.RemoveAt(i);
+					} else if (source == CityBuilding.Source.Built) {
+						cb.source = CityBuilding.Source.ProvidedByWonder;
+					} else {
+						cb.source = CityBuilding.Source.Built;
+					}
+					return;
+				}
+				++i;
+			}
 		}
 
 		public void AddUnit(UnitPrototype prototype, GameData gameData) {

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -25,6 +25,7 @@ namespace C7GameData {
 		private SavData savData;
 		private PediaIcons pediaIcons;
 		private readonly ID.Factory ids;
+		private Dictionary<TileLocation, int> continentLookup = new();
 
 		private static ILogger log = Log.ForContext<ImportCiv3>();
 
@@ -601,6 +602,24 @@ namespace C7GameData {
 				}
 				save.Cities.Add(saveCity);
 			}
+
+			// Save which continent each tile is on, to avoid expensive scans
+			// for wonders that grant a building to all tiles on the same
+			// continent.
+			int tileIndex = 0;
+			foreach (QueryCiv3.Sav.TILE civ3Tile in savData.Tile) {
+				(int X, int Y) = GetMapCoordinates(tileIndex, savData.Wrld.Width);
+				continentLookup[new TileLocation(X, Y)] = civ3Tile.Continent;
+				++tileIndex;
+			}
+
+			// Now that we have all the normal city buildings loaded, we can go
+			// through and add any buildings that are the result of wonders.
+			foreach (SaveCity sc in save.Cities) {
+				for (int i = 0; i < sc.buildings.Count; ++i) {
+					AddBuildingsGrantedByWonders(sc, sc.buildings[i]);
+				}
+			}
 		}
 
 		List<SaveCityBuilding> ImportCityBuildingsFromSav(int cityIndex) {
@@ -694,6 +713,93 @@ namespace C7GameData {
 
 				save.Cities.Add(saveCity);
 			}
+
+			// Save which continent each tile is on, to avoid expensive scans
+			// for wonders that grant a building to all tiles on the same
+			// continent.
+			int tileIndex = 0;
+			foreach (QueryCiv3.Biq.TILE civ3Tile in biq.Tile) {
+				(int X, int Y) = GetMapCoordinates(tileIndex, biq.Wmap[0].Width);
+				continentLookup[new TileLocation(X, Y)] = civ3Tile.Continent;
+				++tileIndex;
+			}
+
+			// Now that we have all the normal city buildings loaded, we can go
+			// through and add any buildings that are the result of wonders.
+			foreach (SaveCity sc in save.Cities) {
+				for (int i = 0; i < sc.buildings.Count; ++i) {
+					AddBuildingsGrantedByWonders(sc, sc.buildings[i]);
+				}
+			}
+		}
+
+		// Add any buildings granted by wonders (like how the Pyramids give
+		// granaries to all cities on the continent).
+		private void AddBuildingsGrantedByWonders(SaveCity sc, SaveCityBuilding scb) {
+			BiqData theBiq = biq.City is null ? defaultBiq : biq;
+			SaveBuilding sb = save.Buildings.Find(x => x.name == scb.building);
+
+			if (sb.buildingGainedInEveryCity != null) {
+				SaveCityBuilding newBuilding = new() {
+					building = sb.buildingGainedInEveryCity,
+					builtByPlayer = scb.builtByPlayer,
+					year = scb.year,
+					// TODO: Could this be calculated by the year the wonder
+					// was built multiplied by the culture per turn of the
+					// added building?
+					totalCulture = 0,
+					source = CityBuilding.Source.ProvidedByWonder,
+				};
+
+				foreach (SaveCity c in save.Cities) {
+					// Ignore cities owned by other players.
+					if (c.owner != sc.owner) {
+						continue;
+					}
+
+					// Add the appropriate building, specifying it came from a
+					// wonder or upgrading an existing building of the same type.
+					AddSaveCityBuildingOrUpgradeSource(c, newBuilding);
+				}
+			}
+			if (sb.buildingGainedInEveryCityOnContinent != null) {
+				SaveCityBuilding newBuilding = new() {
+					building = sb.buildingGainedInEveryCityOnContinent,
+					builtByPlayer = scb.builtByPlayer,
+					year = scb.year,
+					// TODO: Could this be calculated by the year the wonder
+					// was built multiplied by the culture per turn of the
+					// added building?
+					totalCulture = 0,
+					source = CityBuilding.Source.ProvidedByWonder,
+				};
+
+				foreach (SaveCity c in save.Cities) {
+					// Ignore cities owned by other players.
+					if (c.owner != sc.owner) {
+						continue;
+					}
+
+					// Ignore cities on other continents.
+					if (continentLookup[c.location] != continentLookup[sc.location]) {
+						continue;
+					}
+
+					// Add the appropriate building, specifying it came from a
+					// wonder or upgrading an existing building of the same type.
+					AddSaveCityBuildingOrUpgradeSource(c, newBuilding);
+				}
+			}
+		}
+
+		private void AddSaveCityBuildingOrUpgradeSource(SaveCity sc, SaveCityBuilding scb) {
+			foreach (SaveCityBuilding b in sc.buildings) {
+				if (b.building == scb.building) {
+					b.source = CityBuilding.Source.BuiltAndThenProvidedByWonder;
+					return;
+				}
+			}
+			sc.buildings.Add(scb);
 		}
 
 		private static IEnumerable<UnitAction> GetUnitActions(PRTO prto) {
@@ -928,6 +1034,13 @@ namespace C7GameData {
 
 				if (bldg.RenderedObsoleteBy != -1) {
 					building.renderedObsoleteBy = save.Techs[bldg.RequiredAdvance].id;
+				}
+
+				if (bldg.GainInEveryCity >= 0) {
+					building.buildingGainedInEveryCity = Bldg[bldg.GainInEveryCity].Name;
+				}
+				if (bldg.GainInEveryCityOnContinent >= 0) {
+					building.buildingGainedInEveryCityOnContinent = Bldg[bldg.GainInEveryCityOnContinent].Name;
 				}
 
 				building.flags = LoadBuildingFlags(bldg).ToHashSet();

--- a/C7Engine/C7GameData/Save/SaveBuilding.cs
+++ b/C7Engine/C7GameData/Save/SaveBuilding.cs
@@ -31,6 +31,11 @@ namespace C7GameData.Save {
 		public int iconRowIndex;
 		public ID? renderedObsoleteBy;
 
+		// The name of the building this building gives to every city in the
+		// empire on on the continent (like the pyramids or the internet).
+		public string buildingGainedInEveryCity;
+		public string buildingGainedInEveryCityOnContinent;
+
 		// Assorted boolean flags for the building. They're stored in this set
 		// rather than as booleans to avoid bloating the json file.
 		public HashSet<Flag> flags = new();

--- a/C7Engine/C7GameData/Save/SaveCity.cs
+++ b/C7Engine/C7GameData/Save/SaveCity.cs
@@ -14,6 +14,7 @@ namespace C7GameData.Save {
 		public ID builtByPlayer;
 		public int year;
 		public int totalCulture;
+		public CityBuilding.Source source = CityBuilding.Source.Built;
 
 		public SaveCityBuilding() { }
 
@@ -22,6 +23,7 @@ namespace C7GameData.Save {
 			builtByPlayer = cityBuilding.builtByPlayer.id;
 			year = cityBuilding.year;
 			totalCulture = cityBuilding.totalCulture;
+			source = cityBuilding.source;
 		}
 
 		public CityBuilding ToCityBuilding(List<Building> buildings, List<Player> players) {
@@ -30,6 +32,7 @@ namespace C7GameData.Save {
 				builtByPlayer = players.Find(player => player.id == builtByPlayer),
 				year = year,
 				totalCulture = totalCulture,
+				source = source,
 			};
 		}
 

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -11,8 +11,17 @@ namespace C7Engine {
 			City newCity = new City(tileWithNewCity, owner, name, gameData.ids.CreateID("city"));
 			if (owner.cities.Count == 0) {
 				newCity.capital = true;
-				newCity.AddBuilding(gameData.Buildings.Find(x => x.isCenterOfEmpire));
+				newCity.AddBuilding(gameData.Buildings.Find(x => x.isCenterOfEmpire), CityBuilding.Source.Built);
 			}
+
+			// Apply any wonder effects to the new city (like adding a granary
+			// if we already have the pyramids).
+			foreach (City c in owner.cities) {
+				foreach (CityBuilding cb in c.buildings) {
+					cb.building.EffectsOnNewCities(c, newCity);
+				}
+			}
+
 			gameData.cities.Add(newCity);
 			owner.cities.Add(newCity);
 			tileWithNewCity.cityAtTile = newCity;
@@ -41,6 +50,13 @@ namespace C7Engine {
 			Tile tile = EngineStorage.gameData.map.tileAt(X, Y);
 			tile.DisbandNonDefendingUnits();
 			Player owner = tile.cityAtTile.owner;
+
+			// If this city had a wonder that was providing buildings in other
+			// cities, ensure everything gets updated properly.
+			foreach (CityBuilding cb in tile.cityAtTile.buildings) {
+				cb.building.DestructionEffects(tile.cityAtTile);
+			}
+
 			tile.cityAtTile.RemoveAllCitizens();
 			tile.cityAtTile.owner.cities.Remove(tile.cityAtTile);
 			EngineStorage.gameData.cities.Remove(tile.cityAtTile);


### PR DESCRIPTION
I spent a while considering how to implement this, since it seems like there are two ways:

1. Add the wonder-provided cities to each city, which is what this PR does.

2. Any time we need to look at the buildings in a city, check all of the other cities for great wonders and see if they would add a building to our city.

Option 2 seemed worse to me, and would have to be done carefully to avoid some annoying recursion. Option 1 also makes it easy to track where a building came from, which would allow us to easily implement the "you can sell a granary if you built it before you got the pyramids" logic of the original game.

The downside to option 1 is some duplication of logic between the game runtime and the import logic, but it doesn't seem excessive. Let me know if you disagree.
