### PR TITLE
Support picking which civ to play as in a scenario

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -115,7 +115,7 @@ public partial class Game : Node2D {
 				GamePaths.LuaRulesDir,
 				GamePaths.DefaultBicPath,
 				(scenarioSearchPath) => {
-					// WHen the game loading logic tries to load the PediaIcons file, set the
+					// When the game loading logic tries to load the PediaIcons file, set the
 					// scenario search path and then use our Civ3MediaPath searching logic to
 					// find the correct version of the file.
 					//

--- a/C7/UIElements/Civ3FileDialog.cs
+++ b/C7/UIElements/Civ3FileDialog.cs
@@ -9,6 +9,9 @@ public partial class Civ3FileDialog : FileDialog {
 	GlobalSingleton Global;
 	private ILogger log;
 
+	// If true, go to scenario setup after loading, for scenarios.
+	public bool GoToScenarioSetupAfterLoading = false;
+
 	public override void _Ready() {
 		base._Ready();
 		log = LogManager.ForContext<Civ3FileDialog>();
@@ -34,7 +37,11 @@ public partial class Civ3FileDialog : FileDialog {
 		if (FileMode == FileDialog.FileModeEnum.OpenFile) {
 			log.Information($"loading {path}");
 			Global.LoadGamePath = path;
-			GetTree().ChangeSceneToFile("res://C7Game.tscn");
+			if (GoToScenarioSetupAfterLoading) {
+				GetTree().ChangeSceneToFile("res://UIElements/NewGame/scenario_setup.tscn");
+			} else {
+				GetTree().ChangeSceneToFile("res://C7Game.tscn");
+			}
 		} else {
 			if (!path.EndsWith(".json")) {
 				path = path + ".json";

--- a/C7/UIElements/MainMenu/MainMenu.cs
+++ b/C7/UIElements/MainMenu/MainMenu.cs
@@ -41,6 +41,7 @@ public partial class MainMenu : Node {
 
 		LoadDialog.SetDirectoryForLoading(@"Conquests/Saves");
 		LoadScenarioDialog.SetDirectoryForLoading(@"Conquests/Scenarios");
+		LoadScenarioDialog.GoToScenarioSetupAfterLoading = true;
 
 		ButtonContainer.NewGame.Pressed += GoToWorldSetup;
 		ButtonContainer.QuickStart.Pressed += GoToWorldSetup;

--- a/C7/UIElements/NewGame/ScenarioSetup.cs
+++ b/C7/UIElements/NewGame/ScenarioSetup.cs
@@ -32,11 +32,6 @@ public partial class ScenarioSetup : Control {
 
 	[Export] Label loadingLabel;
 
-	ID.Factory ids;
-
-	// TODO: read this from the rules based on the world size
-	const int NUM_OPPONENTS = 7;
-
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
 		background.Texture = TextureLoader.Load("player_setup.background");
@@ -44,11 +39,9 @@ public partial class ScenarioSetup : Control {
 		SaveGame save = GetSave();
 
 		// Set up buttons for the civs the player can play as.
-		//
-		// TODO: Bump this to Dutch once we bump the release.
 		civilizations = save.Civilizations;
 		playerListContainer.Columns = (int)Math.Ceiling(save.Civilizations.Count / 12.0);
-		string initiallySelectedCiv = save.Civilizations.Any(x => x.name == "Carthage") ? "Carthage" : save.Civilizations[1].name;
+		string initiallySelectedCiv = save.Civilizations[1].name;
 		foreach (Civilization civ in save.Civilizations) {
 			if (civ.name == "A Barbarian Chiefdom") {
 				continue;
@@ -117,8 +110,14 @@ public partial class ScenarioSetup : Control {
 	}
 
 	private SaveGame GetSave() {
-		GlobalSingleton global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
-		return SaveManager.LoadSave(global.LoadGamePath,
+		string loadGamePath;
+		try {
+			loadGamePath = GetNode<GlobalSingleton>("/root/GlobalSingleton").LoadGamePath;
+		} catch (Exception e) {
+			// Provide a default for the editor, which can't use GlobalSingleton
+			loadGamePath = Util.Civ3MediaPath("Conquests/Conquests/9 WWII in the Pacific.biq");
+		}
+		return SaveManager.LoadSave(loadGamePath,
 									GamePaths.DefaultBicPath,
 									(string scenarioSearchPath) => {
 										// See corresponding logic in Game.cs

--- a/C7/UIElements/NewGame/ScenarioSetup.cs
+++ b/C7/UIElements/NewGame/ScenarioSetup.cs
@@ -1,0 +1,159 @@
+using Godot;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using C7GameData;
+using C7Engine;
+using ConvertCiv3Media;
+using C7GameData.Save;
+using Serilog;
+
+[Tool]
+public partial class ScenarioSetup : Control {
+	private static ILogger log = LogManager.ForContext<ScenarioSetup>();
+
+	[Export] TextureRect background;
+
+	[Export] GridContainer playerListContainer;
+	List<Civilization> civilizations = new();
+	Civilization civilization = null;
+	ButtonGroup playerListButtonGroup = new();
+	TextureRect leaderHead = new();
+	[Export] Label civLabel;
+
+	[Export] GridContainer difficultyContainer;
+
+	Difficulty difficulty = null;
+	ButtonGroup difficultyButtonGroup = new();
+
+	[Export] TextureButton confirm;
+	[Export] TextureButton cancel;
+
+	[Export] Label loadingLabel;
+
+	ID.Factory ids;
+
+	// TODO: read this from the rules based on the world size
+	const int NUM_OPPONENTS = 7;
+
+	// Called when the node enters the scene tree for the first time.
+	public override void _Ready() {
+		background.Texture = TextureLoader.Load("player_setup.background");
+
+		SaveGame save = GetSave();
+
+		// Set up buttons for the civs the player can play as.
+		//
+		// TODO: Bump this to Dutch once we bump the release.
+		civilizations = save.Civilizations;
+		playerListContainer.Columns = (int)Math.Ceiling(save.Civilizations.Count / 12.0);
+		string initiallySelectedCiv = save.Civilizations.Any(x => x.name == "Carthage") ? "Carthage" : save.Civilizations[1].name;
+		foreach (Civilization civ in save.Civilizations) {
+			if (civ.name == "A Barbarian Chiefdom") {
+				continue;
+			}
+
+			Civ3MenuButton button = new() {
+				Text = civ.name,
+				FontSize = 12,
+				textPosition = Civ3MenuButton.TextPosition.TextLeftOfIcon,
+				ButtonGroup = playerListButtonGroup,
+				ToggleMode = true,
+			};
+			button.Pressed += () => {
+				this.civilization = civ;
+				DisplaySelectedLeader();
+			};
+			playerListContainer.AddChild(button);
+
+			if (civ.name == initiallySelectedCiv) {
+				button.ButtonPressed = true;
+				this.civilization = civ;
+			}
+		}
+		background.AddChild(leaderHead);
+		DisplaySelectedLeader();
+
+		// Set up the difficulty buttons
+		difficultyContainer.Columns = save.Difficulties.Count;
+		string initiallySelectedDifficulty = save.Difficulties.Any(x => x.Name == "Regent") ? "Regent" : save.Difficulties[0].Name;
+		foreach (Difficulty difficulty in save.Difficulties) {
+			CenterContainer container = new();
+			difficultyContainer.AddChild(container);
+
+			Civ3MenuButton button = new(Civ3MenuButton.TextPosition.TextAboveIcon) {
+				Text = difficulty.Name,
+				ButtonGroup = difficultyButtonGroup,
+				ToggleMode = true,
+			};
+			button.Pressed += () => { this.difficulty = difficulty; };
+			container.AddChild(button);
+			if (difficulty.Name == initiallySelectedDifficulty) {
+				button.ButtonPressed = true;
+				this.difficulty = difficulty;
+			}
+			container.CustomMinimumSize = new Vector2(843.0f / difficultyContainer.Columns, 0);
+		}
+
+		TextureLoader.SetButtonTextures(confirm, "ui.confirm");
+		confirm.Pressed += CreateGame;
+
+		TextureLoader.SetButtonTextures(cancel, "ui.cancel");
+		cancel.Pressed += BackToMainMenu;
+	}
+
+	private void BackToMainMenu() {
+		GetTree().ChangeSceneToFile("res://UIElements/MainMenu/main_menu.tscn");
+	}
+
+	private void DisplaySelectedLeader() {
+		leaderHead.Texture = TextureLoader.Load("leader_heads", civilization);
+		leaderHead.Scale = new Vector2(1.7f, 1.7f);
+		leaderHead.SetPosition(new Vector2(414, 46));
+
+		string traits = string.Join(", ", civilization.traits);
+		civLabel.Text = $"{civilization.leader} of the {civilization.noun}\n({traits})";
+	}
+
+	private SaveGame GetSave() {
+		GlobalSingleton global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
+		return SaveManager.LoadSave(global.LoadGamePath,
+									GamePaths.DefaultBicPath,
+									(string scenarioSearchPath) => {
+										// See corresponding logic in Game.cs
+										Util.setModPath(scenarioSearchPath);
+										log.Debug("RelativeModPath ", scenarioSearchPath);
+										return Util.Civ3MediaPath("Text/PediaIcons.txt");
+									});
+	}
+
+	private void CreateGame() {
+		GlobalSingleton global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
+		loadingLabel.Visible = true;
+		SaveGame save = GetSave();
+
+		// World generation can take a bit of time if multiple attempts are
+		// needed, so we don't want to tie up the UI thread.
+		Thread thread = new(() => { UpdateSaveAndStartGame(save, global); });
+		thread.Start();
+	}
+
+	private void UpdateSaveAndStartGame(SaveGame save, GlobalSingleton Global) {
+		foreach (SavePlayer sp in save.Players) {
+			sp.human = sp.civilization == this.civilization.name;
+		}
+		save.GameDifficulty = difficulty;
+
+		log.Information("saving updated scenario");
+		save.Save(GamePaths.DefaultGeneratedGamePath);
+		Global.LoadGamePath = GamePaths.DefaultGeneratedGamePath;
+
+		log.Information("opening map");
+		CallDeferred("StartGame");
+	}
+
+	private void StartGame() {
+		GetTree().ChangeSceneToFile("res://C7Game.tscn");
+	}
+}

--- a/C7/UIElements/NewGame/scenario_setup.tscn
+++ b/C7/UIElements/NewGame/scenario_setup.tscn
@@ -1,0 +1,136 @@
+[gd_scene load_steps=9 format=3 uid="uid://3453656756"]
+
+[ext_resource type="Script" path="res://UIElements/NewGame/ScenarioSetup.cs" id="1"]
+[ext_resource type="Script" uid="uid://doqipc4rnaotx" path="res://UIElements/Civ3TextureRect.cs" id="2"]
+[ext_resource type="Script" uid="uid://dcrdcjop64t6t" path="res://UIElements/Civ3TextureButton.cs" id="3"]
+
+[sub_resource type="InputEventKey" id="InputEventKey_8ublj"]
+device = -1
+keycode = 4194309
+
+[sub_resource type="Shortcut" id="Shortcut_33b04"]
+events = [SubResource("InputEventKey_8ublj")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_klcu1"]
+device = -1
+keycode = 4194305
+
+[sub_resource type="Shortcut" id="Shortcut_7oyjg"]
+events = [SubResource("InputEventKey_klcu1")]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ld2d8"]
+
+[node name="Control" type="CenterContainer" node_paths=PackedStringArray("background", "playerListContainer", "civLabel", "difficultyContainer", "confirm", "cancel", "loadingLabel")]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1")
+background = NodePath("Background")
+playerListContainer = NodePath("Background/CenterContainer/PlayerListContainer")
+civLabel = NodePath("Background/CivLabel")
+difficultyContainer = NodePath("Background/DifficultyContainer")
+confirm = NodePath("Background/Confirm")
+cancel = NodePath("Background/Cancel")
+loadingLabel = NodePath("Background/LoadingLabel")
+
+[node name="Background" type="TextureRect" parent="."]
+layout_mode = 2
+script = ExtResource("2")
+
+[node name="Label" type="Label" parent="Background"]
+layout_mode = 0
+offset_left = 114.0
+offset_top = 25.0
+offset_right = 326.0
+offset_bottom = 57.0
+theme_override_font_sizes/font_size = 24
+text = "PLAYER SETUP"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Label2" type="Label" parent="Background"]
+layout_mode = 0
+offset_left = 147.0
+offset_top = 77.0
+offset_right = 294.0
+offset_bottom = 99.0
+theme_override_font_sizes/font_size = 15
+text = "YOUR CIVILIZATION"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Label4" type="Label" parent="Background"]
+layout_mode = 0
+offset_left = 110.0
+offset_top = 642.0
+offset_right = 257.0
+offset_bottom = 664.0
+theme_override_font_sizes/font_size = 15
+text = "DIFFICULTY"
+vertical_alignment = 1
+
+[node name="CenterContainer" type="CenterContainer" parent="Background"]
+layout_mode = 0
+offset_left = 72.0
+offset_top = 122.0
+offset_right = 386.0
+offset_bottom = 460.0
+
+[node name="PlayerListContainer" type="GridContainer" parent="Background/CenterContainer"]
+layout_mode = 2
+theme_override_constants/h_separation = 10
+theme_override_constants/v_separation = 10
+columns = 3
+
+[node name="DifficultyContainer" type="GridContainer" parent="Background"]
+layout_mode = 0
+offset_left = 91.0
+offset_top = 690.0
+offset_right = 934.0
+offset_bottom = 750.0
+columns = 8
+
+[node name="CivLabel" type="Label" parent="Background"]
+layout_mode = 0
+offset_left = 421.0
+offset_top = 289.0
+offset_right = 608.0
+offset_bottom = 368.0
+text = "Hannibal of the Carthaginians
+(Industrious, Seafaring)"
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 2
+
+[node name="Confirm" type="TextureButton" parent="Background"]
+layout_mode = 0
+offset_left = 960.0
+offset_top = 728.0
+offset_right = 979.0
+offset_bottom = 747.0
+shortcut = SubResource("Shortcut_33b04")
+script = ExtResource("3")
+
+[node name="Cancel" type="TextureButton" parent="Background"]
+layout_mode = 0
+offset_left = 988.0
+offset_top = 729.0
+offset_right = 1007.0
+offset_bottom = 748.0
+shortcut = SubResource("Shortcut_7oyjg")
+script = ExtResource("3")
+
+[node name="LoadingLabel" type="Label" parent="Background"]
+visible = false
+layout_mode = 0
+offset_left = 310.0
+offset_top = 325.0
+offset_right = 717.0
+offset_bottom = 434.0
+theme_override_font_sizes/font_size = 38
+theme_override_styles/normal = SubResource("StyleBoxFlat_ld2d8")
+text = "Loading..."
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/C7Engine/C7GameData/ID.cs
+++ b/C7Engine/C7GameData/ID.cs
@@ -34,9 +34,11 @@ namespace C7GameData {
 		}
 
 		public static ID FromString(string str) {
-			string[] split = str.Split('-', 2);
-			string key = split[0];
-			int n = split[1] == "none" ? magicNoneIdNumber : int.Parse(split[1]);
+			List<string> split = str.Split('-').ToList();
+			// To handle units like "Man-O-War" we need to only look at the final
+			// element of the .Split call to get the id.
+			string key = string.Join("-", split.GetRange(0, split.Count - 1));
+			int n = split[split.Count - 1] == "none" ? magicNoneIdNumber : int.Parse(split[split.Count - 1]);
 			if (n < 0) {
 				throw new Exception($"ID cannot have a negative number, got {n}");
 			}


### PR DESCRIPTION
The scenario picker is 90% duplicated from the player setup logic, but is different enough (no map generation, no starting unit logic, etc) that I think it deserves its own class/scene.

Amusingly I think this code could also be used to allow loading a save game and playing it as a different civilization from whatever turn the game was saved as.

<img width="807" height="605" alt="image" src="https://github.com/user-attachments/assets/d436d75d-e677-4c99-8e2c-57494c35e0c2" />

Because this now loads/saves a scenario I had to fix a parsing bug that "Man-O-War-1" turned up as well.