### PR TITLE
Define a C7 spiral function and use it for a "neighbors of rank X" function

### DIFF
--- a/C7/Map/TileAssignmentLayer.cs
+++ b/C7/Map/TileAssignmentLayer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using C7GameData;
 using Godot;
@@ -21,7 +22,7 @@ namespace C7.Map {
 			if (city == null) {
 				return;
 			}
-			workableTiles = city.GetWorkableTiles();
+			workableTiles = city.GetWorkableTiles().ToHashSet();
 
 			// Include the city center in the "workable" tiles to avoid having
 			// a border drawn there.

--- a/C7Engine/AI/ChooseProducible.cs
+++ b/C7Engine/AI/ChooseProducible.cs
@@ -248,7 +248,7 @@ namespace C7Engine {
 			if (building.culturePerTurn > 0) {
 				int unclaimedTilesInOuterRing = 0;
 				int enemyTilesInOuterRing = 0;
-				foreach (Tile t in city.GetTilesOfRank(2)) {
+				foreach (Tile t in city.location.GetTilesWithinRankDistance(2)) {
 					if (t.OwningPlayer() == null) {
 						++unclaimedTilesInOuterRing;
 					} else if (t.OwningPlayer() != city.owner) {

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -644,8 +644,8 @@ namespace C7GameData {
 		//
 		// TODO: we should make this configurable to allow for the bigger cross
 		// if a mod wants it.
-		public HashSet<Tile> GetWorkableTiles() {
-			HashSet<Tile> result = new();
+		public List<Tile> GetWorkableTiles() {
+			List<Tile> result = new();
 			foreach (Tile t in GetTilesOfRank(2)) {
 				// Skip tiles not owned by this player.
 				if (t.owningCity == null || t.owningCity.owner != this.owner) {
@@ -664,41 +664,21 @@ namespace C7GameData {
 
 		// The list of tiles that are within the borders of this city, without
 		// taking into account border collisions with other cities.
-		public HashSet<Tile> GetTilesWithinBorders() {
+		public List<Tile> GetTilesWithinBorders() {
 			return GetTilesOfRank(GetBorderExpansionLevel());
 		}
 
-		public HashSet<Tile> GetTilesOfRank(int rank) {
-			HashSet<Tile> result = new();
-			HashSet<Tile> knownTiles = new();
-
-			Stack<Tile> toCheck = new();
-			toCheck.Push(location);
-			knownTiles.Add(location);
-
-			while (toCheck.Count > 0) {
-				Tile t = toCheck.Pop();
-
-				// Skip tiles that are too far away.
-				if (location.rankDistanceTo(t) > rank) {
-					continue;
-				}
-
+		// Like GetTilesWithinRankDistance, but with the filtering of ocean
+		// tiles for city border calculations.
+		private List<Tile> GetTilesOfRank(int rank) {
+			List<Tile> result = new();
+			foreach (Tile t in location.GetTilesWithinRankDistance(rank)) {
 				// Ocean tiles may only hold claims of rank 2.
 				if (t.baseTerrainTypeKey == "ocean" && rank > 2) {
 					continue;
 				}
-
-				// Otherwise this tile is close enough. Check its neighbors next.
 				result.Add(t);
-				foreach (Tile neighbor in t.neighbors.Values) {
-					if (!knownTiles.Contains(neighbor)) {
-						toCheck.Push(neighbor);
-						knownTiles.Add(t);
-					}
-				}
 			}
-
 			return result;
 		}
 

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -512,6 +512,89 @@ namespace C7GameData {
 			}
 			return location;
 		}
+
+		// Returns the tile at a "neighbor index", where 0 is this tile, 1 is
+		// due north, 2 is NE, 3 is E, and so on in a clockwise spiral.
+		// Index 9 is N+N, 10 is N+NE, etc.
+		//
+		// This is slightly different than the civ3 spiral, which starts with 
+		// the NE and goes clockwise. Ring 2 of the civ3 spiral is the BFC tiles,
+		// but rings beyond that get stranger. We don't need to match the civ3
+		// spiral exactly, and this is much simpler to understand. 
+		public Tile GetTileAtNeighborIndex(int neighborIndex) {
+			// Special case: Index 0 is this tile.
+			if (neighborIndex <= 0) {
+				return this;
+			}
+
+			int xDelta = 0;
+			int yDelta = 0;
+
+			// Figure out which ring we're in.
+			int ringNumber = 0;
+			do {
+				ringNumber++;
+			} while (Math.Pow(2 * ringNumber + 1, 2) <= neighborIndex);
+
+			// Figure out how many tiles are in the previous ring.
+			// For ring 2, we get (2*2 - 1)^2, which is 9.
+			int cellsInInnerRings = (ringNumber * 2 - 1) * (ringNumber * 2 - 1);
+
+			// Figure out the index of this neighbor within our ring.
+			int indexInRing1Based = neighborIndex - cellsInInnerRings;
+
+			// Our ring is a square with 4 sides, and each side has
+			// (ringNumber*2 + 1) tiles in it. But then we have the overlap of
+			// each corner, so excluding the overlap we have ringNumber*2 tiles
+			// per side.
+			//
+			// For ring 1, the 4 sections of size 2 are
+			//    (N, NE), (E, SE), (S, SW), (W, NW)
+			int cellsPerSquareEdge = ringNumber * 2;
+
+			// Define segment boundaries based on 1-based index within the ring
+			int segment1End = cellsPerSquareEdge;
+			int segment2End = 2 * cellsPerSquareEdge;
+			int segment3End = 3 * cellsPerSquareEdge;
+			int segment4End = 4 * cellsPerSquareEdge;
+
+			if (indexInRing1Based <= segment1End) {
+				// This is the side that goes from N to 1 short of E.
+				// N and NE for ring 1.
+				xDelta = indexInRing1Based;
+				yDelta = indexInRing1Based - cellsPerSquareEdge;
+			} else if (indexInRing1Based <= segment2End) {
+				// This is the side that goes from E to 1 short of S.
+				// E and SE for ring 1.
+				xDelta = segment2End - indexInRing1Based;
+				yDelta = indexInRing1Based - cellsPerSquareEdge;
+			} else if (indexInRing1Based <= segment3End) {
+				// This is the side that goes from S to 1 short of W.
+				// S and SW for ring 1.
+				xDelta = segment2End - indexInRing1Based;
+				yDelta = segment3End - indexInRing1Based;
+			} else {
+				// This is the side that goes from W to 1 short of N.
+				// W and NW for ring 1.
+				xDelta = indexInRing1Based - segment4End;
+				yDelta = segment3End - indexInRing1Based;
+			}
+
+			return map.tileAt(XCoordinate + xDelta, YCoordinate + yDelta);
+		}
+
+		public List<Tile> GetTilesWithinRankDistance(int rank) {
+			List<Tile> result = new();
+			for (int i = 0; i < (rank * 2 + 1) * (rank * 2 + 1); ++i) {
+				Tile t = GetTileAtNeighborIndex(i);
+				if (rankDistanceTo(t) <= rank) {
+					result.Add(t);
+				}
+			}
+
+			return result;
+		}
+
 		public MapUnit FindTopDefender(MapUnit opponent) {
 			if (unitsOnTile.Count > 0) {
 				IEnumerable<MapUnit> potentialDefenders = unitsOnTile.Where(u => u.CanDefendAgainst(opponent));

--- a/C7Engine/MapGenerator.cs
+++ b/C7Engine/MapGenerator.cs
@@ -1101,7 +1101,7 @@ namespace C7Engine {
 			minLuxurySpacing = Math.Max(2, minLuxurySpacing);
 			minLuxurySpacing = Math.Min(minLuxurySpacing, 10);
 
-			foreach (Tile x in GetTilesWithinRankDistance(t, minLuxurySpacing)) {
+			foreach (Tile x in t.GetTilesWithinRankDistance(minLuxurySpacing)) {
 				if (x.Resource != null
 					&& x.Resource != Resource.NONE
 					&& x.Resource.Category == ResourceCategory.LUXURY
@@ -1122,42 +1122,13 @@ namespace C7Engine {
 		private static bool HasSufficientLandNeighborsForResource(Tile t) {
 			int landTiles = 0;
 
-			foreach (Tile x in GetTilesWithinRankDistance(t, 2)) {
+			foreach (Tile x in t.GetTilesWithinRankDistance(2)) {
 				if (x.IsLand()) {
 					++landTiles;
 				}
 			}
 
 			return landTiles >= 1;
-		}
-
-		private static HashSet<Tile> GetTilesWithinRankDistance(Tile location, int rank) {
-			HashSet<Tile> result = new();
-			HashSet<Tile> knownTiles = new();
-
-			Stack<Tile> toCheck = new();
-			toCheck.Push(location);
-			knownTiles.Add(location);
-
-			while (toCheck.Count > 0) {
-				Tile t = toCheck.Pop();
-
-				// Skip tiles that are too far away.
-				if (location.rankDistanceTo(t) > rank) {
-					continue;
-				}
-
-				// Otherwise this tile is close enough. Check its neighbors next.
-				result.Add(t);
-				foreach (Tile neighbor in t.neighbors.Values) {
-					if (!knownTiles.Contains(neighbor)) {
-						toCheck.Push(neighbor);
-						knownTiles.Add(t);
-					}
-				}
-			}
-
-			return result;
 		}
 
 		private static void PlaceStrategicResourceType(Random rand, WorldCharacteristics wc, GameMap m, Resource r, List<int> tileIndicies) {
@@ -1207,7 +1178,7 @@ namespace C7Engine {
 			minSpacing = Math.Min(minSpacing, 10);
 
 			// Ensure strategic resources of the same kind don't clump up.
-			foreach (Tile x in GetTilesWithinRankDistance(t, minSpacing)) {
+			foreach (Tile x in t.GetTilesWithinRankDistance(minSpacing)) {
 				if (x.Resource != null
 					&& x.Resource != Resource.NONE
 					&& x.Resource.Category == ResourceCategory.STRATEGIC
@@ -1359,7 +1330,7 @@ namespace C7Engine {
 			}
 
 			// No barbarian camps within the big fat cross of another camp.
-			foreach (Tile n in GetTilesWithinRankDistance(t, 2)) {
+			foreach (Tile n in t.GetTilesWithinRankDistance(2)) {
 				if (n.hasBarbarianCamp) {
 					return false;
 				}
@@ -1502,7 +1473,7 @@ namespace C7Engine {
 
 			// Calculate the score for tiles in the immediate area.
 			int score = 0;
-			foreach (Tile n in GetTilesWithinRankDistance(t, 1)) {
+			foreach (Tile n in t.GetTilesWithinRankDistance(1)) {
 				score += CommercePoints * n.commerceYield(player).yield;
 				score += ShieldPoints * n.productionYield(player).yield;
 				score += FoodPoints * n.foodYield(player).yield;
@@ -1517,7 +1488,7 @@ namespace C7Engine {
 
 			// Then do it again for the full big fat cross, effectively weighting
 			// the immediate neighbors at a 2x rate.
-			foreach (Tile n in GetTilesWithinRankDistance(t, 2)) {
+			foreach (Tile n in t.GetTilesWithinRankDistance(2)) {
 				score += CommercePoints * n.commerceYield(player).yield;
 				score += ShieldPoints * n.productionYield(player).yield;
 				score += FoodPoints * n.foodYield(player).yield;
@@ -1535,7 +1506,7 @@ namespace C7Engine {
 			// Try to get a rough sense of the number of surrounding land tiles
 			// on the same continent, to avoid players getting stuck on a
 			// peninsula.
-			foreach (Tile n in GetTilesWithinRankDistance(t, 4)) {
+			foreach (Tile n in t.GetTilesWithinRankDistance(4)) {
 				if (n.continent == t.continent) {
 					score += LandTilePoints;
 				}


### PR DESCRIPTION
This speeds up the map generation test, from ~20 seconds to ~10 seconds, on my admittedly crappy laptop.

This will also let us award chopped forests to the "nearest" city, even if it isn't exactly the same pattern as civ 3. The civ3 pattern gets really weird past ring size 2, and this is much easier to understand.

Here's the spiral visualized:

![image](https://github.com/user-attachments/assets/a80034fd-7842-4c69-84dd-e7b133628939)
