### PR TITLE
Fix a bug in the end turn disorder popup

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -484,6 +484,7 @@ public partial class Game : Node2D {
 		}
 
 		// Prompt the user if they would have a city riot when the turn ended.
+		bool doEndTurn = true;
 		EngineStorage.ReadGameData((GameData gameData) => {
 			foreach (City city in controller.cities) {
 				if (!controller.isHuman) {
@@ -501,11 +502,14 @@ public partial class Game : Node2D {
 								DoActualEndTurn();
 							}),
 						PopupOverlay.PopupCategory.Advisor);
+					doEndTurn = false;
 					return;
 				}
 			}
 		});
-		DoActualEndTurn();
+		if (doEndTurn) {
+			DoActualEndTurn();
+		}
 	}
 
 	private void DoActualEndTurn() {


### PR DESCRIPTION
This was broken in [this commit](https://github.com/C7-Game/Prototype/commit/df509b2ab484d88b3b48eb756b06f7aac56a9d14), because the early `return` statement if we showed the popup only returned out of the game data access lambda, not out of the method entirely. So we always ended the turn, and then the "let them riot" button would end the turn again.