### PR TITLE
Fix import of building defense bonuses

### DIFF
--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -72472,7 +72472,7 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "combatDefenseBonus": 50,
+      "combatDefenseBonus": 0.5,
       "maintenanceCost": 0,
       "iconRowIndex": 7,
       "flags": [
@@ -73593,7 +73593,7 @@
       "isSmallWonder": false,
       "culturePerTurn": 0,
       "contentFacesInCity": 0,
-      "combatDefenseBonus": 50,
+      "combatDefenseBonus": 0.5,
       "maintenanceCost": 1,
       "iconRowIndex": 75,
       "traits": [

--- a/C7Engine/C7GameData/Building.cs
+++ b/C7Engine/C7GameData/Building.cs
@@ -103,7 +103,7 @@ namespace C7GameData {
 		public bool doublesCityGrowthRate;
 		public bool providesWalls;
 		public bool onlyUsefulInTowns;
-		public int combatDefenseBonus;
+		public StrengthBonus? combatDefenseBonus;
 
 		public int culturePerTurn = 0;
 		public int maintenanceCost = 0;
@@ -132,12 +132,17 @@ namespace C7GameData {
 			culturePerTurn = building.culturePerTurn;
 			maintenanceCost = building.maintenanceCost;
 			iconRowIndex = building.iconRowIndex;
+
 			if (building.contentFacesInCity < 0) {
 				unhappyFacesInCity = -building.contentFacesInCity;
 			} else {
 				contentFacesInCity = building.contentFacesInCity;
 			}
-			combatDefenseBonus = building.combatDefenseBonus;
+
+			if (building.combatDefenseBonus > 0) {
+				combatDefenseBonus = new(name, building.combatDefenseBonus);
+			}
+
 			isCenterOfEmpire = building.flags.Contains(SaveBuilding.Flag.IsCenterOfEmpire);
 			increasesLuxuryTrade = building.flags.Contains(SaveBuilding.Flag.IncreasesLuxuryTrade);
 			reducesCorruption = building.flags.Contains(SaveBuilding.Flag.ReducesCorruption);

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -441,9 +441,11 @@ namespace C7GameData {
 				yield return gD.cityLevel1DefenseBonus;
 			}
 
+			bool isTown = residents.Count <= gD.rules.MaximumLevel1CitySize;
+
 			// Buildings, such as walls, can also give bonuses.
 			foreach (CityBuilding cb in GetBuildings()) {
-				if (cb.building.combatDefenseBonus == 0) {
+				if (cb.building.combatDefenseBonus is not StrengthBonus defenseBonus) {
 					continue;
 				}
 
@@ -452,10 +454,8 @@ namespace C7GameData {
 				//
 				// But if the building is only useful in towns we need to check
 				// the city size before providing the bonus.
-				if (!cb.building.onlyUsefulInTowns) {
-					yield return new StrengthBonus(cb.building.name, cb.building.combatDefenseBonus);
-				} else if (residents.Count <= gD.rules.MaximumLevel1CitySize) {
-					yield return new StrengthBonus(cb.building.name, cb.building.combatDefenseBonus);
+				if (!cb.building.onlyUsefulInTowns || isTown) {
+					yield return defenseBonus;
 				}
 			}
 		}

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -925,7 +925,7 @@ namespace C7GameData {
 					culturePerTurn=bldg.Culture,
 					contentFacesInCity=bldg.ContentFaces - bldg.UnhappyFaces,
 					iconRowIndex=pediaIcons.buildingToRowNumberMapping[bldg.CivilopediaEntry],
-					combatDefenseBonus=bldg.DefenseBonus,
+					combatDefenseBonus=bldg.DefenseBonus / 100.0,
 					maintenanceCost=bldg.MaintenanceCost,
 				};
 

--- a/C7Engine/C7GameData/Save/SaveBuilding.cs
+++ b/C7Engine/C7GameData/Save/SaveBuilding.cs
@@ -38,7 +38,7 @@ namespace C7GameData.Save {
 		public bool isSmallWonder;
 		public int culturePerTurn;
 		public int contentFacesInCity;
-		public int combatDefenseBonus;
+		public double combatDefenseBonus;
 		public int maintenanceCost;
 		public int iconRowIndex;
 		public ID? renderedObsoleteBy;


### PR DESCRIPTION
This commit fixes a bug related to the import of building defense bonuses from Civ3 files. Previously, the defense bonuses were imported as integers representing the percentage of the bonus (e.g., 50 for Walls). However, the C7 Engine expected these values to be in decimal format (e.g., 0.5 for a 50% bonus)

This commit also refactors the Building class to use the StrengthBonus struct to store the defense bonus. This change makes it more consistent with the codebase.