### PR TITLE
Make the civ3 menu button a standalone object

### DIFF
--- a/C7/Text/TextureConfigs/civ3.lua
+++ b/C7/Text/TextureConfigs/civ3.lua
@@ -108,6 +108,11 @@ textures.ui = {
       crop_region = { 22, 1, 20, 20 },
       shadows = false,
     },
+    pressed = {
+      path = BUTTONS,
+      crop_region = { 43, 1, 20, 20 },
+      shadows = false,
+    },
   },
   confirm = {
     normal = {

--- a/C7/UIElements/MainMenu/Civ3MenuButton.cs
+++ b/C7/UIElements/MainMenu/Civ3MenuButton.cs
@@ -1,0 +1,170 @@
+using Godot;
+using System;
+
+// The standard civ3 menu button with the circle icon and text attached.
+//
+// This is its own class to allow use in the editor and to allow reuse.
+[GlobalClass]
+[Tool]
+public partial class Civ3MenuButton : BaseButton {
+	public enum TextPosition {
+		TextLeftOfIcon,
+		TextRightOfIcon,
+		TextAboveIcon,
+		TextBelowIcon
+	}
+
+	private Texture2D normalTexture = TextureLoader.Load("ui.button.inactive");
+	private Texture2D hoverTexture = TextureLoader.Load("ui.button.hover");
+	private Texture2D pressedTexture = TextureLoader.Load("ui.button.pressed");
+
+	private string _text;
+	[Export]
+	public string Text {
+		get => _text;
+		set {
+			_text = value;
+			if (label != null) {
+				label.Text = _text;
+			}
+		}
+	}
+	private int _fontSize;
+	[Export]
+	public int FontSize {
+		get => _fontSize;
+		set {
+			_fontSize = value;
+			if (label != null) {
+				label.AddThemeFontSizeOverride("font_size", _fontSize);
+			}
+		}
+	}
+	private TextPosition _textPosition;
+	[Export]
+	public TextPosition textPosition {
+		get => _textPosition;
+		set {
+			_textPosition = value;
+			if (label != null && textureRect != null) {
+				SetUpLayout();
+			}
+		}
+	}
+
+	private Color fontColor;
+	private Color hoverColor;
+	private Color pressedColor;
+
+	private Label label;
+	private TextureRect textureRect;
+	private BoxContainer boxContainer;
+
+	private bool hovered = false;
+
+	public Civ3MenuButton() {
+		textPosition = TextPosition.TextRightOfIcon;
+	}
+
+	public Civ3MenuButton(TextPosition textPosition = TextPosition.TextRightOfIcon) {
+		this.textPosition = textPosition;
+	}
+
+	public override void _Ready() {
+		fontColor = GetThemeColor("font_color", "Button");
+		hoverColor = GetThemeColor("font_hover_color", "Button");
+		pressedColor = GetThemeColor("font_pressed_color", "Button");
+
+		// Set up the label and texture.
+		label = new() {
+			Text = Text,
+			MouseFilter = MouseFilterEnum.Pass,
+			VerticalAlignment = VerticalAlignment.Center,
+			HorizontalAlignment = HorizontalAlignment.Center,
+			SizeFlagsHorizontal = SizeFlags.ShrinkCenter,
+			SizeFlagsVertical = SizeFlags.ShrinkCenter,
+		};
+		label.AddThemeFontSizeOverride("font_size", FontSize);
+
+		textureRect = new() {
+			Texture = normalTexture,
+			MouseFilter = MouseFilterEnum.Pass,
+			CustomMinimumSize = new Vector2(normalTexture.GetWidth(), normalTexture.GetHeight()),
+			ExpandMode = TextureRect.ExpandModeEnum.IgnoreSize,
+			SizeFlagsHorizontal = SizeFlags.ShrinkCenter,
+			SizeFlagsVertical = SizeFlags.ShrinkCenter,
+		};
+
+		SetUpLayout();
+
+		// Hook up our code to the button signals.
+		MouseEntered += () => {
+			hovered = true;
+			UpdateVisuals();
+		};
+		MouseExited += () => {
+			hovered = false;
+			UpdateVisuals();
+		};
+		Pressed += UpdateVisuals;
+		Toggled += (bool toggledOn) => { UpdateVisuals(); };
+
+		UpdateVisuals();
+	}
+
+	private void SetUpLayout() {
+		if (boxContainer != null) {
+			boxContainer.RemoveChild(label);
+			boxContainer.RemoveChild(textureRect);
+			RemoveChild(boxContainer);
+			boxContainer.QueueFree();
+		}
+
+		// Depending on the text positioning, add the label and texture as children
+		// of the appropriate layout.
+		if (textPosition == TextPosition.TextAboveIcon || textPosition == TextPosition.TextBelowIcon) {
+			boxContainer = new VBoxContainer();
+		} else {
+			boxContainer = new HBoxContainer();
+		}
+		boxContainer.SetAnchorsPreset(LayoutPreset.FullRect);
+		boxContainer.MouseFilter = MouseFilterEnum.Pass;
+		AddChild(boxContainer);
+
+		if (textPosition == TextPosition.TextAboveIcon || textPosition == TextPosition.TextLeftOfIcon) {
+			boxContainer.AddChild(label);
+			boxContainer.AddChild(textureRect);
+		} else {
+			boxContainer.AddChild(textureRect);
+			boxContainer.AddChild(label);
+		}
+	}
+
+	// Expand the size of the button to contain the texture and the label.
+	public override Vector2 _GetMinimumSize() {
+		if (boxContainer == null) {
+			return base._GetMinimumSize();
+		}
+		return boxContainer.GetCombinedMinimumSize();
+	}
+
+	public void UpdateVisuals() {
+		Texture2D currentTexture = normalTexture;
+		Color currentTextColor = fontColor;
+
+		// ButtonPressed is true if ToggleMode is on and button is selected
+		// DrawMode.Pressed is true if mouse is down on the button
+		bool isEffectivelyPressed = (ToggleMode && ButtonPressed) || GetDrawMode() == DrawMode.Pressed;
+
+		if (isEffectivelyPressed) {
+			currentTexture = pressedTexture;
+			currentTextColor = pressedColor;
+		} else if (hovered) {
+			currentTexture = hoverTexture;
+			currentTextColor = hoverColor;
+		}
+
+		textureRect.Texture = currentTexture;
+		label.AddThemeColorOverride("font_color", currentTextColor);
+	}
+}

--- a/C7/UIElements/MainMenu/MenuButtonContainer.cs
+++ b/C7/UIElements/MainMenu/MenuButtonContainer.cs
@@ -3,97 +3,54 @@ using System;
 
 [Tool]
 public partial class MenuButtonContainer : VBoxContainer {
-	public partial class MenuButton : HBoxContainer {
-		private TextureButton textureButton;
-		private Button labelButton;
-
-		private TextureButton TextureButton => textureButton;
-		private Button LabelButton => labelButton;
-
-		public string Text {
-			get => labelButton?.Text ?? string.Empty;
-			set {
-				if (labelButton != null)
-					labelButton.Text = value;
-			}
-		}
-
-		public Action Pressed;
-
-		public MenuButton() : this("") {
-		}
-
-		public MenuButton(string text) {
-			textureButton = new TextureButton();
-			labelButton = new Button();
-
-			Theme theme = new();
-			theme.SetFontSize("font_size", "Button", 14);
-			labelButton.Theme = theme;
-
-			labelButton.Text = text;
-
-			textureButton.TextureNormal = TextureLoader.Load("ui.button.inactive");
-			textureButton.TextureHover = TextureLoader.Load("ui.button.hover");
-
-			labelButton.Pressed += () => { Pressed?.Invoke(); };
-			textureButton.Pressed += () => { Pressed?.Invoke(); };
-		}
-
-		public override void _Ready() {
-			AddChild(textureButton);
-			AddChild(labelButton);
-		}
-	}
-
-	public MenuButton NewGame { get; private set; }
-	public MenuButton QuickStart { get; private set; }
-	public MenuButton Tutorial { get; private set; }
-	public MenuButton LoadGame { get; private set; }
-	public MenuButton LoadScenario { get; private set; }
-	public MenuButton HallOfFame { get; private set; }
-	public MenuButton ToggleGraphics { get; private set; }
-	public MenuButton Preferences { get; private set; }
-	public MenuButton AudioPreferences { get; private set; }
-	public MenuButton Credits { get; private set; }
-	public MenuButton Exit { get; private set; }
+	public Civ3MenuButton NewGame { get; private set; }
+	public Civ3MenuButton QuickStart { get; private set; }
+	public Civ3MenuButton Tutorial { get; private set; }
+	public Civ3MenuButton LoadGame { get; private set; }
+	public Civ3MenuButton LoadScenario { get; private set; }
+	public Civ3MenuButton HallOfFame { get; private set; }
+	public Civ3MenuButton ToggleGraphics { get; private set; }
+	public Civ3MenuButton Preferences { get; private set; }
+	public Civ3MenuButton AudioPreferences { get; private set; }
+	public Civ3MenuButton Credits { get; private set; }
+	public Civ3MenuButton Exit { get; private set; }
 
 	public override void _Ready() {
 		CreateButtons();
 	}
 
 	private void CreateButtons() {
-		NewGame = new MenuButton("New Game");
+		NewGame = new Civ3MenuButton() { Text = "New Game" };
 		AddChild(NewGame);
 
-		QuickStart = new MenuButton("Quick Start");
+		QuickStart = new Civ3MenuButton() { Text = "Quick Start" };
 		AddChild(QuickStart);
 
-		Tutorial = new MenuButton("Tutorial");
+		Tutorial = new Civ3MenuButton() { Text = "Tutorial" };
 		AddChild(Tutorial);
 
-		LoadGame = new MenuButton("Load Game");
+		LoadGame = new Civ3MenuButton() { Text = "Load Game" };
 		AddChild(LoadGame);
 
-		LoadScenario = new MenuButton("Load Scenario");
+		LoadScenario = new Civ3MenuButton() { Text = "Load Scenario" };
 		AddChild(LoadScenario);
 
-		HallOfFame = new MenuButton("Hall of Fame");
+		HallOfFame = new Civ3MenuButton() { Text = "Hall of Fame" };
 		AddChild(HallOfFame);
 
-		ToggleGraphics = new MenuButton("Turn on C7 Graphics");
+		ToggleGraphics = new Civ3MenuButton() { Text = "Turn on C7 Graphics" };
 		AddChild(ToggleGraphics);
 
-		Preferences = new MenuButton("Preferences");
+		Preferences = new Civ3MenuButton() { Text = "Preferences" };
 		AddChild(Preferences);
 
-		AudioPreferences = new MenuButton("Audio Preferences");
+		AudioPreferences = new Civ3MenuButton() { Text = "Audio Preferences" };
 		AddChild(AudioPreferences);
 
-		Credits = new MenuButton("Credits");
+		Credits = new Civ3MenuButton() { Text = "Credits" };
 		AddChild(Credits);
 
-		Exit = new MenuButton("Exit");
+		Exit = new Civ3MenuButton() { Text = "Exit" };
 		AddChild(Exit);
 	}
 }

--- a/C7/UIElements/Popups/Popup.cs
+++ b/C7/UIElements/Popups/Popup.cs
@@ -35,30 +35,19 @@ public partial class Popup : TextureRect {
 
 	const int HTILE_SIZE = 61;
 	const int VTILE_SIZE = 44;
-	private readonly static int BUTTON_LABEL_OFFSET = 0;    //Necessary in Godot 3, appears unnecessary in 4
 
-	private static ImageTexture InactiveButton = TextureLoader.Load("ui.button.inactive");
-	private static ImageTexture HoverButton = TextureLoader.Load("ui.button.hover");
 	private static Dictionary<(int, int), ImageTexture> backgroundCache = new Dictionary<(int, int), ImageTexture>();
 
 	protected void AddButton(string label, int verticalPosition, Action action) {
 		const int HORIZONTAL_POSITION = 30;
-		TextureButton newButton = new TextureButton();
-		newButton.TextureNormal = InactiveButton;
-		newButton.TextureHover = HoverButton;
-		newButton.SetPosition(new Vector2(HORIZONTAL_POSITION, verticalPosition));
-		AddChild(newButton);
-		newButton.Pressed += action;
 
-		Theme theme = new Theme();
-		theme.SetFontSize("font_size", "Button", 14);
-		Button newButtonLabel = new Button();
-		newButtonLabel.Theme = theme;
-		newButtonLabel.Text = label;
-
-		newButtonLabel.SetPosition(new Vector2(HORIZONTAL_POSITION + 25, verticalPosition + BUTTON_LABEL_OFFSET));
-		AddChild(newButtonLabel);
-		newButtonLabel.Pressed += action;
+		Civ3MenuButton button = new() {
+			Text = label,
+			FontSize = 14,
+		};
+		button.SetPosition(new Vector2(HORIZONTAL_POSITION, verticalPosition));
+		AddChild(button);
+		button.Pressed += action;
 	}
 
 	protected void AddHeader(string text, int vOffset) {


### PR DESCRIPTION
This makes the texture and text both change colors at the same time and centralizes the logic so I can reuse it in the player setup logic.

In the player setup logic I'll need the text on the other side of the texture for the civ selection, and the text on top of the texture for the difficulty.