### PR TITLE
Display textures for borders over hilly terrain

### DIFF
--- a/C7/Lua/texture_configs/c7.lua
+++ b/C7/Lua/texture_configs/c7.lua
@@ -1,9 +1,10 @@
 --[[
-	This configuration file holds a table with texture definitions for "modern" graphics.
+	This configuration file returns a table with texture definitions for "modern" graphics.
 	It produces this table by copying the config of the civ3 assets and replaces the paths to the original Civilization 3 PCX textures with modern PNG versions.
 	To add new replacement texture to the config modify the "c7_texture_list" table.
 --]]
 local civ3_textures = require "civ3"
+local utils = require "utils"
 
 local c7_texture_list = {
   "Art/buttonsFINAL.png",
@@ -101,112 +102,80 @@ local c7_texture_list = {
   "Art/city screen/buildings-large.png",
 }
 
--- Helper: Strip file extension from path
-local function strip_extension(path) return path:match "^(.-)%.[^%.]+$" or path end
-
 -- Build lookup table from c7_texture_list without extensions
 local lookup = {}
 for _, path in ipairs(c7_texture_list) do
-  lookup[strip_extension(path)] = path
+  lookup[utils.strip_extension(path)] = path
 end
 
--- Recursive traversal
-local function traverse(value)
-  -- string leaf
-  if type(value) == "string" then
-    local stripped = strip_extension(value)
-    return lookup[stripped] or value
-
-  -- Table with "path" key
-  elseif type(value) == "table" and type(value.path) == "string" then
-    local stripped = strip_extension(value.path)
-    local png_path = lookup[stripped]
-
-    -- Copy rest of the table (in case it has extra keys)
-    local result = {}
-    for k, v in pairs(value) do
-      result[k] = traverse(v)
-    end
-
-    result.path = png_path or value.path
-
-    return result
-
-  -- General nested table
-  elseif type(value) == "table" then
-    local result = {}
-    for k, v in pairs(value) do
-      result[k] = traverse(v)
-    end
-    return result
-  end
-
-  -- Return any other primitive as-is
-  return value
+local function path_transformer(path)
+  local stripped = utils.strip_extension(path)
+  return lookup[stripped] or path
 end
+
+local c7_textures = utils.transform_paths(civ3_textures, path_transformer)
 
 -- For ease of editing, we define the civ colors as hex codes, not 1x1 px images
-civ3_textures.civ_colors.color_0 = { path = "", hex_color = "F0F8FF" }  -- Alice Blue (whiteish)
-civ3_textures.civ_colors.color_1 = { path = "", hex_color = "E6194B" }  -- Red
-civ3_textures.civ_colors.color_2 = { path = "", hex_color = "F58231" }  -- Orange
-civ3_textures.civ_colors.color_3 = { path = "", hex_color = "FFE119" }  -- Yellow
-civ3_textures.civ_colors.color_4 = { path = "", hex_color = "3CB44B" }  -- Green
-civ3_textures.civ_colors.color_5 = { path = "", hex_color = "4363D8" }  -- Blue
-civ3_textures.civ_colors.color_6 = { path = "", hex_color = "000075" }  -- Navy
-civ3_textures.civ_colors.color_7 = { path = "", hex_color = "FABED4" }  -- Pink
-civ3_textures.civ_colors.color_8 = { path = "", hex_color = "911EB4" }  -- Purple
-civ3_textures.civ_colors.color_9 = { path = "", hex_color = "9A6324" }  -- Brown
-civ3_textures.civ_colors.color_10 = { path = "", hex_color = "AAFFC3" }  -- Mint
-civ3_textures.civ_colors.color_11 = { path = "", hex_color = "42D4F4" }  -- Cyan
-civ3_textures.civ_colors.color_12 = { path = "", hex_color = "F032E6" }  -- Magenta
-civ3_textures.civ_colors.color_13 = { path = "", hex_color = "808000" }  -- Olive
-civ3_textures.civ_colors.color_14 = { path = "", hex_color = "DCBEFF" }  -- Lavender
-civ3_textures.civ_colors.color_15 = { path = "", hex_color = "A9A9A9" }  -- Grey
-civ3_textures.civ_colors.color_16 = { path = "", hex_color = "008080" }  -- Teal
-civ3_textures.civ_colors.color_17 = { path = "", hex_color = "FFD700" }  -- Gold
-civ3_textures.civ_colors.color_18 = { path = "", hex_color = "800000" }  -- Maroon
-civ3_textures.civ_colors.color_19 = { path = "", hex_color = "00FF00" }  -- Lime
-civ3_textures.civ_colors.color_20 = { path = "", hex_color = "FFC0CB" }  -- Hot Pink
-civ3_textures.civ_colors.color_21 = { path = "", hex_color = "4682B4" }  -- Steel Blue
-civ3_textures.civ_colors.color_22 = { path = "", hex_color = "D2B48C" }  -- Tan
-civ3_textures.civ_colors.color_23 = { path = "", hex_color = "FF7F50" }  -- Coral
-civ3_textures.civ_colors.color_24 = { path = "", hex_color = "6A5ACD" }  -- Slate Blue
-civ3_textures.civ_colors.color_25 = { path = "", hex_color = "2E8B57" }  -- Sea Green
-civ3_textures.civ_colors.color_26 = { path = "", hex_color = "DAA520" }  -- Goldenrod
-civ3_textures.civ_colors.color_27 = { path = "", hex_color = "C71585" }  -- Medium Violet Red
-civ3_textures.civ_colors.color_28 = { path = "", hex_color = "556B2F" }  -- Dark Olive Green
-civ3_textures.civ_colors.color_29 = { path = "", hex_color = "8B4513" }  -- Saddle Brown
-civ3_textures.civ_colors.color_30 = { path = "", hex_color = "B0C4DE" }  -- Light Steel Blue
-civ3_textures.civ_colors.color_31 = { path = "", hex_color = "696969" }  -- Dim Gray
+c7_textures.civ_colors.color_0 = { path = "", hex_color = "F0F8FF" } -- Alice Blue (whiteish)
+c7_textures.civ_colors.color_1 = { path = "", hex_color = "E6194B" } -- Red
+c7_textures.civ_colors.color_2 = { path = "", hex_color = "F58231" } -- Orange
+c7_textures.civ_colors.color_3 = { path = "", hex_color = "FFE119" } -- Yellow
+c7_textures.civ_colors.color_4 = { path = "", hex_color = "3CB44B" } -- Green
+c7_textures.civ_colors.color_5 = { path = "", hex_color = "4363D8" } -- Blue
+c7_textures.civ_colors.color_6 = { path = "", hex_color = "000075" } -- Navy
+c7_textures.civ_colors.color_7 = { path = "", hex_color = "FABED4" } -- Pink
+c7_textures.civ_colors.color_8 = { path = "", hex_color = "911EB4" } -- Purple
+c7_textures.civ_colors.color_9 = { path = "", hex_color = "9A6324" } -- Brown
+c7_textures.civ_colors.color_10 = { path = "", hex_color = "AAFFC3" } -- Mint
+c7_textures.civ_colors.color_11 = { path = "", hex_color = "42D4F4" } -- Cyan
+c7_textures.civ_colors.color_12 = { path = "", hex_color = "F032E6" } -- Magenta
+c7_textures.civ_colors.color_13 = { path = "", hex_color = "808000" } -- Olive
+c7_textures.civ_colors.color_14 = { path = "", hex_color = "DCBEFF" } -- Lavender
+c7_textures.civ_colors.color_15 = { path = "", hex_color = "A9A9A9" } -- Grey
+c7_textures.civ_colors.color_16 = { path = "", hex_color = "008080" } -- Teal
+c7_textures.civ_colors.color_17 = { path = "", hex_color = "FFD700" } -- Gold
+c7_textures.civ_colors.color_18 = { path = "", hex_color = "800000" } -- Maroon
+c7_textures.civ_colors.color_19 = { path = "", hex_color = "00FF00" } -- Lime
+c7_textures.civ_colors.color_20 = { path = "", hex_color = "FFC0CB" } -- Hot Pink
+c7_textures.civ_colors.color_21 = { path = "", hex_color = "4682B4" } -- Steel Blue
+c7_textures.civ_colors.color_22 = { path = "", hex_color = "D2B48C" } -- Tan
+c7_textures.civ_colors.color_23 = { path = "", hex_color = "FF7F50" } -- Coral
+c7_textures.civ_colors.color_24 = { path = "", hex_color = "6A5ACD" } -- Slate Blue
+c7_textures.civ_colors.color_25 = { path = "", hex_color = "2E8B57" } -- Sea Green
+c7_textures.civ_colors.color_26 = { path = "", hex_color = "DAA520" } -- Goldenrod
+c7_textures.civ_colors.color_27 = { path = "", hex_color = "C71585" } -- Medium Violet Red
+c7_textures.civ_colors.color_28 = { path = "", hex_color = "556B2F" } -- Dark Olive Green
+c7_textures.civ_colors.color_29 = { path = "", hex_color = "8B4513" } -- Saddle Brown
+c7_textures.civ_colors.color_30 = { path = "", hex_color = "B0C4DE" } -- Light Steel Blue
+c7_textures.civ_colors.color_31 = { path = "", hex_color = "696969" } -- Dim Gray
 
-
-civ3_textures.animations.cursor = {
-    path = "Art/Animations/Cursor.png",
-    animation_rows = 2,
-    animation_cols = 9,
-    frame_duration = .6
+c7_textures.animations.cursor = {
+  path = "Art/Animations/Cursor.png",
+  animation_rows = 2,
+  animation_cols = 9,
+  frame_duration = 0.6,
 }
-civ3_textures.animations.disorder = {
-    path = "Art/Animations/DisorderDefault.png",
-    animation_rows = 1,
-    animation_cols = 6,
-    frame_duration = .6
+c7_textures.animations.disorder = {
+  path = "Art/Animations/DisorderDefault.png",
+  animation_rows = 1,
+  animation_cols = 6,
+  frame_duration = 0.6,
 }
 
-function civ3_textures.tech_icons.small:map_object_to_sprite(tech)
-  if (tech:GetType().Name ~= "Tech") then
-    error "Expected a Tech object"
-  end
-
+function c7_textures.tech_icons.small:map_object_to_sprite(tech)
   return {
     path = "Art/Tech Chooser/Icons/placeholder.png",
   }
 end
 
-function civ3_textures.leader_heads:map_object_to_sprite(player_or_civ)
+function c7_textures.leader_heads:map_object_to_sprite(player_or_civ)
   return {
     path = "Art/Advisors/placeholder_leaderhead.png",
   }
 end
 
-return traverse(civ3_textures)
+function c7_textures.borders:find_column(_)
+  return 0
+end
+
+return c7_textures

--- a/C7/Lua/texture_configs/civ3.lua
+++ b/C7/Lua/texture_configs/civ3.lua
@@ -458,5 +458,6 @@ textures.unit_icons = require "civ3.unit_icons"
 textures.building_icons = require "civ3.building_icons"
 textures.tech_icons = require "civ3.tech_icons"
 textures.leader_heads = require "civ3.leader_heads"
+textures.borders = require "civ3.borders"
 
 return textures

--- a/C7/Lua/texture_configs/civ3/advisor_heads.lua
+++ b/C7/Lua/texture_configs/civ3/advisor_heads.lua
@@ -13,7 +13,7 @@ local advisor_heads = {
 }
 
 function advisor_heads:map_object_to_sprite(details)
-  if (details:GetType().Name ~= "AdvisorGraphicsDetails") then
+  if details:GetType().Name ~= "AdvisorGraphicsDetails" then
     error "Expected a AdvisorGraphicsDetails object"
   end
 
@@ -47,12 +47,13 @@ function advisor_heads:map_object_to_sprite(details)
 
   return {
     path = path,
-    crop_region = { 
-        1 + mood_col * IMAGE_SIZE, 
-        (details.eraIndex + 1) * IMAGE_SIZE - CROP_HEIGHT,
-        IMAGE_SIZE - 1,
-        CROP_HEIGHT,
+    crop_region = {
+      1 + mood_col * IMAGE_SIZE,
+      (details.eraIndex + 1) * IMAGE_SIZE - CROP_HEIGHT,
+      IMAGE_SIZE - 1,
+      CROP_HEIGHT,
     },
+    shadows = false,
   }
 end
 

--- a/C7/Lua/texture_configs/civ3/borders.lua
+++ b/C7/Lua/texture_configs/civ3/borders.lua
@@ -1,0 +1,42 @@
+local texture_width = 128
+local texture_height = 72
+
+--[[
+The PCX image contains 4 rows and 2 columns:
+Each row corresponds to a border direction.
+The first column contains border textures for regular terrain.
+The second column contains border textures for hills and mountains
+-]]
+local borders = { extra_data = { path = "Art/Terrain/Territory.pcx" } }
+
+function borders:find_column(border_config)
+  local column = 0
+  if border_config.isHilly then
+    column = 1
+  end
+  return column
+end
+
+function borders:find_row(border_config)
+  local direction = border_config.direction
+  local direction_to_row = {
+    [direction.NORTHWEST] = 0,
+    [direction.NORTHEAST] = 1,
+    [direction.SOUTHWEST] = 2,
+    [direction.SOUTHEAST] = 3,
+  }
+  return direction_to_row[direction]
+end
+
+function borders:map_object_to_sprite(border_config)
+  local column = self:find_column(border_config)
+  local row = self:find_row(border_config)
+
+  return {
+    path = self.extra_data.path,
+    transparent_color_indexes = { 1, 254, 255 },
+    crop_region = { column * texture_width, row * texture_height, texture_width, texture_height },
+  }
+end
+
+return borders

--- a/C7/Lua/texture_configs/civ3/terrain.lua
+++ b/C7/Lua/texture_configs/civ3/terrain.lua
@@ -147,27 +147,4 @@ terrain.fog_of_war = {
   pure_alpha = true,
 }
 
-terrain.borders = {
-  northwest_flat = {
-    path = TERRAIN .. "Territory.pcx",
-    transparent_color_indexes = { 1, 254, 255 },
-    crop_region = { 0, 0, 128, 72, }
-  },
-  northeast_flat = {
-    path = TERRAIN .. "Territory.pcx",
-    transparent_color_indexes = { 1, 254, 255 },
-    crop_region = { 0, 72, 128, 72, }
-  },
-  southwest_flat = {
-    path = TERRAIN .. "Territory.pcx",
-    transparent_color_indexes = { 1, 254, 255 },
-    crop_region = { 0, 144, 128, 72, }
-  },
-  southeast_flat = {
-    path = TERRAIN .. "Territory.pcx",
-    transparent_color_indexes = { 1, 254, 255 },
-    crop_region = { 0, 216, 128, 72, }
-  },
-}
-
 return terrain

--- a/C7/Lua/texture_configs/utils.lua
+++ b/C7/Lua/texture_configs/utils.lua
@@ -1,0 +1,24 @@
+-- Recursively walk the configuration table, copying the table and
+-- applying 'path_transformer' to texture paths
+local function transform_paths(value, path_transformer)
+  if type(value) == "string" then
+    return path_transformer(value)
+  end
+
+  if type(value) == "table" then
+    local result = {}
+    for k, v in pairs(value) do
+      result[k] = transform_paths(v, path_transformer)
+    end
+    return result
+  end
+
+  return value
+end
+
+-- Helper: Strip file extension from path
+local function strip_extension(path)
+  return path:match "^(.-)%.[^%.]+$" or path
+end
+
+return { transform_paths = transform_paths, strip_extension = strip_extension }

--- a/C7/Map/BorderLayer.cs
+++ b/C7/Map/BorderLayer.cs
@@ -2,22 +2,17 @@ using System.Collections.Generic;
 using C7GameData;
 using Godot;
 using ConvertCiv3Media;
+using System;
 
 namespace C7.Map {
 	// The layer responsible for drawing civilization borders.
 	public class BorderLayer : LooseLayer {
-		private readonly string texturePath = "Art/Terrain/Territory.pcx";
-		private readonly ImageTexture[] borderGraphics = new ImageTexture[8];
+		public record struct TextureDetails(
+			TileDirection direction,
+			bool isHilly
+		);
 
-		private readonly Dictionary<TileDirection, ImageTexture> directionToTexture = new();
-		private readonly Dictionary<(TileDirection, Color), ImageTexture> textureCache = new();
-
-		public BorderLayer() {
-			directionToTexture[TileDirection.NORTHWEST] = TextureLoader.Load("terrain.borders.northwest_flat");
-			directionToTexture[TileDirection.NORTHEAST] = TextureLoader.Load("terrain.borders.northeast_flat");
-			directionToTexture[TileDirection.SOUTHWEST] = TextureLoader.Load("terrain.borders.southwest_flat");
-			directionToTexture[TileDirection.SOUTHEAST] = TextureLoader.Load("terrain.borders.southeast_flat");
-		}
+		private readonly Dictionary<(TextureDetails, Color), ImageTexture> textureCache = new();
 
 		// TODO: This method doesn't precisely mirror Civ3 coloring
 		private static Color CalcSecondaryColor(Color mainColor) {
@@ -29,16 +24,21 @@ namespace C7.Map {
 		/// - The color of civilization, passed as an argument to this method.
 		/// - The secondary color, which is derived from the civilization color.
 		/// The resulting texture is cached.
-		private ImageTexture GetBorderTexture(TileDirection dir, Color borderColor) {
-			if (textureCache.TryGetValue((dir, borderColor), out ImageTexture res)) {
+		private ImageTexture GetBorderTexture(Tile tile, TileDirection dir, Color borderColor) {
+			TextureDetails textureDetails = new() {
+				direction = dir,
+				isHilly = tile.overlayTerrainType.isHilly() && tile.neighbors[dir].overlayTerrainType.isHilly()
+			};
+
+			if (textureCache.TryGetValue((textureDetails, borderColor), out ImageTexture res)) {
 				return res;
 			}
 
-			ImageTexture texture = directionToTexture[dir];
+			ImageTexture texture = TextureLoader.Load("borders", textureDetails);
 
 			Color secondaryColor = CalcSecondaryColor(borderColor);
 
-			Dictionary<Color, Color> colorReplacements = new Dictionary<Color, Color>
+			Dictionary<Color, Color> colorReplacements = new()
 			{
 				{ Color.Color8(236, 255, 0), borderColor },
 				{ Color.Color8(255, 0, 0), secondaryColor}
@@ -47,7 +47,7 @@ namespace C7.Map {
 			Image image = Util.TransformColors(texture.GetImage(), colorReplacements);
 
 			var newTexture = ImageTexture.CreateFromImage(image);
-			textureCache[(dir, borderColor)] = newTexture;
+			textureCache[(textureDetails, borderColor)] = newTexture;
 
 			return newTexture;
 		}
@@ -58,10 +58,11 @@ namespace C7.Map {
 			}
 
 			Color borderColor = TextureLoader.LoadColor(tile.owningCity.owner.colorIndex);
+			TileDirection[] borderDirections = [TileDirection.NORTHEAST, TileDirection.NORTHWEST, TileDirection.SOUTHEAST, TileDirection.SOUTHWEST];
 
-			foreach (TileDirection dir in directionToTexture.Keys) {
+			foreach (TileDirection dir in borderDirections) {
 				if (tile.neighbors[dir].owningCity?.owner != tile.owningCity?.owner) {
-					ImageTexture texture = GetBorderTexture(dir, borderColor);
+					ImageTexture texture = GetBorderTexture(tile, dir, borderColor);
 					Vector2 size = texture.GetSize();
 					Vector2 offset = size/2;
 					// this value were found experimentally to improve alignment with the grid

--- a/C7/TextureLoader.cs
+++ b/C7/TextureLoader.cs
@@ -86,7 +86,7 @@ public static class TextureLoader {
 		// the LuaRulesEngine static constructor.
 		UserData.RegisterType<CityGraphicsDetails>();
 		UserData.RegisterType<PopHead.TextureKey>();
-		UserData.RegisterType<Civilization>();
+		UserData.RegisterType<BorderLayer.TextureDetails>();
 
 		// Note, we register all of AdvisorHeader rather than just
 		// AdvisorHead.AdvisorGraphicsDetails because we access the nums


### PR DESCRIPTION
This PR adds logic for displaying textures for borders that go through mountains, hills and volcanoes. It also includes a minor cleanup in lua texture scripts. The change doesn't affect the standalone mode, since we don't yet have custom graphics for this type of border.

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/e15f41fb-4074-4ea5-a90a-9cccc866a71f" />
