### PR TITLE
Refactor: improve game creation

### DIFF
--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -64,6 +64,9 @@ namespace C7GameData {
 		// a road is built or a city is created/destroyed.
 		private TradeNetwork tradeNetwork;
 
+		// An action called after initialization of EngineStorage
+		internal Action onGameCreation;
+
 		public GameData() {
 			map = new GameMap();
 			if (seed == -1) {

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using C7Engine;
 
 namespace C7GameData.Save {
 
@@ -119,13 +120,19 @@ namespace C7GameData.Save {
 			data.UpdateTileOwners();
 			data.InvalidateCachedTradeNetwork();
 
-			foreach (Player p in data.players) {
+			data.onGameCreation += OnGameCreation;
+
+			return data;
+		}
+
+		private void OnGameCreation() {
+			foreach (Player p in EngineStorage.gameData.players) {
 				// Backfill citizen assignments for scenarios that don't specify
 				// them.
 				foreach (City c in p.cities) {
 					foreach (CityResident cr in c.residents) {
 						if (cr.citizenType.IsDefaultCitizen && cr.tileWorked == Tile.NONE) {
-							C7Engine.AI.CityTileAssignmentAI.AssignNewCitizenToTile(data, cr);
+							C7Engine.AI.CityTileAssignmentAI.AssignNewCitizenToTile(EngineStorage.gameData, cr);
 						}
 					}
 				}
@@ -138,11 +145,9 @@ namespace C7GameData.Save {
 				// TODO: this may require more than one loop, because if all the
 				// citizens are happy it reduces wasted shields via we love the
 				// king day.
-				p.DoCorruptionCalculations(data);
-				p.RecalculateCitizenMoods(data);
+				p.DoCorruptionCalculations(EngineStorage.gameData);
+				p.RecalculateCitizenMoods(EngineStorage.gameData);
 			}
-
-			return data;
 		}
 
 		private GameData InitializeGameData() {

--- a/C7Engine/EntryPoints/CreateGame.cs
+++ b/C7Engine/EntryPoints/CreateGame.cs
@@ -22,6 +22,7 @@ namespace C7Engine {
 			GameData gameData = save.ToGameData(luaRulesDir);
 
 			EngineStorage.gameData = gameData;
+			EngineStorage.gameData.onGameCreation();
 
 			// TODO: (pcen) initially, in the false branch I assigned gameData.CreateDummyGameData
 			// to humanPlayer, but this is not correct since there are already players and units in


### PR DESCRIPTION
This commit improves mechanism for game creation.

Previously, some logic for initializing the game state was run as part of the save loading class, before the EngineStorage was initialized. As a result, some methods had accepted GameData object as an argument, instead of reading it from the EngineStorage, as is commonly done in the codebase.

In my view, this was problematic, since it introduced a split in codebase and required adjusting the code based on whether it would be run during game creation. This commit addresses this issue by introducing an action field "onGameCreation" to GameData. Now, the SaveGame class only binds the initializing logic to this action, which is executed in the CreateGame class after the EngineStorage is properly initialized.

Methods that accept GameData as argument still exist in the project. Some of them relate to the game creation mechanism, and some of them were written this way because previously it wasn't possible to access EngineStorage from the C7GameData namespace. I think we should gradually refactor them out in favor of accessing GameData through the EngineStorage.