### PR TITLE
Add city defense bonuses, including from walls 

### DIFF
--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -67363,6 +67363,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 1,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 0,
       "flags": [
         "isCenterOfEmpire"
@@ -67376,6 +67378,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 1,
       "flags": [
         "veteranGroundUnits"
@@ -67393,6 +67397,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 2,
       "flags": [
         "doublesCityGrowthRate"
@@ -67407,6 +67413,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 1,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 3,
       "traits": [
         "religious"
@@ -67421,6 +67429,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 4,
       "flags": [
         "increasesLuxuryTrade"
@@ -67438,6 +67448,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 5,
       "traits": [
         "scientific"
@@ -67452,6 +67464,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 6,
       "flags": [
         "reducesCorruption"
@@ -67466,6 +67480,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 8,
+      "combatDefenseBonus": 50,
       "iconRowIndex": 7,
       "traits": [
         "militaristic"
@@ -67480,6 +67496,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 8,
       "flags": [
         "allowsCitySize2"
@@ -67498,6 +67516,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 9,
       "traits": [
         "commercial"
@@ -67513,6 +67533,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 3,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 10,
       "traits": [
         "religious"
@@ -67528,6 +67550,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 11,
       "traits": [
         "scientific"
@@ -67542,6 +67566,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 2,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 12
     },
     {
@@ -67553,6 +67579,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 13,
       "requiredResources": [
         "Iron"
@@ -67568,6 +67596,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 14
     },
     {
@@ -67579,6 +67609,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 15,
       "traits": [
         "agricultural"
@@ -67594,6 +67626,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 16,
       "requiredResources": [
         "Coal"
@@ -67609,6 +67643,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 17,
       "flags": [
         "mustBeNearRiver"
@@ -67624,6 +67660,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 18,
       "requiredResources": [
         "Uranium"
@@ -67638,6 +67676,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 19,
       "flags": [
         "allowsCitySize3"
@@ -67653,6 +67693,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 20,
       "traits": [
         "scientific"
@@ -67667,6 +67709,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 21,
       "requiredResources": [
         "Rubber"
@@ -67681,6 +67725,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 22,
       "traits": [
         "militaristic"
@@ -67698,6 +67744,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 23,
       "flags": [
         "mustBeCoastal"
@@ -67721,6 +67769,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 24,
       "traits": [
         "agricultural"
@@ -67735,6 +67785,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 25,
       "flags": [
         "mustBeCoastal",
@@ -67756,6 +67808,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 26,
       "flags": [
         "mustBeCoastal",
@@ -67774,6 +67828,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 27,
       "traits": [
         "militaristic",
@@ -67789,6 +67845,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 28,
       "flags": [
         "reducesCorruption"
@@ -67803,6 +67861,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 30,
       "traits": [
         "religious",
@@ -67819,6 +67879,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 3,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 31,
       "renderedObsoleteBy": "tech-45",
       "traits": [
@@ -67835,6 +67897,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 32,
       "renderedObsoleteBy": "tech-59",
       "flags": [
@@ -67855,6 +67919,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 33,
       "renderedObsoleteBy": "tech-42",
       "flags": [
@@ -67875,6 +67941,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 6,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 34,
       "renderedObsoleteBy": "tech-30",
       "traits": [
@@ -67890,6 +67958,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 35,
       "renderedObsoleteBy": "tech-25",
       "traits": [
@@ -67905,6 +67975,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 36,
       "renderedObsoleteBy": "tech-39",
       "traits": [
@@ -67921,6 +67993,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 37,
       "traits": [
         "militaristic"
@@ -67935,6 +68009,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 6,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 38,
       "traits": [
         "religious"
@@ -67949,6 +68025,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 39,
       "flags": [
         "mustBeCoastal"
@@ -67968,6 +68046,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 40,
       "traits": [
         "expansionist"
@@ -67982,6 +68062,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 8,
       "contentFacesInCity": 8,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 41,
       "flags": [
         "allowsCitySize3"
@@ -67996,6 +68078,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 42,
       "traits": [
         "militaristic"
@@ -68010,6 +68094,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 6,
       "contentFacesInCity": 2,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 43,
       "traits": [
         "religious"
@@ -68024,6 +68110,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 6,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 44,
       "traits": [
         "scientific"
@@ -68038,6 +68126,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 45,
       "traits": [
         "commercial",
@@ -68053,6 +68143,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 46,
       "traits": [
         "agricultural"
@@ -68067,6 +68159,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 47,
       "flags": [
         "mustBeNearRiver"
@@ -68085,6 +68179,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 48,
       "traits": [
         "scientific"
@@ -68099,6 +68195,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 49,
       "traits": [
         "commercial"
@@ -68113,6 +68211,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 50,
       "traits": [
         "militaristic",
@@ -68131,6 +68231,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 1,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 51,
       "traits": [
         "scientific",
@@ -68146,6 +68248,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 52,
       "traits": [
         "scientific"
@@ -68160,6 +68264,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 53,
       "traits": [
         "expansionist"
@@ -68173,6 +68279,8 @@
       "isSmallWonder": true,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 54,
       "traits": [
         "religious",
@@ -68187,6 +68295,8 @@
       "isSmallWonder": true,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 55,
       "requiredResources": [
         "Iron",
@@ -68201,6 +68311,8 @@
       "isSmallWonder": true,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 56,
       "flags": [
         "forbiddenPalace"
@@ -68218,6 +68330,8 @@
       "isSmallWonder": true,
       "culturePerTurn": 1,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 57,
       "traits": [
         "militaristic"
@@ -68231,6 +68345,8 @@
       "isSmallWonder": true,
       "culturePerTurn": 1,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 58,
       "traits": [
         "militaristic"
@@ -68245,6 +68361,8 @@
       "isSmallWonder": true,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 59
     },
     {
@@ -68256,6 +68374,8 @@
       "isSmallWonder": true,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 60,
       "traits": [
         "scientific"
@@ -68274,6 +68394,8 @@
       "isSmallWonder": true,
       "culturePerTurn": 1,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 61,
       "traits": [
         "militaristic"
@@ -68288,6 +68410,8 @@
       "isSmallWonder": true,
       "culturePerTurn": 1,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 62,
       "traits": [
         "militaristic",
@@ -68303,6 +68427,8 @@
       "isSmallWonder": true,
       "culturePerTurn": 1,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 63,
       "traits": [
         "militaristic"
@@ -68317,6 +68443,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 64,
       "requiredResources": [
         "Aluminum"
@@ -68331,6 +68459,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 65,
       "requiredResources": [
         "Aluminum"
@@ -68345,6 +68475,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 66,
       "requiredResources": [
         "Aluminum"
@@ -68359,6 +68491,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 67,
       "requiredResources": [
         "Aluminum"
@@ -68373,6 +68507,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 68,
       "requiredResources": [
         "Uranium"
@@ -68387,6 +68523,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 69,
       "requiredResources": [
         "Aluminum"
@@ -68401,6 +68539,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 70,
       "requiredResources": [
         "Aluminum",
@@ -68416,6 +68556,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 71,
       "requiredResources": [
         "Aluminum"
@@ -68430,6 +68572,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 72,
       "requiredResources": [
         "Aluminum"
@@ -68444,6 +68588,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 73,
       "requiredResources": [
         "Aluminum",
@@ -68459,6 +68605,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 74,
       "traits": [
         "militaristic",
@@ -68481,6 +68629,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 50,
       "iconRowIndex": 75,
       "traits": [
         "militaristic"
@@ -68496,6 +68646,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 76,
       "traits": [
         "commercial"
@@ -68511,6 +68663,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 77,
       "flags": [
         "increasesTradeInWater"
@@ -68529,6 +68683,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 78,
       "renderedObsoleteBy": "tech-30",
       "traits": [
@@ -68544,6 +68700,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 79,
       "renderedObsoleteBy": "tech-39",
       "traits": [
@@ -68563,6 +68721,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 3,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 80,
       "traits": [
         "scientific",
@@ -68578,6 +68738,8 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 81,
       "renderedObsoleteBy": "tech-45",
       "traits": [
@@ -68594,6 +68756,8 @@
       "isSmallWonder": true,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
+      "bombardDefenseBonus": 0,
+      "combatDefenseBonus": 0,
       "iconRowIndex": 56,
       "flags": [
         "forbiddenPalace"

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -67363,7 +67363,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 1,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 0,
       "flags": [
@@ -67378,7 +67377,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 1,
       "flags": [
@@ -67397,7 +67395,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 2,
       "flags": [
@@ -67413,7 +67410,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 1,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 3,
       "traits": [
@@ -67429,7 +67425,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 4,
       "flags": [
@@ -67448,7 +67443,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 5,
       "traits": [
@@ -67464,7 +67458,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 6,
       "flags": [
@@ -67480,9 +67473,12 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 8,
       "combatDefenseBonus": 50,
       "iconRowIndex": 7,
+      "flags": [
+        "providesWalls",
+        "canOnlyBeBuiltInTowns"
+      ],
       "traits": [
         "militaristic"
       ]
@@ -67496,7 +67492,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 8,
       "flags": [
@@ -67516,7 +67511,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 9,
       "traits": [
@@ -67533,7 +67527,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 3,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 10,
       "traits": [
@@ -67550,7 +67543,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 11,
       "traits": [
@@ -67566,7 +67558,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 2,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 12
     },
@@ -67579,7 +67570,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 13,
       "requiredResources": [
@@ -67596,7 +67586,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 14
     },
@@ -67609,7 +67598,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 15,
       "traits": [
@@ -67626,7 +67614,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 16,
       "requiredResources": [
@@ -67643,7 +67630,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 17,
       "flags": [
@@ -67660,7 +67646,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 18,
       "requiredResources": [
@@ -67676,7 +67661,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 19,
       "flags": [
@@ -67693,7 +67677,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 20,
       "traits": [
@@ -67709,7 +67692,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 21,
       "requiredResources": [
@@ -67725,7 +67707,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 22,
       "traits": [
@@ -67744,7 +67725,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 23,
       "flags": [
@@ -67769,7 +67749,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 24,
       "traits": [
@@ -67785,7 +67764,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 25,
       "flags": [
@@ -67808,7 +67786,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 26,
       "flags": [
@@ -67828,7 +67805,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 27,
       "traits": [
@@ -67845,7 +67821,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 28,
       "flags": [
@@ -67861,7 +67836,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 30,
       "traits": [
@@ -67879,7 +67853,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 3,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 31,
       "renderedObsoleteBy": "tech-45",
@@ -67897,7 +67870,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 32,
       "renderedObsoleteBy": "tech-59",
@@ -67919,7 +67891,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 33,
       "renderedObsoleteBy": "tech-42",
@@ -67941,7 +67912,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 6,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 34,
       "renderedObsoleteBy": "tech-30",
@@ -67958,7 +67928,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 35,
       "renderedObsoleteBy": "tech-25",
@@ -67975,7 +67944,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 36,
       "renderedObsoleteBy": "tech-39",
@@ -67993,7 +67961,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 37,
       "traits": [
@@ -68009,7 +67976,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 6,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 38,
       "traits": [
@@ -68025,7 +67991,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 39,
       "flags": [
@@ -68046,7 +68011,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 40,
       "traits": [
@@ -68062,7 +68026,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 8,
       "contentFacesInCity": 8,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 41,
       "flags": [
@@ -68078,7 +68041,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 42,
       "traits": [
@@ -68094,7 +68056,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 6,
       "contentFacesInCity": 2,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 43,
       "traits": [
@@ -68110,7 +68071,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 6,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 44,
       "traits": [
@@ -68126,7 +68086,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 45,
       "traits": [
@@ -68143,7 +68102,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 46,
       "traits": [
@@ -68159,7 +68117,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 47,
       "flags": [
@@ -68179,7 +68136,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 48,
       "traits": [
@@ -68195,7 +68151,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 49,
       "traits": [
@@ -68211,7 +68166,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 50,
       "traits": [
@@ -68231,7 +68185,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 1,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 51,
       "traits": [
@@ -68248,7 +68201,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 52,
       "traits": [
@@ -68264,7 +68216,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 3,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 53,
       "traits": [
@@ -68279,7 +68230,6 @@
       "isSmallWonder": true,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 54,
       "traits": [
@@ -68295,7 +68245,6 @@
       "isSmallWonder": true,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 55,
       "requiredResources": [
@@ -68311,7 +68260,6 @@
       "isSmallWonder": true,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 56,
       "flags": [
@@ -68330,7 +68278,6 @@
       "isSmallWonder": true,
       "culturePerTurn": 1,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 57,
       "traits": [
@@ -68345,7 +68292,6 @@
       "isSmallWonder": true,
       "culturePerTurn": 1,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 58,
       "traits": [
@@ -68361,7 +68307,6 @@
       "isSmallWonder": true,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 59
     },
@@ -68374,7 +68319,6 @@
       "isSmallWonder": true,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 60,
       "traits": [
@@ -68394,7 +68338,6 @@
       "isSmallWonder": true,
       "culturePerTurn": 1,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 61,
       "traits": [
@@ -68410,7 +68353,6 @@
       "isSmallWonder": true,
       "culturePerTurn": 1,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 62,
       "traits": [
@@ -68427,7 +68369,6 @@
       "isSmallWonder": true,
       "culturePerTurn": 1,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 63,
       "traits": [
@@ -68443,7 +68384,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 64,
       "requiredResources": [
@@ -68459,7 +68399,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 65,
       "requiredResources": [
@@ -68475,7 +68414,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 66,
       "requiredResources": [
@@ -68491,7 +68429,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 67,
       "requiredResources": [
@@ -68507,7 +68444,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 68,
       "requiredResources": [
@@ -68523,7 +68459,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 69,
       "requiredResources": [
@@ -68539,7 +68474,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 70,
       "requiredResources": [
@@ -68556,7 +68490,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 71,
       "requiredResources": [
@@ -68572,7 +68505,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 72,
       "requiredResources": [
@@ -68588,7 +68520,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 73,
       "requiredResources": [
@@ -68605,7 +68536,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 74,
       "traits": [
@@ -68629,7 +68559,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 50,
       "iconRowIndex": 75,
       "traits": [
@@ -68646,7 +68575,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 76,
       "traits": [
@@ -68663,7 +68591,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 77,
       "flags": [
@@ -68683,7 +68610,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 78,
       "renderedObsoleteBy": "tech-30",
@@ -68700,7 +68626,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 4,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 79,
       "renderedObsoleteBy": "tech-39",
@@ -68721,7 +68646,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 3,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 80,
       "traits": [
@@ -68738,7 +68662,6 @@
       "isSmallWonder": false,
       "culturePerTurn": 2,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 81,
       "renderedObsoleteBy": "tech-45",
@@ -68756,7 +68679,6 @@
       "isSmallWonder": true,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "bombardDefenseBonus": 0,
       "combatDefenseBonus": 0,
       "iconRowIndex": 56,
       "flags": [

--- a/C7Engine/C7GameData/Building.cs
+++ b/C7Engine/C7GameData/Building.cs
@@ -9,7 +9,7 @@ namespace C7GameData {
 		public static Dictionary<SaveBuilding.Flag, Func<City, bool>> productionRules = new()
 		{
 			{ SaveBuilding.Flag.MustBeCoastal, MustBeCoastal },
-			{ SaveBuilding.Flag.MustBeNearRiver, MustBeNearRiver }
+			{ SaveBuilding.Flag.MustBeNearRiver, MustBeNearRiver },
 		};
 
 		public static Dictionary<SaveBuilding.Flag, Action<MapUnit>> unitProductionEffects = new()
@@ -87,6 +87,8 @@ namespace C7GameData {
 		public bool allowsCitySize2;
 		public bool allowsCitySize3;
 		public bool doublesCityGrowthRate;
+		public int bombardDefenseBonus;
+		public int combatDefenseBonus;
 
 		public int culturePerTurn = 0;
 
@@ -119,6 +121,8 @@ namespace C7GameData {
 			} else {
 				contentFacesInCity = building.contentFacesInCity;
 			}
+			bombardDefenseBonus = building.bombardDefenseBonus;
+			combatDefenseBonus = building.combatDefenseBonus;
 			isCenterOfEmpire = building.flags.Contains(SaveBuilding.Flag.IsCenterOfEmpire);
 			increasesLuxuryTrade = building.flags.Contains(SaveBuilding.Flag.IncreasesLuxuryTrade);
 			reducesCorruption = building.flags.Contains(SaveBuilding.Flag.ReducesCorruption);
@@ -190,6 +194,12 @@ namespace C7GameData {
 			}
 
 			if (!productionPrerequisites.All(func => func(city))) {
+				return false;
+			}
+
+			// Walls (buildings with non-zero bombard defense) can only be built
+			// in towns, not cities or larger.
+			if (dataSource.bombardDefenseBonus > 0 && city.residents.Count > city.owner.rules.MaximumLevel1CitySize) {
 				return false;
 			}
 

--- a/C7Engine/C7GameData/Building.cs
+++ b/C7Engine/C7GameData/Building.cs
@@ -10,6 +10,7 @@ namespace C7GameData {
 		{
 			{ SaveBuilding.Flag.MustBeCoastal, MustBeCoastal },
 			{ SaveBuilding.Flag.MustBeNearRiver, MustBeNearRiver },
+			{ SaveBuilding.Flag.CanOnlyBeBuiltInTowns, CanOnlyBeBuiltInTowns },
 		};
 
 		public static Dictionary<SaveBuilding.Flag, Action<MapUnit>> unitProductionEffects = new()
@@ -61,6 +62,10 @@ namespace C7GameData {
 		private static bool MustBeNearRiver(City city) {
 			return city.location.BordersRiver();
 		}
+
+		private static bool CanOnlyBeBuiltInTowns(City city) {
+			return city.residents.Count <= city.owner.rules.MaximumLevel1CitySize;
+		}
 	}
 
 	public class Building : IProducible {
@@ -87,7 +92,8 @@ namespace C7GameData {
 		public bool allowsCitySize2;
 		public bool allowsCitySize3;
 		public bool doublesCityGrowthRate;
-		public int bombardDefenseBonus;
+		public bool providesWalls;
+		public bool onlyUsefulInTowns;
 		public int combatDefenseBonus;
 
 		public int culturePerTurn = 0;
@@ -121,7 +127,6 @@ namespace C7GameData {
 			} else {
 				contentFacesInCity = building.contentFacesInCity;
 			}
-			bombardDefenseBonus = building.bombardDefenseBonus;
 			combatDefenseBonus = building.combatDefenseBonus;
 			isCenterOfEmpire = building.flags.Contains(SaveBuilding.Flag.IsCenterOfEmpire);
 			increasesLuxuryTrade = building.flags.Contains(SaveBuilding.Flag.IncreasesLuxuryTrade);
@@ -130,6 +135,8 @@ namespace C7GameData {
 			allowsCitySize2 = building.flags.Contains(SaveBuilding.Flag.AllowsCitySize2);
 			allowsCitySize3 = building.flags.Contains(SaveBuilding.Flag.AllowsCitySize3);
 			doublesCityGrowthRate = building.flags.Contains(SaveBuilding.Flag.DoublesCityGrowthRate);
+			providesWalls = building.flags.Contains(SaveBuilding.Flag.ProvidesWalls);
+			onlyUsefulInTowns = building.flags.Contains(SaveBuilding.Flag.CanOnlyBeBuiltInTowns);
 			dataSource = building;
 
 			foreach (var kvp in BuildingRules.productionRules) {
@@ -194,12 +201,6 @@ namespace C7GameData {
 			}
 
 			if (!productionPrerequisites.All(func => func(city))) {
-				return false;
-			}
-
-			// Walls (buildings with non-zero bombard defense) can only be built
-			// in towns, not cities or larger.
-			if (dataSource.bombardDefenseBonus > 0 && city.residents.Count > city.owner.rules.MaximumLevel1CitySize) {
 				return false;
 			}
 

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -373,8 +373,7 @@ namespace C7GameData {
 
 		public bool HasWalls() {
 			foreach (CityBuilding cb in buildings) {
-				// TODO: figure out how to determine this properly
-				if (cb.building.name == "Walls") {
+				if (cb.building.providesWalls) {
 					return true;
 				}
 			}
@@ -401,13 +400,12 @@ namespace C7GameData {
 
 				// If this building doesn't have the "only useful in towns" flag
 				// we can always provide the bonus regardless of the city size.
-				if (!cb.building.onlyUsefulInTowns) {
-					yield return new StrengthBonus(cb.building.name, cb.building.combatDefenseBonus);
-				}
-
+				// 
 				// But if the building is only useful in towns we need to check
 				// the city size before providing the bonus.
-				if (residents.Count <= gD.rules.MaximumLevel1CitySize) {
+				if (!cb.building.onlyUsefulInTowns) {
+					yield return new StrengthBonus(cb.building.name, cb.building.combatDefenseBonus);
+				} else if (residents.Count <= gD.rules.MaximumLevel1CitySize) {
 					yield return new StrengthBonus(cb.building.name, cb.building.combatDefenseBonus);
 				}
 			}

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -381,6 +381,40 @@ namespace C7GameData {
 			return false;
 		}
 
+		public IEnumerable<StrengthBonus> GetDefenseBonuses() {
+			GameData gD = EngineStorage.gameData;
+
+			// Cities give defense bonuses based on their size.
+			if (residents.Count > gD.rules.MaximumLevel2CitySize) {
+				yield return gD.cityLevel3DefenseBonus;
+			} else if (residents.Count > gD.rules.MaximumLevel1CitySize) {
+				yield return gD.cityLevel2DefenseBonus;
+			} else {
+				yield return gD.cityLevel1DefenseBonus;
+			}
+
+			// Buildings, such as walls, can also give bonuses.
+			foreach (CityBuilding cb in buildings) {
+				if (cb.building.combatDefenseBonus == 0) {
+					continue;
+				}
+
+				// Combat defense bonus with no bombard defense bonus means that
+				// this isn't walls, so we can give the bonus regardless of the
+				// size of the city.
+				if (cb.building.bombardDefenseBonus == 0) {
+					yield return new StrengthBonus(cb.building.name, cb.building.combatDefenseBonus);
+				}
+
+				// A non-zero bombard defense bonus means this building is
+				// considered to be walls, so the bonus is only active when the
+				// city size is level 1.
+				if (residents.Count <= gD.rules.MaximumLevel1CitySize) {
+					yield return new StrengthBonus(cb.building.name, cb.building.combatDefenseBonus);
+				}
+			}
+		}
+
 		/**
 		 * Computes turn production.  If the production queue finishes,
 		 * returns the item that is built.  Otherwise, returns null.

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -399,16 +399,14 @@ namespace C7GameData {
 					continue;
 				}
 
-				// Combat defense bonus with no bombard defense bonus means that
-				// this isn't walls, so we can give the bonus regardless of the
-				// size of the city.
-				if (cb.building.bombardDefenseBonus == 0) {
+				// If this building doesn't have the "only useful in towns" flag
+				// we can always provide the bonus regardless of the city size.
+				if (!cb.building.onlyUsefulInTowns) {
 					yield return new StrengthBonus(cb.building.name, cb.building.combatDefenseBonus);
 				}
 
-				// A non-zero bombard defense bonus means this building is
-				// considered to be walls, so the bonus is only active when the
-				// city size is level 1.
+				// But if the building is only useful in towns we need to check
+				// the city size before providing the bonus.
 				if (residents.Count <= gD.rules.MaximumLevel1CitySize) {
 					yield return new StrengthBonus(cb.building.name, cb.building.combatDefenseBonus);
 				}

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -925,7 +925,6 @@ namespace C7GameData {
 					culturePerTurn=bldg.Culture,
 					contentFacesInCity=bldg.ContentFaces - bldg.UnhappyFaces,
 					iconRowIndex=pediaIcons.buildingToRowNumberMapping[bldg.CivilopediaEntry],
-					bombardDefenseBonus=bldg.BombardDefense,
 					combatDefenseBonus=bldg.DefenseBonus,
 				};
 
@@ -951,6 +950,12 @@ namespace C7GameData {
 
 				building.flags = LoadBuildingFlags(bldg).ToHashSet();
 				building.traits = LoadBuildingTraits(bldg).ToHashSet();
+
+				// Buildings with bombard defense are treated as walls in civ3.
+				if (bldg.BombardDefense > 0) {
+					building.flags.Add(SaveBuilding.Flag.ProvidesWalls);
+					building.flags.Add(SaveBuilding.Flag.CanOnlyBeBuiltInTowns);
+				}
 
 				save.Buildings.Add(building);
 			}

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -925,6 +925,8 @@ namespace C7GameData {
 					culturePerTurn=bldg.Culture,
 					contentFacesInCity=bldg.ContentFaces - bldg.UnhappyFaces,
 					iconRowIndex=pediaIcons.buildingToRowNumberMapping[bldg.CivilopediaEntry],
+					bombardDefenseBonus=bldg.BombardDefense,
+					combatDefenseBonus=bldg.DefenseBonus,
 				};
 
 				if (bldg.RequiredAdvance != -1) {

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -181,9 +181,11 @@ namespace C7GameData {
 				if ((!role.Bombarding()) && (attackDirection is TileDirection dir) && location.HasRiverCrossing(dir.reversed()))
 					yield return gD.riverCrossingBonus;
 
-				// TODO: Bonus should vary depending on city level. First we must load the thresholds for level 2/3 into the scenario data.
-				if (location.cityAtTile != null)
-					yield return gD.cityLevel2DefenseBonus;
+				if (location.cityAtTile != null) {
+					foreach (StrengthBonus sb in location.cityAtTile.GetDefenseBonuses()) {
+						yield return sb;
+					}
+				}
 			}
 		}
 
@@ -365,7 +367,8 @@ namespace C7GameData {
 			var unitOriginalOrientation = facingDirection;
 			facingDirection = location.directionTo(tile);
 
-			double bombardStrength  = StrengthVersus(target, CombatRole.Bombard       , facingDirection);
+			// TODO: Figure out the bombard defense that walls grant.
+			double bombardStrength  = StrengthVersus(target, CombatRole.Bombard, facingDirection);
 			double defenderStrength = target.StrengthVersus(this, CombatRole.BombardDefense, facingDirection);
 			double attackerOdds = bombardStrength / (bombardStrength + defenderStrength);
 			if (Double.IsNaN(attackerOdds))

--- a/C7Engine/C7GameData/Save/SaveBuilding.cs
+++ b/C7Engine/C7GameData/Save/SaveBuilding.cs
@@ -28,6 +28,8 @@ namespace C7GameData.Save {
 		public bool isSmallWonder;
 		public int culturePerTurn;
 		public int contentFacesInCity;
+		public int bombardDefenseBonus;
+		public int combatDefenseBonus;
 		public int iconRowIndex;
 		public ID? renderedObsoleteBy;
 

--- a/C7Engine/C7GameData/Save/SaveBuilding.cs
+++ b/C7Engine/C7GameData/Save/SaveBuilding.cs
@@ -18,6 +18,8 @@ namespace C7GameData.Save {
 			AllowsCitySize2,
 			AllowsCitySize3,
 			DoublesCityGrowthRate,
+			ProvidesWalls,
+			CanOnlyBeBuiltInTowns,
 		}
 		public string name;
 		public int shieldCost;
@@ -28,7 +30,6 @@ namespace C7GameData.Save {
 		public bool isSmallWonder;
 		public int culturePerTurn;
 		public int contentFacesInCity;
-		public int bombardDefenseBonus;
 		public int combatDefenseBonus;
 		public int iconRowIndex;
 		public ID? renderedObsoleteBy;


### PR DESCRIPTION
This is largely based on [this post](https://apolyton.net/forum/miscellaneous/archives/civ3-strategy-archive/100310-how-do-walls-really-work), but the with the difference that the wall bonus does go away for level 2 and 3 cities (which have their own defensive bonuses).
