### PR TITLE
Stop using `UIGameDataAccess`, use a method accessor instead

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -153,49 +153,55 @@ public partial class Game : Node2D {
 	}
 
 	private void InitializeMapView() {
-		using UIGameDataAccess gameDataAccess = new();
-		GameMap map = gameDataAccess.gameData.map;
+		EngineStorage.ReadGameData((GameData gameData) => {
+			GameMap map = gameData.map;
 
-		Vector2? cameraLocation = null;
-		if (mapView != null) {
-			cameraLocation = mapView.cameraLocation;
-			RemoveChild(mapView);
-		}
-
-		mapView = new MapView(this, map.numTilesWide, map.numTilesTall, map.wrapHorizontally, map.wrapVertically);
-		AddChild(mapView);
-
-		mapView.cameraZoom = (float)1.0;
-		mapView.gridLayer.visible = false;
-
-		if (!cameraLocation.HasValue) {
-			// Set initial camera location. If the UI controller has any cities, focus on their capital. Otherwise, focus on their
-			// starting settler.
-			if (controller.cities.Count > 0) {
-				City capital = controller.cities.Find(c => c.IsCapital());
-				if (capital != null)
-					mapView.centerCameraOnTile(capital.location);
-			} else {
-				MapUnit startingSettler = controller.units.Find(u => u.unitType.actions.Contains(UnitAction.BuildCity));
-				if (startingSettler != null)
-					mapView.centerCameraOnTile(startingSettler.location);
+			Vector2? cameraLocation = null;
+			if (mapView != null) {
+				cameraLocation = mapView.cameraLocation;
+				RemoveChild(mapView);
 			}
-		} else {
-			mapView.cameraLocation = cameraLocation.Value;
-		}
 
-		// Allow the city screen to control whether tile assignments
-		// are visible and map UI locations back to map locations.
-		cityScreen.tileAssignmentLayer = mapView.tileAssignmentLayer;
-		cityScreen.mapView = mapView;
-		cityScreen.citizenTypes = gameDataAccess.gameData.citizenTypes;
+			mapView = new MapView(this, map.numTilesWide, map.numTilesTall, map.wrapHorizontally, map.wrapVertically);
+			AddChild(mapView);
 
-		// Allow the domestic advisor to trigger popups.
-		advisor.domesticAdvisor.SetPopupOverlay(popupOverlay);
+			mapView.cameraZoom = (float)1.0;
+			mapView.gridLayer.visible = false;
+
+			if (!cameraLocation.HasValue) {
+				// Set initial camera location. If the UI controller has any cities, focus on their capital. Otherwise, focus on their
+				// starting settler.
+				if (controller.cities.Count > 0) {
+					City capital = controller.cities.Find(c => c.IsCapital());
+					if (capital != null)
+						mapView.centerCameraOnTile(capital.location);
+				} else {
+					MapUnit startingSettler =
+						controller.units.Find(u => u.unitType.actions.Contains(UnitAction.BuildCity));
+					if (startingSettler != null)
+						mapView.centerCameraOnTile(startingSettler.location);
+				}
+			} else {
+				mapView.cameraLocation = cameraLocation.Value;
+			}
+
+			// Allow the city screen to control whether tile assignments
+			// are visible and map UI locations back to map locations.
+			cityScreen.tileAssignmentLayer = mapView.tileAssignmentLayer;
+			cityScreen.mapView = mapView;
+			cityScreen.citizenTypes = gameData.citizenTypes;
+
+			// Allow the domestic advisor to trigger popups.
+			advisor.domesticAdvisor.SetPopupOverlay(popupOverlay);
+		});
+	}
+
+	public void processEngineMessages() {
+		EngineStorage.ReadGameData((GameData gameData) => { processEngineMessagesLocked(gameData); });
 	}
 
 	// Must only be called while holding the game data mutex
-	public void processEngineMessages(GameData gameData) {
+	public void processEngineMessagesLocked(GameData gameData) {
 		MessageToUI msg;
 		while (EngineStorage.messagesToUI.TryDequeue(out msg)) {
 			switch (msg) {
@@ -311,34 +317,30 @@ public partial class Game : Node2D {
 	// waiting messages b/c some of them might pertain to animations. TODO: Consider processing only the animation messages here.
 	// Must only be called while holding the game data mutex
 	public void updateAnimations(GameData gameData) {
-		processEngineMessages(gameData);
+		processEngineMessagesLocked(gameData);
 		animTracker.update();
 	}
 
 	public override void _Process(double delta) {
 		ProcessActions();
+		processEngineMessages();
 
-		// TODO: Is it necessary to keep the game data mutex locked for this entire method?
-		using (var gameDataAccess = new UIGameDataAccess()) {
-			GameData gameData = gameDataAccess.gameData;
+		if (!errorOnLoad) {
+			if (CurrentState == GameState.PlayerTurn) {
+				// If the selected unit is unfortified, prepare to autoselect the next one if it becomes fortified
+				if ((CurrentlySelectedUnit != MapUnit.NONE) && (!CurrentlySelectedUnit.isFortified))
+					KeepCSUWhenFortified = false;
 
-			processEngineMessages(gameData);
-
-			if (!errorOnLoad) {
-				if (CurrentState == GameState.PlayerTurn) {
-					// If the selected unit is unfortified, prepare to autoselect the next one if it becomes fortified
-					if ((CurrentlySelectedUnit != MapUnit.NONE) && (!CurrentlySelectedUnit.isFortified))
-						KeepCSUWhenFortified = false;
-
-					// Advance off the currently selected unit to the next one if it's out of moves or HP and not playing an
-					// animation we want to watch, or if it's fortified and we aren't set to keep fortified units selected.
-					if ((CurrentlySelectedUnit != MapUnit.NONE) &&
-						(((!CurrentlySelectedUnit.movementPoints.canMove || CurrentlySelectedUnit.hitPointsRemaining <= 0) &&
-						  !animTracker.getUnitAppearance(CurrentlySelectedUnit).DeservesPlayerAttention()) ||
-						 (CurrentlySelectedUnit.isFortified && !KeepCSUWhenFortified) ||
-						 CurrentlySelectedUnit.isAutomated))
+				// Advance off the currently selected unit to the next one if it's out of moves or HP and not playing an
+				// animation we want to watch, or if it's fortified and we aren't set to keep fortified units selected.
+				if ((CurrentlySelectedUnit != MapUnit.NONE) &&
+					(((!CurrentlySelectedUnit.movementPoints.canMove || CurrentlySelectedUnit.hitPointsRemaining <= 0) &&
+					  !animTracker.getUnitAppearance(CurrentlySelectedUnit).DeservesPlayerAttention()) ||
+					 (CurrentlySelectedUnit.isFortified && !KeepCSUWhenFortified) ||
+					 CurrentlySelectedUnit.isAutomated))
+					EngineStorage.ReadGameData((GameData gameData) => {
 						GetNextAutoselectedUnit(gameData);
-				}
+					});
 			}
 		}
 	}
@@ -414,38 +416,39 @@ public partial class Game : Node2D {
 	}
 
 	private void OnPlayerStartTurn() {
-		using UIGameDataAccess gameDataAccess = new();
-		log.Information("Starting player turn");
+		EngineStorage.ReadGameData((GameData gameData) => {
+			log.Information("Starting player turn");
 
-		// If the player can now pick a new government, force them to do so.
-		// When the popup is closed we call OnPlayerStartTurn again. This isn't
-		// ideal, but we don't yet have a general purpose "show a popup and
-		// wait for the player to acknowledge it" system.
-		if (controller.government.transitionType && TurnHandling.GetTurnNumber() >= controller.inAnarchyUntilTurn) {
-			popupOverlay.ShowPopup(
-				new GovernmentSelection(controller, controller.GetAvailableGovernments(gameDataAccess.gameData)),
-				PopupOverlay.PopupCategory.Info);
-		}
-
-		// If the player can pick a new tech to research, prompt them to do so
-		// once they have a city.
-		if (controller.cities.Count > 0
-				&& controller.currentlyResearchedTech == null
-				&& controller.GetAvailableTechsToResearch(gameDataAccess.gameData).Count > 0) {
-			popupOverlay.ShowPopup(
-					new ScienceSelection(controller),
+			// If the player can now pick a new government, force them to do so.
+			// When the popup is closed we call OnPlayerStartTurn again. This isn't
+			// ideal, but we don't yet have a general purpose "show a popup and
+			// wait for the player to acknowledge it" system.
+			if (controller.government.transitionType && TurnHandling.GetTurnNumber() >= controller.inAnarchyUntilTurn) {
+				popupOverlay.ShowPopup(
+					new GovernmentSelection(controller, controller.GetAvailableGovernments(gameData)),
 					PopupOverlay.PopupCategory.Info);
-		}
+			}
 
-		// Allow fast forwarding in observer mode.
-		if (gameDataAccess.gameData.observerMode && turnsLeftToFastForward > 0) {
-			--turnsLeftToFastForward;
-			new MsgEndTurn().send();
-			return;
-		}
+			// If the player can pick a new tech to research, prompt them to do so
+			// once they have a city.
+			if (controller.cities.Count > 0
+					&& controller.currentlyResearchedTech == null
+					&& controller.GetAvailableTechsToResearch(gameData).Count > 0) {
+				popupOverlay.ShowPopup(
+						new ScienceSelection(controller),
+						PopupOverlay.PopupCategory.Info);
+			}
 
-		CurrentState = GameState.PlayerTurn;
-		GetNextAutoselectedUnit(gameDataAccess.gameData);
+			// Allow fast forwarding in observer mode.
+			if (gameData.observerMode && turnsLeftToFastForward > 0) {
+				--turnsLeftToFastForward;
+				new MsgEndTurn().send();
+				return;
+			}
+
+			CurrentState = GameState.PlayerTurn;
+			GetNextAutoselectedUnit(gameData);
+		});
 	}
 
 	private void OnPlayerEndTurn() {
@@ -454,12 +457,13 @@ public partial class Game : Node2D {
 		}
 
 		// Prompt the user if they would have a city riot when the turn ended.
-		{
-			using UIGameDataAccess gDA = new();
+		EngineStorage.ReadGameData((GameData gameData) => {
 			foreach (City city in controller.cities) {
-				if (!controller.isHuman) { continue; }
+				if (!controller.isHuman) {
+					continue;
+				}
 
-				City.Mood cityMood = city.RecalculateCitizenMoods(gDA.gameData);
+				City.Mood cityMood = city.RecalculateCitizenMoods(gameData);
 				if (cityMood == City.Mood.Unhappy) {
 					popupOverlay.ShowPopup(
 						new ConfirmationPopup(
@@ -473,7 +477,7 @@ public partial class Game : Node2D {
 					return;
 				}
 			}
-		}
+		});
 		DoActualEndTurn();
 	}
 
@@ -579,8 +583,10 @@ public partial class Game : Node2D {
 	}
 
 	private Tile PositionToTile(Vector2 position) {
-		using var gameDataAccess = new UIGameDataAccess();
-		Tile tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, position);
+		Tile tile = null;
+		EngineStorage.ReadGameData((GameData gameData) => {
+			tile = mapView.tileOnScreenAt(gameData.map, position);
+		});
 		return tile;
 	}
 
@@ -603,8 +609,9 @@ public partial class Game : Node2D {
 	private void OnDoubleLeftMouseButtonClick(InputEventMouseButton eventMouseButton) {
 		Tile tile = PositionToTile(eventMouseButton.Position);
 		if (tile?.cityAtTile?.owner == controller) {
-			using UIGameDataAccess gDA = new();
-			ShowCityScreenForCity(gDA.gameData, tile.cityAtTile);
+			EngineStorage.ReadGameData((GameData gameData) => {
+				ShowCityScreenForCity(gameData, tile.cityAtTile);
+			});
 		}
 	}
 
@@ -729,17 +736,18 @@ public partial class Game : Node2D {
 	}
 
 	private void ToggleObserverMode() {
-		using UIGameDataAccess gameDataAccess = new UIGameDataAccess();
-		gameDataAccess.gameData.observerMode = !gameDataAccess.gameData.observerMode;
-		if (gameDataAccess.gameData.observerMode) {
-			SetObserverModeOn(gameDataAccess);
-		} else {
-			SetObserverModeOff(gameDataAccess);
-		}
+		EngineStorage.ReadGameData((GameData gameData) => {
+			gameData.observerMode = !gameData.observerMode;
+			if (gameData.observerMode) {
+				SetObserverModeOn(gameData);
+			} else {
+				SetObserverModeOff(gameData);
+			}
+		});
 	}
 
-	private void SetObserverModeOn(UIGameDataAccess gameDataAccess) {
-		foreach (Player player in gameDataAccess.gameData.players) {
+	private void SetObserverModeOn(GameData gameData) {
+		foreach (Player player in gameData.players) {
 			player.isHuman = false;
 		}
 		SetAnimationsEnabled(false);
@@ -751,8 +759,8 @@ public partial class Game : Node2D {
 				PopupOverlay.PopupCategory.Advisor);
 	}
 
-	private void SetObserverModeOff(UIGameDataAccess gameDataAccess) {
-		foreach (Player player in gameDataAccess.gameData.players) {
+	private void SetObserverModeOff(GameData gameData) {
+		foreach (Player player in gameData.players) {
 			if (player.id == EngineStorage.uiControllerID) {
 				player.isHuman = true;
 			}
@@ -760,8 +768,9 @@ public partial class Game : Node2D {
 	}
 
 	private void ToggleGridCoordinates() {
-		using UIGameDataAccess gameDataAccess = new UIGameDataAccess();
-		gameDataAccess.gameData.showGridCoordinates = !gameDataAccess.gameData.showGridCoordinates;
+		EngineStorage.ReadGameData((GameData gameData) => {
+			gameData.showGridCoordinates = !gameData.showGridCoordinates;
+		});
 	}
 
 	private void ToggleC7Graphics() {
@@ -866,9 +875,10 @@ public partial class Game : Node2D {
 		}
 
 		if (currentAction == C7Action.UnitWait) {
-			using var gameDataAccess = new UIGameDataAccess();
-			UnitInteractions.waitUnit(gameDataAccess.gameData, CurrentlySelectedUnit.id);
-			GetNextAutoselectedUnit(gameDataAccess.gameData);
+			EngineStorage.ReadGameData((GameData gameData) => {
+				UnitInteractions.waitUnit(gameData, CurrentlySelectedUnit.id);
+				GetNextAutoselectedUnit(gameData);
+			});
 		}
 
 		if (currentAction == C7Action.UnitFortify) {
@@ -911,12 +921,14 @@ public partial class Game : Node2D {
 		}
 
 		if (currentAction == C7Action.UnitBuildCity && CurrentlySelectedUnit != MapUnit.NONE && (CurrentlySelectedUnit?.canBuildCity() ?? false)) {
-			using var gameDataAccess = new UIGameDataAccess();
-			MapUnit currentUnit = gameDataAccess.gameData.GetUnit(CurrentlySelectedUnit.id);
-			log.Debug(currentUnit.Describe());
-			if (currentUnit.canBuildCity()) {
-				popupOverlay.ShowPopup(new BuildCityDialog(controller.GetNextCityName()), PopupOverlay.PopupCategory.Advisor);
-			}
+			EngineStorage.ReadGameData((GameData gameData) => {
+				MapUnit currentUnit = gameData.GetUnit(CurrentlySelectedUnit.id);
+				log.Debug(currentUnit.Describe());
+				if (currentUnit.canBuildCity()) {
+					popupOverlay.ShowPopup(new BuildCityDialog(controller.GetNextCityName()),
+						PopupOverlay.PopupCategory.Advisor);
+				}
+			});
 		}
 
 		Terraform terraform = C7Action.ToTerraform(currentAction);
@@ -944,24 +956,26 @@ public partial class Game : Node2D {
 		if (info == null || info.moveCost == -1) {
 			return;
 		}
-		using UIGameDataAccess gameDataAccess = new();
-		int currentTurn = gameDataAccess.gameData.turn;
 
-		// If this move would require declaring war, display a popup that checks
-		// if the player really wants to declare war. If they do, declare the
-		// war for them, clear out the player, and call this method again.
-		if (info.requiresWarDeclarationOnPlayer != null) {
-			GotoInfo stashed = info;
-			popupOverlay.ShowPopup(new WarConfirmation(stashed.requiresWarDeclarationOnPlayer,
-				() => {
-					controller.DeclareWarOn(info.requiresWarDeclarationOnPlayer, currentTurn);
-					stashed.requiresWarDeclarationOnPlayer = null;
-					HandleGotoClick(stashed);
-				}), PopupOverlay.PopupCategory.Advisor);
-			return;
-		}
+		EngineStorage.ReadGameData((GameData gameData) => {
+			int currentTurn = gameData.turn;
 
-		new MsgSetUnitPath(CurrentlySelectedUnit.id, info.path).send();
+			// If this move would require declaring war, display a popup that checks
+			// if the player really wants to declare war. If they do, declare the
+			// war for them, clear out the player, and call this method again.
+			if (info.requiresWarDeclarationOnPlayer != null) {
+				GotoInfo stashed = info;
+				popupOverlay.ShowPopup(new WarConfirmation(stashed.requiresWarDeclarationOnPlayer,
+					() => {
+						controller.DeclareWarOn(info.requiresWarDeclarationOnPlayer, currentTurn);
+						stashed.requiresWarDeclarationOnPlayer = null;
+						HandleGotoClick(stashed);
+					}), PopupOverlay.PopupCategory.Advisor);
+				return;
+			}
+
+			new MsgSetUnitPath(CurrentlySelectedUnit.id, info.path).send();
+		});
 	}
 
 	private GotoInfo GetGotoInfo(Vector2 mousePos) {
@@ -970,46 +984,49 @@ public partial class Game : Node2D {
 		// We're in "goto" mode and moved the mouse over a tile.
 		//
 		// Figure out which tile it was.
-		using UIGameDataAccess gameDataAccess = new();
-		Tile tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, mousePos);
-		result.destinationTile = tile;
+		EngineStorage.ReadGameData((GameData gameData) => {
+			Tile tile = mapView.tileOnScreenAt(gameData.map, mousePos);
+			result.destinationTile = tile;
 
-		// Figure out what unit is in goto mode. If the tile we're hovering over is
-		// different than the tile the unit is on, calculate the path to move there.
-		MapUnit unit = tile == null ? null : gameDataAccess.gameData.GetUnit(CurrentlySelectedUnit.id);
-		if (unit != null && unit.location != tile) {
-			result.path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, tile);
-			result.moveCost = result.path.PathCost(unit.location, unit.unitType.movement, unit.movementPoints.remaining);
-			result.pathCoords = result.path.GetPathCoords();
+			// Figure out what unit is in goto mode. If the tile we're hovering over is
+			// different than the tile the unit is on, calculate the path to move there.
+			MapUnit unit = tile == null ? null : gameData.GetUnit(CurrentlySelectedUnit.id);
+			if (unit != null && unit.location != tile) {
+				result.path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, tile);
+				result.moveCost =
+					result.path.PathCost(unit.location, unit.unitType.movement, unit.movementPoints.remaining);
+				result.pathCoords = result.path.GetPathCoords();
 
-			// If we couldn't path onto the tile, but the tile is next to us and
-			// we could enter the tile if combat is allowed (or if we could
-			// declare war with the move) mark the path.
-			if (result.moveCost == -1
+				// If we couldn't path onto the tile, but the tile is next to us and
+				// we could enter the tile if combat is allowed (or if we could
+				// declare war with the move) mark the path.
+				if (result.moveCost == -1
 					&& unit.location.distanceTo(tile) == 1
 					&& unit.CanEnterTile(tile, allowCombat: true, allowWarDeclaration: true)) {
-				Queue<Tile> pathQueue = new();
-				pathQueue.Enqueue(tile);
+					Queue<Tile> pathQueue = new();
+					pathQueue.Enqueue(tile);
 
-				result.path = new TilePath(tile, pathQueue);
-				result.moveCost = result.path.PathCost(unit.location, unit.unitType.movement, unit.movementPoints.remaining);
-				result.pathCoords = result.path.GetPathCoords();
-				result.attackingMove = true;
+					result.path = new TilePath(tile, pathQueue);
+					result.moveCost = result.path.PathCost(unit.location, unit.unitType.movement,
+						unit.movementPoints.remaining);
+					result.pathCoords = result.path.GetPathCoords();
+					result.attackingMove = true;
 
-				// If we couldn't enter this tile without a war declaration,
-				// record which civ we need to declare war on.
-				if (!unit.CanEnterTile(tile, allowCombat: true, allowWarDeclaration: false)) {
-					if (tile.cityAtTile != null) {
-						result.requiresWarDeclarationOnPlayer = tile.cityAtTile.owner;
-					} else {
-						result.requiresWarDeclarationOnPlayer = tile.unitsOnTile[0].owner;
+					// If we couldn't enter this tile without a war declaration,
+					// record which civ we need to declare war on.
+					if (!unit.CanEnterTile(tile, allowCombat: true, allowWarDeclaration: false)) {
+						if (tile.cityAtTile != null) {
+							result.requiresWarDeclarationOnPlayer = tile.cityAtTile.owner;
+						} else {
+							result.requiresWarDeclarationOnPlayer = tile.unitsOnTile[0].owner;
+						}
 					}
 				}
+			} else {
+				// Hide the goto cursor, we don't have a valid move.
+				result.moveCost = -1;
 			}
-		} else {
-			// Hide the goto cursor, we don't have a valid move.
-			result.moveCost = -1;
-		}
+		});
 
 		return result;
 	}

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -464,9 +464,7 @@ public partial class LooseView : Node2D {
 	public override void _Draw() {
 		base._Draw();
 
-		using (var gameDataAccess = new UIGameDataAccess()) {
-			GameData gD = gameDataAccess.gameData;
-
+		EngineStorage.ReadGameData((GameData gD) => {
 			// Iterating over visible tiles is unfortunately pretty expensive. Assemble a list of Tile references and centers first so we don't
 			// have to reiterate for each layer. Doing this improves framerate significantly.
 			MapView.VisibleRegion visRegion = mapView.getVisibleRegion();
@@ -475,8 +473,11 @@ public partial class LooseView : Node2D {
 				if (gD.map.isRowAt(Y)) {
 					for (int X = visRegion.getRowStartX(Y); X < visRegion.lowerRightX; X += 2) {
 						Tile tile = gD.map.tileAt(X, Y);
-						if (IsTileKnown(tile, gameDataAccess)) {
-							visibleTiles.Add(new VisibleTile { tile = tile, tileCenter = MapView.cellSize * new Vector2(X + 1, Y + 1) });
+						if (IsTileKnown(tile, gD)) {
+							visibleTiles.Add(new VisibleTile {
+								tile = tile,
+								tileCenter = MapView.cellSize * new Vector2(X + 1, Y + 1)
+							});
 						}
 					}
 				}
@@ -489,8 +490,10 @@ public partial class LooseView : Node2D {
 				foreach (VisibleTile vT in visibleTiles) {
 					layer.drawObject(this, gD, vT.tile, vT.tileCenter);
 				}
+
 				layer.onEndDraw(this, gD);
 			}
+
 			if (stopwatch.ElapsedMilliseconds > 100) {
 				log.Information($"-> End draw: {stopwatch.ElapsedMilliseconds} milliseconds");
 			}
@@ -502,19 +505,22 @@ public partial class LooseView : Node2D {
 							for (int X = visRegion.getRowStartX(Y); X < visRegion.lowerRightX; X += 2) {
 								Tile tile = gD.map.tileAt(X, Y);
 								if (tile != Tile.NONE) {
-									VisibleTile invisibleTile = new VisibleTile { tile = tile, tileCenter = MapView.cellSize * new Vector2(X + 1, Y + 1) };
+									VisibleTile invisibleTile = new VisibleTile {
+										tile = tile,
+										tileCenter = MapView.cellSize * new Vector2(X + 1, Y + 1)
+									};
 									layer.drawObject(this, gD, tile, invisibleTile.tileCenter);
 								}
 							}
 				}
 			}
-		}
+		});
 	}
-	private static bool IsTileKnown(Tile tile, UIGameDataAccess gameDataAccess) {
-		if (gameDataAccess.gameData.observerMode) {
+	private static bool IsTileKnown(Tile tile, GameData gameData) {
+		if (gameData.observerMode) {
 			return true;
 		}
-		TileKnowledge knowledge = gameDataAccess.gameData.GetHumanPlayers()[0].tileKnowledge;
+		TileKnowledge knowledge = gameData.GetHumanPlayers()[0].tileKnowledge;
 		return tile != Tile.NONE && knowledge.isTileKnown(tile);
 	}
 }

--- a/C7/UIElements/Advisors/DomesticAdvisor.cs
+++ b/C7/UIElements/Advisors/DomesticAdvisor.cs
@@ -142,58 +142,59 @@ public partial class DomesticAdvisor : Control {
 	public void ShowAdvisor() {
 		Show();
 
-		using UIGameDataAccess gameDataAccess = new();
-		Player player = gameDataAccess.gameData.GetHumanPlayers()[0];
+		EngineStorage.ReadGameData((GameData gameData) => {
+			Player player = gameData.GetHumanPlayers()[0];
 
-		int scienceRate = player.scienceRate;
-		int luxuryRate = player.luxuryRate;
+			int scienceRate = player.scienceRate;
+			int luxuryRate = player.luxuryRate;
 
-		scienceSliderIcon.SetPosition(new Vector2(CalculateSliderXPos(scienceRate), scienceSliderY));
-		luxurySliderIcon.SetPosition(new Vector2(CalculateSliderXPos(luxuryRate), luxurySliderY));
-		scienceSliderLabel.Text = $"{scienceRate * 10}%";
-		luxurySliderLabel.Text = $"{luxuryRate * 10}%";
+			scienceSliderIcon.SetPosition(new Vector2(CalculateSliderXPos(scienceRate), scienceSliderY));
+			luxurySliderIcon.SetPosition(new Vector2(CalculateSliderXPos(luxuryRate), luxurySliderY));
+			scienceSliderLabel.Text = $"{scienceRate * 10}%";
+			luxurySliderLabel.Text = $"{luxuryRate * 10}%";
 
-		governmentLabel.Text = $"{player.government.name}";
-		scienceStatus.Text = player.SummarizeScience(gameDataAccess.gameData);
-		treasury.Text = $"Treasury: {player.gold}";
+			governmentLabel.Text = $"{player.government.name}";
+			scienceStatus.Text = player.SummarizeScience(gameData);
+			treasury.Text = $"Treasury: {player.gold}";
 
-		// TODO: fill these in.
-		incomeDetails.Text = "From cities: +??\nFrom taxmen: +??\nFrom other civs: +??\nFrom interest: +??";
-		expenseDetails.Text = "-??: Science\n-??: Entertainment\n-??: Corruption\n-??: Maintenance\n-??: Unit costs\n-??: To other civs";
-		incomeSummary.Text = "??";
-		expenseSummary.Text = "??";
+			// TODO: fill these in.
+			incomeDetails.Text = "From cities: +??\nFrom taxmen: +??\nFrom other civs: +??\nFrom interest: +??";
+			expenseDetails.Text = "-??: Science\n-??: Entertainment\n-??: Corruption\n-??: Maintenance\n-??: Unit costs\n-??: To other civs";
+			incomeSummary.Text = "??";
+			expenseSummary.Text = "??";
 
-		int goldPerTurn = player.CalculateGoldPerTurn();
-		if (goldPerTurn > 0) {
-			sumSummary.Text = $"Net gain: {goldPerTurn}";
-			growth.Text = "Growing!";
-		} else if (goldPerTurn < 0) {
-			sumSummary.Text = $"Net loss: {goldPerTurn}";
-			growth.Text = "Shrinking!";
-		} else {
-			sumSummary.Text = $"Neutral: {goldPerTurn}";
-			growth.Text = "Balanced";
-		}
+			int goldPerTurn = player.CalculateGoldPerTurn();
+			if (goldPerTurn > 0) {
+				sumSummary.Text = $"Net gain: {goldPerTurn}";
+				growth.Text = "Growing!";
+			} else if (goldPerTurn < 0) {
+				sumSummary.Text = $"Net loss: {goldPerTurn}";
+				growth.Text = "Shrinking!";
+			} else {
+				sumSummary.Text = $"Neutral: {goldPerTurn}";
+				growth.Text = "Balanced";
+			}
 
-		//TODO: Randomize or set logically
-		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Domestic, AdvisorHead.Mood.Happy, player.EraIndex());
+			//TODO: Randomize or set logically
+			advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Domestic, AdvisorHead.Mood.Happy, player.EraIndex());
 
-		// Disable the change government button unless we have a government to
-		// switch to.
-		changeGovernment.Disabled = player.GetAvailableGovernments(gameDataAccess.gameData).Count == 1;
+			// Disable the change government button unless we have a government to
+			// switch to.
+			changeGovernment.Disabled = player.GetAvailableGovernments(gameData).Count == 1;
 
-		if (player.government.transitionType && player.inAnarchyUntilTurn > gameDataAccess.gameData.turn) {
-			DialogBoxAdvise.Text = $"{player.inAnarchyUntilTurn - gameDataAccess.gameData.turn} turns of anarchy left";
-		}
+			if (player.government.transitionType && player.inAnarchyUntilTurn > gameData.turn) {
+				DialogBoxAdvise.Text = $"{player.inAnarchyUntilTurn - gameData.turn} turns of anarchy left";
+			}
 
-		foreach (var node in cityListContainer.GetChildren()) {
-			cityListContainer.RemoveChild(node);
-			node.QueueFree();
-		}
+			foreach (var node in cityListContainer.GetChildren()) {
+				cityListContainer.RemoveChild(node);
+				node.QueueFree();
+			}
 
-		foreach (City city in player.cities) {
-			cityListContainer.AddChild(MakeCityRow(city));
-		}
+			foreach (City city in player.cities) {
+				cityListContainer.AddChild(MakeCityRow(city));
+			}
+		});
 	}
 
 	private int CalculateSliderXPos(int sliderRate) {
@@ -208,25 +209,24 @@ public partial class DomesticAdvisor : Control {
 	}
 
 	private void ChangeGovernments() {
-		using UIGameDataAccess gameDataAccess = new();
-		Player player = gameDataAccess.gameData.GetHumanPlayers()[0];
+		EngineStorage.ReadGameData((GameData gameData) => {
+			Player player = gameData.GetHumanPlayers()[0];
 
-		if (player.government.transitionType) {
+			if (player.government.transitionType) {
+				popupOverlay.ShowPopup(
+					new InformationalPopup("You already started a revolution. Remember?"),
+					PopupOverlay.PopupCategory.Advisor);
+				return;
+			}
+
 			popupOverlay.ShowPopup(
-				new InformationalPopup("You already started a revolution. Remember?"),
-				PopupOverlay.PopupCategory.Advisor);
-			return;
-		}
-
-		popupOverlay.ShowPopup(
 				new ConfirmationPopup(
 					"You say you want a revolution?",
 					"Yes, you know it's gonna be alright.",
 					"No. You can count me out.",
-					() => {
-						new StartGovernmentTransitionMsg(player).send();
-					}),
+					() => { new StartGovernmentTransitionMsg(player).send(); }),
 				PopupOverlay.PopupCategory.Advisor);
+		});
 	}
 
 	private HBoxContainer MakeCityRow(City city) {

--- a/C7/UIElements/Advisors/MilitaryAdvisor.cs
+++ b/C7/UIElements/Advisors/MilitaryAdvisor.cs
@@ -34,8 +34,8 @@ public partial class MilitaryAdvisor : TextureRect {
 		AddChild(GoBackButton);
 		GoBackButton.Pressed += ReturnToMenu;
 
-		using (UIGameDataAccess gameDataAccess = new()) {
-			Player player = gameDataAccess.gameData.GetHumanPlayers()[0];
+		EngineStorage.ReadGameData((GameData gameData) => {
+			Player player = gameData.GetHumanPlayers()[0];
 			var (totalUnits, allowedUnits, unitSupportCost) = player.TotalUnitsAllowedUnitsAndSupportCost();
 
 			AddChild(totalUnitsLabel);
@@ -55,11 +55,11 @@ public partial class MilitaryAdvisor : TextureRect {
 
 			TextureRect advisorHead = new();
 			//TODO: Randomize or set logically
-			advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Military, AdvisorHead.Mood.Happy, player.EraIndex());
+			advisorHead.Texture =
+				AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Military, AdvisorHead.Mood.Happy, player.EraIndex());
 			advisorHead.SetPosition(new Vector2(851, 0));
 			AddChild(advisorHead);
-		}
-
+		});
 	}
 
 	private void ReturnToMenu() {

--- a/C7/UIElements/Advisors/ScienceAdvisor.cs
+++ b/C7/UIElements/Advisors/ScienceAdvisor.cs
@@ -21,11 +21,12 @@ public partial class ScienceAdvisor : TextureRect {
 	public override void _Ready() {
 		this.CreateUI();
 
-		using UIGameDataAccess gameDataAccess = new();
-		List<Tech> techs = gameDataAccess.gameData.techs;
-		Player player = gameDataAccess.gameData.GetHumanPlayers()[0];
-		eraName = player.eraCivilopediaName;
-		this.DrawTechTree(eraName, player, techs, player.GetAvailableTechsToResearch(gameDataAccess.gameData));
+		EngineStorage.ReadGameData((GameData gameData) => {
+			List<Tech> techs = gameData.techs;
+			Player player = gameData.GetHumanPlayers()[0];
+			eraName = player.eraCivilopediaName;
+			this.DrawTechTree(eraName, player, techs, player.GetAvailableTechsToResearch(gameData));
+		});
 	}
 
 	private void CreateUI() {
@@ -146,11 +147,12 @@ public partial class ScienceAdvisor : TextureRect {
 		}
 		techBoxes.Clear();
 
-		using UIGameDataAccess gameDataAccess = new();
-		List<Tech> techs = gameDataAccess.gameData.techs;
-		Player player = gameDataAccess.gameData.GetHumanPlayers()[0];
-		eraName = Player.EraIndexToEra(Player.EraIndex(eraName) + delta);
-		DrawTechTree(eraName, player, techs, player.GetAvailableTechsToResearch(gameDataAccess.gameData));
+		EngineStorage.ReadGameData((GameData gameData) => {
+			List<Tech> techs = gameData.techs;
+			Player player = gameData.GetHumanPlayers()[0];
+			eraName = Player.EraIndexToEra(Player.EraIndex(eraName) + delta);
+			DrawTechTree(eraName, player, techs, player.GetAvailableTechsToResearch(gameData));
+		});
 	}
 
 	private void ReturnToMenu() {

--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -154,22 +154,24 @@ public partial class CityScreen : Control {
 			if (eventMouseButton.ButtonIndex == MouseButton.Left) {
 				GetViewport().SetInputAsHandled();
 				if (eventMouseButton.IsPressed()) {
-					using UIGameDataAccess gameDataAccess = new();
-					if (productionMenu != null) {
-						productionMenu.Visible = false;
-					}
-					Tile tile = mapView.tileOnScreenAt(gameDataAccess.gameData.map, eventMouseButton.Position);
-					if (tile != null) {
-						HandleReassignment(tile);
+					EngineStorage.ReadGameData((GameData gameData) => {
+						if (productionMenu != null) {
+							productionMenu.Visible = false;
+						}
 
-						// Recalculate moods after changing tile assignments.
-						tileAssignmentLayer.city.RecalculateCitizenMoods(gameDataAccess.gameData);
+						Tile tile = mapView.tileOnScreenAt(gameData.map, eventMouseButton.Position);
+						if (tile != null) {
+							HandleReassignment(tile);
 
-						RenderPopHeads(tileAssignmentLayer.city);
-						RenderFoodDetails(tileAssignmentLayer.city);
-						RenderCommerceDetails(tileAssignmentLayer.city);
-						RenderProductionDetails(tileAssignmentLayer.city);
-					}
+							// Recalculate moods after changing tile assignments.
+							tileAssignmentLayer.city.RecalculateCitizenMoods(gameData);
+
+							RenderPopHeads(tileAssignmentLayer.city);
+							RenderFoodDetails(tileAssignmentLayer.city);
+							RenderCommerceDetails(tileAssignmentLayer.city);
+							RenderProductionDetails(tileAssignmentLayer.city);
+						}
+					});
 				}
 			}
 		}
@@ -605,9 +607,10 @@ public partial class CityScreen : Control {
 		productionButtonLabel.SetTextAndCenterLabel($"{city.itemBeingProduced.name}");
 
 		productionMenu.AddItems(city, (IProducible p) => {
-			using UIGameDataAccess gameDataAccess = new();
-			city.SetItemBeingProduced(p);
-			RenderProductionDetails(city);
+			EngineStorage.ReadGameData((GameData gameData) => {
+				city.SetItemBeingProduced(p);
+				RenderProductionDetails(city);
+			});
 		});
 	}
 
@@ -764,8 +767,7 @@ public partial class CityScreen : Control {
 				++index;
 				RenderPopHeads(city);
 
-				using UIGameDataAccess gDa = new();
-				RenderCommerceDetails(city);
+				EngineStorage.ReadGameData((GameData gameData) => { RenderCommerceDetails(city); });
 			};
 
 			background.AddChild(tb);
@@ -775,21 +777,23 @@ public partial class CityScreen : Control {
 	}
 
 	private void SwitchToNextCity() {
-		using UIGameDataAccess gameDataAccess = new();
-		City currentCity = tileAssignmentLayer.city;
-		List<City> cities = currentCity.owner.cities;
-		City nextCity = cities[(cities.IndexOf(currentCity) + 1) % cities.Count];
-		nextCity.RecalculateCitizenMoods(gameDataAccess.gameData);
-		OnShowCityScreen(new ParameterWrapper<City>(nextCity));
+		EngineStorage.ReadGameData((GameData gameData) => {
+			City currentCity = tileAssignmentLayer.city;
+			List<City> cities = currentCity.owner.cities;
+			City nextCity = cities[(cities.IndexOf(currentCity) + 1) % cities.Count];
+			nextCity.RecalculateCitizenMoods(gameData);
+			OnShowCityScreen(new ParameterWrapper<City>(nextCity));
+		});
 	}
 
 	private void SwitchToPreviousCity() {
-		using UIGameDataAccess gameDataAccess = new();
-		City currentCity = tileAssignmentLayer.city;
-		List<City> cities = currentCity.owner.cities;
-		City previousCity = cities[(cities.IndexOf(currentCity) + cities.Count - 1) % cities.Count];
-		previousCity.RecalculateCitizenMoods(gameDataAccess.gameData);
-		OnShowCityScreen(new ParameterWrapper<City>(previousCity));
+		EngineStorage.ReadGameData((GameData gameData) => {
+			City currentCity = tileAssignmentLayer.city;
+			List<City> cities = currentCity.owner.cities;
+			City previousCity = cities[(cities.IndexOf(currentCity) + cities.Count - 1) % cities.Count];
+			previousCity.RecalculateCitizenMoods(gameData);
+			OnShowCityScreen(new ParameterWrapper<City>(previousCity));
+		});
 	}
 
 	private int AddDefaultCitizen(CityResident cr, int xPos, int eraNum) {

--- a/C7/UIElements/Civ3FileDialog.cs
+++ b/C7/UIElements/Civ3FileDialog.cs
@@ -1,3 +1,5 @@
+using C7Engine;
+using C7GameData;
 using Godot;
 using Serilog;
 
@@ -39,9 +41,9 @@ public partial class Civ3FileDialog : FileDialog {
 			}
 
 			log.Information($"Saving game to {path}");
-			using (C7Engine.UIGameDataAccess gameDataAccess = new()) {
-				C7GameData.Save.SaveGame.FromGameData(gameDataAccess.gameData).Save(path);
-			}
+			EngineStorage.ReadGameData((GameData gameData) => {
+				C7GameData.Save.SaveGame.FromGameData(gameData).Save(path);
+			});
 		}
 	}
 }

--- a/C7/UIElements/Diplomacy/DealScreen.cs
+++ b/C7/UIElements/Diplomacy/DealScreen.cs
@@ -14,7 +14,7 @@ using ConvertCiv3Media;
 //
 // The basic idea is to have all the possible items present in both components,
 // and then use the shared TradeOffer object to determine what is visible. So
-// when a technology is clicked in the trading tree, it is added to the 
+// when a technology is clicked in the trading tree, it is added to the
 // TradeOffer object, and then we refresh the UIs of the trading tree and the
 // trade offer ui to swap the visibility.
 //
@@ -68,127 +68,129 @@ public partial class DealScreen : TextureRect {
 
 		this.Texture = TextureLoader.Load("diplomacy.deal");
 
-		using UIGameDataAccess gameDataAccess = new();
-		GameData gD = gameDataAccess.gameData;
-		Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
-		Player humanPlayer = gD.players.Find(x => x.id == humanPlayerId);
-		bool playersAtWar = humanPlayer.playerRelationships[opponentPlayer.id].atWar;
-		GetParent<Diplomacy>().AddLeaderHeadAndLabel(this, opponentPlayer, fontTheme);
+		EngineStorage.ReadGameData((GameData gD) => {
+			Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
+			Player humanPlayer = gD.players.Find(x => x.id == humanPlayerId);
+			bool playersAtWar = humanPlayer.playerRelationships[opponentPlayer.id].atWar;
+			GetParent<Diplomacy>().AddLeaderHeadAndLabel(this, opponentPlayer, fontTheme);
 
-		// Figure out which technologies can be traded by each player, if any.
-		List<Tech> techsOpponentCanTrade = gD.techs.FindAll(x => {
-			return opponentPlayer.knownTechs.Contains(x.id) && !humanPlayer.knownTechs.Contains(x.id);
+			// Figure out which technologies can be traded by each player, if any.
+			List<Tech> techsOpponentCanTrade = gD.techs.FindAll(x => {
+				return opponentPlayer.knownTechs.Contains(x.id) && !humanPlayer.knownTechs.Contains(x.id);
+			});
+			List<Tech> techsHumanCanTrade = gD.techs.FindAll(x => {
+				return humanPlayer.knownTechs.Contains(x.id) && !opponentPlayer.knownTechs.Contains(x.id);
+			});
+
+			// Left hand side UI components.
+			opponentTree = new TradingTree(fontTheme, opponentPlayer.gold, techsOpponentCanTrade, opponentOffer,
+				playersAtWar);
+			AddChild(opponentTree);
+			opponentTree.Position = new Vector2(45, 220);
+
+			Label weWant = new();
+			weWant.Text = "We Want";
+			weWant.SetPosition(new Vector2(320, 440));
+			weWant.Theme = blueFontTheme;
+			AddChild(weWant);
+
+			opponentOfferUi = new(fontTheme, techsOpponentCanTrade, opponentPlayer.gold, opponentOffer, playersAtWar,
+				HorizontalAlignment.Left);
+			AddChild(opponentOfferUi);
+			opponentOfferUi.Position = new Vector2(314, 453);
+
+			// Right hand side UI components.
+			humanTree = new TradingTree(fontTheme, humanPlayer.gold, techsHumanCanTrade, humanOffer, playersAtWar);
+			AddChild(humanTree);
+			humanTree.Position = new Vector2(789, 220);
+
+			Label weOffer = new();
+			weOffer.Text = "We Offer";
+			weOffer.SetPosition(new Vector2(660, 440));
+			weOffer.Theme = blueFontTheme;
+			AddChild(weOffer);
+
+			humanOfferUi = new(fontTheme, techsHumanCanTrade, humanPlayer.gold, humanOffer, playersAtWar,
+				HorizontalAlignment.Right);
+			AddChild(humanOfferUi);
+			humanOfferUi.Position = new Vector2(527, 453);
+
+			var syncUis = () => {
+				opponentTree.RefreshUiForOffer();
+				humanTree.RefreshUiForOffer();
+				opponentOfferUi.RefreshUiForOffer();
+				humanOfferUi.RefreshUiForOffer();
+			};
+
+			// Link up the tree components appropriately.
+			opponentTree.HandleClicks(humanTree, () => {
+				syncUis();
+				UpdateText();
+			});
+			humanTree.HandleClicks(opponentTree, () => {
+				syncUis();
+				UpdateText();
+			});
+
+			humanOfferUi.HandleClicks(opponentOfferUi, () => {
+				syncUis();
+				UpdateText();
+			});
+			opponentOfferUi.HandleClicks(humanOfferUi, () => {
+				syncUis();
+				UpdateText();
+			});
+
+			// Add the buttons at the bottom.
+			acceptDeal = new();
+			acceptDeal.Text = "\"Will you accept this deal?\"";
+			acceptDeal.SetPosition(new Vector2(512 - 205, 650));
+			acceptDeal.Theme = fontTheme;
+			acceptDeal.Pressed += AttemptDeal;
+			AddChild(acceptDeal);
+
+			Button goodbye = new();
+			goodbye.Text = "\"Never mind...\"";
+			goodbye.SetPosition(new Vector2(512 - 205, 670));
+			goodbye.Theme = fontTheme;
+			goodbye.Pressed += () => { GetParent<Diplomacy>().Hide(); };
+			AddChild(goodbye);
+
+			// And the text from the opponent, if they reject a deal.
+			opponentResponse = new();
+			opponentResponse.Text = "\"Let's get down to business...\"";
+			opponentResponse.SetPosition(new Vector2(512 - 205, 345));
+			opponentResponse.Theme = fontTheme;
+			AddChild(opponentResponse);
 		});
-		List<Tech> techsHumanCanTrade = gD.techs.FindAll(x => {
-			return humanPlayer.knownTechs.Contains(x.id) && !opponentPlayer.knownTechs.Contains(x.id);
-		});
-
-		// Left hand side UI components.
-		opponentTree = new TradingTree(fontTheme, opponentPlayer.gold, techsOpponentCanTrade, opponentOffer, playersAtWar);
-		AddChild(opponentTree);
-		opponentTree.Position = new Vector2(45, 220);
-
-		Label weWant = new();
-		weWant.Text = "We Want";
-		weWant.SetPosition(new Vector2(320, 440));
-		weWant.Theme = blueFontTheme;
-		AddChild(weWant);
-
-		opponentOfferUi = new(fontTheme, techsOpponentCanTrade, opponentPlayer.gold, opponentOffer, playersAtWar, HorizontalAlignment.Left);
-		AddChild(opponentOfferUi);
-		opponentOfferUi.Position = new Vector2(314, 453);
-
-		// Right hand side UI components.
-		humanTree = new TradingTree(fontTheme, humanPlayer.gold, techsHumanCanTrade, humanOffer, playersAtWar);
-		AddChild(humanTree);
-		humanTree.Position = new Vector2(789, 220);
-
-		Label weOffer = new();
-		weOffer.Text = "We Offer";
-		weOffer.SetPosition(new Vector2(660, 440));
-		weOffer.Theme = blueFontTheme;
-		AddChild(weOffer);
-
-		humanOfferUi = new(fontTheme, techsHumanCanTrade, humanPlayer.gold, humanOffer, playersAtWar, HorizontalAlignment.Right);
-		AddChild(humanOfferUi);
-		humanOfferUi.Position = new Vector2(527, 453);
-
-		var syncUis = () => {
-			opponentTree.RefreshUiForOffer();
-			humanTree.RefreshUiForOffer();
-			opponentOfferUi.RefreshUiForOffer();
-			humanOfferUi.RefreshUiForOffer();
-		};
-
-		// Link up the tree components appropriately.
-		opponentTree.HandleClicks(humanTree, () => {
-			syncUis();
-			UpdateText();
-		});
-		humanTree.HandleClicks(opponentTree, () => {
-			syncUis();
-			UpdateText();
-		});
-
-		humanOfferUi.HandleClicks(opponentOfferUi, () => {
-			syncUis();
-			UpdateText();
-		});
-		opponentOfferUi.HandleClicks(humanOfferUi, () => {
-			syncUis();
-			UpdateText();
-		});
-
-		// Add the buttons at the bottom.
-		acceptDeal = new();
-		acceptDeal.Text = "\"Will you accept this deal?\"";
-		acceptDeal.SetPosition(new Vector2(512 - 205, 650));
-		acceptDeal.Theme = fontTheme;
-		acceptDeal.Pressed += AttemptDeal;
-		AddChild(acceptDeal);
-
-		Button goodbye = new();
-		goodbye.Text = "\"Never mind...\"";
-		goodbye.SetPosition(new Vector2(512 - 205, 670));
-		goodbye.Theme = fontTheme;
-		goodbye.Pressed += () => { GetParent<Diplomacy>().Hide(); };
-		AddChild(goodbye);
-
-		// And the text from the opponent, if they reject a deal.
-		opponentResponse = new();
-		opponentResponse.Text = "\"Let's get down to business...\"";
-		opponentResponse.SetPosition(new Vector2(512 - 205, 345));
-		opponentResponse.Theme = fontTheme;
-		AddChild(opponentResponse);
 	}
 
 	private void AttemptDeal() {
 		// TODO: This seems to be only usage of UIGameDataAccess that mutates
 		// state - can this be a message instead?
-		using UIGameDataAccess gameDataAccess = new();
-		GameData gD = gameDataAccess.gameData;
+		EngineStorage.ReadGameData((GameData gD) => {
+			Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
+			Player humanPlayer = gD.players.Find(x => x.id == humanPlayerId);
 
-		Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
-		Player humanPlayer = gD.players.Find(x => x.id == humanPlayerId);
+			// If the deal is acceptable, execute it and go back to the previous
+			// screen.
+			if (opponentPlayer.WouldAcceptDealFrom(gD, humanPlayer, humanOffer, opponentOffer)) {
+				opponentPlayer.ExecuteDeal(gD, humanPlayer, humanOffer, opponentOffer);
 
-		// If the deal is acceptable, execute it and go back to the previous
-		// screen.
-		if (opponentPlayer.WouldAcceptDealFrom(gD, humanPlayer, humanOffer, opponentOffer)) {
-			opponentPlayer.ExecuteDeal(gD, humanPlayer, humanOffer, opponentOffer);
-
-			GetParent<Diplomacy>().ShowTalkScreenForPlayer(humanPlayerId, opponentPlayerId);
-			return;
-		}
+				GetParent<Diplomacy>().ShowTalkScreenForPlayer(humanPlayerId, opponentPlayerId);
+			}
+		});
 	}
 
 	private void UpdateText() {
-		using UIGameDataAccess gameDataAccess = new();
-		GameData gD = gameDataAccess.gameData;
-		Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
-		Player humanPlayer = gD.players.Find(x => x.id == humanPlayerId);
+		EngineStorage.ReadGameData((GameData gD) => {
+			Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
+			Player humanPlayer = gD.players.Find(x => x.id == humanPlayerId);
 
-		int theirGoldValue = opponentOffer.GoldEquivalentFor(gD, opponentPlayer);
-		int ourGoldValue = humanOffer.GoldEquivalentFor(gD, opponentPlayer);
-		opponentResponse.Text = $"\"I value my offer at {theirGoldValue} gold and I value your offer at {ourGoldValue} gold\"";
+			int theirGoldValue = opponentOffer.GoldEquivalentFor(gD, opponentPlayer);
+			int ourGoldValue = humanOffer.GoldEquivalentFor(gD, opponentPlayer);
+			opponentResponse.Text =
+				$"\"I value my offer at {theirGoldValue} gold and I value your offer at {ourGoldValue} gold\"";
+		});
 	}
 }

--- a/C7/UIElements/Diplomacy/Diplomacy.cs
+++ b/C7/UIElements/Diplomacy/Diplomacy.cs
@@ -43,18 +43,17 @@ public partial class Diplomacy : CenterContainer {
 	public void ShowTalkScreenForPlayer(ID humanPlayer, ID opponentPlayer) {
 		RemoveOtherScreens();
 
-		using (UIGameDataAccess gameDataAccess = new()) {
-			GameData gd = gameDataAccess.gameData;
+		EngineStorage.ReadGameData((GameData gd) => {
 			Player opponent = gd.players.Find(x => x.id == opponentPlayer);
 			Player human = gd.players.Find(x => x.id == humanPlayer);
 			if (!opponent.WillAcceptCommunicationFrom(human, gd.turn)) {
 				popupOverlay.ShowPopup(
 					new InformationalPopup(
 						$"The {opponent.civilization.noun} refused to acknowledge our envoy!"),
-						PopupOverlay.PopupCategory.Advisor);
+					PopupOverlay.PopupCategory.Advisor);
 				return;
 			}
-		}
+		});
 
 		talkScreen = new TalkScreen(humanPlayer, opponentPlayer);
 		AddChild(talkScreen);

--- a/C7/UIElements/Diplomacy/TalkScreen.cs
+++ b/C7/UIElements/Diplomacy/TalkScreen.cs
@@ -32,15 +32,14 @@ public partial class TalkScreen : TextureRect {
 
 		this.Texture = TextureLoader.Load("diplomacy.offer");
 
-		string civNameText;
-		string leaderName;
-		using (UIGameDataAccess gameDataAccess = new()) {
-			GameData gD = gameDataAccess.gameData;
+		string civNameText = "";
+		string leaderName = "";
+		EngineStorage.ReadGameData((GameData gD) => {
 			Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
 			GetParent<Diplomacy>().AddLeaderHeadAndLabel(this, opponentPlayer, fontTheme);
 			civNameText = $"{opponentPlayer.civilization.name} (Cautious)";
 			leaderName = opponentPlayer.civilization.leader;
-		}
+		});
 
 		Button proposeDeal = new();
 		proposeDeal.Text = "We would like to propose a deal...";
@@ -67,14 +66,14 @@ public partial class TalkScreen : TextureRect {
 	}
 
 	private void DeclareWar() {
-		using UIGameDataAccess gameDataAccess = new();
-		GameData gD = gameDataAccess.gameData;
-		Player humanPlayer = gD.players.Find(x => x.id == humanPlayerId);
-		Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
-		GetParent<Diplomacy>().popupOverlay.ShowPopup(new WarConfirmation(opponentPlayer,
+		EngineStorage.ReadGameData((GameData gD) => {
+			Player humanPlayer = gD.players.Find(x => x.id == humanPlayerId);
+			Player opponentPlayer = gD.players.Find(x => x.id == opponentPlayerId);
+			GetParent<Diplomacy>().popupOverlay.ShowPopup(new WarConfirmation(opponentPlayer,
 				() => {
 					humanPlayer.DeclareWarOn(opponentPlayer, gD.turn);
 					GetParent<Diplomacy>().Hide();
 				}), PopupOverlay.PopupCategory.Advisor);
+		});
 	}
 }

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -148,10 +148,8 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 
 		// Update our information each time we're drawn, just like the tile and
 		// city scenes.
-		using (UIGameDataAccess gameDataAccess = new()) {
-			GameData gD = gameDataAccess.gameData;
-			// There may be no human players in observer mode.
-			Player player = gD.GetHumanPlayers().Count > 0 ? gD.GetHumanPlayers()[0] : gD.players[1];
+		EngineStorage.ReadGameData((GameData gD) => {
+			Player player = gD.GetHumanPlayers()[0];
 
 			// Gold per turn and turn indicator.
 			{
@@ -171,7 +169,7 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 
 			// Civ and government.
 			civAndGovt.SetTextAndCenterLabel($"{player.civilization.name} - {player.government.name} (5.5.0)");
-		}
+		});
 
 		base._Process(delta);
 	}

--- a/C7/UIElements/GameStatus/StatusMenu.cs
+++ b/C7/UIElements/GameStatus/StatusMenu.cs
@@ -17,29 +17,28 @@ public partial class StatusMenu : Control {
 	}
 
 	public override void _Process(double delta) {
-		using UIGameDataAccess gameDataAccess = new();
-		GameData gD = gameDataAccess.gameData;
-		if (gD.observerMode) {
-			return;
-		}
+		EngineStorage.ReadGameData((GameData gD) => {
+			if (gD.observerMode) {
+				return;
+			}
 
-		Player player = gD.GetHumanPlayers()[0];
+			Player player = gD.GetHumanPlayers()[0];
 
-		// Only show the diplomacy button if we have civs to talk to.
-		if (player.playerRelationships.Count > 0) {
-			openDiplomacy.ShowButton();
-		}
+			// Only show the diplomacy button if we have civs to talk to.
+			if (player.playerRelationships.Count > 0) {
+				openDiplomacy.ShowButton();
+			}
 
-		// TODO: Don't show the palace button if the player can't start building the palace
-		openPalaceScreen.ShowButton();
+			// TODO: Don't show the palace button if the player can't start building the palace
+			openPalaceScreen.ShowButton();
+		});
 	}
 
 	private void OpenDiplomacyPopup() {
-		using (UIGameDataAccess gameDataAccess = new()) {
-			GameData gD = gameDataAccess.gameData;
+		EngineStorage.ReadGameData((GameData gD) => {
 			Player player = gD.GetHumanPlayers()[0];
 
 			popupOverlay.ShowPopup(new DiplomacySelection(player, gD.players), PopupOverlay.PopupCategory.Info);
-		}
+		});
 	}
 }

--- a/C7/UIElements/Popups/ScienceSelection.cs
+++ b/C7/UIElements/Popups/ScienceSelection.cs
@@ -75,18 +75,19 @@ public partial class ScienceSelection : Popup {
 		PopupMenu popup = optionButton.GetPopup();
 		popup.AddThemeStyleboxOverride("panel", styleBox);
 
-		using UIGameDataAccess gameDataAccess = new();
-		foreach (Tech tech in player.GetAvailableTechsToResearch(gameDataAccess.gameData)) {
-			int turns = player.EstimateTurnsToResearch(gameDataAccess.gameData, tech);
-			string turnsStr = turns == int.MaxValue ? "--" : $"{turns}";
-			optionButton.AddItem($"{tech.Name} ({turnsStr} turns)");
-			options.Add(tech);
-		}
+		EngineStorage.ReadGameData((GameData gameData) => {
+			foreach (Tech tech in player.GetAvailableTechsToResearch(gameData)) {
+				int turns = player.EstimateTurnsToResearch(gameData, tech);
+				string turnsStr = turns == int.MaxValue ? "--" : $"{turns}";
+				optionButton.AddItem($"{tech.Name} ({turnsStr} turns)");
+				options.Add(tech);
+			}
 
-		for (int i = 0; i < popup.ItemCount; ++i) {
-			popup.SetItemAsRadioCheckable(i, false);
-			popup.SetItemAsCheckable(i, false);
-		}
+			for (int i = 0; i < popup.ItemCount; ++i) {
+				popup.SetItemAsRadioCheckable(i, false);
+				popup.SetItemAsCheckable(i, false);
+			}
+		});
 
 		return optionButton;
 	}

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -135,10 +135,10 @@ public partial class RightClickTileMenu : RightClickMenu {
 	public void ResetItems(Tile tile, Dictionary<ID, bool> uiUpdatedUnitStates = null) {
 		RemoveAll();
 
-		bool observerMode;
-		using (UIGameDataAccess gameDataAccess = new()) {
-			observerMode = gameDataAccess.gameData.observerMode;
-		}
+		bool observerMode = false;
+		EngineStorage.ReadGameData((GameData gameData) => {
+			observerMode = gameData.observerMode;
+		});
 
 		int fortifiedCount = 0;
 		List<MapUnit> playerUnits = tile.unitsOnTile.FindAll(unit => unit.owner.id == game.controller.id || observerMode);
@@ -166,14 +166,16 @@ public partial class RightClickTileMenu : RightClickMenu {
 			});
 			AddItem("Hurry Production", () => {
 				this.CloseAndDelete();
-				using UIGameDataAccess gDA = new();
-				City.HurryProductionDetails details = tile.cityAtTile.GetHurryProductionDetails();
-				new MsgDisplayHurryProductionPopup(tile.cityAtTile, details).send();
+				EngineStorage.ReadGameData((GameData gameData) => {
+					City.HurryProductionDetails details = tile.cityAtTile.GetHurryProductionDetails();
+					new MsgDisplayHurryProductionPopup(tile.cityAtTile, details).send();
+				});
 			});
 			AddItem("Zoom to city", () => {
 				this.CloseAndDelete();
-				using UIGameDataAccess gDA = new();
-				game.ShowCityScreenForCity(gDA.gameData, tile.cityAtTile);
+				EngineStorage.ReadGameData((GameData gameData) => {
+					game.ShowCityScreenForCity(gameData, tile.cityAtTile);
+				});
 			});
 		}
 
@@ -203,26 +205,27 @@ public partial class RightClickTileMenu : RightClickMenu {
 	}
 
 	public void SelectUnit(ID id) {
-		using (var gameDataAccess = new UIGameDataAccess()) {
-			MapUnit toSelect = gameDataAccess.gameData.mapUnits.Find(u => u.id == id);
+		EngineStorage.ReadGameData((GameData gameData) => {
+			MapUnit toSelect = gameData.mapUnits.Find(u => u.id == id);
 			if (toSelect != null && toSelect.owner == game.controller) {
 				bool canMove = game.setSelectedUnit(toSelect);
 				if (!canMove) {
 					ShowCannotMovePopup();
 				}
+
 				new MsgSetFortification(toSelect.id, false).send();
 				ResetItems(toSelect.location, new Dictionary<ID, bool>() { { toSelect.id, false } });
 			}
-		}
+		});
 		if (!Input.IsKeyPressed(Godot.Key.Shift)) {
 			CloseAndDelete();
 		}
 	}
 
 	public void ForAll(int tileX, int tileY, bool isFortify) {
-		using (var gameDataAccess = new UIGameDataAccess()) {
+		EngineStorage.ReadGameData((GameData gameData) => {
 			bool hasSelectedUnit = false;
-			Tile tile = gameDataAccess.gameData.map.tileAt(tileX, tileY);
+			Tile tile = gameData.map.tileAt(tileX, tileY);
 			Dictionary<ID, bool> modified = new Dictionary<ID, bool>();
 			foreach (MapUnit unit in tile.unitsOnTile) {
 				if (unit.isFortified != isFortify) {
@@ -237,8 +240,9 @@ public partial class RightClickTileMenu : RightClickMenu {
 					}
 				}
 			}
+
 			ResetItems(tile, modified);
-		}
+		});
 		if (!Input.IsKeyPressed(Godot.Key.Shift)) {
 			CloseAndDelete();
 		}
@@ -262,14 +266,16 @@ public partial class RightClickCityMenu : RightClickMenu {
 			});
 			AddItem("Hurry Production", () => {
 				this.CloseAndDelete();
-				using UIGameDataAccess gDA = new();
-				City.HurryProductionDetails details = tile.cityAtTile.GetHurryProductionDetails();
-				new MsgDisplayHurryProductionPopup(tile.cityAtTile, details).send();
+				EngineStorage.ReadGameData((GameData gameData) => {
+					City.HurryProductionDetails details = tile.cityAtTile.GetHurryProductionDetails();
+					new MsgDisplayHurryProductionPopup(tile.cityAtTile, details).send();
+				});
 			});
 			AddItem("Zoom to city", () => {
 				this.CloseAndDelete();
-				using UIGameDataAccess gDA = new();
-				game.ShowCityScreenForCity(gDA.gameData, tile.cityAtTile);
+				EngineStorage.ReadGameData((GameData gameData) => {
+					game.ShowCityScreenForCity(gameData, tile.cityAtTile);
+				});
 			});
 		}
 	}

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -9,7 +9,7 @@ namespace C7GameData {
 		public Building building;
 		public Player builtByPlayer;
 		public int year;
-		public int totalCulture; // This represents the total culture produced by the building. 
+		public int totalCulture; // This represents the total culture produced by the building.
 								 // In Civ3, this value is displayed in the cultural advisor tab
 	}
 
@@ -292,7 +292,7 @@ namespace C7GameData {
 
 				// If we completed a great wonder, mark it as completed so no
 				// other civ can build it. If any other cities are building the
-				// wonder then change production to the most expensive option, 
+				// wonder then change production to the most expensive option,
 				// to avoid wasting the shields.
 				//
 				// TODO: This should interrupt the player's turn to let them
@@ -449,7 +449,7 @@ namespace C7GameData {
 
 				// If this building doesn't have the "only useful in towns" flag
 				// we can always provide the bonus regardless of the city size.
-				// 
+				//
 				// But if the building is only useful in towns we need to check
 				// the city size before providing the bonus.
 				if (!cb.building.onlyUsefulInTowns) {
@@ -493,7 +493,7 @@ namespace C7GameData {
 
 			// Using our value of corruption, figure out how much useful
 			// production we have to work with. Special case anarchy, where no
-			// useful production is available. We do this here rather than 
+			// useful production is available. We do this here rather than
 			// setting corruption to 100% because CorruptableValue would give us
 			// one useful commerce in that situation.
 			//
@@ -839,7 +839,7 @@ namespace C7GameData {
 			contentToHappyMoves -= 2 * ApplyMoodChange(contentToHappyMoves / 2, unhappy, happy);
 
 			// Account for the remainder of the integer division
-			// (ApplyMoodChange ignores a negative input). 
+			// (ApplyMoodChange ignores a negative input).
 			ApplyMoodChange(contentToHappyMoves, unhappy, content);
 		}
 
@@ -869,7 +869,7 @@ namespace C7GameData {
 			int unhappyToContentMoves = 0;
 
 			// Each citizen lost to pop rushing has a 20 turn penalty, so
-			// multiple citizens lost causes multiple unhappy faces. 
+			// multiple citizens lost causes multiple unhappy faces.
 			if (turnsOfUnhappinessDueToPopRushing > 0) {
 				contentToHappyMoves -= (turnsOfUnhappinessDueToPopRushing - 1) / gameData.rules.TurnPenaltyForEachHurrySacrifice + 1;
 			}

--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -165,7 +165,7 @@ namespace C7GameData {
 			unit.location.unitsOnTile.Remove(unit);
 			mapUnits.Remove(unit);
 
-			// TODO: why not just do Player p = unit.owner; p.units.Remove(unit);?	
+			// TODO: why not just do Player p = unit.owner; p.units.Remove(unit);?
 			foreach (Player player in players) {
 				if (player.units.Contains(unit)) {
 					player.units.Remove(unit);

--- a/C7Engine/EngineStorage.cs
+++ b/C7Engine/EngineStorage.cs
@@ -50,21 +50,11 @@ namespace C7Engine {
 			engineThread = new Thread(processActions);
 			engineThread.Start();
 		}
-	}
 
-	public class UIGameDataAccess : IDisposable {
-		public UIGameDataAccess() {
+		public static void ReadGameData(Action<GameData> accessor) {
 			EngineStorage.gameDataMutex.WaitOne();
-		}
-
-		public void Dispose() {
+			accessor(gameData);
 			EngineStorage.gameDataMutex.ReleaseMutex();
-		}
-
-		public GameData gameData {
-			get {
-				return EngineStorage.gameData;
-			}
 		}
 	}
 }

--- a/C7Engine/EntryPoints/CreateGame.cs
+++ b/C7Engine/EntryPoints/CreateGame.cs
@@ -15,7 +15,6 @@ namespace C7Engine {
 		public static Player createGame(string loadFilePath, string defaultBicPath,
 										Func<string, string> getPediaIconsPath) {
 			EngineStorage.createThread();
-			EngineStorage.gameDataMutex.WaitOne();
 
 			SaveGame save = SaveManager.LoadSave(loadFilePath, defaultBicPath, getPediaIconsPath);
 			GameData gameData = save.ToGameData();
@@ -38,7 +37,6 @@ namespace C7Engine {
 			TurnHandling.OnBeginTurn(); // Call for the first turn
 			TurnHandling.AdvanceTurn();
 
-			EngineStorage.gameDataMutex.ReleaseMutex();
 			return humanPlayer;
 		}
 	}

--- a/EngineTests/GameData/SaveTest.cs
+++ b/EngineTests/GameData/SaveTest.cs
@@ -121,33 +121,34 @@ public class SaveTests {
 	}
 
 	private void CheckAiInvariants() {
-		using UIGameDataAccess gda = new();
-		GameData game = gda.gameData;
+		EngineStorage.ReadGameData((GameData gameData) => {
+			GameData game = gameData;
 
-		foreach (Player p in game.players) {
-			foreach (MapUnit u in p.units) {
-				if (u.unitType.name != "Settler") {
-					continue;
-				}
+			foreach (Player p in game.players) {
+				foreach (MapUnit u in p.units) {
+					if (u.unitType.name != "Settler") {
+						continue;
+					}
 
-				// We don't require an escort if the settler is in a city.
-				if (u.location.cityAtTile != null) {
-					continue;
-				}
+					// We don't require an escort if the settler is in a city.
+					if (u.location.cityAtTile != null) {
+						continue;
+					}
 
-				// This is a settler not in a city - make sure it has an escort.
-				if (u.currentAI is SettlerAI settlerAi) {
-					if (settlerAi.data.escort != null) {
-						Assert.Equal(settlerAi.data.escort.location, u.location);
-					} else {
-						// This assertion is tempting, but will sometimes fire
-						// if the escort is disbanded due to unit support costs.
-						//
-						// Assert.True(u.location.unitsOnTile.Count > 1, $"{u} {u.location}");
+					// This is a settler not in a city - make sure it has an escort.
+					if (u.currentAI is SettlerAI settlerAi) {
+						if (settlerAi.data.escort != null) {
+							Assert.Equal(settlerAi.data.escort.location, u.location);
+						} else {
+							// This assertion is tempting, but will sometimes fire
+							// if the escort is disbanded due to unit support costs.
+							//
+							// Assert.True(u.location.unitsOnTile.Count > 1, $"{u} {u.location}");
+						}
 					}
 				}
 			}
-		}
+		});
 	}
 
 	[Fact]
@@ -168,10 +169,10 @@ public class SaveTests {
 
 		// Make the player a human again so we can save and load the game.
 		human.isHuman = true;
-		GameData game;
-		using (UIGameDataAccess gda = new()) {
-			game = gda.gameData;
-		}
+		GameData game = null;
+		EngineStorage.ReadGameData((GameData gameData) => {
+			game = gameData;
+		});
 		Assert.Equal(50, game.turn);
 
 		// Save the game.
@@ -200,8 +201,8 @@ public class SaveTests {
 		Player human = CreateHeadlessGame(developerSave);
 		WaitForStartTurnMessage();
 
-		using UIGameDataAccess gda = new();
-		GameData gd = gda.gameData;
+		GameData gd = null;
+		EngineStorage.ReadGameData((GameData gameData) => { gd = gameData; });
 
 		Tile t0 = gd.map.tileAt(97, 33);
 		Tile t1 = gd.map.tileAt(99, 33);


### PR DESCRIPTION
This will allow us to stop using a `Mutex` and instead just use `lock`, as we don't require inter process coordination. This also gives us a natural scoping mechanism - a couple of times I've accidentally hit a deadlock from forgetting the `using` statement on the `UIGameDataAccess` object.