### PR TITLE
Hook up the world gen seed to the game seed

### DIFF
--- a/C7/UIElements/NewGame/PlayerSetup.cs
+++ b/C7/UIElements/NewGame/PlayerSetup.cs
@@ -228,6 +228,7 @@ public partial class PlayerSetup : Control {
 	private void DoWorldGenerationAndstartGame(SaveGame save, GlobalSingleton Global) {
 		log.Information("Starting map generation");
 		save.Map = new SaveMap(MapGenerator.GenerateMap(Global.WorldCharacteristics));
+		save.Seed = Global.WorldCharacteristics.mapSeed;
 		log.Information("Done with map generation");
 		Random rand = new(Global.WorldCharacteristics.mapSeed + 0x531);
 		ids = new(save);


### PR DESCRIPTION
This was making it confusing when looking at the log file - if you grabbed the newest seed it wouldn't result in the same map generation, because we were regenerating a new seed in `GameData.cs`.