### PR TITLE
Fix graphical issues with CityLayer

### DIFF
--- a/C7/Map/CityLabelScene.cs
+++ b/C7/Map/CityLabelScene.cs
@@ -5,7 +5,7 @@ using Godot;
 namespace C7.Map {
 	public partial class CityLabelScene : Node2D {
 		City city;
-		Vector2I tileCenter;
+		public Vector2I tileCenter;
 		Color civColor;
 
 		const byte TRANSPARENCY = 192; // 25%
@@ -66,9 +66,8 @@ namespace C7.Map {
 			nonEmbassyStar = TextureLoader.Load("icons.capital_star");
 		}
 
-		public CityLabelScene(City city, Vector2I tileCenter) {
+		public CityLabelScene(City city) {
 			this.city = city;
-			this.tileCenter = tileCenter;
 
 			civColor = new Color(Util.LoadColor(city.owner.colorIndex), TRANSPARENCY);
 

--- a/C7/Map/CityLayer.cs
+++ b/C7/Map/CityLayer.cs
@@ -23,12 +23,16 @@ namespace C7.Map {
 			}
 
 			City city = tile.cityAtTile;
+			Vector2I tileCenter2I = new((int)tileCenter.X, (int)tileCenter.Y);
+
 			if (!citySceneLookup.ContainsKey(city)) {
-				CityScene cityScene = new CityScene(city, new Vector2I((int)tileCenter.X, (int)tileCenter.Y));
+				CityScene cityScene = new CityScene(city);
+				cityScene.SetTileCenter(tileCenter2I);
 				looseView.AddChild(cityScene);
 				citySceneLookup[city] = cityScene;
 			} else {
 				CityScene scene = citySceneLookup[city];
+				scene.SetTileCenter(tileCenter2I);
 				scene._Draw();
 			}
 		}

--- a/C7/Map/CityScene.cs
+++ b/C7/Map/CityScene.cs
@@ -18,17 +18,22 @@ namespace C7.Map {
 		private ImageTexture cityTexture;
 		private TextureRect cityGraphics = new TextureRect();
 		private CityLabelScene cityLabelScene;
-		private AnimatedSprite2D disorderSprite;
 		private City city;
 		private Rules rules;
 		private CityGraphicsDetails cachedDetails;
 		private Vector2I tileCenter;
 
-		public CityScene(City city, Vector2I tileCenter) {
-			cityLabelScene = new CityLabelScene(city, tileCenter);
+		private AnimatedSprite2D disorderSprite;
+		private static SpriteFrames disorderFrames = new();
+
+		static CityScene() {
+			AnimationManager.loadNonTintedAnimation("Art/Animations/Disorder/DisorderDefault.flc", "disorder", ref disorderFrames);
+		}
+
+		public CityScene(City city) {
+			cityLabelScene = new CityLabelScene(city);
 			this.city = city;
 			this.rules = city.owner.rules;
-			this.tileCenter = tileCenter;
 
 			cachedDetails = GetCityGraphicsDetails(city);
 			ConfigureCityGraphics(cachedDetails);
@@ -37,9 +42,7 @@ namespace C7.Map {
 			AddChild(cityLabelScene);
 
 			disorderSprite = new();
-			SpriteFrames frames = new();
-			disorderSprite.SpriteFrames = frames;
-			AnimationManager.loadNonTintedAnimation("Art/Animations/Disorder/DisorderDefault.flc", "disorder", ref frames);
+			disorderSprite.SpriteFrames = disorderFrames;
 			disorderSprite.Animation = "disorder";
 			disorderSprite.Position = tileCenter + new Vector2(0, -32);
 			AddChild(disorderSprite);
@@ -60,6 +63,18 @@ namespace C7.Map {
 			} else {
 				disorderSprite.Hide();
 			}
+		}
+
+		public void SetTileCenter(Vector2I tileCenter) {
+			this.tileCenter = tileCenter;
+
+			disorderSprite.Position = tileCenter + new Vector2(0, -32);
+			cityLabelScene.tileCenter = tileCenter;
+
+			cityGraphics.Position = new(
+				tileCenter.X - (float)0.5 * cityTexture.GetWidth(),
+				tileCenter.Y - (float)0.5 * cityTexture.GetHeight()
+			);
 		}
 
 		private CityGraphicsDetails GetCityGraphicsDetails(City c) {
@@ -84,8 +99,6 @@ namespace C7.Map {
 		private void ConfigureCityGraphics(CityGraphicsDetails details) {
 			cityTexture = TextureLoader.Load("cities", details);
 
-			cityGraphics.OffsetLeft = tileCenter.X - (float)0.5 * cityTexture.GetWidth();
-			cityGraphics.OffsetTop = tileCenter.Y - (float)0.5 * cityTexture.GetHeight();
 			cityGraphics.MouseFilter = Control.MouseFilterEnum.Ignore;
 			cityGraphics.Texture = cityTexture;
 		}


### PR DESCRIPTION
Previously, the city graphics disappeared when wrapping around the map. This was caused by setting a city scene position only on scene creation, while it required updates on map wrapping. This commit fixes it by updating a city scene position on each frame.

This commit also fixes a bug that caused the city graphics to be rendered in the wrong size around the world wrap line. It was caused by setting the city graphics' OffsetLeft to a negative value. It was fixed by updating the Position property instead, which correctly handles negative values.

Also, this commit introduces a performance improvement by loading the disorder animation in the static CityScene constructor, instead of loading it on every scene initialization. On my end, it noticeably improved the frame rate.