### PR TITLE
Fix an annoying bug where units would skip their turn by accident 

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -875,7 +875,13 @@ public partial class Game : Node2D {
 			SetAnimationsEnabled(true);
 		}
 
-		// actions with unit buttons
+		// actions with unit buttons, which are only relevant during the player
+		// turn.
+		if (CurrentState != GameState.PlayerTurn) {
+			return;
+		}
+
+
 		if (currentAction == C7Action.UnitHold) {
 			new ActionToEngineMsg(() => CurrentlySelectedUnit?.skipTurn()).send();
 		}


### PR DESCRIPTION
We were accepting the "unit hold" command while the game state hadn't yet changed to the player turn, so sometimes this resulted in skipping a unit's turn unintentionally.
