### PR TITLE
Port TextureLoader to Moonsharp

### DIFF
--- a/C7/C7.csproj
+++ b/C7/C7.csproj
@@ -14,7 +14,6 @@
     <ProjectReference Include="..\C7Engine\C7Engine.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NLua" Version="1.7.5" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -112,8 +112,8 @@ public partial class Game : Node2D {
 
 			controller = CreateGame.createGame(
 				Global.LoadGamePath,
-				Global.LuaRulesDir,
-				Global.DefaultBicPath,
+				GamePaths.LuaRulesDir,
+				GamePaths.DefaultBicPath,
 				(scenarioSearchPath) => {
 					// WHen the game loading logic tries to load the PediaIcons file, set the
 					// scenario search path and then use our Civ3MediaPath searching logic to
@@ -801,7 +801,7 @@ public partial class Game : Node2D {
 	}
 
 	private void ToggleC7Graphics() {
-		TextureLoader.ToggleModernGraphics();
+		Global.ToggleModernGraphics();
 		InitializeMapView();
 	}
 

--- a/C7/GamePaths.cs
+++ b/C7/GamePaths.cs
@@ -1,0 +1,18 @@
+public static class GamePaths {
+	// This is the 'static map' used in lieu of terrain generation
+	public const string DefaultGamePath = "./Text/c7-static-map-save.json";
+
+	public const string LuaRulesDir = "./Lua/rules/";
+	public const string TextureConfigsDir = "./Lua/texture_configs/";
+
+	public const string ModernGraphicsConfig = "c7.lua";
+	public const string ClassicGraphicsConfig = "civ3.lua";
+
+	// The file where a generated map is saved, until we get more advanced ways
+	// to generate new games.
+	// TODO: improve this.
+	public const string DefaultGeneratedGamePath = "./Text/c7-autosave-turn-0.json";
+
+	// For now this needs to get passed to QueryCiv3 when importing.
+	public static string DefaultBicPath { get => Util.GetCiv3Path() + "/Conquests/conquests.biq"; }
+}

--- a/C7/GlobalSingleton.cs
+++ b/C7/GlobalSingleton.cs
@@ -12,25 +12,21 @@ public partial class GlobalSingleton : Node {
 	// which then should blank it again to prevent reloading same if going back to main menu
 	// and back to game
 	public string LoadGamePath;
-	// For now this needs to get passed to QueryCiv3 when importing.
-	public string DefaultBicPath { get => Util.GetCiv3Path() + @"/Conquests/conquests.biq"; }
 
-	// This is the 'static map' used in lieu of terrain generation
-	public string DefaultGamePath { get => @"./Text/c7-static-map-save.json"; }
-
-	public string LuaRulesDir { get => "./Lua/rules/"; }
-
-	// The file where a generated map is saved, until we get more advanced ways
-	// to generate new games.
-	// TODO: improve this.
-	public string DefaultGeneratedGamePath { get => @"./Text/c7-autosave-turn-0.json"; }
-
-	public void ResetLoadGamePath() {
-		LoadGamePath = DefaultGamePath;
-	}
+	public bool ModernGraphicsActive { get; private set; }
 
 	// The characteristics of the world to generate. This exists in the singleton
 	// to allow the world setup screen to pass the information to the player
 	// setup screen, which is what actually kicks off the world generation.
 	public WorldCharacteristics WorldCharacteristics;
+
+	public void ResetLoadGamePath() {
+		LoadGamePath = GamePaths.DefaultGamePath;
+	}
+
+	public void ToggleModernGraphics() {
+		string newConfig = ModernGraphicsActive ? GamePaths.ClassicGraphicsConfig : GamePaths.ModernGraphicsConfig;
+		TextureLoader.SetConfig(GamePaths.TextureConfigsDir, newConfig);
+		ModernGraphicsActive = !ModernGraphicsActive;
+	}
 }

--- a/C7/Lua/texture_configs/civ3/resources.lua
+++ b/C7/Lua/texture_configs/civ3/resources.lua
@@ -15,7 +15,7 @@ function resources.large:map_object_to_sprite(resource)
   end
 
   local icon = resource.Icon
-  local row = icon // 6
+  local row = math.floor(icon / 6)
   local col = icon % 6
 
   return {

--- a/C7/TextureLoader.cs
+++ b/C7/TextureLoader.cs
@@ -1,9 +1,12 @@
 using System;
-using NLua;
 using Godot;
 using ConvertCiv3Media;
 using System.Collections.Generic;
 using System.IO;
+using MoonSharp.Interpreter;
+using Script = MoonSharp.Interpreter.Script;
+using MoonSharp.Interpreter.Loaders;
+using C7.Map;
 
 public readonly record struct CropRegion(int LeftStart, int TopStart, int CroppedWidth, int CroppedHeight);
 
@@ -40,14 +43,8 @@ public static class TextureLoader {
 		public readonly bool UseAlpha => AlphaPath != null;
 	}
 
-	private static Lua lua;
-	private static LuaTable civ3TextureConfig;
-	private static LuaTable c7TextureConfig;
-
-	// currently used config
-	private static LuaTable textureConfig;
-	// whether the currently used config represent the CIV3 or the custom C7 graphics
-	private static bool modernGraphics;
+	private static Script lua;
+	private static Table textureConfig;
 
 	private static Dictionary<string, ImageTexture> textureCache = [];
 	private static Dictionary<string, Pcx> PcxCache = [];
@@ -57,14 +54,30 @@ public static class TextureLoader {
 	private static Dictionary<(string configKey, object obj), ImageTexture> objectMappingCache = [];
 
 	static TextureLoader() {
-		lua = new Lua();
-		lua.DoString($"package.path = './Lua/texture_configs/?.lua;./Lua/texture_configs/*/?.lua'");
+		UserData.RegisterType<CityGraphicsDetails>();
+		UserData.RegisterType<PopHead.TextureKey>();
 
-		civ3TextureConfig = (LuaTable)lua.DoFile("./Lua/texture_configs/civ3.lua")[0];
-		c7TextureConfig = (LuaTable)lua.DoFile("./Lua/texture_configs/c7.lua")[0];
+		// We need to register the "Type" type to be able to inspect
+		// the types of C# objects in the Lua code
+		UserData.RegisterType<Type>();
 
-		textureConfig = civ3TextureConfig;
-		modernGraphics = false;
+		SetConfig(GamePaths.TextureConfigsDir, GamePaths.ClassicGraphicsConfig);
+	}
+
+	public static void SetConfig(string configDir, string configScript) {
+		ClearCache();
+
+		lua = new Script();
+		lua.Options.ScriptLoader = new FileSystemScriptLoader {
+			ModulePaths = [
+				Path.Combine(configDir, "?.lua"),
+				Path.Combine(configDir, "*", "?.lua")
+			]
+		};
+
+		string fullScriptPath = Path.Combine(configDir, configScript);
+		DynValue res = lua.DoFile(fullScriptPath);
+		textureConfig = res.Table;
 	}
 
 	/// Returns a texture based on the config key.
@@ -94,6 +107,9 @@ public static class TextureLoader {
 	/// using (configKey, obj) as key.  Note, that caching shouldn't
 	/// be used for objects whose texture-affecting properties can
 	/// change.
+	///
+	/// Note that the type of the object passed to the method should
+	/// be registered as Moonsharp userdata.
 	public static ImageTexture Load(string configKey, object obj, bool useCache = false) {
 		var cacheKey = (configKey, obj);
 
@@ -101,14 +117,15 @@ public static class TextureLoader {
 			return cachedTexture;
 
 		object entry = GetEntryByPath(configKey);
-
-		if (entry is not LuaTable table)
+		if (entry is not Table table)
 			throw new Exception($"Table expected for key: {configKey}");
 
-		if (table["map_object_to_sprite"] is not LuaFunction func)
+		if (table["map_object_to_sprite"] is not Closure func)
 			throw new Exception("Custom mapping function expected");
 
-		ImageTexture texture = LoadFromLuaObject(func.Call(table, obj)[0]);
+		object result = func.Call(table, DynValue.FromObject(lua, obj)).ToObject();
+
+		ImageTexture texture = LoadFromLuaObject(result);
 
 		if (useCache)
 			objectMappingCache[cacheKey] = texture;
@@ -123,7 +140,7 @@ public static class TextureLoader {
 	public static void SetButtonTextures(TextureButton button, string configKey) {
 		object entry = GetEntryByPath(configKey);
 
-		if (entry is not LuaTable table)
+		if (entry is not Table table)
 			throw new Exception($"Table expected for key: {configKey}");
 
 		button.TextureNormal = LoadFromLuaObject(table["normal"]);
@@ -142,7 +159,7 @@ public static class TextureLoader {
 			};
 		}
 
-		if (entry is LuaTable table) {
+		if (entry is Table table) {
 			if (table["path"] == null) {
 				throw new ArgumentException("Texture configuration missing required 'path' property");
 			}
@@ -161,21 +178,19 @@ public static class TextureLoader {
 
 	private static ImageTexture LoadFromConfigEntry(ConfigEntry config) {
 		string ext = Path.GetExtension(config.Path).ToLowerInvariant();
-		if (config.UseAlpha && ext == ".pcx") {
-			return LoadWithAlphaBlend(config.Path, config.AlphaPath!, config.CropRegion, config.AlphaRowOffset);
-		}
 
 		return ext switch {
 			".png" => LoadFromPNG(config.Path, config.CropRegion),
+			".pcx" when config.UseAlpha => LoadWithAlphaBlend(config.Path, config.AlphaPath!, config.CropRegion, config.AlphaRowOffset),
 			".pcx" => LoadFromPCX(config.Path, config.CropRegion, config.ColorOptions),
 			_ => throw new FormatException($"Unknown texture format: {config.Path}"),
 		};
 	}
 
 	// Helper method to extract crop region from a table
-	private static CropRegion? ExtractCropRegion(LuaTable table) {
+	private static CropRegion? ExtractCropRegion(Table table) {
 		object cropRegionObj = table["crop_region"];
-		if (cropRegionObj is LuaTable cropRegion) {
+		if (cropRegionObj is Table cropRegion) {
 			try {
 				int x = Convert.ToInt32(cropRegion[1]);
 				int y = Convert.ToInt32(cropRegion[2]);
@@ -206,7 +221,7 @@ public static class TextureLoader {
 		object current = textureConfig;
 
 		foreach (string part in parts) {
-			if (current is LuaTable table && table[part] != null) {
+			if (current is Table table && table[part] != null) {
 				current = table[part];
 			} else {
 				return null;
@@ -281,19 +296,6 @@ public static class TextureLoader {
 		PcxCache.Clear();
 		PngCache.Clear();
 		textureCache.Clear();
-		configKeyCache.Clear();
-		objectMappingCache.Clear();
-	}
-
-	public static void ToggleModernGraphics() {
-		if (modernGraphics) {
-			modernGraphics = false;
-			textureConfig = civ3TextureConfig;
-		} else {
-			modernGraphics = true;
-			textureConfig = c7TextureConfig;
-		}
-
 		configKeyCache.Clear();
 		objectMappingCache.Clear();
 	}

--- a/C7/UIElements/CityScreen/PopHead.cs
+++ b/C7/UIElements/CityScreen/PopHead.cs
@@ -4,9 +4,14 @@ using C7GameData;
 
 // A utility class for rendering pop heads.
 public class PopHead {
+	public record struct TextureKey {
+		public CityResident cityResident;
+		public int eraNum;
+	}
+
 	public const int HEAD_SIZE = 48;
 
 	public static ImageTexture GetTexture(CityResident cityResident, int eraNum) {
-		return TextureLoader.Load("popheads", new { cityResident, eraNum });
+		return TextureLoader.Load("popheads", new TextureKey() { cityResident = cityResident, eraNum = eraNum });
 	}
 }

--- a/C7/UIElements/MainMenu/MainMenu.cs
+++ b/C7/UIElements/MainMenu/MainMenu.cs
@@ -54,16 +54,21 @@ public partial class MainMenu : Node {
 		ButtonContainer.Exit.Pressed += _on_Exit_pressed;
 
 		ButtonContainer.ToggleGraphics.Pressed += () => {
-			if (ButtonContainer.ToggleGraphics.Text == "Turn on C7 Graphics") {
-				ButtonContainer.ToggleGraphics.Text = "Turn on Civ3 Graphics";
-			} else {
-				ButtonContainer.ToggleGraphics.Text = "Turn on C7 Graphics";
-			}
-			TextureLoader.ToggleModernGraphics();
+			Global.ToggleModernGraphics();
+			SetToggleGraphicsText();
 		};
+		SetToggleGraphicsText();
 
 		// Hide select home folder if valid path is present as proven by reaching this point in code
 		SetCiv3Home.Visible = false;
+	}
+
+	private void SetToggleGraphicsText() {
+		if (Global.ModernGraphicsActive) {
+			ButtonContainer.ToggleGraphics.Text = "Turn on Civ3 Graphics";
+		} else {
+			ButtonContainer.ToggleGraphics.Text = "Turn on C7 Graphics";
+		}
 	}
 
 	public void GoToWorldSetup() {

--- a/C7/UIElements/NewGame/PlayerSetup.cs
+++ b/C7/UIElements/NewGame/PlayerSetup.cs
@@ -204,14 +204,7 @@ public partial class PlayerSetup : Control {
 	}
 
 	private SaveGame GetSave() {
-		if (!Engine.IsEditorHint()) {
-			GlobalSingleton Global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
-			return SaveManager.LoadSave(Global.DefaultGamePath, Global.DefaultBicPath, (string unused) => { return unused; });
-		} else {
-			// Hardcoded fallback for the godot editor, which doesn't handle the
-			// global.
-			return SaveManager.LoadSave(@"./Text/c7-static-map-save.json", "", (string unused) => { return unused; });
-		}
+		return SaveManager.LoadSave(GamePaths.DefaultGamePath, GamePaths.DefaultBicPath, (string unused) => { return unused; });
 	}
 
 	private void CreateGame() {
@@ -276,8 +269,8 @@ public partial class PlayerSetup : Control {
 		save.GameDifficulty = difficulty;
 
 		log.Information("saving generated map");
-		save.Save(Global.DefaultGeneratedGamePath);
-		Global.LoadGamePath = Global.DefaultGeneratedGamePath;
+		save.Save(GamePaths.DefaultGeneratedGamePath);
+		Global.LoadGamePath = GamePaths.DefaultGeneratedGamePath;
 
 		log.Information("opening map");
 		CallDeferred("StartGame");

--- a/C7/UIElements/NewGame/WorldSetup.cs
+++ b/C7/UIElements/NewGame/WorldSetup.cs
@@ -314,7 +314,7 @@ public partial class WorldSetup : Control {
 	private void CreateGame() {
 		GlobalSingleton Global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
 		Global.ResetLoadGamePath();
-		SaveGame save = SaveManager.LoadSave(Global.DefaultGamePath, Global.DefaultBicPath, (string unused) => { return unused; });
+		SaveGame save = SaveManager.LoadSave(GamePaths.DefaultGamePath, GamePaths.DefaultBicPath, (string unused) => { return unused; });
 
 		Global.WorldCharacteristics = new WorldCharacteristics() {
 			landform = landform,

--- a/C7Engine/LuaRulesEngine.cs
+++ b/C7Engine/LuaRulesEngine.cs
@@ -96,6 +96,10 @@ public class LuaRulesEngine {
 	Script script = new();
 	Table rules;
 
+	static LuaRulesEngine() {
+		RegisterTypes();
+	}
+
 	/// Initializes the Lua state.
 	///
 	/// Accepts the path to the directory containing Lua scripts,
@@ -104,7 +108,6 @@ public class LuaRulesEngine {
 		if (rules != null)
 			throw new InvalidOperationException("Engine already initialized");
 
-		RegisterTypes();
 		RegisterEnums();
 		RegisterGlobals();
 
@@ -150,7 +153,7 @@ public class LuaRulesEngine {
 		throw new ArgumentException($"Function path '{functionPath}' did not resolve to a function.");
 	}
 
-	void RegisterTypes() {
+	static void RegisterTypes() {
 		var types = Assembly.GetExecutingAssembly()
 							.GetTypes()
 							.Where(t =>


### PR DESCRIPTION
Since the rules engine was implemented using Moonsharp (see reasons for this choice in #764), TextureLoader is ported to Moonsharp from NLua to avoid having two Lua implementations in the project.

The port itself was pretty straightforward, the only significant difference is that now types of objects passed to TextureLoader should be explicitly registered with Moonsharp.

This PR also makes a few minor code reorganizations:

- Logic for toggling between civ3 and modern graphics was moved from TextureLoader to GlobalSingleton. Now TextureLoader can load configs from arbitrary paths, which would be useful for modding.

- Constant file paths was moved from GlobalSingleton to a new static class GamePaths. In my view, GlobalSingleton wasn't really a good fit for storing constant paths, since its responsibility is to manage mutable state shared between the scenes, not provide access to constants.