### PR TITLE
Refactor unit selection logic

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=19 format=3 uid="uid://cldl5nk4n61m2"]
+[gd_scene load_steps=20 format=3 uid="uid://cldl5nk4n61m2"]
 
 [ext_resource type="Script" uid="uid://yxhiwx46tety" path="res://Game.cs" id="1"]
 [ext_resource type="Script" uid="uid://cfenrvu7tnp40" path="res://DoubleClickHandler.cs" id="2_t735q"]
+[ext_resource type="Script" uid="uid://dflpmvue8o7uo" path="res://UnitSelector.cs" id="2_w8hq2"]
 [ext_resource type="Script" uid="uid://ifoasmoofo6r" path="res://UIElements/Advisors/Advisors.cs" id="3"]
 [ext_resource type="Script" uid="uid://bvmc8fimjfo2j" path="res://Animations/AnimationController.cs" id="3_rmrhh"]
 [ext_resource type="Script" uid="uid://3wtlmr00bmfb" path="res://UIElements/UpperLeftNav/MenuButton.cs" id="4"]
@@ -19,7 +20,7 @@
 [ext_resource type="PackedScene" uid="uid://dkcu255o1qrt1" path="res://UIElements/PalaceScreen/palace_screen.tscn" id="14_ud8vi"]
 [ext_resource type="PackedScene" uid="uid://da7hbbufyfllg" path="res://UIElements/Advisors/domestic_advisor.tscn" id="15"]
 
-[node name="C7Game" type="Node" node_paths=PackedStringArray("Toolbar", "popupOverlay", "cityScreen", "advisor", "diplomacy", "palaceScreen", "doubleClickHandler", "animationController")]
+[node name="C7Game" type="Node" node_paths=PackedStringArray("Toolbar", "popupOverlay", "cityScreen", "advisor", "diplomacy", "palaceScreen", "doubleClickHandler", "animationController", "unitSelector")]
 script = ExtResource("1")
 Toolbar = NodePath("CanvasLayer/Control/ToolBar/MarginContainer/HBoxContainer")
 popupOverlay = NodePath("CanvasLayer/PopupOverlay")
@@ -29,6 +30,11 @@ diplomacy = NodePath("CanvasLayer/Diplomacy")
 palaceScreen = NodePath("CanvasLayer/PalaceScreen")
 doubleClickHandler = NodePath("DoubleClickHandler")
 animationController = NodePath("AnimationController")
+unitSelector = NodePath("UnitSelector")
+
+[node name="UnitSelector" type="Node" parent="." node_paths=PackedStringArray("game")]
+script = ExtResource("2_w8hq2")
+game = NodePath("..")
 
 [node name="DoubleClickHandler" type="Node" parent="."]
 script = ExtResource("2_t735q")
@@ -229,13 +235,13 @@ control = NodePath("../Control")
 unique_name_in_owner = true
 visible = false
 
-[connection signal="NewAutoselectedUnit" from="." to="CanvasLayer/Control/UnitButtons" method="OnNewUnitSelected"]
-[connection signal="NewAutoselectedUnit" from="." to="CanvasLayer/Control/GameStatus/LowerRightInfoBox" method="OnNewUnitSelected"]
-[connection signal="NoMoreAutoselectableUnits" from="." to="CanvasLayer/Control/UnitButtons" method="OnNoMoreAutoselectableUnits"]
-[connection signal="NoMoreAutoselectableUnits" from="." to="CanvasLayer/Control/GameStatus/LowerRightInfoBox" method="SetEndOfTurnStatus"]
 [connection signal="ShowCityScreen" from="." to="CanvasLayer/CityScreen" method="OnShowCityScreen"]
 [connection signal="ShowSpecificAdvisor" from="." to="CanvasLayer/Advisor" method="OnShowSpecificAdvisor"]
 [connection signal="TurnEnded" from="." to="CanvasLayer/Control/GameStatus/LowerRightInfoBox" method="StopToggling"]
