### PR TITLE
Allow selecting the civ to play as and the opponents!

### DIFF
--- a/C7/GlobalSingleton.cs
+++ b/C7/GlobalSingleton.cs
@@ -1,5 +1,6 @@
 using Godot;
 using QueryCiv3;
+using C7Engine;
 
 /****
 	Need to pass values from one scene to another, particularly when loading
@@ -25,4 +26,9 @@ public partial class GlobalSingleton : Node {
 	public void ResetLoadGamePath() {
 		LoadGamePath = DefaultGamePath;
 	}
+
+	// The characteristics of the world to generate. This exists in the singleton
+	// to allow the world setup screen to pass the information to the player
+	// setup screen, which is what actually kicks off the world generation.
+	public WorldCharacteristics WorldCharacteristics;
 }

--- a/C7/Text/TextureConfigs/civ3.lua
+++ b/C7/Text/TextureConfigs/civ3.lua
@@ -340,6 +340,7 @@ textures.palace = {
 }
 
 textures.world_setup = require "civ3.world_setup"
+textures.player_setup = require "civ3.player_setup"
 
 textures.diplomacy = {
   deal = "Art/Diplomacy/counter.pcx",

--- a/C7/Text/TextureConfigs/civ3/player_setup.lua
+++ b/C7/Text/TextureConfigs/civ3/player_setup.lua
@@ -1,0 +1,7 @@
+local PLAYER_SETUP = "Art/PlayerSetup/"
+
+local player_setup = {
+  background = PLAYER_SETUP .. "playerSetup.pcx",
+}
+
+return player_setup

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -75152,6 +75152,7 @@
       "leader": "Temujin",
       "colorIndex": 3,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\x_temujin advisor.pcx",
       "cityNames": [
         "Karakorum",
         "Ta-Tu",
@@ -75199,6 +75200,7 @@
       "leader": "Isabella",
       "colorIndex": 5,
       "leaderGender": "female",
+      "leaderArtFile": "art\\advisors\\x_isabell advisor.pcx",
       "cityNames": [
         "Madrid",
         "Barcelona",
@@ -75247,6 +75249,7 @@
       "leader": "Ragnar Lodbrok",
       "colorIndex": 8,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\x_ragnar advisor.pcx",
       "cityNames": [
         "Trondheim",
         "Bergen",
@@ -75297,6 +75300,7 @@
       "leader": "Osman",
       "colorIndex": 2,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\x_osman advisor.pcx",
       "cityNames": [
         "Istanbul",
         "Edrine",
@@ -75343,6 +75347,7 @@
       "leader": "Brennus",
       "colorIndex": 4,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\x_brennus advisor.pcx",
       "cityNames": [
         "Entremont",
         "Alesia",
@@ -75390,6 +75395,7 @@
       "leader": "Abu Bakr",
       "colorIndex": 7,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\x_abu bakr advisor.pcx",
       "cityNames": [
         "Mecca",
         "Medina",
@@ -75435,6 +75441,7 @@
       "leader": "Hannibal",
       "colorIndex": 9,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\x_Hannibal advisor.pcx",
       "cityNames": [
         "Carthage",
         "Utica",
@@ -75482,6 +75489,7 @@
       "leader": "Wang Kon",
       "colorIndex": 6,
       "leaderGender": "male",
+      "leaderArtFile": "art\\advisors\\x_Wang Kon advisor.pcx",
       "cityNames": [
         "Seoul",
         "P\u0027yongyang",
@@ -75876,7 +75884,10 @@
     "foodNeededToGrowForLevel1Cities": 20,
     "foodNeededToGrowForLevel2Cities": 40,
     "foodNeededToGrowForLevel3Cities": 60,
-    "buildingDiscountForCivTraits": 0.5
+    "buildingDiscountForCivTraits": 0.5,
+    "startUnitType1": "Settler",
+    "startUnitType2": "Worker",
+    "scoutUnitType": "Scout"
   },
   "techs": [
     {

--- a/C7/UIElements/MainMenu/Civ3MenuButton.cs
+++ b/C7/UIElements/MainMenu/Civ3MenuButton.cs
@@ -125,7 +125,9 @@ public partial class Civ3MenuButton : BaseButton {
 		if (textPosition == TextPosition.TextAboveIcon || textPosition == TextPosition.TextBelowIcon) {
 			boxContainer = new VBoxContainer();
 		} else {
-			boxContainer = new HBoxContainer();
+			boxContainer = new HBoxContainer() {
+				Alignment = (textPosition == TextPosition.TextLeftOfIcon) ? BoxContainer.AlignmentMode.End : BoxContainer.AlignmentMode.Begin,
+			};
 		}
 		boxContainer.SetAnchorsPreset(LayoutPreset.FullRect);
 		boxContainer.MouseFilter = MouseFilterEnum.Pass;

--- a/C7/UIElements/NewGame/PlayerSetup.cs
+++ b/C7/UIElements/NewGame/PlayerSetup.cs
@@ -1,0 +1,322 @@
+using Godot;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using C7GameData;
+using C7Engine;
+using ConvertCiv3Media;
+using C7GameData.Save;
+using Serilog;
+
+[Tool]
+public partial class PlayerSetup : Control {
+	private static ILogger log = LogManager.ForContext<PlayerSetup>();
+
+	[Export] TextureRect background;
+
+	[Export] GridContainer playerListContainer;
+	List<Civilization> civilizations = new();
+	Civilization civilization = null;
+	ButtonGroup playerListButtonGroup = new();
+	TextureRect leaderHead = new();
+	[Export] Label civLabel;
+
+	[Export] GridContainer opponentListContainer;
+	List<OptionButton> opponentSelectors = new();
+
+	[Export] GridContainer difficultyContainer;
+
+	Difficulty difficulty = null;
+	ButtonGroup difficultyButtonGroup = new();
+
+	[Export] TextureButton confirm;
+	[Export] TextureButton cancel;
+
+	[Export] Label loadingLabel;
+
+	ID.Factory ids;
+
+	// TODO: read this from the rules based on the world size
+	const int NUM_OPPONENTS = 7;
+
+	// Called when the node enters the scene tree for the first time.
+	public override void _Ready() {
+		background.Texture = TextureLoader.Load("player_setup.background");
+
+		SaveGame save = GetSave();
+
+		// Set up buttons for the civs the player can play as.
+		//
+		// TODO: Bump this to Dutch once we bump the release.
+		civilizations = save.Civilizations;
+		playerListContainer.Columns = (int)Math.Ceiling(save.Civilizations.Count / 12.0);
+		string initiallySelectedCiv = save.Civilizations.Any(x => x.name == "Carthage") ? "Carthage" : save.Civilizations[1].name;
+		foreach (Civilization civ in save.Civilizations) {
+			if (civ.name == "A Barbarian Chiefdom") {
+				continue;
+			}
+
+			Civ3MenuButton button = new() {
+				Text = civ.name,
+				FontSize = 12,
+				textPosition = Civ3MenuButton.TextPosition.TextLeftOfIcon,
+				ButtonGroup = playerListButtonGroup,
+				ToggleMode = true,
+			};
+			button.Pressed += () => {
+				this.civilization = civ;
+				UpdateOpponentSelectors();
+				DisplaySelectedLeader();
+			};
+			playerListContainer.AddChild(button);
+
+			if (civ.name == initiallySelectedCiv) {
+				button.ButtonPressed = true;
+				this.civilization = civ;
+			}
+		}
+		background.AddChild(leaderHead);
+		DisplaySelectedLeader();
+
+		// Set up the options for opponents.
+		AddOpponentSelectors();
+
+		// Set up the difficulty buttons
+		difficultyContainer.Columns = save.Difficulties.Count;
+		string initiallySelectedDifficulty = save.Difficulties.Any(x => x.Name == "Regent") ? "Regent" : save.Difficulties[0].Name;
+		foreach (Difficulty difficulty in save.Difficulties) {
+			CenterContainer container = new();
+			difficultyContainer.AddChild(container);
+
+			Civ3MenuButton button = new(Civ3MenuButton.TextPosition.TextAboveIcon) {
+				Text = difficulty.Name,
+				ButtonGroup = difficultyButtonGroup,
+				ToggleMode = true,
+			};
+			button.Pressed += () => { this.difficulty = difficulty; };
+			container.AddChild(button);
+			if (difficulty.Name == initiallySelectedDifficulty) {
+				button.ButtonPressed = true;
+				this.difficulty = difficulty;
+			}
+			container.CustomMinimumSize = new Vector2(843.0f / difficultyContainer.Columns, 0);
+		}
+
+		TextureLoader.SetButtonTextures(confirm, "ui.confirm");
+		confirm.Pressed += CreateGame;
+
+		TextureLoader.SetButtonTextures(cancel, "ui.cancel");
+		cancel.Pressed += BackToMainMenu;
+	}
+
+	private void BackToMainMenu() {
+		GetTree().ChangeSceneToFile("res://UIElements/MainMenu/main_menu.tscn");
+	}
+
+	private void AddOpponentSelectors() {
+		// TODO: The number of opponents should come from the rule set.
+		for (int i = 0; i < NUM_OPPONENTS; ++i) {
+			OptionButton optionButton = new();
+			StyleBoxFlat styleBox = new() {
+				BorderColor = Color.Color8(150, 150, 150, 220),
+				BgColor = Color.Color8(255, 255, 255, 0),
+				BorderWidthBottom = 2,
+				BorderWidthLeft = 2,
+				BorderWidthRight = 2,
+				BorderWidthTop = 2,
+				ContentMarginLeft = 4,
+				ContentMarginRight = 4,
+				ContentMarginTop = 4,
+				ContentMarginBottom = 4
+			};
+			optionButton.AddThemeStyleboxOverride("normal", styleBox);
+			optionButton.AddThemeStyleboxOverride("hover", styleBox); ;
+			optionButton.AddThemeStyleboxOverride("pressed", styleBox);
+
+			PopupMenu popup = optionButton.GetPopup();
+			popup.AddThemeStyleboxOverride("panel", styleBox);
+			popup.MaxSize = new Vector2I(popup.MaxSize.X, 300);
+			opponentSelectors.Add(optionButton);
+
+			CenterContainer container = new();
+			opponentListContainer.AddChild(container);
+			container.AddChild(optionButton);
+
+			container.CustomMinimumSize = new Vector2(312.0f / opponentListContainer.Columns, 315.0f / NUM_OPPONENTS);
+			optionButton.CustomMinimumSize = new Vector2(290.0f / opponentListContainer.Columns, optionButton.CustomMinimumSize.Y);
+
+			foreach (Civilization civ in civilizations) {
+				if (civ.name == "A Barbarian Chiefdom") {
+					continue;
+				}
+				optionButton.AddItem(civ.name);
+			}
+
+			// Add (and default to) random for each opponent.
+			optionButton.AddItem("Random");
+			optionButton.Select(popup.ItemCount - 1);
+
+			for (int k = 0; k < popup.ItemCount; ++k) {
+				popup.SetItemAsRadioCheckable(k, false);
+				popup.SetItemAsCheckable(k, false);
+			}
+		}
+
+		UpdateOpponentSelectors();
+	}
+
+	private void UpdateOpponentSelectors() {
+		foreach (OptionButton ob in opponentSelectors) {
+			int index = civilizations.FindIndex(x => x == this.civilization);
+
+			for (int i = 0; i < ob.GetPopup().ItemCount; ++i) {
+				ob.SetItemDisabled(i, this.civilization.name == ob.GetItemText(i));
+			}
+
+			// If the player decides to play as civ X and one of the opponent
+			// selectors has X selected, change it to random.
+			if (ob.Selected == index) {
+				ob.Select(ob.GetPopup().ItemCount - 1);
+			}
+		}
+	}
+
+	private void DisplaySelectedLeader() {
+		Pcx headPcx = TextureLoader.LoadPCX(civilization.leaderArtFile);
+		leaderHead.Texture = PCXToGodot.getImageTextureFromPCX(
+					headPcx,
+					new(0, 115, 115, 115),
+					new(false, [255]));
+		leaderHead.Scale = new Vector2(1.7f, 1.7f);
+		leaderHead.SetPosition(new Vector2(414, 46));
+
+		string traits = string.Join(", ", civilization.traits);
+		civLabel.Text = $"{civilization.leader} of the {civilization.noun}\n({traits})";
+	}
+
+	private SaveGame GetSave() {
+		try {
+			GlobalSingleton Global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
+			return SaveManager.LoadSave(Global.DefaultGamePath, Global.DefaultBicPath, (string unused) => { return unused; });
+		} catch (Exception e) {
+			// Hardcoded fallback for the godot editor, which doesn't handle the
+			// global.
+			return SaveManager.LoadSave(@"./Text/c7-autosave-turn-0.json", "", (string unused) => { return unused; });
+		}
+	}
+
+	private void CreateGame() {
+		loadingLabel.Visible = true;
+		GlobalSingleton global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
+
+		// World generation can take a bit of time if multiple attempts are
+		// needed, so we don't want to tie up the UI thread.
+		Thread thread = new(() => { DoWorldGenerationAndstartGame(global); });
+		thread.Start();
+	}
+
+	private void DoWorldGenerationAndstartGame(GlobalSingleton Global) {
+		SaveGame save = GetSave();
+		log.Information("Starting map generation");
+		save.Map = new SaveMap(MapGenerator.GenerateMap(Global.WorldCharacteristics));
+		log.Information("Done with map generation");
+		Random rand = new(Global.WorldCharacteristics.mapSeed + 0x531);
+		ids = new(save);
+
+		// Hack: reuse the save but clear out the non-barbarian players.
+		// 
+		// Longer term we'll need to split out our own
+		// "conquests.bic" type file and load that - until then we'll use this
+		// hack of reusing the static save.
+		//
+		// Start at index 1 to skip the barbarians.
+		save.Players.RemoveRange(1, save.Players.Count - 1);
+
+		// Clear out the units, we'll add new ones.
+		save.Units.Clear();
+
+		// Add the human player.
+		AddPlayer(save, this.civilization,
+				  Global.WorldCharacteristics.defaultGovernment.id,
+				  isHuman: true);
+
+		// Add the opponents.
+		HashSet<string> taken = new();
+		taken.Add(this.civilization.name);
+
+		foreach (OptionButton ob in opponentSelectors) {
+			string selectedName = ob.GetItemText(ob.Selected);
+			if (taken.Contains(selectedName)) {
+				selectedName = "Random";
+			}
+
+			if (selectedName == "Random") {
+				do {
+					selectedName = civilizations[rand.Next(1, civilizations.Count)].name;
+				} while (taken.Contains(selectedName));
+			}
+			taken.Add(selectedName);
+
+			Civilization civ = civilizations.Find(x => x.name == selectedName);
+			AddPlayer(save, civ,
+					  Global.WorldCharacteristics.defaultGovernment.id,
+					  isHuman: false);
+		}
+
+		log.Information("saving generated map");
+		save.Save(Global.DefaultGeneratedGamePath);
+		Global.LoadGamePath = Global.DefaultGeneratedGamePath;
+
+		log.Information("opening map");
+		CallDeferred("StartGame");
+	}
+
+	private void AddPlayer(SaveGame save, Civilization civ, ID defaultGovernment, bool isHuman) {
+		SavePlayer player = new() {
+			human = isHuman,
+			id = ids.CreateID("Player"),
+			colorIndex = civ.colorIndex,
+			barbarian = false,
+			civilization = civ.name,
+			knownTechs = civ.startingTechs,
+			// TODO: stop hardcoding this
+			eraCivilopediaName = "ERAS_Ancient_Times",
+			// TODO: load this from the rules
+			gold = 10,
+			governmentId = defaultGovernment,
+		};
+		save.Players.Add(player);
+
+		SaveTile startingTile = save.Map.startingLocations[save.Players.Count - 2];
+		TileLocation startingLocation = new TileLocation(startingTile.X, startingTile.Y);
+
+		AddUnit(save, player, save.Rules.StartUnitType1, startingLocation);
+		AddUnit(save, player, save.Rules.StartUnitType2, startingLocation);
+		if (civ.traits.Contains(Civilization.Trait.Expansionist)) {
+			AddUnit(save, player, save.Rules.ScoutUnitType, startingLocation);
+		}
+	}
+
+	private void AddUnit(SaveGame save, SavePlayer player, string unitType, TileLocation location) {
+		SaveUnit unit = new() {
+			id = ids.CreateID(unitType),
+			prototype = unitType,
+			owner = player.id,
+			previousLocation = new TileLocation(-1, -1),
+			currentLocation = location,
+
+			// TODO: stop hardcoding these
+			hitPointsRemaining = 3,
+			movePointsRemaining = 1,
+			experience = "Regular",
+
+			facingDirection = TileDirection.NORTH,
+		};
+		save.Units.Add(unit);
+	}
+
+	private void StartGame() {
+		GetTree().ChangeSceneToFile("res://C7Game.tscn");
+	}
+}

--- a/C7/UIElements/NewGame/PlayerSetup.cs
+++ b/C7/UIElements/NewGame/PlayerSetup.cs
@@ -161,23 +161,31 @@ public partial class PlayerSetup : Control {
 				popup.SetItemAsRadioCheckable(k, false);
 				popup.SetItemAsCheckable(k, false);
 			}
+
+			optionButton.ItemSelected += (long i) => { UpdateOpponentSelectors(); };
 		}
 
 		UpdateOpponentSelectors();
 	}
 
 	private void UpdateOpponentSelectors() {
-		foreach (OptionButton ob in opponentSelectors) {
-			int index = civilizations.FindIndex(x => x == this.civilization);
+		HashSet<string> civsTaken = new();
+		civsTaken.Add(civilization.name);
 
-			for (int i = 0; i < ob.GetPopup().ItemCount; ++i) {
-				ob.SetItemDisabled(i, this.civilization.name == ob.GetItemText(i));
-			}
+		foreach (OptionButton ob in opponentSelectors) {
+			string selection = ob.GetItemText(ob.Selected);
 
 			// If the player decides to play as civ X and one of the opponent
-			// selectors has X selected, change it to random.
-			if (ob.Selected == index) {
+			// selectors has X selected, change it to random. Similarly if one
+			// of the previous option buttons has selected this civ.
+			if (civsTaken.Contains(selection)) {
 				ob.Select(ob.GetPopup().ItemCount - 1);
+			} else if (selection != "Random") {
+				civsTaken.Add(selection);
+			}
+
+			for (int i = 0; i < ob.GetPopup().ItemCount; ++i) {
+				ob.SetItemDisabled(i, civsTaken.Contains(ob.GetItemText(i)));
 			}
 		}
 	}
@@ -196,10 +204,10 @@ public partial class PlayerSetup : Control {
 	}
 
 	private SaveGame GetSave() {
-		try {
+		if (!Engine.IsEditorHint()) {
 			GlobalSingleton Global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
 			return SaveManager.LoadSave(Global.DefaultGamePath, Global.DefaultBicPath, (string unused) => { return unused; });
-		} catch (Exception e) {
+		} else {
 			// Hardcoded fallback for the godot editor, which doesn't handle the
 			// global.
 			return SaveManager.LoadSave(@"./Text/c7-static-map-save.json", "", (string unused) => { return unused; });

--- a/C7/UIElements/NewGame/PlayerSetup.cs
+++ b/C7/UIElements/NewGame/PlayerSetup.cs
@@ -202,22 +202,22 @@ public partial class PlayerSetup : Control {
 		} catch (Exception e) {
 			// Hardcoded fallback for the godot editor, which doesn't handle the
 			// global.
-			return SaveManager.LoadSave(@"./Text/c7-autosave-turn-0.json", "", (string unused) => { return unused; });
+			return SaveManager.LoadSave(@"./Text/c7-static-map-save.json", "", (string unused) => { return unused; });
 		}
 	}
 
 	private void CreateGame() {
 		loadingLabel.Visible = true;
 		GlobalSingleton global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
+		SaveGame save = GetSave();
 
 		// World generation can take a bit of time if multiple attempts are
 		// needed, so we don't want to tie up the UI thread.
-		Thread thread = new(() => { DoWorldGenerationAndstartGame(global); });
+		Thread thread = new(() => { DoWorldGenerationAndstartGame(save, global); });
 		thread.Start();
 	}
 
-	private void DoWorldGenerationAndstartGame(GlobalSingleton Global) {
-		SaveGame save = GetSave();
+	private void DoWorldGenerationAndstartGame(SaveGame save, GlobalSingleton Global) {
 		log.Information("Starting map generation");
 		save.Map = new SaveMap(MapGenerator.GenerateMap(Global.WorldCharacteristics));
 		log.Information("Done with map generation");

--- a/C7/UIElements/NewGame/WorldSetup.cs
+++ b/C7/UIElements/NewGame/WorldSetup.cs
@@ -8,7 +8,7 @@ using Serilog;
 
 [Tool]
 public partial class WorldSetup : Control {
-	private static ILogger log = LogManager.ForContext<MainMenu>();
+	private static ILogger log = LogManager.ForContext<WorldSetup>();
 
 	[Export] TextureRect background;
 
@@ -69,8 +69,6 @@ public partial class WorldSetup : Control {
 	[Export] TextureButton cancel;
 
 	[Export] LineEdit seedInput;
-
-	[Export] Label loadingLabel;
 
 	WorldCharacteristics.Landform landform = WorldCharacteristics.Landform.Pangaea;
 	WorldCharacteristics.OceanCoverage ocean = WorldCharacteristics.OceanCoverage.Percent_70;
@@ -314,20 +312,11 @@ public partial class WorldSetup : Control {
 	}
 
 	private void CreateGame() {
-		loadingLabel.Visible = true;
 		GlobalSingleton Global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
-
-		// World generation can take a bit of time if multiple attempts are
-		// needed, so we don't want to tie up the UI thread.
-		Thread thread = new(() => { DoWorldGenerationAndstartGame(Global); });
-		thread.Start();
-	}
-
-	private void DoWorldGenerationAndstartGame(GlobalSingleton Global) {
 		Global.ResetLoadGamePath();
-
 		SaveGame save = SaveManager.LoadSave(Global.DefaultGamePath, Global.DefaultBicPath, (string unused) => { return unused; });
-		save.Map = new SaveMap(MapGenerator.GenerateMap(new WorldCharacteristics() {
+
+		Global.WorldCharacteristics = new WorldCharacteristics() {
 			landform = landform,
 			oceanCoverage = ocean,
 			age = age,
@@ -345,37 +334,9 @@ public partial class WorldSetup : Control {
 			resources = save.Resources,
 			defaultGovernment = save.Governments.Find(x => x.defaultType),
 			mapSeed = Int32.Parse(seedInput.Text),
-		}));
+		};
 
-		// Hack: reposition the initial units to the starting locations from the
-		// generated map. Longer term we'll need to split out our own
-		// "conquests.bic" type file and load that - until then we'll use this
-		// hack of grabbing it from the static save.
-		//
-		// Start at index 1 to skip the barbarians.
-		for (int i = 1; i < save.Players.Count; ++i) {
-			SaveTile startingTile = save.Map.startingLocations[i - 1];
-			TileLocation startingLocation = new TileLocation(startingTile.X, startingTile.Y);
-			SavePlayer player = save.Players[i];
-
-			foreach (SaveUnit unit in save.Units) {
-				if (unit.owner == player.id) {
-					unit.currentLocation = startingLocation;
-				}
-			}
-			player.tileKnowledge.Clear();
-		}
-
-		log.Information("saving generated map");
-		save.Save(Global.DefaultGeneratedGamePath);
-		Global.LoadGamePath = Global.DefaultGeneratedGamePath;
-
-		log.Information("opening map");
-		CallDeferred("StartGame");
-	}
-
-	private void StartGame() {
-		GetTree().ChangeSceneToFile("res://C7Game.tscn");
+		GetTree().ChangeSceneToFile("res://UIElements/NewGame/player_setup.tscn");
 	}
 
 	private void BackToMainMenu() {

--- a/C7/UIElements/NewGame/player_setup.tscn
+++ b/C7/UIElements/NewGame/player_setup.tscn
@@ -1,0 +1,154 @@
+[gd_scene load_steps=3 format=3 uid="uid://4e71j27bd536"]
+
+[ext_resource type="Script" path="res://UIElements/NewGame/PlayerSetup.cs" id="1"]
+[ext_resource type="Script" path="res://UIElements/Civ3TextureRect.cs" id="2"]
+[ext_resource type="Script" path="res://UIElements/Civ3TextureButton.cs" id="3"]
+
+[sub_resource type="InputEventKey" id="InputEventKey_8ublj"]
+device = -1
+keycode = 4194309
+
+[sub_resource type="Shortcut" id="Shortcut_33b04"]
+events = [SubResource("InputEventKey_8ublj")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_klcu1"]
+device = -1
+keycode = 4194305
+
+[sub_resource type="Shortcut" id="Shortcut_7oyjg"]
+events = [SubResource("InputEventKey_klcu1")]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ld2d8"]
+
+[node name="Control" type="CenterContainer" node_paths=PackedStringArray("background", "playerListContainer", "opponentListContainer", "difficultyContainer", "civLabel", "confirm", "cancel", "loadingLabel")]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1")
+background = NodePath("Background")
+playerListContainer = NodePath("Background/CenterContainer/PlayerListContainer")
+opponentListContainer = NodePath("Background/OpponentListContainer")
+difficultyContainer = NodePath("Background/DifficultyContainer")
+civLabel = NodePath("Background/CivLabel")
+confirm = NodePath("Background/Confirm")
+cancel = NodePath("Background/Cancel")
+loadingLabel = NodePath("Background/LoadingLabel")
+
+[node name="Background" type="TextureRect" parent="."]
+layout_mode = 2
+script = ExtResource("2")
+
+[node name="Label" type="Label" parent="Background"]
+layout_mode = 0
+offset_left = 114.0
+offset_top = 25.0
+offset_right = 326.0
+offset_bottom = 57.0
+theme_override_font_sizes/font_size = 24
+text = "PLAYER SETUP"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Label2" type="Label" parent="Background"]
+layout_mode = 0
+offset_left = 147.0
+offset_top = 77.0
+offset_right = 294.0
+offset_bottom = 99.0
+theme_override_font_sizes/font_size = 15
+text = "YOUR CIVILIZATION"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Label3" type="Label" parent="Background"]
+layout_mode = 0
+offset_left = 734.0
+offset_top = 78.0
+offset_right = 881.0
+offset_bottom = 100.0
+theme_override_font_sizes/font_size = 15
+text = "YOUR RIVALS"
+vertical_alignment = 1
+
+[node name="Label4" type="Label" parent="Background"]
+layout_mode = 0
+offset_left = 110.0
+offset_top = 642.0
+offset_right = 257.0
+offset_bottom = 664.0
+theme_override_font_sizes/font_size = 15
+text = "DIFFICULTY"
+vertical_alignment = 1
+
+[node name="OpponentListContainer" type="GridContainer" parent="Background"]
+layout_mode = 0
+offset_left = 636.0
+offset_top = 123.0
+offset_right = 948.0
+offset_bottom = 458.0
+
+[node name="CenterContainer" type="CenterContainer" parent="Background"]
+layout_mode = 0
+offset_left = 72.0
+offset_top = 122.0
+offset_right = 386.0
+offset_bottom = 460.0
+
+[node name="PlayerListContainer" type="GridContainer" parent="Background/CenterContainer"]
+layout_mode = 2
+theme_override_constants/h_separation = 10
+theme_override_constants/v_separation = 10
+columns = 3
+
+[node name="DifficultyContainer" type="GridContainer" parent="Background"]
+layout_mode = 0
+offset_left = 91.0
+offset_top = 690.0
+offset_right = 934.0
+offset_bottom = 750.0
+columns = 8
+
+[node name="CivLabel" type="Label" parent="Background"]
+layout_mode = 0
+offset_left = 421.0
+offset_top = 289.0
+offset_right = 608.0
+offset_bottom = 368.0
+text = "Foo of the Bars
+(Expansionist, Agricultural, Industrial)"
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 2
+
+[node name="Confirm" type="TextureButton" parent="Background"]
+layout_mode = 0
+offset_left = 960.0
+offset_top = 728.0
+offset_right = 979.0
+offset_bottom = 747.0
+shortcut = SubResource("Shortcut_33b04")
+script = ExtResource("3")
+
+[node name="Cancel" type="TextureButton" parent="Background"]
+layout_mode = 0
+offset_left = 988.0
+offset_top = 729.0
+offset_right = 1007.0
+offset_bottom = 748.0
+shortcut = SubResource("Shortcut_7oyjg")
+script = ExtResource("3")
+
+[node name="LoadingLabel" type="Label" parent="Background"]
+visible = false
+layout_mode = 0
+offset_left = 310.0
+offset_top = 325.0
+offset_right = 717.0
+offset_bottom = 434.0
+theme_override_font_sizes/font_size = 38
+theme_override_styles/normal = SubResource("StyleBoxFlat_ld2d8")
+text = "Loading..."
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/C7/UIElements/NewGame/world_setup.tscn
+++ b/C7/UIElements/NewGame/world_setup.tscn
@@ -40,9 +40,7 @@ keycode = 4194305
 [sub_resource type="Shortcut" id="Shortcut_7oyjg"]
 events = [SubResource("InputEventKey_klcu1")]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ld2d8"]
-
-[node name="Control" type="CenterContainer" node_paths=PackedStringArray("background", "pangaeaLabel", "continentsLabel", "archipelagoLabel", "pangaea60", "pangaea70", "pangaea80", "continents60", "continents70", "continents80", "archipelago60", "archipelago70", "archipelago80", "pangaea60Large", "pangaea70Large", "pangaea80Large", "continents60Large", "continents70Large", "continents80Large", "archipelago60Large", "archipelago70Large", "archipelago80Large", "arid", "normal", "wet", "cool", "temperate", "warm", "billion3", "billion4", "billion5", "aridLarge", "normalLarge", "wetLarge", "coolLarge", "temperateLarge", "warmLarge", "billion3Large", "billion4Large", "billion5Large", "tinySize", "smallSize", "standardSize", "largeSize", "hugeSize", "randomSize", "confirm", "cancel", "seedInput", "loadingLabel")]
+[node name="Control" type="CenterContainer" node_paths=PackedStringArray("background", "pangaeaLabel", "continentsLabel", "archipelagoLabel", "pangaea60", "pangaea70", "pangaea80", "continents60", "continents70", "continents80", "archipelago60", "archipelago70", "archipelago80", "pangaea60Large", "pangaea70Large", "pangaea80Large", "continents60Large", "continents70Large", "continents80Large", "archipelago60Large", "archipelago70Large", "archipelago80Large", "arid", "normal", "wet", "cool", "temperate", "warm", "billion3", "billion4", "billion5", "aridLarge", "normalLarge", "wetLarge", "coolLarge", "temperateLarge", "warmLarge", "billion3Large", "billion4Large", "billion5Large", "tinySize", "smallSize", "standardSize", "largeSize", "hugeSize", "randomSize", "confirm", "cancel", "seedInput")]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -98,7 +96,6 @@ randomSize = NodePath("Background/RandomSize")
 confirm = NodePath("Background/Confirm")
 cancel = NodePath("Background/Cancel")
 seedInput = NodePath("Background/SeedInput")
-loadingLabel = NodePath("Background/LoadingLabel")
 
 [node name="Background" type="TextureRect" parent="."]
 layout_mode = 2
@@ -759,16 +756,3 @@ offset_right = 1007.0
 offset_bottom = 748.0
 shortcut = SubResource("Shortcut_7oyjg")
 script = ExtResource("3")
-
-[node name="LoadingLabel" type="Label" parent="Background"]
-visible = false
-layout_mode = 0
-offset_left = 310.0
-offset_top = 325.0
-offset_right = 717.0
-offset_bottom = 434.0
-theme_override_font_sizes/font_size = 38
-theme_override_styles/normal = SubResource("StyleBoxFlat_ld2d8")
-text = "Loading..."
-horizontal_alignment = 1
-vertical_alignment = 1

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -355,6 +355,7 @@ namespace C7GameData {
 				if (artName != null) {
 					civ.leaderArtFile = artName;
 				}
+
 				save.Civilizations.Add(civ);
 				i++;
 			}
@@ -1311,6 +1312,9 @@ namespace C7GameData {
 			save.Rules.CitizenValueInShields = rule.CitizenValueInShields;
 			save.Rules.TurnPenaltyForEachHurrySacrifice = rule.TurnPenaltyForEachHurrySacrifice;
 			save.GameDifficulty = save.Difficulties[rule.DefaultDifficultyLevel];
+			save.Rules.StartUnitType1 = theBiq.Prto[rule.StartUnitType1].Name;
+			save.Rules.StartUnitType2 = theBiq.Prto[rule.StartUnitType2].Name;
+			save.Rules.ScoutUnitType = theBiq.Prto[rule.Scout].Name;
 		}
 
 		private static void SetWorldWrap(SavData civ3Save, SaveGame save) {

--- a/C7Engine/C7GameData/PediaIcons.cs
+++ b/C7Engine/C7GameData/PediaIcons.cs
@@ -86,7 +86,7 @@ namespace C7GameData {
 		}
 
 		public string GetLeaderArtName(string civilopediaEntry) {
-			string key = "#" + civilopediaEntry;
+			string key = "#" + civilopediaEntry.ToUpper();
 			if (!raceToArtMapping.ContainsKey(key)) {
 				return null;
 			}

--- a/C7Engine/C7GameData/Rules.cs
+++ b/C7Engine/C7GameData/Rules.cs
@@ -11,5 +11,8 @@ namespace C7GameData {
 		public int FoodNeededToGrowForLevel2Cities = 40;
 		public int FoodNeededToGrowForLevel3Cities = 60;
 		public float BuildingDiscountForCivTraits = .5f;
+		public string StartUnitType1;
+		public string StartUnitType2;
+		public string ScoutUnitType;
 	}
 }


### PR DESCRIPTION
This continues to hackily use the static save as a base, which will eventually need to be replaced by a `conquests.bic` type file that we can use to pull the rules from.

This PR is fairly large so I didn't want to do more than the minimum, but here are some things that I'd like to get to:
 - Actually supporting different difficulties
 - Handling the case of two civs having the same color
 - Adding a "random" button for the player's civ (this requires importing another pcx file and reworking some of the button handling code so I put it off)
 - Making this work for scenarios (which should be doable with some tweaks)

A couple of notes on this PR:
 - When I previously imported the leader heads a couple of civ's were missed because the pediaicons lookup shouldn't be case sensitive, but some civ's have fields that aren't all in caps.
 - I had to fix an alignment issue with the civ3 menu button when the button is on the right
 - I've continued the easier approach of using the pcx leader head rather than loading the full screen thing, like I did in the diplomacy screens. We can always improve this later.

![image](https://github.com/user-attachments/assets/3f0f12e3-8ee6-4f8e-9a2d-7c25c6586670)
