### PR TITLE
Replace `GetHumanPlayers()[0]` with `GetFirstHumanPlayer()` 

### DIFF
--- a/C7/Map/FogOfWarLayer.cs
+++ b/C7/Map/FogOfWarLayer.cs
@@ -26,7 +26,7 @@ namespace C7.Map {
 			Tile east = tile.neighbors[TileDirection.NORTHEAST];
 			Tile west = tile.neighbors[TileDirection.NORTHWEST];
 
-			TileKnowledge tileKnowledge = gameData.GetHumanPlayers()[0].tileKnowledge;
+			TileKnowledge tileKnowledge = gameData.GetFirstHumanPlayer().tileKnowledge;
 			int column = 0;
 			int row = 0;
 

--- a/C7/Map/ResourceLayer.cs
+++ b/C7/Map/ResourceLayer.cs
@@ -28,7 +28,7 @@ namespace C7.Map {
 			if (gameData.observerMode) {
 				return true;
 			}
-			return gameData.GetHumanPlayers()[0].KnowsAboutResource(t.Resource);
+			return gameData.GetFirstHumanPlayer().KnowsAboutResource(t.Resource);
 		}
 	}
 }

--- a/C7/Map/UnitLayer.cs
+++ b/C7/Map/UnitLayer.cs
@@ -286,6 +286,6 @@ public partial class UnitLayer : LooseLayer {
 
 		// Only draw units on active tiles - otherwise if the tile is only known
 		// but not actively seen, we can't see units.
-		return gameData.GetHumanPlayers()[0].tileKnowledge.isActiveTile(t);
+		return gameData.GetFirstHumanPlayer().tileKnowledge.isActiveTile(t);
 	}
 }

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -520,7 +520,7 @@ public partial class LooseView : Node2D {
 		if (gameData.observerMode) {
 			return true;
 		}
-		TileKnowledge knowledge = gameData.GetHumanPlayers()[0].tileKnowledge;
+		TileKnowledge knowledge = gameData.GetFirstHumanPlayer().tileKnowledge;
 		return tile != Tile.NONE && knowledge.isTileKnown(tile);
 	}
 }

