### PR TITLE
Tile.cs: Remove some superfluous fields

### DIFF
--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -674,7 +674,7 @@ namespace C7GameData {
 			List<Tile> result = new();
 			foreach (Tile t in location.GetTilesWithinRankDistance(rank)) {
 				// Ocean tiles may only hold claims of rank 2.
-				if (t.baseTerrainTypeKey == "ocean" && rank > 2) {
+				if (t.baseTerrainType.Key == "ocean" && rank > 2) {
 					continue;
 				}
 				result.Add(t);

--- a/C7Engine/C7GameData/Save/SaveTile.cs
+++ b/C7Engine/C7GameData/Save/SaveTile.cs
@@ -16,8 +16,8 @@ namespace C7GameData.Save {
 			Y = tile.YCoordinate;
 			continent = tile.continent;
 			isFreshWater = tile.isFreshWater;
-			baseTerrain = tile.baseTerrainTypeKey;
-			overlayTerrain = tile.overlayTerrainTypeKey;
+			baseTerrain = tile.baseTerrainType.Key;
+			overlayTerrain = tile.overlayTerrainType.Key;
 			if (tile.Resource != Resource.NONE) {
 				resource = tile.ResourceKey;
 			}
@@ -50,9 +50,7 @@ namespace C7GameData.Save {
 				YCoordinate = Y,
 				continent = continent,
 				isFreshWater = isFreshWater,
-				baseTerrainTypeKey = baseTerrain,
 				baseTerrainType = terrainTypes.Find(tt => tt.Key == baseTerrain),
-				overlayTerrainTypeKey = overlayTerrain,
 				overlayTerrainType = terrainTypes.Find(tt => tt.Key == overlayTerrain),
 				hasBarbarianCamp = features.Contains("barbarianCamp"),
 				// TODO: load working tile

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -70,9 +70,7 @@ namespace C7GameData {
 		public int biomeRegion = -1;
 
 		public City owningCity; // The city whose border contains this tile
-		public string baseTerrainTypeKey { get; set; }
 		public TerrainType baseTerrainType = TerrainType.NONE;
-		public string overlayTerrainTypeKey { get; set; }
 		public TerrainType overlayTerrainType = TerrainType.NONE;
 
 		private City _cityAtTile;
@@ -659,7 +657,6 @@ namespace C7GameData {
 
 		public void ClearTerrainOverlay() {
 			overlayTerrainType = baseTerrainType;
-			overlayTerrainTypeKey = baseTerrainTypeKey;
 		}
 
 		public Tile Copy() {

--- a/C7Engine/TerrainTextureFiles.cs
+++ b/C7Engine/TerrainTextureFiles.cs
@@ -28,8 +28,6 @@ namespace C7Engine {
 		public static void AssignTextureDetails(Random rand, List<TerrainType> terrainTypes, GameMap m) {
 			foreach (Tile t in m.tiles) {
 				t.ExtraInfo = new();
-				t.overlayTerrainTypeKey = t.overlayTerrainType.Key;
-				t.baseTerrainTypeKey = t.baseTerrainType.Key;
 
 				Dictionary<string, int> terrainCounts = new();
 				foreach (TerrainType tt in terrainTypes) {


### PR DESCRIPTION
We don't need the key stored as a separate field.
