### PR TITLE
Award shields after chopping a forest

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -308,6 +308,12 @@ public partial class Game : Node2D {
 					// interesting happens.
 					turnsLeftToFastForward = 0;
 					break;
+				case MsgShowTemporaryPopup mSTP:
+					TemporaryPopup popup = new(mSTP.message, 1);
+					popup.SetPosition(mapView.screenLocationOfTile(mSTP.location, true) + new Vector2(0, -64));
+					AddChild(popup);
+					popup.ShowPopup();
+					break;
 			}
 		}
 	}

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -75877,6 +75877,7 @@
     "maximumResearchTime": 50,
     "minimumResearchTime": 4,
     "shieldValueInGold": 4,
+    "forestValueInShields": 10,
     "citizenValueInShields": 20,
     "turnPenaltyForEachHurrySacrifice": 20,
     "maximumLevel1CitySize": 6,

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -1309,6 +1309,7 @@ namespace C7GameData {
 			save.Rules.MaximumLevel1CitySize = rule.MaximumLevel1CitySize;
 			save.Rules.MaximumLevel2CitySize = rule.MaximumLevel2CitySize;
 			save.Rules.ShieldValueInGold = rule.ShieldValueInGold;
+			save.Rules.ForestValueInShields = rule.ForestValueInShields;
 			save.Rules.CitizenValueInShields = rule.CitizenValueInShields;
 			save.Rules.TurnPenaltyForEachHurrySacrifice = rule.TurnPenaltyForEachHurrySacrifice;
 			save.GameDifficulty = save.Difficulties[rule.DefaultDifficultyLevel];

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -46,7 +46,7 @@ namespace C7GameData {
 
 		public TileDirection facingDirection;
 
-		public int WorkerProgressTowardsJob { get; set; }
+		public float WorkerProgressTowardsJob { get; set; }
 		public Terraform WorkerJob { get; set; }
 
 
@@ -144,8 +144,14 @@ namespace C7GameData {
 		private const int JOB_PROGRESS_WORKER = 2;
 		private const int JOB_PROGRESS_SLAVE = 1;
 
-		private static int GetWorkerJobCost(Terraform workerJob) {
-			return workerJob.TurnsToComplete;
+		private static int GetWorkerJobCost(Tile tile, Terraform workerJob) {
+			// For the movement cost multiplier, see note 7
+			// (https://apolyton.net/forum/civilization-series/civilization-iii/59815-civilization-iii-bic-file-format-2nd-thread?p=1362768#post1362768)
+			// For example, clearing a forest has a cost of 4, but with a nomral
+			// worker that would take 2 turns. In order for the job to take the
+			// expected 4 turns we need to multiply by the movement cost of the
+			// terrain. This also makes roading hills/mountains more expensive.
+			return workerJob.TurnsToComplete * tile.overlayTerrainType.movementCost;
 		}
 
 		public void animate(MapUnit.AnimatedAction action, bool wait, AnimationEnding ending = AnimationEnding.Stop) {
@@ -571,8 +577,8 @@ namespace C7GameData {
 			return true;
 		}
 
-		private int SumWorkerProgress(Tile tile, Terraform workerJob) {
-			int result = 0;
+		private float SumWorkerProgress(Tile tile, Terraform workerJob) {
+			float result = 0;
 			foreach (MapUnit unit in tile.unitsOnTile) {
 				if (WorkerJob == workerJob) {
 					result += WorkerProgressTowardsJob;
@@ -598,7 +604,7 @@ namespace C7GameData {
 				updateWorkerJob();
 
 				// See if this worker finished the job.
-				if (SumWorkerProgress(location, WorkerJob) >= GetWorkerJobCost(WorkerJob)) {
+				if ((int)SumWorkerProgress(location, WorkerJob) >= GetWorkerJobCost(location, WorkerJob)) {
 					location.FinishWorkerJob(WorkerJob);
 				}
 			}
@@ -677,7 +683,12 @@ namespace C7GameData {
 		}
 
 		public void updateWorkerJob() {
-			WorkerProgressTowardsJob += JOB_PROGRESS_WORKER;
+			float progressPerTurn = JOB_PROGRESS_WORKER;
+			if (owner.civilization.traits.Contains(Civilization.Trait.Industrious)) {
+				progressPerTurn *= 1.5f;
+			}
+
+			WorkerProgressTowardsJob += progressPerTurn;
 			movementPoints.onConsumeAll();
 		}
 

--- a/C7Engine/C7GameData/Rules.cs
+++ b/C7Engine/C7GameData/Rules.cs
@@ -3,6 +3,7 @@ namespace C7GameData {
 		public int MaximumResearchTime;
 		public int MinimumResearchTime;
 		public int ShieldValueInGold;
+		public int ForestValueInShields;
 		public int CitizenValueInShields;
 		public int TurnPenaltyForEachHurrySacrifice;
 		public int MaximumLevel1CitySize;

--- a/C7Engine/C7GameData/Save/SaveTile.cs
+++ b/C7Engine/C7GameData/Save/SaveTile.cs
@@ -38,6 +38,9 @@ namespace C7GameData.Save {
 			if (tile.hasBarbarianCamp) {
 				features.Add("barbarianCamp");
 			}
+			if (tile.hasHadForestCleared) {
+				features.Add("hasHadForestCleared");
+			}
 
 			overlays.AddRange(tile.overlays.GetImprovements().Select(i => i.key));
 		}
@@ -53,6 +56,7 @@ namespace C7GameData.Save {
 				baseTerrainType = terrainTypes.Find(tt => tt.Key == baseTerrain),
 				overlayTerrainType = terrainTypes.Find(tt => tt.Key == overlayTerrain),
 				hasBarbarianCamp = features.Contains("barbarianCamp"),
+				hasHadForestCleared = features.Contains("hasHadForestCleared"),
 				// TODO: load working tile
 				ResourceKey = resource is null ? Resource.NONE.Key : resource,
 				riverNorth = features.Contains("riverNorth"),

--- a/C7Engine/C7GameData/Save/SaveUnit.cs
+++ b/C7Engine/C7GameData/Save/SaveUnit.cs
@@ -15,7 +15,7 @@ namespace C7GameData.Save {
 		public string action; // "fortified"
 		public TileDirection facingDirection;
 		public string experience;
-		public int WorkerProgressTowardsJob;
+		public float WorkerProgressTowardsJob;
 		public ID WorkerJob;
 
 		// True for multiple types of automation, including worker automation

--- a/C7Engine/C7GameData/Terraform.cs
+++ b/C7Engine/C7GameData/Terraform.cs
@@ -14,7 +14,10 @@ public static class TerraformRules {
 		{UnitAction.BuildRailroad, (_, tile) => tile.overlays.Add(TerrainImprovement.railroad)},
 		{UnitAction.ClearWetlands, (_, tile) => tile.ClearTerrainOverlay()},
 		// TODO: add bonus shields to the nearest city - should only happen the first time a forest is cleared
-		{UnitAction.ClearForest, (_, tile) => tile.ClearTerrainOverlay()},
+		{UnitAction.ClearForest, (_, tile) => {
+			tile.MaybeAwardForestClearingShields();
+			tile.ClearTerrainOverlay();
+		}},
 	};
 
 	public static readonly Dictionary<UnitAction, Func<Player, Tile, bool>> ActionValidators = new() {

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -492,13 +492,8 @@ namespace C7GameData {
 				return;
 			}
 
-			for (int i = 1; i < 25; ++i) {
-				// We don't award shields beyond rank 2.
-				Tile other = GetTileAtNeighborIndex(i);
-				if (other.rankDistanceTo(this) > 2) {
-					continue;
-				}
-
+			// Check all the tiles within rank 2 of the forest.
+			foreach (Tile other in GetTilesWithinRankDistance(2)) {
 				if (other.cityAtTile == null) {
 					continue;
 				}
@@ -623,6 +618,8 @@ namespace C7GameData {
 			return map.tileAt(XCoordinate + xDelta, YCoordinate + yDelta);
 		}
 
+		// Returns the tiles in the spiral ordering defined by 
+		// GetTileAtNeighborIndex(i).
 		public List<Tile> GetTilesWithinRankDistance(int rank) {
 			List<Tile> result = new();
 			for (int i = 0; i < (rank * 2 + 1) * (rank * 2 + 1); ++i) {

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -115,6 +115,10 @@ namespace C7GameData {
 		public bool riverWest;
 		public bool riverNorthwest;
 
+		// The first time a forest is cleared on a tile it can award shields to
+		// a nearby city.
+		public bool hasHadForestCleared = false;
+
 		public TileOverlays overlays;
 
 		public Tile(ID id) {
@@ -474,6 +478,44 @@ namespace C7GameData {
 				return owningCity.owner;
 			}
 			return null;
+		}
+
+		public void MaybeAwardForestClearingShields() {
+			if (hasHadForestCleared) {
+				return;
+			}
+			hasHadForestCleared = true;
+
+			// Shields can only be awarded if the forest is within some city's
+			// borders.
+			if (OwningPlayer() == null) {
+				return;
+			}
+
+			for (int i = 1; i < 25; ++i) {
+				// We don't award shields beyond rank 2.
+				Tile other = GetTileAtNeighborIndex(i);
+				if (other.rankDistanceTo(this) > 2) {
+					continue;
+				}
+
+				if (other.cityAtTile == null) {
+					continue;
+				}
+
+				// Shields aren't awarded to wonders.
+				if (other.cityAtTile.itemBeingProduced is Building b
+					&& (b.greatWonderProperties != null || b.isSmallWonder)) {
+					continue;
+				}
+
+				City c = other.cityAtTile;
+				int shieldsAwarded = EngineStorage.gameData.rules.ForestValueInShields;
+				c.shieldsStored += shieldsAwarded;
+				c.shieldsStored = Math.Min(c.shieldsStored, c.owner.ShieldCost(c.itemBeingProduced));
+				new MsgShowTemporaryPopup($"{shieldsAwarded} shields awarded for clearing forests", other).send();
+				return;
+			}
 		}
 
 		// Returns the X and Y coordinates of the neighbor in the specified direction.

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -105,4 +105,14 @@ namespace C7Engine {
 			this.happy = happy;
 		}
 	}
+
+	public class MsgShowTemporaryPopup : MessageToUI {
+		public string message;
+		public Tile location;
+
+		public MsgShowTemporaryPopup(string message, Tile location) {
+			this.message = message;
+			this.location = location;
+		}
+	}
 }


### PR DESCRIPTION
While here I also fixed the cost of an improvement so it is more expensive on terrain with higher movement costs (otherwise forest chops took 2 turns) and added handling for industrious civs.

![image](https://github.com/user-attachments/assets/c00b8f56-103f-4016-a1a1-02b7b6a0e35c)