--- a/C7/UIElements/Advisors/DomesticAdvisor.cs
+++ b/C7/UIElements/Advisors/DomesticAdvisor.cs
@@ -143,7 +143,7 @@ public partial class DomesticAdvisor : Control {
 		Show();
 
 		EngineStorage.ReadGameData((GameData gameData) => {
-			Player player = gameData.GetHumanPlayers()[0];
+			Player player = gameData.GetFirstHumanPlayer();
 
 			int scienceRate = player.scienceRate;
 			int luxuryRate = player.luxuryRate;
@@ -210,7 +210,7 @@ public partial class DomesticAdvisor : Control {
 
 	private void ChangeGovernments() {
 		EngineStorage.ReadGameData((GameData gameData) => {
-			Player player = gameData.GetHumanPlayers()[0];
+			Player player = gameData.GetFirstHumanPlayer();
 
 			if (player.government.transitionType) {
 				popupOverlay.ShowPopup(

--- a/C7/UIElements/Advisors/MilitaryAdvisor.cs
+++ b/C7/UIElements/Advisors/MilitaryAdvisor.cs
@@ -35,7 +35,7 @@ public partial class MilitaryAdvisor : TextureRect {
 		GoBackButton.Pressed += ReturnToMenu;
 
 		EngineStorage.ReadGameData((GameData gameData) => {
-			Player player = gameData.GetHumanPlayers()[0];
+			Player player = gameData.GetFirstHumanPlayer();
 			var (totalUnits, allowedUnits, unitSupportCost) = player.TotalUnitsAllowedUnitsAndSupportCost();
 
 			AddChild(totalUnitsLabel);

--- a/C7/UIElements/Advisors/ScienceAdvisor.cs
+++ b/C7/UIElements/Advisors/ScienceAdvisor.cs
@@ -23,7 +23,7 @@ public partial class ScienceAdvisor : TextureRect {
 
 		EngineStorage.ReadGameData((GameData gameData) => {
 			List<Tech> techs = gameData.techs;
-			Player player = gameData.GetHumanPlayers()[0];
+			Player player = gameData.GetFirstHumanPlayer();
 			eraName = player.eraCivilopediaName;
 			this.DrawTechTree(eraName, player, techs, player.GetAvailableTechsToResearch(gameData));
 		});
@@ -149,7 +149,7 @@ public partial class ScienceAdvisor : TextureRect {
 
 		EngineStorage.ReadGameData((GameData gameData) => {
 			List<Tech> techs = gameData.techs;
-			Player player = gameData.GetHumanPlayers()[0];
+			Player player = gameData.GetFirstHumanPlayer();
 			eraName = Player.EraIndexToEra(Player.EraIndex(eraName) + delta);
 			DrawTechTree(eraName, player, techs, player.GetAvailableTechsToResearch(gameData));
 		});

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -149,7 +149,7 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 		// Update our information each time we're drawn, just like the tile and
 		// city scenes.
 		EngineStorage.ReadGameData((GameData gD) => {
-			Player player = gD.GetHumanPlayers()[0];
+			Player player = gD.GetFirstHumanPlayer();
 
 			// Gold per turn and turn indicator.
 			{

--- a/C7/UIElements/GameStatus/StatusMenu.cs
+++ b/C7/UIElements/GameStatus/StatusMenu.cs
@@ -22,7 +22,7 @@ public partial class StatusMenu : Control {
 				return;
 			}
 
-			Player player = gD.GetHumanPlayers()[0];
+			Player player = gD.GetFirstHumanPlayer();
 
 			// Only show the diplomacy button if we have civs to talk to.
 			if (player.playerRelationships.Count > 0) {
@@ -36,7 +36,7 @@ public partial class StatusMenu : Control {
 
 	private void OpenDiplomacyPopup() {
 		EngineStorage.ReadGameData((GameData gD) => {
-			Player player = gD.GetHumanPlayers()[0];
+			Player player = gD.GetFirstHumanPlayer();
 
 			popupOverlay.ShowPopup(new DiplomacySelection(player, gD.players), PopupOverlay.PopupCategory.Info);
 		});

--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -65,8 +65,25 @@ namespace C7GameData {
 			rng = new Random(seed);
 		}
 
-		public List<Player> GetHumanPlayers() {
-			return players.FindAll(p => p.isHuman);
+		// Returns the first human player in the set of players, or the first
+		// non-barbarian player if we're in observer mode (where the human player
+		// is no longer marked as human).
+		public Player GetFirstHumanPlayer() {
+			foreach (Player p in players) {
+				if (p.isHuman) {
+					return p;
+				}
+			}
+
+			if (observerMode) {
+				foreach (Player p in players) {
+					if (!p.isBarbarians) {
+						return p;
+					}
+				}
+			}
+
+			return null;
 		}
 
 		public MapUnit GetUnit(ID id) {

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -183,7 +183,7 @@ namespace C7Engine {
 		}
 
 		public override void process() {
-			Player player = EngineStorage.gameData.GetHumanPlayers()[0];
+			Player player = EngineStorage.gameData.GetFirstHumanPlayer();
 			if (player.currentlyResearchedTech == techId) {
 				return;
 			}
@@ -220,7 +220,7 @@ namespace C7Engine {
 		}
 
 		public override void process() {
-			Player player = EngineStorage.gameData.GetHumanPlayers()[0];
+			Player player = EngineStorage.gameData.GetFirstHumanPlayer();
 
 			if (moreScience && player.scienceRate == 10 || lessScience && player.scienceRate == 0) {
 				return;


### PR DESCRIPTION
This removes an apparently high source of memory usage (according to Jetbrains Rider) since this is called for every tile. It also means that several UI elements work better in observer mode.
