### PR TITLE
Allow launching in "standalone" mode, with no civ3 assets

### DIFF
--- a/C7/AnimationManager.cs
+++ b/C7/AnimationManager.cs
@@ -153,11 +153,13 @@ public partial class AnimationManager {
 			AudioStreamWav wav;
 			string pathKey = rootPath + "/" + fileName;
 			if (!wavs.TryGetValue(pathKey, out wav)) {
-				wav = Util.LoadWAVFromDisk(Util.Civ3MediaPath(pathKey));
+				wav = Util.LoadCiv3WAVFromDisk(pathKey);
 				wavs.Add(pathKey, wav);
 			}
-			audioPlayer.Stream = wav;
-			audioPlayer.Play();
+			if (wav != null) {
+				audioPlayer.Stream = wav;
+				audioPlayer.Play();
+			}
 		}
 	}
 

--- a/C7/GamePaths.cs.uid
+++ b/C7/GamePaths.cs.uid
@@ -1,0 +1,1 @@
+uid://c4ycshje5qac8

--- a/C7/GlobalSingleton.cs
+++ b/C7/GlobalSingleton.cs
@@ -15,6 +15,12 @@ public partial class GlobalSingleton : Node {
 
 	public bool ModernGraphicsActive { get; private set; }
 
+	public GlobalSingleton() {
+		if (C7Settings.UseStandaloneMode()) {
+			ToggleModernGraphics();
+		}
+	}
+
 	// The characteristics of the world to generate. This exists in the singleton
 	// to allow the world setup screen to pass the information to the player
 	// setup screen, which is what actually kicks off the world generation.

--- a/C7/PCXToGodot.cs
+++ b/C7/PCXToGodot.cs
@@ -135,15 +135,32 @@ public partial class PCXToGodot : GodotObject {
 		int[] baseLayer = new int[width * height];
 		int[] tintLayer = new int[width * height];
 
-		Pcx whitePcx = TextureLoader.LoadPCX("Art/Units/Palettes/ntp00.pcx");
-		int[] whiteColorData = loadPalette(whitePcx.Palette, true);
+		// If ntp00.pcx doesn't exist, don't try to match the full palette for
+		// the "clothes" of the unit's animation - just make it solid white. We
+		// lose any sort of shading or shadows on the unit's clothing, but this
+		// is good enough for standalone mode, at least for now.
+		//
+		// TODO: consider how to improve this - do we need to include a similar
+		// palette in the c7 data? Is this information present in the flc files?
+		Func<int, int> getWhiteColorData;
+		try {
+			Pcx whitePcx = TextureLoader.LoadPCX("Art/Units/Palettes/ntp00.pcx");
+			int[] whiteColorData = loadPalette(whitePcx.Palette, true);
+			getWhiteColorData = (int index) => {
+				return whiteColorData[index];
+			};
+		} catch (Exception e) {
+			getWhiteColorData = (int index) => {
+				return ((int)new Color(1, 1, 1, 1).ToArgb32());
+			};
+		}
 
 		for (int i = 0; i < width * height; i++) {
 			int index = colorIndices[i];
 			bool tinted = index < 16 || (index < 64 && index % 2 == 0);
 			bool shadow = index >= SHADOW_START_INDEX && index <= CIVCOLOR_START_INDEX;
 			if (tinted) {
-				tintLayer[i] = whiteColorData[index];
+				tintLayer[i] = getWhiteColorData(i);
 				baseLayer[i] = 0; // transparent
 			} else if (shadow) {
 				// shadow belongs to the base texture

--- a/C7/PCXToGodot.cs
+++ b/C7/PCXToGodot.cs
@@ -160,7 +160,7 @@ public partial class PCXToGodot : GodotObject {
 			bool tinted = index < 16 || (index < 64 && index % 2 == 0);
 			bool shadow = index >= SHADOW_START_INDEX && index <= CIVCOLOR_START_INDEX;
 			if (tinted) {
-				tintLayer[i] = getWhiteColorData(i);
+				tintLayer[i] = getWhiteColorData(index);
 				baseLayer[i] = 0; // transparent
 			} else if (shadow) {
 				// shadow belongs to the base texture

--- a/C7/UIElements/MainMenu/MainMenu.cs
+++ b/C7/UIElements/MainMenu/MainMenu.cs
@@ -18,12 +18,14 @@ public partial class MainMenu : Node {
 	MenuButtonContainer ButtonContainer;
 	[Export]
 	AudioStreamPlayer player;
+	[Export] Button UseStandaloneMode;
 
 	GlobalSingleton Global;
 
 	public override void _Ready() {
 		log = LogManager.ForContext<MainMenu>();
 		log.Debug("enter MainMenu._Ready");
+		UseStandaloneMode.Pressed += UseStandaloneModePressed;
 
 		DisplayServer.WindowSetTitle("C7 - Godot 4");
 
@@ -43,6 +45,9 @@ public partial class MainMenu : Node {
 		LoadScenarioDialog.SetDirectoryForLoading(@"Conquests/Scenarios");
 		LoadScenarioDialog.GoToScenarioSetupAfterLoading = true;
 
+		if (ButtonContainer.NewGame == null) {
+			ButtonContainer.CreateButtons();
+		}
 		ButtonContainer.NewGame.Pressed += GoToWorldSetup;
 		ButtonContainer.QuickStart.Pressed += GoToWorldSetup;
 		ButtonContainer.Tutorial.Pressed += StartGame;
@@ -60,8 +65,14 @@ public partial class MainMenu : Node {
 		};
 		SetToggleGraphicsText();
 
+		// We can't toggle to using civ3 graphics without a root.
+		if (Util.GetCiv3Path == null) {
+			ButtonContainer.ToggleGraphics.Visible = false;
+		}
+
 		// Hide select home folder if valid path is present as proven by reaching this point in code
 		SetCiv3Home.Visible = false;
+		UseStandaloneMode.Visible = false;
 	}
 
 	private void SetToggleGraphicsText() {
@@ -113,7 +124,10 @@ public partial class MainMenu : Node {
 	}
 
 	private void PlayButtonPressedSound() {
-		AudioStreamWav wav = Util.LoadWAVFromDisk(Util.Civ3MediaPath("Sounds/Button1.wav"));
+		AudioStreamWav wav = Util.LoadCiv3WAVFromDisk("Sounds/Button1.wav");
+		if (wav == null) {
+			return;
+		}
 		player.Stream = wav;
 		player.Play();
 	}
@@ -127,6 +141,13 @@ public partial class MainMenu : Node {
 		C7Settings.SetValue("locations", "civ3InstallDir", path);
 		C7Settings.SaveSettings();
 		// This function should only be reachable if DisplayTitleScreen failed on previous runs, so should be OK to run here
+		DisplayTitleScreen();
+	}
+
+	private void UseStandaloneModePressed() {
+		Global.ToggleModernGraphics();
+		C7Settings.SetValue("locations", "useStandaloneMode", "true");
+		C7Settings.SaveSettings();
 		DisplayTitleScreen();
 	}
 }

--- a/C7/UIElements/MainMenu/MainMenu.cs
+++ b/C7/UIElements/MainMenu/MainMenu.cs
@@ -45,6 +45,10 @@ public partial class MainMenu : Node {
 		LoadScenarioDialog.SetDirectoryForLoading(@"Conquests/Scenarios");
 		LoadScenarioDialog.GoToScenarioSetupAfterLoading = true;
 
+		// If couldn't find the button textures when ButtonContainer._Ready, then
+		// these buttons will be null, so be sure to recreate them if we call
+		// DisplayTitleScreen after picking standalone mode or getting the civ3
+		// home path set.
 		if (ButtonContainer.NewGame == null) {
 			ButtonContainer.CreateButtons();
 		}
@@ -65,8 +69,8 @@ public partial class MainMenu : Node {
 		};
 		SetToggleGraphicsText();
 
-		// We can't toggle to using civ3 graphics without a root.
-		if (Util.GetCiv3Path == null) {
+		// We can't toggle to using civ3 graphics in standalone mode.
+		if (C7Settings.UseStandaloneMode()) {
 			ButtonContainer.ToggleGraphics.Visible = false;
 		}
 

--- a/C7/UIElements/MainMenu/MenuButtonContainer.cs
+++ b/C7/UIElements/MainMenu/MenuButtonContainer.cs
@@ -19,7 +19,7 @@ public partial class MenuButtonContainer : VBoxContainer {
 		CreateButtons();
 	}
 
-	private void CreateButtons() {
+	public void CreateButtons() {
 		NewGame = new Civ3MenuButton() { Text = "New Game" };
 		AddChild(NewGame);
 

--- a/C7/UIElements/MainMenu/main_menu.tscn
+++ b/C7/UIElements/MainMenu/main_menu.tscn
@@ -1,23 +1,24 @@
 [gd_scene load_steps=9 format=3 uid="uid://gnt0y3og7nk6"]
 
-[ext_resource type="Script" path="res://UIElements/MainMenu/MainMenu.cs" id="1_akneh"]
+[ext_resource type="Script" uid="uid://dgpuse88jc2hc" path="res://UIElements/MainMenu/MainMenu.cs" id="1_akneh"]
 [ext_resource type="Texture2D" uid="uid://s55xvcaini8h" path="res://title-screen.png" id="2_erxyj"]
-[ext_resource type="Script" path="res://UIElements/MainMenu/MenuButtonContainer.cs" id="3_t1nuq"]
-[ext_resource type="Script" path="res://UIElements/MainMenu/MainMenuMusicPlayer.cs" id="4_tqr50"]
+[ext_resource type="Script" uid="uid://ca14gkdccjfcg" path="res://UIElements/MainMenu/MenuButtonContainer.cs" id="3_t1nuq"]
+[ext_resource type="Script" uid="uid://dauceqein40wj" path="res://UIElements/MainMenu/MainMenuMusicPlayer.cs" id="4_tqr50"]
 [ext_resource type="PackedScene" uid="uid://bvncm1bgcii5e" path="res://UIElements/civ3_file_dialog.tscn" id="5_rw2g7"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_gmerc"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_vbij8"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_e20w6"]
 
-[node name="MainMenu" type="Node" node_paths=PackedStringArray("LoadDialog", "SetCiv3Home", "SetCiv3HomeDialog", "LoadScenarioDialog", "ButtonContainer", "player")]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_gmerc"]
+
+[node name="MainMenu" type="Node" node_paths=PackedStringArray("LoadDialog", "SetCiv3Home", "SetCiv3HomeDialog", "LoadScenarioDialog", "ButtonContainer", "UseStandaloneMode", "player")]
 script = ExtResource("1_akneh")
 LoadDialog = NodePath("LoadDialog")
 SetCiv3Home = NodePath("SetCiv3Home")
 SetCiv3HomeDialog = NodePath("SetCiv3HomeDialog")
 LoadScenarioDialog = NodePath("LoadScenarioDialog")
+UseStandaloneMode = NodePath("UseStandaloneMode")
 ButtonContainer = NodePath("Control/MainMenuContainer")
 player = NodePath("SoundEffectPlayer")
 
@@ -81,10 +82,40 @@ size_flags_horizontal = 4
 size_flags_vertical = 4
 theme_override_constants/h_separation = 50
 theme_override_font_sizes/font_size = 24
-theme_override_styles/normal = SubResource("StyleBoxFlat_gmerc")
 theme_override_styles/hover = SubResource("StyleBoxFlat_vbij8")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_e20w6")
+theme_override_styles/normal = SubResource("StyleBoxFlat_gmerc")
 text = "Select Civ3 Home Folder"
+
+[node name="UseStandaloneMode" type="Button" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -157.0
+offset_top = 54.0
+offset_right = 157.0
+offset_bottom = 120.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_constants/h_separation = 50
+theme_override_font_sizes/font_size = 24
+theme_override_styles/hover = SubResource("StyleBoxFlat_vbij8")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_e20w6")
+theme_override_styles/normal = SubResource("StyleBoxFlat_gmerc")
+text = "Play in standalone mode"
+
+[node name="Label" type="Label" parent="UseStandaloneMode"]
+layout_mode = 0
+offset_top = 48.0
+offset_right = 314.0
+offset_bottom = 68.0
+theme_override_font_sizes/font_size = 11
+text = "Warning: AI was used for some placeholder art"
+horizontal_alignment = 1
 
 [node name="SetCiv3HomeDialog" type="FileDialog" parent="."]
 mode = 3

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -81,7 +81,7 @@ public partial class PopupOverlay : HBoxContainer {
 		if (soundFile == "") {
 			log.Error("Invalid popup category");
 		}
-		AudioStreamWav wav = Util.LoadWAVFromDisk(Util.Civ3MediaPath(soundFile));
+		AudioStreamWav wav = Util.LoadCiv3WAVFromDisk(soundFile);
 
 		// 1. prevent mouse interaction with non-UI elements (ie. the map)
 		MouseFilter = MouseFilterEnum.Stop;
@@ -93,7 +93,9 @@ public partial class PopupOverlay : HBoxContainer {
 		setMouseFilter(control, MouseFilterEnum.Ignore);
 
 		Show();
-		PlaySound(wav);
+		if (wav != null) {
+			PlaySound(wav);
+		}
 	}
 
 	/**

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -129,9 +129,9 @@ public partial class Util {
 		}
 
 		// Next, before trying the base Civ paths, see if we have it packaged 
-		// with C7 and are using modern graphics.
+		// with C7 and are in standalone mode.
+		string c7Path = FileExistsIgnoringCase(getProjectDirectoryPath(), mediaPath);
 		if (C7Settings.UseStandaloneMode()) {
-			string c7Path = FileExistsIgnoringCase(getProjectDirectoryPath(), mediaPath);
 			if (c7Path != null) {
 				return c7Path;
 			} else {
@@ -139,7 +139,7 @@ public partial class Util {
 			}
 		}
 
-		//Finally, check the base Civ paths
+		//Next, check the base Civ paths
 		string[] basePaths = new string[] {
 			"Conquests",
 			"civ3PTW",
@@ -149,6 +149,13 @@ public partial class Util {
 			string actualCasePath = CheckForCiv3Media(mediaPath, basePaths[i]);
 			if (actualCasePath != null)
 				return actualCasePath;
+		}
+
+		// Finally, use a c7 path even if we aren't in standalone mode, but only
+		// if we can't find the path in civ3 graphics. This allows us to toggle
+		// to c7 art when we aren't in standalone mode.
+		if (c7Path != null) {
+			return c7Path;
 		}
 
 		throw new ApplicationException("Media path not found: " + mediaPath);

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -128,10 +128,15 @@ public partial class Util {
 			}
 		}
 
-		//Next, before trying the base Civ paths, see if we have it packaged with C7
-		string c7Path = FileExistsIgnoringCase(getProjectDirectoryPath(), mediaPath);
-		if (c7Path != null) {
-			return c7Path;
+		// Next, before trying the base Civ paths, see if we have it packaged 
+		// with C7 and are using modern graphics.
+		if (C7Settings.UseStandaloneMode()) {
+			string c7Path = FileExistsIgnoringCase(getProjectDirectoryPath(), mediaPath);
+			if (c7Path != null) {
+				return c7Path;
+			} else {
+				throw new ApplicationException("Media path not found: " + mediaPath);
+			}
 		}
 
 		//Finally, check the base Civ paths
@@ -244,6 +249,19 @@ public partial class Util {
 		ImageTexture texIndices = ImageTexture.CreateFromImage(imgIndices);
 
 		return (new FlicSheet { palette = texPalette, indices = texIndices, spriteWidth = flic.Width, spriteHeight = flic.Height }, flic);
+	}
+
+	// Like LoadWAVFromDisk, but the path is a relative path, not the result of
+	// calling Civ3MediaPath.
+	//
+	// The result may be null if modern graphics are active, as we do not yet
+	// have sound replacements.
+	public static AudioStreamWav? LoadCiv3WAVFromDisk(string path) {
+		try {
+			return LoadWAVFromDisk(Civ3MediaPath(path));
+		} catch (Exception e) {
+			return null;
+		}
 	}
 
 	static public AudioStreamWav LoadWAVFromDisk(string path) {

--- a/C7Engine/C7Settings.cs
+++ b/C7Engine/C7Settings.cs
@@ -36,5 +36,22 @@ namespace C7Engine {
 			}
 			return settings[section][key];
 		}
+
+		public static string GetSettingsValueOrDefault(string section, string key, string defaultValue) {
+			if (settings == null) {
+				LoadSettings();
+			}
+			if (settings[section] == null) {
+				return defaultValue;
+			}
+			if (settings[section][key] == null) {
+				return defaultValue;
+			}
+			return settings[section][key];
+		}
+
+		public static bool UseStandaloneMode() {
+			return GetSettingsValueOrDefault("locations", "useStandaloneMode", "false") == "true";
+		}
 	}
 }


### PR DESCRIPTION
Now if you launch the game and the civ3 install path isn't auto detected, there is an option to select the install path, but also to play in standalone mode. The standalone mode button warns that AI was used for some placeholder art - we want to be up front about that.

<img width="788" height="610" alt="image" src="https://github.com/user-attachments/assets/8261b511-f17d-4382-b663-108e8a2a00ed" />

In this mode we can then start a game, after picking the world settings, civ, opponents, and difficulty level:

<img width="921" height="610" alt="image" src="https://github.com/user-attachments/assets/f1e2bfb3-a3fb-4c52-9cba-919a5f24e652" />

At that point things partially break, because we don't have any units included in our c7 art directory besides the settler. We can still build buildings and such, but the log is full of complaints about `Art/Units/Worker/Worker.INI`.