### PR TITLE
Mark starving cities with a red label

### DIFF
--- a/C7/Map/CityLabelScene.cs
+++ b/C7/Map/CityLabelScene.cs
@@ -52,7 +52,7 @@ namespace C7.Map {
 			popSizeTheme.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
 			popSizeTheme.SetFontSize("font_size", "Label", 18);
 			popThemeRed.DefaultFont = midSizedFont;
-			popThemeRed.SetColor("font_color", "Label", Color.Color8(255, 255, 255, 255));
+			popThemeRed.SetColor("font_color", "Label", Color.Color8(255, 0, 0, 255));
 			popThemeRed.SetFontSize("font_size", "Label", 18);
 
 			//Mid-Size font skips the cache as it sets a custom size


### PR DESCRIPTION
This is just a minor fix: a system for this was already in place, but for some reason the color for starving cities was incorrectly set to white

![image](https://github.com/user-attachments/assets/e8fe97e7-5c6c-4be2-b2f8-2db63f879f8c)
