### PR TITLE
Fix assembly unloading issues (#793)

### DIFF
--- a/C7/UIElements/Civ3TextureButton.cs
+++ b/C7/UIElements/Civ3TextureButton.cs
@@ -1,9 +1,16 @@
 using Godot;
-using System.Collections.Generic;
 
 [GlobalClass]
 [Tool]
 public partial class Civ3TextureButton : TextureButton {
+	[Export] string textureConfigKey;
+
+	public override void _Ready() {
+		if (textureConfigKey != null) {
+			TextureLoader.SetButtonTextures(this, textureConfigKey);
+		}
+	}
+
 	public override void _ValidateProperty(Godot.Collections.Dictionary property) {
 		Util.ApplyNoSaveFlag(property, [PropertyName.TextureNormal, PropertyName.TextureHover, PropertyName.TexturePressed]);
 	}

--- a/C7/UIElements/Civ3TextureRect.cs
+++ b/C7/UIElements/Civ3TextureRect.cs
@@ -1,9 +1,16 @@
 using Godot;
-using System.Collections.Generic;
 
 [GlobalClass]
 [Tool]
 public partial class Civ3TextureRect : TextureRect {
+	[Export] string textureConfigKey;
+
+	public override void _Ready() {
+		if (textureConfigKey != null) {
+			Texture = TextureLoader.Load(textureConfigKey);
+		}
+	}
+
 	public override void _ValidateProperty(Godot.Collections.Dictionary property) {
 		Util.ApplyNoSaveFlag(property, [PropertyName.Texture]);
 	}

--- a/C7/UIElements/NewGame/PlayerSetup.cs
+++ b/C7/UIElements/NewGame/PlayerSetup.cs
@@ -9,7 +9,6 @@ using ConvertCiv3Media;
 using C7GameData.Save;
 using Serilog;
 
-[Tool]
 public partial class PlayerSetup : Control {
 	private static ILogger log = LogManager.ForContext<PlayerSetup>();
 
@@ -42,8 +41,6 @@ public partial class PlayerSetup : Control {
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
-		background.Texture = TextureLoader.Load("player_setup.background");
-
 		SaveGame save = GetSave();
 
 		// Set up buttons for the civs the player can play as.
@@ -103,10 +100,7 @@ public partial class PlayerSetup : Control {
 			container.CustomMinimumSize = new Vector2(843.0f / difficultyContainer.Columns, 0);
 		}
 
-		TextureLoader.SetButtonTextures(confirm, "ui.confirm");
 		confirm.Pressed += CreateGame;
-
-		TextureLoader.SetButtonTextures(cancel, "ui.cancel");
 		cancel.Pressed += BackToMainMenu;
 	}
 

--- a/C7/UIElements/NewGame/ScenarioSetup.cs
+++ b/C7/UIElements/NewGame/ScenarioSetup.cs
@@ -9,7 +9,6 @@ using ConvertCiv3Media;
 using C7GameData.Save;
 using Serilog;
 
-[Tool]
 public partial class ScenarioSetup : Control {
 	private static ILogger log = LogManager.ForContext<ScenarioSetup>();
 
@@ -34,8 +33,6 @@ public partial class ScenarioSetup : Control {
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
-		background.Texture = TextureLoader.Load("player_setup.background");
-
 		SaveGame save = GetSave();
 
 		// Set up buttons for the civs the player can play as.
@@ -89,10 +86,7 @@ public partial class ScenarioSetup : Control {
 			container.CustomMinimumSize = new Vector2(843.0f / difficultyContainer.Columns, 0);
 		}
 
-		TextureLoader.SetButtonTextures(confirm, "ui.confirm");
 		confirm.Pressed += CreateGame;
-
-		TextureLoader.SetButtonTextures(cancel, "ui.cancel");
 		cancel.Pressed += BackToMainMenu;
 	}
 
@@ -110,13 +104,7 @@ public partial class ScenarioSetup : Control {
 	}
 
 	private SaveGame GetSave() {
-		string loadGamePath;
-		try {
-			loadGamePath = GetNode<GlobalSingleton>("/root/GlobalSingleton").LoadGamePath;
-		} catch (Exception e) {
-			// Provide a default for the editor, which can't use GlobalSingleton
-			loadGamePath = Util.Civ3MediaPath("Conquests/Conquests/9 WWII in the Pacific.biq");
-		}
+		string loadGamePath = GetNode<GlobalSingleton>("/root/GlobalSingleton").LoadGamePath;
 		return SaveManager.LoadSave(loadGamePath,
 									GamePaths.DefaultBicPath,
 									(string scenarioSearchPath) => {

--- a/C7/UIElements/NewGame/player_setup.tscn
+++ b/C7/UIElements/NewGame/player_setup.tscn
@@ -39,6 +39,7 @@ loadingLabel = NodePath("Background/LoadingLabel")
 [node name="Background" type="TextureRect" parent="."]
 layout_mode = 2
 script = ExtResource("2")
+textureConfigKey = "player_setup.background"
 
 [node name="Label" type="Label" parent="Background"]
 layout_mode = 0
@@ -130,6 +131,7 @@ offset_right = 979.0
 offset_bottom = 747.0
 shortcut = SubResource("Shortcut_33b04")
 script = ExtResource("3")
+textureConfigKey = "ui.confirm"
 
 [node name="Cancel" type="TextureButton" parent="Background"]
 layout_mode = 0
@@ -139,6 +141,7 @@ offset_right = 1007.0
 offset_bottom = 748.0
 shortcut = SubResource("Shortcut_7oyjg")
 script = ExtResource("3")
+textureConfigKey = "ui.cancel"
 
 [node name="LoadingLabel" type="Label" parent="Background"]
 visible = false

--- a/C7/UIElements/NewGame/scenario_setup.tscn
+++ b/C7/UIElements/NewGame/scenario_setup.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=9 format=3 uid="uid://3453656756"]
 
-[ext_resource type="Script" path="res://UIElements/NewGame/ScenarioSetup.cs" id="1"]
+[ext_resource type="Script" uid="uid://dpe8ukuhvtdvx" path="res://UIElements/NewGame/ScenarioSetup.cs" id="1"]
 [ext_resource type="Script" uid="uid://doqipc4rnaotx" path="res://UIElements/Civ3TextureRect.cs" id="2"]
 [ext_resource type="Script" uid="uid://dcrdcjop64t6t" path="res://UIElements/Civ3TextureButton.cs" id="3"]
 
@@ -38,6 +38,7 @@ loadingLabel = NodePath("Background/LoadingLabel")
 [node name="Background" type="TextureRect" parent="."]
 layout_mode = 2
 script = ExtResource("2")
+textureConfigKey = "player_setup.background"
 
 [node name="Label" type="Label" parent="Background"]
 layout_mode = 0
@@ -112,6 +113,7 @@ offset_right = 979.0
 offset_bottom = 747.0
 shortcut = SubResource("Shortcut_33b04")
 script = ExtResource("3")
+textureConfigKey = "ui.confirm"
 
 [node name="Cancel" type="TextureButton" parent="Background"]
 layout_mode = 0
@@ -121,6 +123,7 @@ offset_right = 1007.0
 offset_bottom = 748.0
 shortcut = SubResource("Shortcut_7oyjg")
 script = ExtResource("3")
+textureConfigKey = "ui.cancel"
 
 [node name="LoadingLabel" type="Label" parent="Background"]
 visible = false


### PR DESCRIPTION
This commit fixes assembly unloading issues caused by [Tool] scripts loading the System.Text.Json assembly. It does so by downgrading the problematic [Tool] scripts (PlayerSetup and ScenarioSetup) to regular ones. To compensate for this, it allows binding textures to Civ3TextureButton and Civ3TextureRect via export properties. This lets us have previews for some elements in these scenes, while avoiding executing classes that load the unloadable System.Text.Json assembly.