+[connection signal="NewAutoselectedUnit" from="UnitSelector" to="CanvasLayer/Control/UnitButtons" method="OnNewUnitSelected"]
+[connection signal="NewAutoselectedUnit" from="UnitSelector" to="CanvasLayer/Control/GameStatus/LowerRightInfoBox" method="OnNewUnitSelected"]
+[connection signal="NoMoreAutoselectableUnits" from="UnitSelector" to="CanvasLayer/Control/UnitButtons" method="OnNoMoreAutoselectableUnits"]
+[connection signal="NoMoreAutoselectableUnits" from="UnitSelector" to="CanvasLayer/Control/GameStatus/LowerRightInfoBox" method="SetEndOfTurnStatus"]
 [connection signal="DoubleClick" from="DoubleClickHandler" to="." method="OnDoubleLeftMouseButtonClick"]
 [connection signal="SingleClick" from="DoubleClickHandler" to="." method="OnSingleLeftMouseButtonClick"]
 [connection signal="ActionRequested" from="CanvasLayer/Control/UnitButtons" to="." method="ProcessAction"]

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -11,13 +11,14 @@ using System.Linq;
 public partial class Game : Node {
 	[Signal] public delegate void TurnEndedEventHandler();
 	[Signal] public delegate void ShowSpecificAdvisorEventHandler();
-	[Signal] public delegate void NewAutoselectedUnitEventHandler();
-	[Signal] public delegate void NoMoreAutoselectableUnitsEventHandler();
 	[Signal] public delegate void ShowCityScreenEventHandler();
+
+	[Signal] public delegate void PlayerTurnStartEventHandler();
+	[Signal] public delegate void PlayerTurnEndEventHandler();
 
 	private ILogger log = LogManager.ForContext<Game>();
 
-	enum GameState {
+	public enum GameState {
 		PreGame,
 		PlayerTurn,
 		ComputerTurn
@@ -27,9 +28,9 @@ public partial class Game : Node {
 
 	private MapView mapView;
 
-	GameState CurrentState = GameState.PreGame;
+	public GameState CurrentState { get; private set; } = GameState.PreGame;
 
-	public MapUnit CurrentlySelectedUnit = MapUnit.NONE; //The selected unit.  May be changed by clicking on a unit or the next unit being auto-selected after orders are given for the current one.
+	public MapUnit CurrentlySelectedUnit => unitSelector.CurrentlySelectedUnit;
 	private bool HasCurrentlySelectedUnit() => CurrentlySelectedUnit != MapUnit.NONE;
 
 	// When the game is in "goto" mode, the current destination and the cost of getting
@@ -45,10 +46,6 @@ public partial class Game : Node {
 		public Player requiresWarDeclarationOnPlayer = null;
 	};
 	public GotoInfo gotoInfo = null;
-
-	// Normally if the currently selected unit (CSU) becomes fortified, we advance to the next autoselected unit. If this flag is set, we won't do
-	// that. This is useful so that the unit autoselector can be prevented from interfering with the player selecting fortified units.
-	public bool KeepCSUWhenFortified = false;
 
 	// When in observer mode, the number of turns to play before prompting the
 	// user to advance the turn manually. This allows for more rapid debugging
@@ -78,6 +75,8 @@ public partial class Game : Node {
 	private DoubleClickHandler doubleClickHandler;
 	[Export]
 	public AnimationController animationController;
+	[Export]
+	public UnitSelector unitSelector;
 
 	bool errorOnLoad = false;
 
@@ -214,16 +213,6 @@ public partial class Game : Node {
 						PopupOverlay.PopupCategory.Advisor);
 				}
 				break;
-			case MsgUpdateUiAfterMove mUUAM:
-				// The unit finished moving and still has moves left, so we need to
-				// mark it as the selected unit again.
-				//
-				// Among other things, this will refresh the UI and ensure that the
-				// unit action buttons are correct.
-				if (CurrentlySelectedUnit != MapUnit.NONE) {
-					setSelectedUnit(CurrentlySelectedUnit);
-				}
-				break;
 			case MsgShowScienceAdvisor mSSA:
 				// F6 is the science advisor.
 				// TODO: Move the F* key strings to a set of constants/enum.
@@ -288,25 +277,6 @@ public partial class Game : Node {
 
 		if (EngineStorage.TryDequeueNextMessageToUI(out MessageToUI msg))
 			HandleEngineMessage(msg);
-
-		if (!errorOnLoad) {
-			if (CurrentState == GameState.PlayerTurn) {
-				// If the selected unit is unfortified, prepare to autoselect the next one if it becomes fortified
-				if ((CurrentlySelectedUnit != MapUnit.NONE) && (!CurrentlySelectedUnit.isFortified))
-					KeepCSUWhenFortified = false;
-
-				// Advance off the currently selected unit to the next one if it's out of moves or HP and not playing an
-				// animation we want to watch, or if it's fortified and we aren't set to keep fortified units selected.
-				if ((CurrentlySelectedUnit != MapUnit.NONE) &&
-					(((!CurrentlySelectedUnit.movementPoints.canMove || CurrentlySelectedUnit.hitPointsRemaining <= 0) &&
-					  !animationController.animTracker.getUnitAppearance(CurrentlySelectedUnit).DeservesPlayerAttention()) ||
-					 (CurrentlySelectedUnit.isFortified && !KeepCSUWhenFortified) ||
-					 CurrentlySelectedUnit.isAutomated))
-					EngineStorage.ReadGameData((GameData gameData) => {
-						GetNextAutoselectedUnit(gameData);
-					});
-			}
-		}
 	}
 
 	// If "location" is not already near the center of the screen, moves the camera to bring it into view.
@@ -315,54 +285,6 @@ public partial class Game : Node {
 			Vector2 relativeScreenLocation = mapView.screenLocationOfTile(location, true) / mapView.getVisibleAreaSize();
 			if (relativeScreenLocation.DistanceTo(new Vector2((float)0.5, (float)0.5)) > 0.30)
 				mapView.centerCameraOnTile(location);
-		}
-	}
-
-	/**
-	 * Currently (11/14/2021), all unit selection goes through here.
-	 * Both code paths are in Game.cs for now, so it's local, but we may
-	 * want to change it event driven.
-	 *
-	 * Returns whether the selected unit has remaining moves.
-	 **/
-	public bool setSelectedUnit(MapUnit unit) {
-		unit.availableActions = UnitInteractions.GetAvailableActions(unit);
-
-		if ((unit.path?.PathLength() ?? -1) > 0) {
-			log.Debug("cancelling path for " + unit);
-			unit.path = TilePath.NONE;
-		}
-
-		// Allow cancellation of active worker jobs by clicking on the unit.
-		if (unit.WorkerJob != null) {
-			unit.resetWorkerJob();
-		}
-
-		// Allow cancellation automation via clicking on the unit.
-		if (unit.isAutomated) {
-			unit.isAutomated = false;
-			unit.currentAI = null;
-		}
-
-		this.CurrentlySelectedUnit = unit;
-		this.KeepCSUWhenFortified = unit.isFortified; // If fortified, make sure the autoselector doesn't immediately skip past the unit
-
-		if (unit != MapUnit.NONE) {
-			ensureLocationIsInView(unit.location);
-		}
-
-		if (unit != MapUnit.NONE && !unit.movementPoints.canMove) {
-			return false;
-		}
-
-		// Also emit the signal for a new unit being selected, so other areas such as Game Status and Unit Buttons can update
-		if (CurrentlySelectedUnit != MapUnit.NONE) {
-			ParameterWrapper<MapUnit> wrappedUnit = new ParameterWrapper<MapUnit>(CurrentlySelectedUnit);
-			EmitSignal(SignalName.NewAutoselectedUnit, wrappedUnit);
-			return true;
-		} else {
-			EmitSignal(SignalName.NoMoreAutoselectableUnits);
-			return false;
 		}
 	}
 
@@ -406,8 +328,9 @@ public partial class Game : Node {
 			}
 
 			CurrentState = GameState.PlayerTurn;
-			GetNextAutoselectedUnit(gameData);
 		});
+
+		EmitSignal(SignalName.PlayerTurnStart);
 	}
 
 	private void OnPlayerEndTurn() {
@@ -450,6 +373,7 @@ public partial class Game : Node {
 		log.Information("Starting computer turn");
 		CurrentState = GameState.ComputerTurn;
 		new MsgEndTurn().send(); // Triggers actual backend processing
+		EmitSignal(SignalName.PlayerTurnEnd);
 	}
 
 	public void _on_QuitButton_pressed() {
@@ -568,7 +492,7 @@ public partial class Game : Node {
 			return;
 		}
 
-		bool canMove = setSelectedUnit(to_select);
+		bool canMove = unitSelector.SetSelectedUnit(to_select);
 		if (!canMove) {
 			TemporaryPopup popup = new("This unit has already moved.", 1);
 			popup.SetPosition(eventMouseButton.Position + new Vector2(0, -64));
@@ -813,10 +737,8 @@ public partial class Game : Node {
 		}
 
 		if (currentAction == C7Action.UnitWait) {
-			EngineStorage.ReadGameData((GameData gameData) => {
-				UnitInteractions.waitUnit(gameData, CurrentlySelectedUnit.id);
-				GetNextAutoselectedUnit(gameData);
-			});
+			UnitInteractions.waitUnit(CurrentlySelectedUnit.id);
+			unitSelector.SetNextUnit();
 		}
 
 		if (currentAction == C7Action.UnitFortify) {
@@ -876,10 +798,6 @@ public partial class Game : Node {
 			&& CurrentlySelectedUnit.canPerformTerraformAction(terraform)) {
 			new MsgStartWorkerJob(CurrentlySelectedUnit?.id, terraform).send();
 		}
-	}
-
-	private void GetNextAutoselectedUnit(GameData gameData) {
-		this.setSelectedUnit(UnitInteractions.getNextSelectedUnit(gameData));
 	}
 
 	private void setGotoMode(bool isOn) {

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -129,6 +129,8 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 	}
 
 	private void UpdateUnitInfo(MapUnit NewUnit, TerrainType terrain) {
+		StopToggling();
+
 		terrainType.Text = terrain.DisplayName;
 		terrainType.Visible = true;
 		lblUnitSelected.Text = NewUnit.unitType.name;

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -208,7 +208,7 @@ public partial class RightClickTileMenu : RightClickMenu {
 		EngineStorage.ReadGameData((GameData gameData) => {
 			MapUnit toSelect = gameData.mapUnits.Find(u => u.id == id);
 			if (toSelect != null && toSelect.owner == game.controller) {
-				bool canMove = game.setSelectedUnit(toSelect);
+				bool canMove = game.unitSelector.SetSelectedUnit(toSelect);
 				if (!canMove) {
 					ShowCannotMovePopup();
 				}
@@ -233,7 +233,7 @@ public partial class RightClickTileMenu : RightClickMenu {
 					new MsgSetFortification(unit.id, isFortify).send();
 
 					if (!hasSelectedUnit && !isFortify) {
-						bool canMove = game.setSelectedUnit(unit);
+						bool canMove = game.unitSelector.SetSelectedUnit(unit);
 						if (!canMove) {
 							ShowCannotMovePopup();
 						}

--- a/C7/UnitSelector.cs
+++ b/C7/UnitSelector.cs
@@ -1,0 +1,119 @@
+using C7Engine;
+using C7GameData;
+using Godot;
+using Serilog;
+
+/* This class controls the unit selection during the player turn.  It
+   handles automatic unit selection in the _Process method, and
+   provides methods (SetSelectedUnit, SetNextUnit) for manual
+   selection. */
+[GlobalClass]
+public partial class UnitSelector : Node {
+	private ILogger log = LogManager.ForContext<UnitSelector>();
+
+	[Signal] public delegate void NewAutoselectedUnitEventHandler();
+	[Signal] public delegate void NoMoreAutoselectableUnitsEventHandler();
+
+	[Export] private Game game;
+
+	//The selected unit.  May be changed by clicking on a unit or the next unit being auto-selected after orders are given for the current one.
+	public MapUnit CurrentlySelectedUnit { get; private set; } = MapUnit.NONE;
+
+	// Normally if the currently selected unit (CSU) becomes fortified, we advance to the next autoselected unit. If this flag is set, we won't do
+	// that. This is useful so that the unit autoselector can be prevented from interfering with the player selecting fortified units.
+	private bool KeepCSUWhenFortified = false;
+
+	private bool NoMoreAutoselectableUnitsEmitted = false;
+
+	public override void _Ready() {
+		game.PlayerTurnEnd += () => { NoMoreAutoselectableUnitsEmitted = false; };
+	}
+
+	public override void _Process(double delta) {
+		if (game.CurrentState != Game.GameState.PlayerTurn) return;
+		if (EngineStorage.HasPendingAnimations()) return;
+
+		// If no unit is selected, move to the next one
+		if (CurrentlySelectedUnit == MapUnit.NONE) {
+			SetNextUnit();
+			return;
+		}
+
+		// If the selected unit is unfortified, prepare to autoselect the next one if it becomes fortified
+		if (!CurrentlySelectedUnit.isFortified)
+			KeepCSUWhenFortified = false;
+
+		if (ShouldSkipUnit(CurrentlySelectedUnit))
+			SetNextUnit();
+	}
+
+	private bool ShouldSkipUnit(MapUnit unit) {
+		bool outOfMovesOrDead = !unit.movementPoints.canMove || unit.hitPointsRemaining <= 0;
+		bool notAttentionWorthy = !game.animationController.animTracker
+			.getUnitAppearance(unit)
+			.DeservesPlayerAttention();
+
+		bool shouldSkipForMovement = outOfMovesOrDead && notAttentionWorthy;
+		bool shouldSkipFortified = unit.isFortified && !KeepCSUWhenFortified;
+		bool shouldSkipAutomated = unit.isAutomated;
+
+		return shouldSkipForMovement || shouldSkipFortified || shouldSkipAutomated;
+	}
+
+	public void SetNextUnit() {
+		SetSelectedUnit(UnitInteractions.getNextSelectedUnit());
+	}
+
+	/**
+	 * Currently (11/14/2021), all unit selection goes through here.
+	 * Both code paths are in Game.cs for now, so it's local, but we may
+	 * want to change it event driven.
+	 *
+	 * Returns whether the selected unit has remaining moves.
+	 **/
+	public bool SetSelectedUnit(MapUnit unit) {
+		unit.availableActions = UnitInteractions.GetAvailableActions(unit);
+
+		if ((unit.path?.PathLength() ?? -1) > 0) {
+			log.Debug("cancelling path for " + unit);
+			unit.path = TilePath.NONE;
+		}
+
+		// Allow cancellation of active worker jobs by clicking on the unit.
+		if (unit.WorkerJob != null) {
+			unit.resetWorkerJob();
+		}
+
+		// Allow cancellation automation via clicking on the unit.
+		if (unit.isAutomated) {
+			unit.isAutomated = false;
+			unit.currentAI = null;
+		}
+
+		this.CurrentlySelectedUnit = unit;
+		this.KeepCSUWhenFortified = unit.isFortified; // If fortified, make sure the autoselector doesn't immediately skip past the unit
+
+		if (unit != MapUnit.NONE) {
+			game.ensureLocationIsInView(unit.location);
+		}
+
+		if (unit != MapUnit.NONE && !unit.movementPoints.canMove) {
+			return false;
+		}
+
+		// Also emit the signal for a new unit being selected, so other areas such as Game Status and Unit Buttons can update
+		if (CurrentlySelectedUnit != MapUnit.NONE) {
+			NoMoreAutoselectableUnitsEmitted = false;
+			ParameterWrapper<MapUnit> wrappedUnit = new(CurrentlySelectedUnit);
+			EmitSignal(SignalName.NewAutoselectedUnit, wrappedUnit);
+			return true;
+		}
+
+		if (!NoMoreAutoselectableUnitsEmitted) {
+			NoMoreAutoselectableUnitsEmitted = true;
+			EmitSignal(SignalName.NoMoreAutoselectableUnits);
+		}
+
+		return false;
+	}
+}

--- a/C7/UnitSelector.cs.uid
+++ b/C7/UnitSelector.cs.uid
@@ -1,0 +1,1 @@
+uid://dflpmvue8o7uo

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -689,6 +689,7 @@ namespace C7GameData {
 			}
 			WorkerJob = terraform;
 			setWorkerJobAnimation(terraform.Action);
+			wake();
 			_ = PerformBusyAction();
 		}
 
@@ -737,6 +738,7 @@ namespace C7GameData {
 		}
 
 		public void automate() {
+			wake();
 			isAutomated = true;
 			WorkerAIData? maybeAiData = WorkerAI.MakeAiData(this, owner);
 			if (maybeAiData == null) {
@@ -753,6 +755,7 @@ namespace C7GameData {
 		}
 
 		public void explore() {
+			wake();
 			isAutomated = true;
 			ExplorerAIData? maybeAiData = ExplorerAI.MaybeMakeAiData(this, owner);
 			if (maybeAiData == null) {

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -57,12 +57,6 @@ namespace C7Engine {
 			if (unit == null) return;
 
 			await unit.move(dir, true);
-
-			// The unit moved to a new tile - if it still has movement points,
-			// update the UI to reflect this new position and movement points.
-			if (unit.movementPoints.canMove == true) {
-				new MsgUpdateUiAfterMove().send();
-			}
 		}
 	}
 
@@ -80,12 +74,6 @@ namespace C7Engine {
 			if (unit == null) return;
 
 			await unit.setUnitPath(path);
-
-			// The unit moved to a new tile - if it still has movement points,
-			// update the UI to reflect this new position and movement points.
-			if (unit.movementPoints.canMove == true) {
-				new MsgUpdateUiAfterMove().send();
-			}
 		}
 	}
 

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -53,8 +53,6 @@ namespace C7Engine {
 
 	public class MsgStartTurn : MessageToUI { }
 
-	public class MsgUpdateUiAfterMove : MessageToUI { }
-
 	public class MsgShowScienceAdvisor : MessageToUI { }
 
 	public class MsgUpdateUiAfterDomesticChange : MessageToUI { }

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -10,12 +10,16 @@ namespace C7Engine {
 		private static Queue<MapUnit> waitQueue = new Queue<MapUnit>();
 		private static ILogger log = Log.ForContext<UnitInteractions>();
 
-		public static MapUnit getNextSelectedUnit(GameData gameData) {
-			foreach (Player player in gameData.players.Where(p => p.isHuman)) {
+		public static MapUnit getNextSelectedUnit() {
+			foreach (Player player in EngineStorage.gameData.players.Where(p => p.isHuman)) {
 				//TODO: Should pass in a player GUID instead of checking for human
 				//This current limits us to one human player, although it's better
 				//than the old limit of one non-barbarian player.
 				foreach (MapUnit unit in player.units.Where(u => u.movementPoints.canMove)) {
+					if (unit.isFortified) {
+						continue;
+					}
+
 					if (unit.IsBusy()) {
 						new MsgPerformUnitAction(unit).send();
 						continue;
@@ -74,8 +78,8 @@ namespace C7Engine {
 			waitQueue.Clear();
 		}
 
-		public static void waitUnit(GameData gameData, ID id) {
-			foreach (MapUnit unit in gameData.mapUnits) {
+		public static void waitUnit(ID id) {
+			foreach (MapUnit unit in EngineStorage.gameData.mapUnits) {
 				if (unit.id == id) {
 					log.Verbose("Found matching unit with id " + id + " of type " + unit.GetType().Name + "; adding it to the wait queue");
 					waitQueue.Enqueue(unit);


### PR DESCRIPTION
This PR separates unit selection logic from the Game class into a new specialized UnitSelector class. The only functional change to unit selection is that the game now waits for the Engine to complete animations before proceeding with auto-selection. For example, the game will wait for the fortifying animation or the first cycle of the worker's job animation before switching to a new unit.

As a side note, I think we should split the Game class further, right now it just has too many different responsibilities. I think the parts for managing UI overlays, handling Goto commands, and probably handling input could make good separate components.

This PR also introduces two small bugfixes:
- The lower-right menu stops blinking when you select a unit instead of finishing the turn.
- Units are now woken before performing worker job or becoming automated. This prevents them from doing nothing while automated.