### PR TITLE
Optimize the calculation of trade networks 

### DIFF
--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -161,7 +161,7 @@ public partial class CityScreen : Control {
 
 						Tile tile = mapView.tileOnScreenAt(gameData.map, eventMouseButton.Position);
 						if (tile != null) {
-							HandleReassignment(tile);
+							HandleReassignment(gameData, tile);
 
 							// Recalculate moods after changing tile assignments.
 							tileAssignmentLayer.city.RecalculateCitizenMoods(gameData);
@@ -169,7 +169,7 @@ public partial class CityScreen : Control {
 							RenderPopHeads(tileAssignmentLayer.city);
 							RenderFoodDetails(tileAssignmentLayer.city);
 							RenderCommerceDetails(tileAssignmentLayer.city);
-							RenderProductionDetails(tileAssignmentLayer.city);
+							RenderProductionDetails(gameData, tileAssignmentLayer.city);
 						}
 					});
 				}
@@ -177,7 +177,7 @@ public partial class CityScreen : Control {
 		}
 	}
 
-	private void HandleReassignment(Tile tile) {
+	private void HandleReassignment(GameData gameData, Tile tile) {
 		City city = tileAssignmentLayer.city;
 
 		// We only support clicking on workable tiles or the city center.
@@ -246,12 +246,18 @@ public partial class CityScreen : Control {
 					city = city
 				};
 				city.AddCitizen(newResident);
-				CityTileAssignmentAI.AssignNewCitizenToTile(newResident, manageMoods: true);
+				CityTileAssignmentAI.AssignNewCitizenToTile(gameData, newResident, manageMoods: true);
 			}
 		}
 	}
 
 	private void OnShowCityScreen(ParameterWrapper<City> city) {
+		EngineStorage.ReadGameData((GameData gameData) => {
+			OnShowCityScreenLocked(gameData, city);
+		});
+	}
+
+	private void OnShowCityScreenLocked(GameData gameData, ParameterWrapper<City> city) {
 		this.Show();
 		mapView.centerCameraOnTile(city.Value.location.neighbors[TileDirection.SOUTH]);
 		tileAssignmentLayer.city = city.Value;
@@ -260,10 +266,10 @@ public partial class CityScreen : Control {
 		RenderCulture(city.Value);
 		RenderFoodDetails(city.Value);
 		RenderCommerceDetails(city.Value);
-		RenderProductionDetails(city.Value);
+		RenderProductionDetails(gameData, city.Value);
 		RenderExistingBuildings(city.Value.GetBuildings());
-		RenderStrategicResources(city.Value);
-		RenderLuxuries(city.Value);
+		RenderStrategicResources(gameData, city.Value);
+		RenderLuxuries(gameData, city.Value);
 	}
 
 	private void OnExit() {
@@ -271,8 +277,8 @@ public partial class CityScreen : Control {
 		tileAssignmentLayer.city = null;
 	}
 
-	private void RenderStrategicResources(City city) {
-		Dictionary<C7GameData.Resource, int> resourceCounter = city.GetStrategicResources();
+	private void RenderStrategicResources(GameData gameData, City city) {
+		Dictionary<C7GameData.Resource, int> resourceCounter = city.GetStrategicResources(gameData);
 
 		foreach (var child in strategicResources.GetChildren()) {
 			strategicResources.RemoveChild(child);
@@ -301,8 +307,8 @@ public partial class CityScreen : Control {
 		}
 	}
 
-	private void RenderLuxuries(City city) {
-		Dictionary<C7GameData.Resource, int> resourceCounter = city.GetLuxuries();
+	private void RenderLuxuries(GameData gameData, City city) {
+		Dictionary<C7GameData.Resource, int> resourceCounter = city.GetLuxuries(gameData);
 
 		foreach (var child in luxuriesContainer.GetChildren()) {
 			luxuriesContainer.RemoveChild(child);
@@ -547,7 +553,7 @@ public partial class CityScreen : Control {
 		commerceHappinessDetails.Text = $"{breakdown.happiness} gold/turn to happiness";
 	}
 
-	private void RenderProductionDetails(City city) {
+	private void RenderProductionDetails(GameData gameData, City city) {
 		CorruptableValue shields = city.CurrentProductionYield();
 		RenderShieldBox(city.owner.ShieldCost(city.itemBeingProduced), city.shieldsStored);
 		RenderShieldRow(shields.useful, shields.corrupt);
@@ -606,10 +612,10 @@ public partial class CityScreen : Control {
 		productionButtonLabel.SetPosition(new Vector2(0, 65));
 		productionButtonLabel.SetTextAndCenterLabel($"{city.itemBeingProduced.name}");
 
-		productionMenu.AddItems(city, (IProducible p) => {
+		productionMenu.AddItems(gameData, city, (IProducible p) => {
 			EngineStorage.ReadGameData((GameData gameData) => {
 				city.SetItemBeingProduced(p);
-				RenderProductionDetails(city);
+				RenderProductionDetails(gameData, city);
 			});
 		});
 	}
@@ -782,7 +788,7 @@ public partial class CityScreen : Control {
 			List<City> cities = currentCity.owner.cities;
 			City nextCity = cities[(cities.IndexOf(currentCity) + 1) % cities.Count];
 			nextCity.RecalculateCitizenMoods(gameData);
-			OnShowCityScreen(new ParameterWrapper<City>(nextCity));
+			OnShowCityScreenLocked(gameData, new ParameterWrapper<City>(nextCity));
 		});
 	}
 
@@ -792,7 +798,7 @@ public partial class CityScreen : Control {
 			List<City> cities = currentCity.owner.cities;
 			City previousCity = cities[(cities.IndexOf(currentCity) + cities.Count - 1) % cities.Count];
 			previousCity.RecalculateCitizenMoods(gameData);
-			OnShowCityScreen(new ParameterWrapper<City>(previousCity));
+			OnShowCityScreenLocked(gameData, new ParameterWrapper<City>(previousCity));
 		});
 	}
 

--- a/C7/UIElements/CityScreen/ProductionMenu.cs
+++ b/C7/UIElements/CityScreen/ProductionMenu.cs
@@ -21,7 +21,7 @@ public partial class ProductionMenu : Civ3TextureRect {
 		fontTheme.DefaultFont = font;
 	}
 
-	public void AddItems(City city, Action<IProducible> chooseProduction) {
+	public void AddItems(GameData gameData, City city, Action<IProducible> chooseProduction) {
 		if (tree != null) {
 			itemMapping.Clear();
 			RemoveChild(tree);
@@ -38,7 +38,7 @@ public partial class ProductionMenu : Civ3TextureRect {
 
 		TreeItem root = TradingTree.CreateTreeRoot(tree);
 
-		foreach (IProducible option in city.ListProductionOptions()) {
+		foreach (IProducible option in city.ListProductionOptions(gameData)) {
 			int buildTime = city.TurnsToProduce(option);
 
 			TreeItem child = tree.CreateItem(root);

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -301,10 +301,12 @@ public partial class RightClickChooseProductionMenu : RightClickMenu {
 
 	public RightClickChooseProductionMenu(Game game, City city) : base(game) {
 		cityID = city.id;
-		foreach (IProducible option in city.ListProductionOptions()) {
-			int buildTime = city.TurnsToProduce(option);
-			AddItem($"{option.name} ({buildTime} turns)", () => ChooseProduction(option.name), GetProducibleIcon(option));
-		}
+		EngineStorage.ReadGameData((GameData gameData) => {
+			foreach (IProducible option in city.ListProductionOptions(gameData)) {
+				int buildTime = city.TurnsToProduce(option);
+				AddItem($"{option.name} ({buildTime} turns)", () => ChooseProduction(option.name), GetProducibleIcon(option));
+			}
+		});
 	}
 
 	public void ChooseProduction(string producibleName) {

--- a/C7Engine/AI/CityProductionAI.cs
+++ b/C7Engine/AI/CityProductionAI.cs
@@ -30,7 +30,7 @@ namespace C7Engine {
 		 */
 		public static IProducible GetNextItemToBeProduced(City city, IProducible lastProduced) {
 			List<StrategicPriority> priorities = city.owner.strategicPriorityData;
-			IEnumerable<IProducible> producibles = city.ListProductionOptions();
+			IEnumerable<IProducible> producibles = city.ListProductionOptions(EngineStorage.gameData);
 
 			log.Debug($"Choosing what to produce next in {city.name}");
 

--- a/C7Engine/AI/CityTileAssignmentAI.cs
+++ b/C7Engine/AI/CityTileAssignmentAI.cs
@@ -16,7 +16,7 @@ namespace C7Engine.AI {
 		private static ILogger log = Log.ForContext<CityTileAssignmentAI>();
 
 		// Assigns a citizen, which is alredy part of a city, to a tile, if possible.
-		public static void AssignNewCitizenToTile(CityResident newResident, bool manageMoods = false) {
+		public static void AssignNewCitizenToTile(GameData gameData, CityResident newResident, bool manageMoods = false) {
 			City city = newResident.city;
 			int foodYield = city.CurrentFoodYield();
 
@@ -48,7 +48,7 @@ namespace C7Engine.AI {
 
 			// Check to see if this citizen working a tile would cause the city
 			// to be unhappy. If so, make them an entertainer.
-			City.Mood cityMood = city.RecalculateCitizenMoods(EngineStorage.gameData);
+			City.Mood cityMood = city.RecalculateCitizenMoods(gameData);
 
 			if (cityMood == City.Mood.Unhappy && manageMoods) {
 				newResident.citizenType = city.owner.GetKnownSpecialists().MaxBy(x => x.Luxuries);

--- a/C7Engine/AI/Pathing/EdgeWalker.cs
+++ b/C7Engine/AI/Pathing/EdgeWalker.cs
@@ -59,19 +59,4 @@ namespace C7Engine.Pathing {
 			return result;
 		}
 	}
-
-	public class TradeNetworkWalker : EdgeWalker<Tile> {
-		public override IEnumerable<Edge<Tile>> getEdges(Tile node) {
-			List<Edge<Tile>> result = [];
-
-			// TODO: When buildings are implemented, the logic for airports and harbors should also be included.
-			foreach (Tile neighbor in node.neighbors.Values) {
-				if (neighbor.overlays.HasRoad()) {
-					result.Add(new Edge<Tile>(node, neighbor, 1));
-				}
-			}
-
-			return result;
-		}
-	}
 }

--- a/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
+++ b/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
@@ -35,17 +35,5 @@ namespace C7Engine.Pathing {
 				}
 			);
 		}
-
-		public static PathingAlgorithm GetTradeNetworkAlgorithm() {
-			return new AStarAlgorithm(
-				new TradeNetworkWalker(),
-				(Tile from, Tile to) => {
-					return from.distanceTo(to);
-				},
-				(Tile neighbor, Tile destination) => {
-					return true;
-				}
-			);
-		}
 	}
 }

--- a/C7Engine/AI/Pathing/TradeNetwork.cs
+++ b/C7Engine/AI/Pathing/TradeNetwork.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Linq;
+using System;
+using C7GameData;
+
+namespace C7Engine.Pathing {
+	public class TradeNetworkSegment {
+		public Dictionary<Resource, int> resourceCounts = new();
+		public HashSet<Tile> tiles = new();
+
+		public void AddTile(Tile t, Player p) {
+			tiles.Add(t);
+			if (t.Resource != Resource.NONE && t.OwningPlayer() == p && p.KnowsAboutResource(t.Resource)) {
+				if (resourceCounts.TryGetValue(t.Resource, out int currentCount)) {
+					resourceCounts[t.Resource] = currentCount + 1;
+				} else {
+					resourceCounts[t.Resource] = 1;
+				}
+			}
+		}
+	}
+
+	// A class for calculating the trade networks of a particular player.
+	//
+	// The main idea is that calculating the entire empire's trade network once
+	// is faster than doing it repeatedly for each city. By doing it once we can
+	// do a simple flood fill of the road network, rather than needing to do
+	// actual pathfinding between different tiles.
+	//
+	// TODO: Handle harbors and airports
+	// TODO: Account for passing through the borders of civs we're at war with
+	public class TradeNetwork {
+		public Dictionary<City, TradeNetworkSegment> segments = new();
+
+		public TradeNetwork(Player player) {
+			HashSet<Tile> seen = new();
+
+			foreach (City c in player.cities) {
+				if (segments.ContainsKey(c)) {
+					continue;
+				}
+
+				// If we don't know about this city yet, start a new network
+				// segment and do a flood fill for all roads coming from the
+				// city.
+				TradeNetworkSegment segment = new();
+				segments[c] = segment;
+
+				Queue<Tile> toCheck = new();
+				toCheck.Enqueue(c.location);
+				seen.Add(c.location);
+
+				while (toCheck.Count > 0) {
+					Tile x = toCheck.Dequeue();
+					segment.AddTile(x, player);
+
+					if (x.cityAtTile != null) {
+						segments[x.cityAtTile] = segment;
+					}
+
+					foreach (Tile n in x.neighbors.Values) {
+						if (n.overlays.HasRoad() && !seen.Contains(n)) {
+							seen.Add(n);
+							toCheck.Enqueue(n);
+						}
+					}
+				}
+			}
+		}
+
+		public bool HasTradeAccess(Tile t, Resource r) {
+			foreach (TradeNetworkSegment segment in segments.Values) {
+				if (segment.tiles.Contains(t) && segment.resourceCounts.TryGetValue(r, out int count) && count > 0) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+}

--- a/C7Engine/AI/Pathing/TradeNetwork.cs
+++ b/C7Engine/AI/Pathing/TradeNetwork.cs
@@ -10,7 +10,7 @@ namespace C7Engine.Pathing {
 
 		public void AddTile(Tile t, Player p) {
 			tiles.Add(t);
-			if (t.Resource != Resource.NONE && t.OwningPlayer() == p && p.KnowsAboutResource(t.Resource)) {
+			if (t.Resource != Resource.NONE && t.OwningPlayer() == p) {
 				if (resourceCounts.TryGetValue(t.Resource, out int currentCount)) {
 					resourceCounts[t.Resource] = currentCount + 1;
 				} else {
@@ -29,6 +29,7 @@ namespace C7Engine.Pathing {
 	//
 	// TODO: Handle harbors and airports
 	// TODO: Account for passing through the borders of civs we're at war with
+	// TODO: Invalidate the trade network when war status changes.
 	public class TradeNetwork {
 		public Dictionary<City, TradeNetworkSegment> segments = new();
 

--- a/C7Engine/AI/Pathing/TradeNetwork.cs
+++ b/C7Engine/AI/Pathing/TradeNetwork.cs
@@ -20,7 +20,7 @@ namespace C7Engine.Pathing {
 		}
 	}
 
-	// A class for calculating the trade networks of a particular player.
+	// A class for calculating the trade networks.
 	//
 	// The main idea is that calculating the entire empire's trade network once
 	// is faster than doing it repeatedly for each city. By doing it once we can
@@ -31,13 +31,20 @@ namespace C7Engine.Pathing {
 	// TODO: Account for passing through the borders of civs we're at war with
 	// TODO: Invalidate the trade network when war status changes.
 	public class TradeNetwork {
-		public Dictionary<City, TradeNetworkSegment> segments = new();
+		private Dictionary<Player, Dictionary<City, TradeNetworkSegment>> segments = new();
 
-		public TradeNetwork(Player player) {
+		public TradeNetwork(GameData gameData) {
+			foreach (Player p in gameData.players) {
+				ComputeTradeNetwork(p);
+			}
+		}
+
+		private void ComputeTradeNetwork(Player player) {
 			HashSet<Tile> seen = new();
 
+			segments[player] = new();
 			foreach (City c in player.cities) {
-				if (segments.ContainsKey(c)) {
+				if (segments[player].ContainsKey(c)) {
 					continue;
 				}
 
@@ -45,7 +52,7 @@ namespace C7Engine.Pathing {
 				// segment and do a flood fill for all roads coming from the
 				// city.
 				TradeNetworkSegment segment = new();
-				segments[c] = segment;
+				segments[player][c] = segment;
 
 				Queue<Tile> toCheck = new();
 				toCheck.Enqueue(c.location);
@@ -56,7 +63,7 @@ namespace C7Engine.Pathing {
 					segment.AddTile(x, player);
 
 					if (x.cityAtTile != null) {
-						segments[x.cityAtTile] = segment;
+						segments[player][x.cityAtTile] = segment;
 					}
 
 					foreach (Tile n in x.neighbors.Values) {
@@ -69,8 +76,25 @@ namespace C7Engine.Pathing {
 			}
 		}
 
-		public bool HasTradeAccess(Tile t, Resource r) {
-			foreach (TradeNetworkSegment segment in segments.Values) {
+		// Returns the resources and their counts that are available to the given
+		// city.
+		public Dictionary<Resource, int> GetResourcesAvailableToCity(Player player, City city) {
+			TradeNetworkSegment segment = segments[player][city];
+			Dictionary<Resource, int> result = new();
+			foreach ((Resource r, int count) in segment.resourceCounts) {
+				if (player.KnowsAboutResource(r)) {
+					result[r] = count;
+				}
+			}
+			return result;
+		}
+
+		public bool HasTradeAccess(Tile t, Player p, Resource r) {
+			if (!p.KnowsAboutResource(r)) {
+				return false;
+			}
+
+			foreach (TradeNetworkSegment segment in segments[p].Values) {
 				if (segment.tiles.Contains(t) && segment.resourceCounts.TryGetValue(r, out int count) && count > 0) {
 					return true;
 				}

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -455,7 +455,7 @@ namespace C7Engine {
 						city = city
 					};
 					city.AddCitizen(newResident);
-					CityTileAssignmentAI.AssignNewCitizenToTile(newResident, manageMoods: true);
+					CityTileAssignmentAI.AssignNewCitizenToTile(EngineStorage.gameData, newResident, manageMoods: true);
 				}
 			}
 		}

--- a/C7Engine/AI/UnitAI/WorkerAI.cs
+++ b/C7Engine/AI/UnitAI/WorkerAI.cs
@@ -112,7 +112,7 @@ namespace C7Engine {
 
 			foreach (Terraform terraform in accessibleTerraforms) {
 				Tile tAfterImprovement = t.Copy();
-				terraform.OnComplete(tAfterImprovement);
+				terraform.OnComplete(unit.owner, tAfterImprovement);
 
 				int newCommerce = tAfterImprovement.commerceYield(player).yield;
 				int newShields = tAfterImprovement.productionYield(player).yield;

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -147,7 +147,16 @@ namespace C7GameData {
 		}
 
 		private HashSet<Resource> GetAccessibleResources() {
-			return owner.GetTradeNetwork().segments[this].resourceCounts.Keys.ToHashSet();
+			// We filter by whether the player knows about the resources here
+			// rather than in the trade network itself so that we don't have to
+			// invalidate the trade network when new techs are learned.
+			HashSet<Resource> result = new();
+			foreach (Resource r in owner.GetTradeNetwork().segments[this].resourceCounts.Keys) {
+				if (owner.KnowsAboutResource(r)) {
+					result.Add(r);
+				}
+			}
+			return result;
 		}
 
 		public int FoodNeededToGrow() {
@@ -982,7 +991,7 @@ namespace C7GameData {
 		private Dictionary<Resource, int> ListResourceAccess(ResourceCategory category) {
 			Dictionary<Resource, int> result = new();
 			foreach ((Resource r, int count) in owner.GetTradeNetwork().segments[this].resourceCounts) {
-				if (r.Category == category) {
+				if (r.Category == category && owner.KnowsAboutResource(r)) {
 					result[r] = count;
 				}
 			}

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -147,11 +147,7 @@ namespace C7GameData {
 		}
 
 		private HashSet<Resource> GetAccessibleResources() {
-			return owner.resourcesInBorders
-						.Where(kv => owner.KnowsAboutResource(kv.Key))
-						.Where(kv => kv.Value.Any(t => owner.HasTradeAccess(location, t)))
-						.Select(kv => kv.Key)
-						.ToHashSet();
+			return owner.GetTradeNetwork().segments[this].resourceCounts.Keys.ToHashSet();
 		}
 
 		public int FoodNeededToGrow() {
@@ -984,11 +980,13 @@ namespace C7GameData {
 		}
 
 		private Dictionary<Resource, int> ListResourceAccess(ResourceCategory category) {
-			return owner.resourcesInBorders
-				.Where(kv => kv.Key.Category == category && owner.KnowsAboutResource(kv.Key))
-				.Select(kv => (kv.Key, kv.Value.Where(t => owner.HasTradeAccess(location, t)).Count()))
-				.Where(rc => rc.Item2 > 0)
-				.ToDictionary();
+			Dictionary<Resource, int> result = new();
+			foreach ((Resource r, int count) in owner.GetTradeNetwork().segments[this].resourceCounts) {
+				if (r.Category == category) {
+					result[r] = count;
+				}
+			}
+			return result;
 		}
 
 		public Dictionary<Resource, int> GetStrategicResources() {

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -137,26 +137,17 @@ namespace C7GameData {
 			return result;
 		}
 
-		public IEnumerable<IProducible> ListProductionOptions() {
-			HashSet<Resource> accessibleResources = GetAccessibleResources();
+		public IEnumerable<IProducible> ListProductionOptions(GameData gameData) {
+			HashSet<Resource> accessibleResources = GetAccessibleResources(gameData);
 
-			IEnumerable<IProducible> producibles = EngineStorage.gameData.unitPrototypes.Cast<IProducible>()
-													.Concat(EngineStorage.gameData.Buildings.Cast<IProducible>());
+			IEnumerable<IProducible> producibles = gameData.unitPrototypes.Cast<IProducible>()
+													.Concat(gameData.Buildings.Cast<IProducible>());
 
 			return producibles.Where(p => p.CanProduce(this, accessibleResources));
 		}
 
-		private HashSet<Resource> GetAccessibleResources() {
-			// We filter by whether the player knows about the resources here
-			// rather than in the trade network itself so that we don't have to
-			// invalidate the trade network when new techs are learned.
-			HashSet<Resource> result = new();
-			foreach (Resource r in owner.GetTradeNetwork().segments[this].resourceCounts.Keys) {
-				if (owner.KnowsAboutResource(r)) {
-					result.Add(r);
-				}
-			}
-			return result;
+		private HashSet<Resource> GetAccessibleResources(GameData gameData) {
+			return gameData.GetTradeNetwork().GetResourcesAvailableToCity(owner, this).Keys.ToHashSet();
 		}
 
 		public int FoodNeededToGrow() {
@@ -325,7 +316,7 @@ namespace C7GameData {
 
 		private IProducible GetMostExpensiveItemToProduce() {
 			IProducible best = null;
-			foreach (IProducible ip in ListProductionOptions()) {
+			foreach (IProducible ip in ListProductionOptions(EngineStorage.gameData)) {
 				if (best == null || owner.ShieldCost(ip) > owner.ShieldCost(best)) {
 					best = ip;
 				}
@@ -359,7 +350,7 @@ namespace C7GameData {
 				newResident.city = this;
 				newResident.citizenType = gameData.citizenTypes.Find(x => x.IsDefaultCitizen);
 				AddCitizen(newResident);
-				C7Engine.AI.CityTileAssignmentAI.AssignNewCitizenToTile(newResident);
+				C7Engine.AI.CityTileAssignmentAI.AssignNewCitizenToTile(gameData, newResident);
 
 				if (hasGranary) {
 					foodStored /= 2;
@@ -913,7 +904,7 @@ namespace C7GameData {
 			contentToHappyMoves += CurrentCommerceYield(respectCivilDisorder: false).happiness;
 
 			// As do luxury resources, which can be boosted by marketplaces.
-			int effectiveLux = GetLuxuries().Keys.Count;
+			int effectiveLux = GetLuxuries(gameData).Keys.Count;
 			if (GetBuildings().Any(x => x.building.increasesLuxuryTrade)) {
 				effectiveLux = (int)(Math.Floor(effectiveLux / 2f) * Math.Ceiling(effectiveLux / 2f) + Math.Ceiling(effectiveLux / 2f));
 			}
@@ -988,22 +979,23 @@ namespace C7GameData {
 			}
 		}
 
-		private Dictionary<Resource, int> ListResourceAccess(ResourceCategory category) {
+		private Dictionary<Resource, int> ListResourceAccess(GameData gameData, ResourceCategory category) {
+			Dictionary<Resource, int> availableResources = gameData.GetTradeNetwork().GetResourcesAvailableToCity(owner, this);
 			Dictionary<Resource, int> result = new();
-			foreach ((Resource r, int count) in owner.GetTradeNetwork().segments[this].resourceCounts) {
-				if (r.Category == category && owner.KnowsAboutResource(r)) {
+			foreach ((Resource r, int count) in availableResources) {
+				if (r.Category == category) {
 					result[r] = count;
 				}
 			}
 			return result;
 		}
 
-		public Dictionary<Resource, int> GetStrategicResources() {
-			return ListResourceAccess(ResourceCategory.STRATEGIC);
+		public Dictionary<Resource, int> GetStrategicResources(GameData gameData) {
+			return ListResourceAccess(gameData, ResourceCategory.STRATEGIC);
 		}
 
-		public Dictionary<Resource, int> GetLuxuries() {
-			return ListResourceAccess(ResourceCategory.LUXURY);
+		public Dictionary<Resource, int> GetLuxuries(GameData gameData) {
+			return ListResourceAccess(gameData, ResourceCategory.LUXURY);
 		}
 	}
 }

--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Serilog;
+using C7Engine.Pathing;
 
 namespace C7GameData {
 	public class GameData {
@@ -54,6 +55,10 @@ namespace C7GameData {
 		public bool showGridCoordinates = false;
 
 		public string scenarioSearchPath;   //legacy from Civ3, we'll probably have a more modern format someday but this keeps legacy compatibility
+
+		// The cached trade network for all players. This is invalidated whenever
+		// a road is built or a city is created/destroyed.
+		private TradeNetwork tradeNetwork;
 
 		public GameData() {
 			map = new GameMap();
@@ -225,6 +230,17 @@ namespace C7GameData {
 			}
 
 			return (int)Math.Max(Math.Floor(researchCost), 0);
+		}
+
+		public TradeNetwork GetTradeNetwork() {
+			if (tradeNetwork == null) {
+				tradeNetwork = new(this);
+			}
+			return tradeNetwork;
+		}
+
+		public void InvalidateCachedTradeNetwork() {
+			tradeNetwork = null;
 		}
 
 		// Rules taken from https://forums.civfanatics.com/threads/the-eight-laws-of-border-dynamics.106882/

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -97,10 +97,6 @@ namespace C7GameData {
 		// completing a wonder (like Theory of Evolution).
 		public int freeTechsRemaining = 0;
 
-		// The cached trade network for this player. This is invalidated whenever
-		// a road is built or a city is created/destroyed.
-		private TradeNetwork tradeNetwork;
-
 		public int EraIndex() {
 			return EraIndex(eraCivilopediaName);
 		}
@@ -547,7 +543,7 @@ namespace C7GameData {
 
 					// Update the trade network if borders expanded, as a new
 					// resource may be part of the network.
-					InvalidateCachedTradeNetwork();
+					EngineStorage.gameData.InvalidateCachedTradeNetwork();
 				}
 
 				c.HandleCityGrowth(gameData);
@@ -763,18 +759,6 @@ namespace C7GameData {
 
 		public int ShieldCost(IProducible producible) {
 			return producible.ShieldCost(civilization.traits);
-		}
-
-		// TODO: Take wars into account. Trade networks cannot pass through civilizations the player's at war with
-		public TradeNetwork GetTradeNetwork() {
-			if (tradeNetwork == null) {
-				tradeNetwork = new(this);
-			}
-			return tradeNetwork;
-		}
-
-		public void InvalidateCachedTradeNetwork() {
-			tradeNetwork = null;
 		}
 	}
 

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -544,6 +544,10 @@ namespace C7GameData {
 				// the new citizen can go on one of our new tiles.
 				if (c.UpdateCultureAndCheckForExpansion()) {
 					gameData.UpdateTileOwners();
+
+					// Update the trade network if borders expanded, as a new
+					// resource may be part of the network.
+					InvalidateCachedTradeNetwork();
 				}
 
 				c.HandleCityGrowth(gameData);

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -97,6 +97,10 @@ namespace C7GameData {
 		// completing a wonder (like Theory of Evolution).
 		public int freeTechsRemaining = 0;
 
+		// The cached trade network for this player. This is invalidated whenever
+		// a road is built or a city is created/destroyed.
+		private TradeNetwork tradeNetwork;
+
 		public int EraIndex() {
 			return EraIndex(eraCivilopediaName);
 		}
@@ -758,10 +762,15 @@ namespace C7GameData {
 		}
 
 		// TODO: Take wars into account. Trade networks cannot pass through civilizations the player's at war with
-		public bool HasTradeAccess(Tile from, Tile to) {
-			PathingAlgorithm pathing = PathingAlgorithmChooser.GetTradeNetworkAlgorithm();
+		public TradeNetwork GetTradeNetwork() {
+			if (tradeNetwork == null) {
+				tradeNetwork = new(this);
+			}
+			return tradeNetwork;
+		}
 
-			return from == to || pathing.PathFrom(from, to).path.Count > 0;
+		public void InvalidateCachedTradeNetwork() {
+			tradeNetwork = null;
 		}
 	}
 

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -109,13 +109,15 @@ namespace C7GameData.Save {
 			data.defaultExperienceLevel = data.experienceLevels.Find(el => el.key == DefaultExperienceLevel);
 
 			data.UpdateTileOwners();
+			data.InvalidateCachedTradeNetwork();
+
 			foreach (Player p in data.players) {
 				// Backfill citizen assignments for scenarios that don't specify
 				// them.
 				foreach (City c in p.cities) {
 					foreach (CityResident cr in c.residents) {
 						if (cr.citizenType.IsDefaultCitizen && cr.tileWorked == Tile.NONE) {
-							C7Engine.AI.CityTileAssignmentAI.AssignNewCitizenToTile(cr);
+							C7Engine.AI.CityTileAssignmentAI.AssignNewCitizenToTile(data, cr);
 						}
 					}
 				}

--- a/C7Engine/C7GameData/Terraform.cs
+++ b/C7Engine/C7GameData/Terraform.cs
@@ -9,13 +9,7 @@ public static class TerraformRules {
 	public static readonly Dictionary<UnitAction, Action<Player, Tile>> ActionEffects = new() {
 		{UnitAction.BuildMine, (_, tile) => tile.overlays.Add(TerrainImprovement.mine)},
 		{UnitAction.Irrigate, (_, tile) => tile.overlays.Add(TerrainImprovement.irrigation)},
-		{UnitAction.BuildRoad, (player, tile) => {
-				tile.overlays.Add(TerrainImprovement.road);
-
-				// The trade network needs to be recomputed whenever roads are added.
-				player.InvalidateCachedTradeNetwork();
-			}
-		},
+		{UnitAction.BuildRoad, (player, tile) => tile.overlays.Add(TerrainImprovement.road)},
 		{UnitAction.BuildRailroad, (_, tile) => tile.overlays.Add(TerrainImprovement.railroad)},
 		{UnitAction.ClearWetlands, (_, tile) => tile.ClearTerrainOverlay()},
 		// TODO: add bonus shields to the nearest city - should only happen the first time a forest is cleared
@@ -78,7 +72,7 @@ public class Terraform {
 		bool hasTech = RequiredTech == null || player.knownTechs.Contains(RequiredTech);
 
 		bool hasResources = RequiredResources.All(
-			res => player.GetTradeNetwork().HasTradeAccess(tile, res)
+			res => player.KnowsAboutResource(res) && player.GetTradeNetwork().HasTradeAccess(tile, res)
 		);
 
 		return hasTech && hasResources && ActionValidator(player, tile);

--- a/C7Engine/C7GameData/Terraform.cs
+++ b/C7Engine/C7GameData/Terraform.cs
@@ -6,14 +6,20 @@ using C7GameData.Save;
 namespace C7GameData;
 
 public static class TerraformRules {
-	public static readonly Dictionary<UnitAction, Action<Tile>> ActionEffects = new() {
-		{UnitAction.BuildMine, tile => tile.overlays.Add(TerrainImprovement.mine)},
-		{UnitAction.Irrigate, tile => tile.overlays.Add(TerrainImprovement.irrigation)},
-		{UnitAction.BuildRoad, tile => tile.overlays.Add(TerrainImprovement.road)},
-		{UnitAction.BuildRailroad, tile => tile.overlays.Add(TerrainImprovement.railroad)},
-		{UnitAction.ClearWetlands, tile => tile.ClearTerrainOverlay()},
+	public static readonly Dictionary<UnitAction, Action<Player, Tile>> ActionEffects = new() {
+		{UnitAction.BuildMine, (_, tile) => tile.overlays.Add(TerrainImprovement.mine)},
+		{UnitAction.Irrigate, (_, tile) => tile.overlays.Add(TerrainImprovement.irrigation)},
+		{UnitAction.BuildRoad, (player, tile) => {
+				tile.overlays.Add(TerrainImprovement.road);
+
+				// The trade network needs to be recomputed whenever roads are added.
+				player.InvalidateCachedTradeNetwork();
+			}
+		},
+		{UnitAction.BuildRailroad, (_, tile) => tile.overlays.Add(TerrainImprovement.railroad)},
+		{UnitAction.ClearWetlands, (_, tile) => tile.ClearTerrainOverlay()},
 		// TODO: add bonus shields to the nearest city - should only happen the first time a forest is cleared
-		{UnitAction.ClearForest, tile => tile.ClearTerrainOverlay()},
+		{UnitAction.ClearForest, (_, tile) => tile.ClearTerrainOverlay()},
 	};
 
 	public static readonly Dictionary<UnitAction, Func<Player, Tile, bool>> ActionValidators = new() {
@@ -36,7 +42,7 @@ public class Terraform {
 
 	public List<Resource> RequiredResources = [];
 
-	public Action<Tile> OnComplete;
+	public Action<Player, Tile> OnComplete;
 	private Func<Player, Tile, bool> ActionValidator;
 
 	private SaveTerraform dataSource;
@@ -58,7 +64,7 @@ public class Terraform {
 		if (TerraformRules.ActionEffects.TryGetValue(Action, out var onComplete)) {
 			OnComplete = onComplete;
 		} else {
-			OnComplete = (_) => { };
+			OnComplete = (_, _) => { };
 		}
 
 		if (TerraformRules.ActionValidators.TryGetValue(Action, out var prerequisite)) {
@@ -72,10 +78,7 @@ public class Terraform {
 		bool hasTech = RequiredTech == null || player.knownTechs.Contains(RequiredTech);
 
 		bool hasResources = RequiredResources.All(
-			res =>
-				player.KnowsAboutResource(res) &&
-				player.resourcesInBorders.ContainsKey(res) &&
-				player.resourcesInBorders[res].Any(resTile => player.HasTradeAccess(tile, resTile))
+			res => player.GetTradeNetwork().HasTradeAccess(tile, res)
 		);
 
 		return hasTech && hasResources && ActionValidator(player, tile);

--- a/C7Engine/C7GameData/Terraform.cs
+++ b/C7Engine/C7GameData/Terraform.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using C7GameData.Save;
+using C7Engine;
 
 namespace C7GameData;
 
@@ -72,7 +73,7 @@ public class Terraform {
 		bool hasTech = RequiredTech == null || player.knownTechs.Contains(RequiredTech);
 
 		bool hasResources = RequiredResources.All(
-			res => player.KnowsAboutResource(res) && player.GetTradeNetwork().HasTradeAccess(tile, res)
+			res => EngineStorage.gameData.GetTradeNetwork().HasTradeAccess(tile, player, res)
 		);
 
 		return hasTech && hasResources && ActionValidator(player, tile);

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -636,6 +636,17 @@ namespace C7GameData {
 				throw new InvalidOperationException($"Cannot add {improvement.key} to the tile");
 
 			terrainImprovementByLayer[improvement.layer] = improvement;
+
+			// Hack: don't do this if gamedata is null, which can be true in some
+			// unit tests.
+			if (improvement == TerrainImprovement.road && EngineStorage.gameData != null) {
+				// Recompute all the trade networks whenever roads are added,
+				// because a new road may connect two new civs, which in turn
+				// could indirectly connect multiple other civs.
+				foreach (Player p in EngineStorage.gameData.players) {
+					p.InvalidateCachedTradeNetwork();
+				}
+			}
 		}
 
 		public bool HasImprovement(TerrainImprovement improvement) {

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -545,13 +545,15 @@ namespace C7GameData {
 		/// <param name="currentWorkerJob">the worker job currently finished, must not be null</param>
 		public void FinishWorkerJob(Terraform currentWorkerJob) {
 			// Reset All Workers working on the finished Job
+			Player player = null;
 			foreach (MapUnit unit in unitsOnTile) {
+				player = unit.owner;
 				if (currentWorkerJob == unit.WorkerJob) {
 					unit.resetWorkerJob();
 				}
 			}
 
-			currentWorkerJob.OnComplete(this);
+			currentWorkerJob.OnComplete(player, this);
 		}
 
 		public void Animate(AnimatedEffect effect, bool wait) {

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -640,12 +640,7 @@ namespace C7GameData {
 			// Hack: don't do this if gamedata is null, which can be true in some
 			// unit tests.
 			if (improvement == TerrainImprovement.road && EngineStorage.gameData != null) {
-				// Recompute all the trade networks whenever roads are added,
-				// because a new road may connect two new civs, which in turn
-				// could indirectly connect multiple other civs.
-				foreach (Player p in EngineStorage.gameData.players) {
-					p.InvalidateCachedTradeNetwork();
-				}
+				EngineStorage.gameData.InvalidateCachedTradeNetwork();
 			}
 		}
 

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -26,6 +26,14 @@ namespace C7Engine {
 			// accurate. We do this after adding the resident though, because
 			// cities with zero residents are considered destroyed.
 			gameData.UpdateTileOwners();
+
+			// Now that the city exists and its borders have been established,
+			// invalidate the trade network so it can be recomputed with this
+			// new information.
+			owner.InvalidateCachedTradeNetwork();
+
+			// Assigning citizens to tiles requires knowing luxuries, so this
+			// has to happen after invalidating the trade network.
 			CityTileAssignmentAI.AssignNewCitizenToTile(firstResident);
 
 			newCity.SetItemBeingProduced(CityProductionAI.GetNextItemToBeProduced(newCity, null));
@@ -51,6 +59,11 @@ namespace C7Engine {
 				new MsgCivilizationDestroyed(tile.cityAtTile.owner.civilization).send();
 			}
 			tile.cityAtTile = null;
+
+			// Now that the city has been destroyed and tile owners updated,
+			// invalidate the trade network in case removing this city cut off
+			// resource access.
+			owner.InvalidateCachedTradeNetwork();
 
 			// Redo corruption calculations after a city is destroyed, since it
 			// may change rank corruption values.

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -30,17 +30,17 @@ namespace C7Engine {
 			// Now that the city exists and its borders have been established,
 			// invalidate the trade network so it can be recomputed with this
 			// new information.
-			owner.InvalidateCachedTradeNetwork();
+			gameData.InvalidateCachedTradeNetwork();
 
 			// Assigning citizens to tiles requires knowing luxuries, so this
 			// has to happen after invalidating the trade network.
-			CityTileAssignmentAI.AssignNewCitizenToTile(firstResident);
+			CityTileAssignmentAI.AssignNewCitizenToTile(gameData, firstResident);
 
 			newCity.SetItemBeingProduced(CityProductionAI.GetNextItemToBeProduced(newCity, null));
 
 			// Redo corruption calculations after a city is created, since it
 			// may change rank corruption values.
-			owner.DoCorruptionCalculations(EngineStorage.gameData);
+			owner.DoCorruptionCalculations(gameData);
 
 			return newCity;
 		}
@@ -63,7 +63,7 @@ namespace C7Engine {
 			// Now that the city has been destroyed and tile owners updated,
 			// invalidate the trade network in case removing this city cut off
 			// resource access.
-			owner.InvalidateCachedTradeNetwork();
+			EngineStorage.gameData.InvalidateCachedTradeNetwork();
 
 			// Redo corruption calculations after a city is destroyed, since it
 			// may change rank corruption values.

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -163,7 +163,7 @@ namespace C7Engine {
 		public override void process() {
 			City city = EngineStorage.gameData.cities.Find(c => c.id == cityID);
 			if (city != null) {
-				foreach (IProducible producible in city.ListProductionOptions()) {
+				foreach (IProducible producible in city.ListProductionOptions(EngineStorage.gameData)) {
 					if (producible.name == producibleName) {
 						city.SetItemBeingProduced(producible);
 						break;


### PR DESCRIPTION
Rather than recomputing the pathing on the fly every time we need a city's luxury count, we can compute the whole network and cache it, and only invalidate it when roads are built (and eventually pillaged) and when cities are built and destroyed.

This cuts the runtime of the load conquest scenarios test from ~53 seconds to ~16 seconds on my (admittedly slow) laptop.
