### PR TITLE
Refactor: Decouple Terraform from UnitAction

### DIFF
--- a/C7/Actions.cs.uid
+++ b/C7/Actions.cs.uid
@@ -1,1 +1,0 @@
-uid://cs3anpqv1ke8b

--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -236,6 +236,7 @@ control = NodePath("../Control")
 unique_name_in_owner = true
 visible = false
 
+[connection signal="GameInitialized" from="." to="CanvasLayer/Control/UnitButtons" method="SetUpControlButtons"]
 [connection signal="ShowCityScreen" from="." to="CanvasLayer/CityScreen" method="OnShowCityScreen"]
 [connection signal="ShowSpecificAdvisor" from="." to="CanvasLayer/Advisor" method="OnShowSpecificAdvisor"]
 [connection signal="TurnEnded" from="." to="CanvasLayer/Control/GameStatus/LowerRightInfoBox" method="StopToggling"]

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -16,6 +16,8 @@ public partial class Game : Node {
 	[Signal] public delegate void PlayerTurnStartEventHandler();
 	[Signal] public delegate void PlayerTurnEndEventHandler();
 
+	[Signal] public delegate void GameInitializedEventHandler();
+
 	private ILogger log = LogManager.ForContext<Game>();
 
 	public enum GameState {
@@ -127,6 +129,8 @@ public partial class Game : Node {
 			loadTimer.Stop();
 			TimeSpan stopwatchElapsed = loadTimer.Elapsed;
 			log.Information("Game scene load time: " + Convert.ToInt32(stopwatchElapsed.TotalMilliseconds) + " ms");
+
+			EmitSignal(SignalName.GameInitialized);
 		} catch (Exception ex) {
 			errorOnLoad = true;
 			string message = ex.Message;

--- a/C7/Lua/rules/civ3/terraforms.lua
+++ b/C7/Lua/rules/civ3/terraforms.lua
@@ -1,29 +1,40 @@
 local UnitAction = ENUMS.UnitAction
 local YieldType = ENUMS.Tile_YieldType
+local Civ3FoliageAction = ENUMS.TerrainType_Civ3FoliageAction
 
 local terraforms = {
-  mine_validator = function(context)
-    local mine = context.terraform.Improvement
-    return mine:GetYieldBonus(context.tile.overlayTerrainType, YieldType.Production) > 0
-  end,
+  mine = {
+    validator = function(context)
+      local mine = context.terraform.Improvement
+      return mine:GetYieldBonus(context.tile.overlayTerrainType, YieldType.Production) > 0
+    end,
+  },
 
-  irrigate_validator = function(context)
-    local irrigation = context.terraform.Improvement
-    return context.tile:CanBeIrrigated(irrigation, context.player)
-  end,
+  irrigate = {
+    validator = function(context)
+      local irrigation = context.terraform.Improvement
+      return context.tile:CanBeIrrigated(irrigation, context.player)
+    end,
+  },
 
-  clear_foliage_validator = function(context)
-    return context.tile.overlayTerrainType.allowedWorkerActions:Contains(context.terraform.Action)
-  end,
+  clear_wetlands = {
+    validator = function(context)
+      return context.tile.overlayTerrainType.allowedFoliageAction == Civ3FoliageAction.ClearWetlands
+    end,
+    effect = function(context)
+      context.tile:ClearTerrainOverlay()
+    end,
+  },
 
-  clear_wetlands_effect = function(context)
-    context.tile:ClearTerrainOverlay()
-  end,
-
-  clear_forest_effect = function(context)
-    context.tile:MaybeAwardForestClearingShields()
-    context.tile:ClearTerrainOverlay()
-  end,
+  clear_forest = {
+    validator = function(context)
+      return context.tile.overlayTerrainType.allowedFoliageAction == Civ3FoliageAction.ClearForest
+    end,
+    effect = function(context)
+      context.tile:MaybeAwardForestClearingShields()
+      context.tile:ClearTerrainOverlay()
+    end,
+  },
 }
 
 return terraforms

--- a/C7/Lua/texture_configs/civ3/unit_control.lua
+++ b/C7/Lua/texture_configs/civ3/unit_control.lua
@@ -3,19 +3,19 @@ local INTERFACE = "Art/interface/"
 local function make_entry(x, y)
   local entry = {
     normal = {
-        path = INTERFACE .. "NormButtons.PCX",
-        alpha = INTERFACE .. "ButtonAlpha.pcx",
-        crop_region = { x * 32, y * 32, 32, 32 },
+      path = INTERFACE .. "NormButtons.PCX",
+      alpha = INTERFACE .. "ButtonAlpha.pcx",
+      crop_region = { x * 32, y * 32, 32, 32 },
     },
     hover = {
-        path = INTERFACE .. "rolloverbuttons.PCX",
-        alpha = INTERFACE .. "ButtonAlpha.pcx",
-        crop_region = { x * 32, y * 32, 32, 32 },
+      path = INTERFACE .. "rolloverbuttons.PCX",
+      alpha = INTERFACE .. "ButtonAlpha.pcx",
+      crop_region = { x * 32, y * 32, 32, 32 },
     },
     pressed = {
-        path = INTERFACE .. "highlightedbuttons.PCX",
-        alpha = INTERFACE .. "ButtonAlpha.pcx",
-        crop_region = { x * 32, y * 32, 32, 32 },
+      path = INTERFACE .. "highlightedbuttons.PCX",
+      alpha = INTERFACE .. "ButtonAlpha.pcx",
+      crop_region = { x * 32, y * 32, 32, 32 },
     },
   }
 
@@ -23,27 +23,34 @@ local function make_entry(x, y)
 end
 
 local unit_control = {
-    unit_hold = make_entry(0, 0),
-    unit_wait = make_entry(1, 0),
-    unit_fortify = make_entry(2, 0),
-    unit_disband = make_entry(3, 0),
-    unit_goto = make_entry(4, 0),
-    unit_explore = make_entry(5, 0),
+  unit_hold = make_entry(0, 0),
+  unit_wait = make_entry(1, 0),
+  unit_fortify = make_entry(2, 0),
+  unit_disband = make_entry(3, 0),
+  unit_goto = make_entry(4, 0),
+  unit_explore = make_entry(5, 0),
 
-    unit_build_city = make_entry(5, 2),
-    unit_build_road = make_entry(6, 2),
-    unit_build_railroad = make_entry(7, 2),
+  unit_build_city = make_entry(5, 2),
+  unit_build_road = make_entry(6, 2),
+  unit_build_railroad = make_entry(7, 2),
 
-    unit_build_mine = make_entry(1, 3),
-    unit_irrigate = make_entry(2, 3),
-    unit_clear_forest = make_entry(3, 3),
-    unit_clear_wetlands = make_entry(4, 3),
-    unit_automate = make_entry(7, 3),
+  unit_build_fortress = make_entry(0, 3),
+  unit_build_mine = make_entry(1, 3),
+  unit_irrigate = make_entry(2, 3),
+  unit_clear_forest = make_entry(3, 3),
+  unit_clear_wetlands = make_entry(4, 3),
+  unit_plant_forest = make_entry(5, 3),
+  unit_clear_damage = make_entry(6, 3),
+  unit_automate = make_entry(7, 3),
+  unit_build_airfield = make_entry(1, 4),
+  unit_build_radar_tower = make_entry(2, 4),
+  unit_build_outpost = make_entry(3, 4),
+  unit_build_barricade = make_entry(4, 4),
 
-    movement_indicators = {
-        path = INTERFACE .. "MovementLED.PCX",
-		crop_region = { 0, 0, 36, 8, },
-	},
+  movement_indicators = {
+    path = INTERFACE .. "MovementLED.PCX",
+    crop_region = { 0, 0, 36, 8 },
+  },
 }
 
 return unit_control

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -68124,7 +68124,8 @@
         "Incense",
         "Oasis"
       ],
-      "height": 0
+      "height": 0,
+      "allowedFoliageAction": "none"
     },
     {
       "key": "plains",
@@ -68134,9 +68135,6 @@
       "baseCommerceProduction": 0,
       "movementCost": 1,
       "allowCities": true,
-      "allowedWorkerActions": [
-        "plantForest"
-      ],
       "defenseBonus": {
         "description": "Plains",
         "amount": 0.1
@@ -68149,7 +68147,8 @@
         "Wheat",
         "Sugar"
       ],
-      "height": 0
+      "height": 0,
+      "allowedFoliageAction": "plantForest"
     },
     {
       "key": "grassland",
@@ -68159,9 +68158,6 @@
       "baseCommerceProduction": 0,
       "movementCost": 1,
       "allowCities": true,
-      "allowedWorkerActions": [
-        "plantForest"
-      ],
       "defenseBonus": {
         "description": "Grassland",
         "amount": 0.1
@@ -68173,7 +68169,8 @@
         "Wheat",
         "Tobacco"
       ],
-      "height": 0
+      "height": 0,
+      "allowedFoliageAction": "plantForest"
     },
     {
       "key": "tundra",
@@ -68183,9 +68180,6 @@
       "baseCommerceProduction": 0,
       "movementCost": 1,
       "allowCities": true,
-      "allowedWorkerActions": [
-        "plantForest"
-      ],
       "defenseBonus": {
         "description": "Tundra",
         "amount": 0.1
@@ -68196,7 +68190,8 @@
         "Furs",
         "Game"
       ],
-      "height": 0
+      "height": 0,
+      "allowedFoliageAction": "plantForest"
     },
     {
       "key": "flood plain",
@@ -68213,7 +68208,8 @@
       "allowedResources": [
         "Wheat"
       ],
-      "height": 0
+      "height": 0,
+      "allowedFoliageAction": "none"
     },
     {
       "key": "hills",
@@ -68239,7 +68235,8 @@
         "Sugar",
         "Tobacco"
       ],
-      "height": 2
+      "height": 2,
+      "allowedFoliageAction": "none"
     },
     {
       "key": "mountains",
@@ -68261,7 +68258,8 @@
         "Gems",
         "Gold"
       ],
-      "height": 4
+      "height": 4,
+      "allowedFoliageAction": "none"
     },
     {
       "key": "forest",
@@ -68271,9 +68269,6 @@
       "baseCommerceProduction": 0,
       "movementCost": 2,
       "allowCities": true,
-      "allowedWorkerActions": [
-        "clearForest"
-      ],
       "defenseBonus": {
         "description": "Forest",
         "amount": 0.25
@@ -68288,7 +68283,8 @@
         "Silks",
         "Game"
       ],
-      "height": 1
+      "height": 1,
+      "allowedFoliageAction": "clearForest"
     },
     {
       "key": "jungle",
@@ -68298,9 +68294,6 @@
       "baseCommerceProduction": 0,
       "movementCost": 3,
       "allowCities": true,
-      "allowedWorkerActions": [
-        "clearWetlands"
-      ],
       "defenseBonus": {
         "description": "Jungle",
         "amount": 0.25
@@ -68314,7 +68307,8 @@
         "Gems",
         "Tropical Fruit"
       ],
-      "height": 1
+      "height": 1,
+      "allowedFoliageAction": "clearWetlands"
     },
     {
       "key": "marsh",
@@ -68324,9 +68318,6 @@
       "baseCommerceProduction": 0,
       "movementCost": 2,
       "allowCities": false,
-      "allowedWorkerActions": [
-        "clearWetlands"
-      ],
       "defenseBonus": {
         "description": "Marsh",
         "amount": 0.2
@@ -68337,7 +68328,8 @@
         "Game",
         "Fish"
       ],
-      "height": -2
+      "height": -2,
+      "allowedFoliageAction": "clearWetlands"
     },
     {
       "key": "volcano",
@@ -68351,7 +68343,8 @@
         "description": "Volcano",
         "amount": 0.8
       },
-      "height": 4
+      "height": 4,
+      "allowedFoliageAction": "none"
     },
     {
       "key": "coast",
@@ -68368,7 +68361,8 @@
       "allowedResources": [
         "Fish"
       ],
-      "height": -2
+      "height": -2,
+      "allowedFoliageAction": "none"
     },
     {
       "key": "sea",
@@ -68386,7 +68380,8 @@
         "Whales",
         "Fish"
       ],
-      "height": -2
+      "height": -2,
+      "allowedFoliageAction": "none"
     },
     {
       "key": "ocean",
@@ -68400,7 +68395,8 @@
         "description": "Ocean",
         "amount": 0.1
       },
-      "height": -2
+      "height": -2,
+      "allowedFoliageAction": "none"
     }
   ],
   "terrainImprovements": [
@@ -69218,14 +69214,6 @@
         "Land"
       ],
       "actions": [
-        "buildRoad",
-        "buildRailroad",
-        "buildMine",
-        "irrigate",
-        "clearWetlands",
-        "clearForest",
-        "buildBarricade",
-        "buildFortress",
         "hold",
         "wait",
         "fortify",
@@ -69233,6 +69221,16 @@
         "goto",
         "explore",
         "automate"
+      ],
+      "terraformActions": [
+        "Terraform-4",
+        "Terraform-5",
+        "Terraform-1",
+        "Terraform-2",
+        "Terraform-8",
+        "Terraform-7",
+        "Terraform-13",
+        "Terraform-3"
       ]
     },
     {
@@ -72308,6 +72306,9 @@
         "disband",
         "goto",
         "explore"
+      ],
+      "terraformActions": [
+        "Terraform-3"
       ]
     },
     {
@@ -77275,22 +77276,26 @@
       "name": "Mine",
       "civilopediaEntry": "TFRM_Mine",
       "turnsToComplete": 12,
-      "action": "buildMine",
       "improvement": "mine",
       "validators": [
-        "terraforms.mine_validator"
-      ]
+        "terraforms.mine.validator"
+      ],
+      "animation": "mine",
+      "uiAction": "unit_build_mine",
+      "buttonTexture": "ui.unit_control.unit_build_mine"
     },
     {
       "id": "Terraform-2",
       "name": "Irrigation",
       "civilopediaEntry": "TFRM_Irrigation",
       "turnsToComplete": 8,
-      "action": "irrigate",
       "improvement": "irrigation",
       "validators": [
-        "terraforms.irrigate_validator"
-      ]
+        "terraforms.irrigate.validator"
+      ],
+      "animation": "irrigate",
+      "uiAction": "unit_irrigate",
+      "buttonTexture": "ui.unit_control.unit_irrigate"
     },
     {
       "id": "Terraform-3",
@@ -77298,16 +77303,20 @@
       "civilopediaEntry": "TFRM_Fortress",
       "turnsToComplete": 16,
       "requiredTech": "tech-21",
-      "action": "buildFortress",
-      "improvement": "fortress"
+      "improvement": "fortress",
+      "animation": "fortress",
+      "uiAction": "unit_build_fortress",
+      "buttonTexture": "ui.unit_control.unit_build_fortress"
     },
     {
       "id": "Terraform-4",
       "name": "Road",
       "civilopediaEntry": "TFRM_Road",
       "turnsToComplete": 6,
-      "action": "buildRoad",
-      "improvement": "road"
+      "improvement": "road",
+      "animation": "road",
+      "uiAction": "unit_build_road",
+      "buttonTexture": "ui.unit_control.unit_build_road"
     },
     {
       "id": "Terraform-5",
@@ -77319,8 +77328,10 @@
         "Iron",
         "Coal"
       ],
-      "action": "buildRailroad",
-      "improvement": "railroad"
+      "improvement": "railroad",
+      "animation": "road",
+      "uiAction": "unit_build_railroad",
+      "buttonTexture": "ui.unit_control.unit_build_railroad"
     },
     {
       "id": "Terraform-6",
@@ -77328,40 +77339,47 @@
       "civilopediaEntry": "TFRM_Plant_Forest",
       "turnsToComplete": 18,
       "requiredTech": "tech-24",
-      "action": "plantForest"
+      "animation": "plant",
+      "uiAction": "unit_plant_forest",
+      "buttonTexture": "ui.unit_control.unit_plant_forest"
     },
     {
       "id": "Terraform-7",
       "name": "Clear Forest",
       "civilopediaEntry": "TFRM_Clear_Forest",
       "turnsToComplete": 4,
-      "action": "clearForest",
       "validators": [
-        "terraforms.clear_foliage_validator"
+        "terraforms.clear_forest.validator"
       ],
       "effects": [
-        "terraforms.clear_forest_effect"
-      ]
+        "terraforms.clear_forest.effect"
+      ],
+      "animation": "forest",
+      "uiAction": "unit_clear_forest",
+      "buttonTexture": "ui.unit_control.unit_clear_forest"
     },
     {
       "id": "Terraform-8",
       "name": "Clear Wetlands",
       "civilopediaEntry": "TFRM_Clear_Wetlands",
       "turnsToComplete": 16,
-      "action": "clearWetlands",
       "validators": [
-        "terraforms.clear_foliage_validator"
+        "terraforms.clear_wetlands.validator"
       ],
       "effects": [
-        "terraforms.clear_wetlands_effect"
-      ]
+        "terraforms.clear_wetlands.effect"
+      ],
+      "animation": "jungle",
+      "uiAction": "unit_clear_wetlands",
+      "buttonTexture": "ui.unit_control.unit_clear_wetlands"
     },
     {
       "id": "Terraform-9",
       "name": "Clear Damage",
       "civilopediaEntry": "TFRM_Clear_Damage",
       "turnsToComplete": 24,
-      "action": "clearDamage"
+      "uiAction": "unit_clear_damage",
+      "buttonTexture": "ui.unit_control.unit_clear_damage"
     },
     {
       "id": "Terraform-10",
@@ -77369,7 +77387,8 @@
       "civilopediaEntry": "TFRM_Airfield",
       "turnsToComplete": 1,
       "requiredTech": "tech-59",
-      "action": "buildAirfield"
+      "uiAction": "unit_build_airfield",
+      "buttonTexture": "ui.unit_control.unit_build_airfield"
     },
     {
       "id": "Terraform-11",
@@ -77377,7 +77396,8 @@
       "civilopediaEntry": "TFRM_Radar_Tower",
       "turnsToComplete": 1,
       "requiredTech": "tech-64",
-      "action": "buildRadarTower"
+      "uiAction": "unit_build_radar_tower",
+      "buttonTexture": "ui.unit_control.unit_build_radar_tower"
     },
     {
       "id": "Terraform-12",
@@ -77385,7 +77405,8 @@
       "civilopediaEntry": "TFRM_Outpost",
       "turnsToComplete": 1,
       "requiredTech": "tech-2",
-      "action": "buildOutpost"
+      "uiAction": "unit_build_outpost",
+      "buttonTexture": "ui.unit_control.unit_build_outpost"
     },
     {
       "id": "Terraform-13",
@@ -77393,8 +77414,10 @@
       "civilopediaEntry": "TFRM_Barricades",
       "turnsToComplete": 16,
       "requiredTech": "tech-21",
-      "action": "buildBarricade",
-      "improvement": "barricade"
+      "improvement": "barricade",
+      "animation": "fortress",
+      "uiAction": "unit_build_barricade",
+      "buttonTexture": "ui.unit_control.unit_build_barricade"
     }
   ],
   "governments": [

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -1,7 +1,9 @@
 using Godot;
 using System.Collections.Generic;
+using C7Engine;
 using C7GameData;
 using Serilog;
+using System.Linq;
 
 /*
  UnitButtons contains the buttons at the bottom of the game UI when viewing the
@@ -25,12 +27,20 @@ public partial class UnitButtons : VBoxContainer {
 	[Export]
 	HBoxContainer advancedControls;
 
-	// Called when the node enters the scene tree for the first time.
-	public override void _Ready() {
-		// You can hide buttons like this.  This will come in handy later!
-		// Remember to re-calc the margin after hiding/unhiding buttons, as that may affect the width.
-		// this.GetNode<FortifyButton>("PrimaryUnitControls/FortifyButton").Hide();
+	private static readonly  string[] terraformOrder = [
+		C7Action.UnitBuildRoad,
+		C7Action.UnitBuildRailroad,
+		C7Action.UnitBuildMine,
+		C7Action.UnitIrrigate,
+		C7Action.UnitClearForest,
+		C7Action.UnitClearWetlands,
+		C7Action.UnitBuildFortress,
+		C7Action.UnitBuildBarricade,
+		C7Action.UnitPlantForest,
+		C7Action.UnitClearDamage,
+	];
 
+	private void SetUpControlButtons() {
 		AddNewButton(primaryControls, C7Action.UnitHold);
 		AddNewButton(primaryControls, C7Action.UnitWait);
 		AddNewButton(primaryControls, C7Action.UnitFortify);
@@ -50,26 +60,28 @@ public partial class UnitButtons : VBoxContainer {
 		//superfortify?
 		// AddNewButton(specializedControls, "hurryBuilding");
 		// AddNewButton(specializedControls, "upgrade");
-
-		//TODO: The first two buttons in row index 2, and validate science age/colony are correct
 		// AddNewButton(specializedControls, "sacrifice");
-		// AddNewButton(specializedControls, "scienceAge");  //validate
-		// AddNewButton(specializedControls, "buildColony"); //validate
+		// AddNewButton(specializedControls, "scienceAge");
 		AddNewButton(specializedControls, C7Action.UnitBuildCity);
-		AddNewButton(specializedControls, C7Action.UnitBuildRoad);
-		AddNewButton(specializedControls, C7Action.UnitBuildRailroad);
 
-		// AddNewButton(specializedControls, C7Action.UnitBuildFortress);
-		// AddNewButton(specializedControls, C7Action.UnitBuildBarricade);
-		AddNewButton(specializedControls, C7Action.UnitBuildMine);
-		AddNewButton(specializedControls, C7Action.UnitIrrigate);
-		AddNewButton(specializedControls, C7Action.UnitClearForest);
-		AddNewButton(specializedControls, C7Action.UnitClearWetlands);
-		// AddNewButton(specializedControls, "plantForest");
-		// AddNewButton(specializedControls, "clearDamage");
+		SetUpTerraformButtons();
+
 		AddNewButton(specializedControls, C7Action.UnitAutomate);
 
 		// Row index 4 and later not yet added
+	}
+
+	private void SetUpTerraformButtons() {
+		var terraformOrderMap = terraformOrder
+			.Select((action, index) => new { action, index })
+			.ToDictionary(x => x.action, x => x.index);
+
+		var sortedTerraforms = EngineStorage.gameData.Terraforms
+			.OrderBy(tf => terraformOrderMap.TryGetValue(tf.UIAction, out var idx) ? idx : int.MaxValue);
+
+		foreach (Terraform tf in sortedTerraforms) {
+			AddNewButton(specializedControls, tf.UIAction);
+		}
 	}
 
 	private void AddNewButton(HBoxContainer row, string action) {
@@ -91,16 +103,19 @@ public partial class UnitButtons : VBoxContainer {
 			button.Visible = false;
 		}
 
+		var unitActions = unit.GetAvailableActions().Select(C7Action.ToActionString);
+		var terraformActions = unit.GetAvailableTerraforms().Select(t => t.UIAction);
+		IEnumerable<string> availableActions = unitActions.Concat(terraformActions);
+
 		// Mark all the buttons corresponding to the unit's available actions
 		// as visible. We do this rather than using the unit prototype's actions
 		// so that we don't display buttons that do nothing - we don't want to
 		// show the "road" button if we can't build a road, etc.
-		foreach (UnitAction action in unit.availableActions) {
-			string actionKey = C7Action.ToActionString(action);
-			if (buttonMap.ContainsKey(actionKey)) {
-				buttonMap[actionKey].Visible = true;
+		foreach (string actionKey in availableActions) {
+			if (buttonMap.TryGetValue(actionKey, out TextureButton value)) {
+				value.Visible = true;
 			} else {
-				log.Warning("Could not find button " + action);
+				log.Warning("Could not find button " + actionKey);
 			}
 		}
 

--- a/C7/UnitSelector.cs
+++ b/C7/UnitSelector.cs
@@ -72,8 +72,6 @@ public partial class UnitSelector : Node {
 	 * Returns whether the selected unit has remaining moves.
 	 **/
 	public bool SetSelectedUnit(MapUnit unit) {
-		unit.availableActions = UnitInteractions.GetAvailableActions(unit);
-
 		if ((unit.path?.PathLength() ?? -1) > 0) {
 			log.Debug("cancelling path for " + unit);
 			unit.path = TilePath.NONE;

--- a/C7Engine/AI/ChooseProducible.cs
+++ b/C7Engine/AI/ChooseProducible.cs
@@ -51,7 +51,7 @@ namespace C7Engine {
 
 		private static float ScoreUnit(ProducibleStats stats, City city, Player player, UnitPrototype unit) {
 			bool isSettler = unit.actions.Contains(UnitAction.BuildCity);
-			bool isWorker = unit.actions.Contains(UnitAction.BuildMine);
+			bool isWorker = unit.isWorker;
 			bool atWar = PlayerAI.PlayerIsAtWarWithSomeone(player);
 			bool cityGuarded = city.location.unitsOnTile.Count(u => u.CanDefendOnLand()) > 0;
 			bool hasUnescortedSettler = HasUnescortedSettler(city);
@@ -163,7 +163,7 @@ namespace C7Engine {
 				// If we have unworked tiles and fewer workers than cities, boost
 				// the odds of producing a worker.
 				int numUnworkedTiles = NumUnworkedTiles(city);
-				int numWorkers = player.units.Count(x => x.unitType.actions.Contains(UnitAction.BuildMine));
+				int numWorkers = player.units.Count(x => x.unitType.isWorker);
 				if (numUnworkedTiles > 0 && numWorkers < player.cities.Count * 1.5f) {
 					score += populationCostPenalty * Math.Min(3.0f, 1 + numUnworkedTiles);
 				}

--- a/C7Engine/AI/UnitAI/WorkerAI.cs
+++ b/C7Engine/AI/UnitAI/WorkerAI.cs
@@ -100,12 +100,8 @@ namespace C7Engine {
 			// Don't waste worker moves on unowned tiles. We do allow roading
 			// unowned tiles though.
 			if (t.owningCity == null || t.owningCity.owner != player) {
-				Terraform buildRoad = UnitAction.BuildRoad.ToTerraform();
-
-				if (accessibleTerraforms.Contains(buildRoad)) {
-					return buildRoad;
-				}
-				return null;
+				var buildRoad = accessibleTerraforms.FirstOrDefault(t => t.ProvidesRoad());
+				return buildRoad;
 			}
 
 			int initialCommerce = t.commerceYield(player).yield;
@@ -141,7 +137,7 @@ namespace C7Engine {
 				// seem to have no effect - but we want to encourage hooking up
 				// luxuries.
 				if ((t.Resource.Category == ResourceCategory.LUXURY || t.Resource.Category == ResourceCategory.STRATEGIC)
-					&& terraform == UnitAction.BuildRoad.ToTerraform() && player.KnowsAboutResource(t.Resource)) {
+					&& terraform.ProvidesRoad() && player.KnowsAboutResource(t.Resource)) {
 					currentScore += ResourcePoints;
 				}
 

--- a/C7Engine/Actions.cs
+++ b/C7Engine/Actions.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using C7GameData;
 
+namespace C7Engine;
+
 // The strings for each action correspond to values in project.godot for keyboard shortcuts
 public static class C7Action {
 	public const string EndTurn = "end_turn";
@@ -44,19 +46,6 @@ public static class C7Action {
 
 	private static readonly Dictionary<string, UnitAction> toUnitAction = new() {
 		[UnitBuildCity] = UnitAction.BuildCity,
-		[UnitBuildRoad] = UnitAction.BuildRoad,
-		[UnitBuildRailroad] = UnitAction.BuildRailroad,
-		[UnitBuildMine] = UnitAction.BuildMine,
-		[UnitBuildFortress] = UnitAction.BuildFortress,
-		[UnitClearDamage] = UnitAction.ClearDamage,
-		[UnitBuildAirfield] = UnitAction.BuildAirfield,
-		[UnitBuildRadarTower] = UnitAction.BuildRadarTower,
-		[UnitBuildOutpost] = UnitAction.BuildOutpost,
-		[UnitBuildBarricade] = UnitAction.BuildBarricade,
-		[UnitIrrigate] = UnitAction.Irrigate,
-		[UnitClearWetlands] = UnitAction.ClearWetlands,
-		[UnitClearForest] = UnitAction.ClearForest,
-		[UnitPlantForest] = UnitAction.PlantForest,
 		[UnitBombard] = UnitAction.Bombard,
 		[UnitHold] = UnitAction.Hold,
 		[UnitWait] = UnitAction.Wait,
@@ -92,6 +81,6 @@ public static class C7Action {
 	}
 
 	public static Terraform? ToTerraform(string action) {
-		return ToUnitAction(action)?.ToTerraform();
+		return EngineStorage.gameData.Terraforms.FirstOrDefault(tf => tf.UIAction == action);
 	}
 }

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -18,6 +18,22 @@ namespace C7GameData {
 		public int BaseTerrainImageID;
 	}
 
+	public enum TerraformKey {
+		BuildRoad,
+		BuildRailroad,
+		BuildMine,
+		BuildFortress,
+		ClearDamage,
+		BuildAirfield,
+		BuildRadarTower,
+		BuildOutpost,
+		BuildBarricade,
+		Irrigate,
+		ClearWetlands,
+		ClearForest,
+		PlantForest
+	}
+
 	public class ImportCiv3 {
 		private SaveGame save;
 		private BiqData biq;
@@ -25,6 +41,7 @@ namespace C7GameData {
 		private SavData savData;
 		private PediaIcons pediaIcons;
 		private readonly ID.Factory ids;
+		private Dictionary<TerraformKey, ID> terraformIdByCiv3Key = [];
 
 		private static ILogger log = Log.ForContext<ImportCiv3>();
 
@@ -45,6 +62,7 @@ namespace C7GameData {
 			ImportRaces();
 			ImportTechs();
 			ImportCiv3Resources();
+			ImportTerraforms();
 			ImportUnitPrototypes();
 			ImportUniqueUnitReplacements();
 			ImportUnitUpgrades();
@@ -59,7 +77,6 @@ namespace C7GameData {
 			save.ScenarioSearchPath = biq?.Game[0].ScenarioSearchFolders;
 			ImportBarbarianInfo();
 			ImportCitizenTypes();
-			ImportTerraforms();
 			ImportGovernments();
 			ImportDifficulties();
 			ImportRules();
@@ -739,14 +756,6 @@ namespace C7GameData {
 
 		private static IEnumerable<UnitAction> GetUnitActions(PRTO prto) {
 			if (prto.BuildCity) yield return UnitAction.BuildCity;
-			if (prto.BuildRoad) yield return UnitAction.BuildRoad;
-			if (prto.BuildRailroad) yield return UnitAction.BuildRailroad;
-			if (prto.BuildMine) yield return UnitAction.BuildMine;
-			if (prto.Irrigate) yield return UnitAction.Irrigate;
-			if (prto.ClearJungle) yield return UnitAction.ClearWetlands;
-			if (prto.ClearForest) yield return UnitAction.ClearForest;
-			if (prto.BuildBarricade) yield return UnitAction.BuildBarricade;
-			if (prto.BuildFortress) yield return UnitAction.BuildFortress;
 			if (prto.Bombard) yield return UnitAction.Bombard;
 			if (prto.SkipTurn) yield return UnitAction.Hold;
 			if (prto.Wait) yield return UnitAction.Wait;
@@ -755,6 +764,17 @@ namespace C7GameData {
 			if (prto.GoTo) yield return UnitAction.Goto;
 			if (prto.Explore) yield return UnitAction.Explore;
 			if (prto.Automate) yield return UnitAction.Automate;
+		}
+
+		private static IEnumerable<TerraformKey> GetUnitTerraforms(PRTO prto) {
+			if (prto.BuildRoad) yield return TerraformKey.BuildRoad;
+			if (prto.BuildRailroad) yield return TerraformKey.BuildRailroad;
+			if (prto.BuildMine) yield return TerraformKey.BuildMine;
+			if (prto.Irrigate) yield return TerraformKey.Irrigate;
+			if (prto.ClearJungle) yield return TerraformKey.ClearWetlands;
+			if (prto.ClearForest) yield return TerraformKey.ClearForest;
+			if (prto.BuildBarricade) yield return TerraformKey.BuildBarricade;
+			if (prto.BuildFortress) yield return TerraformKey.BuildFortress;
 		}
 
 		private SaveUnitPrototype.Unique ImportUniqueUnitData(PRTO prto) {
@@ -796,6 +816,7 @@ namespace C7GameData {
 				prototype.bombard = prto.BombardStrength;
 				prototype.iconIndex = prto.IconIndex;
 				prototype.actions.UnionWith(GetUnitActions(prto));
+				prototype.terraformActions.UnionWith(GetUnitTerraforms(prto).Select(tfKey => terraformIdByCiv3Key[tfKey]));
 
 				prototype.unique = ImportUniqueUnitData(prto);
 				prototype.unproducible = IsUnproducible(prto);
@@ -1271,15 +1292,16 @@ namespace C7GameData {
 			for (int i = 0; i < theBiq.Tfrm.Length; ++i) {
 				TFRM t = theBiq.Tfrm[i];
 
+				TerraformKey tfKey = ConvertCiv3Order(t.Order);
+
 				SaveTerraform tf = new() {
 					Id = ids.CreateID("Terraform"),
 					Name = t.Name,
 					CivilopediaEntry = t.CivilopediaEntry,
 					TurnsToComplete = t.TurnsToComplete,
-					Action = ConvertCiv3OrderToAction(t.Order)
 				};
 
-				tf.Improvement = UnitActionToTerrainImprovement(tf.Action);
+				tf.SetUpByTerraformKey(tfKey);
 
 				if (t.Required > -1) {
 					tf.RequiredTech = save.Techs[t.Required].id;
@@ -1291,55 +1313,8 @@ namespace C7GameData {
 					tf.RequiredResources.Add(save.Resources[t.RequiredResource2].Key);
 				}
 
-				LoadTerraformLuaFunctions(tf);
-
 				save.TerraForms.Add(tf);
-			}
-		}
-
-		private static string UnitActionToTerrainImprovement(UnitAction ua) {
-			return ua switch {
-				UnitAction.BuildMine => "mine",
-				UnitAction.Irrigate => "irrigation",
-				UnitAction.BuildFortress => "fortress",
-				UnitAction.BuildBarricade => "barricade",
-				UnitAction.BuildRoad => "road",
-				UnitAction.BuildRailroad => "railroad",
-				_ => null,
-			};
-		}
-
-		private static void LoadTerraformLuaFunctions(SaveTerraform tf) {
-			string actionPath = tf.Action switch {
-				UnitAction.BuildMine => "mine",
-				UnitAction.Irrigate => "irrigate",
-				UnitAction.ClearWetlands => "clear_wetlands",
-				UnitAction.ClearForest => "clear_forest",
-				_ => null,
-			};
-
-			if (actionPath == null)
-				return;
-
-			// Add validator
-			switch (tf.Action) {
-				case UnitAction.BuildMine:
-				case UnitAction.Irrigate:
-					tf.Validators.Add($"terraforms.{actionPath}_validator");
-					break;
-
-				case UnitAction.ClearWetlands:
-				case UnitAction.ClearForest:
-					tf.Validators.Add("terraforms.clear_foliage_validator");
-					break;
-			}
-
-			// Add effect
-			switch (tf.Action) {
-				case UnitAction.ClearWetlands:
-				case UnitAction.ClearForest:
-					tf.Effects.Add($"terraforms.{actionPath}_effect");
-					break;
+				terraformIdByCiv3Key[tfKey] = tf.Id;
 			}
 		}
 
@@ -1367,21 +1342,21 @@ namespace C7GameData {
 			}
 		}
 
-		private static UnitAction ConvertCiv3OrderToAction(string order) {
+		private static TerraformKey ConvertCiv3Order(string order) {
 			return order switch {
-				"Build Mine" => UnitAction.BuildMine,
-				"Irrigate" => UnitAction.Irrigate,
-				"Build Fortress" => UnitAction.BuildFortress,
-				"Build Road" => UnitAction.BuildRoad,
-				"Build Railroad" => UnitAction.BuildRailroad,
-				"Plant Forest" => UnitAction.PlantForest,
-				"Clear Forest" => UnitAction.ClearForest,
-				"Clear Wetlands" => UnitAction.ClearWetlands,
-				"Clear Damage" => UnitAction.ClearDamage,
-				"Build Airfield" => UnitAction.BuildAirfield,
-				"Build Radar Tower" => UnitAction.BuildRadarTower,
-				"Build Outpost" => UnitAction.BuildOutpost,
-				"Build Barricade" or "Build Barricades" => UnitAction.BuildBarricade,
+				"Build Mine" => TerraformKey.BuildMine,
+				"Irrigate" => TerraformKey.Irrigate,
+				"Build Fortress" => TerraformKey.BuildFortress,
+				"Build Road" => TerraformKey.BuildRoad,
+				"Build Railroad" => TerraformKey.BuildRailroad,
+				"Plant Forest" => TerraformKey.PlantForest,
+				"Clear Forest" => TerraformKey.ClearForest,
+				"Clear Wetlands" => TerraformKey.ClearWetlands,
+				"Clear Damage" => TerraformKey.ClearDamage,
+				"Build Airfield" => TerraformKey.BuildAirfield,
+				"Build Radar Tower" => TerraformKey.BuildRadarTower,
+				"Build Outpost" => TerraformKey.BuildOutpost,
+				"Build Barricade" or "Build Barricades" => TerraformKey.BuildBarricade,
 				_ => throw new NotSupportedException($"Unknown order: {order}"),
 			};
 		}

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -51,8 +51,6 @@ namespace C7GameData {
 		public Terraform WorkerJob { get; set; }
 
 
-		[JsonIgnore]
-		public List<UnitAction> availableActions = [];
 		public UnitAI currentAI;
 
 		public MapUnit(ID id) {
@@ -675,20 +673,23 @@ namespace C7GameData {
 		}
 
 		public bool canPerformTerraformAction(Terraform terraform) {
-			return unitType.actions.Contains(terraform.Action) && terraform.MeetsRequirements(owner, location);
+			return unitType.terraformActions.Contains(terraform) && terraform.MeetsRequirements(owner, location);
 		}
 
 		public bool canPerformTerraformAction(Terraform terraform, Tile tile) {
-			return unitType.actions.Contains(terraform.Action) && terraform.MeetsRequirements(owner, tile);
+			return unitType.terraformActions.Contains(terraform) && terraform.MeetsRequirements(owner, tile);
 		}
 
 		public void PerformTerraformAction(Terraform terraform) {
 			if (!canPerformTerraformAction(terraform)) {
-				log.Warning($"can't perform {terraform.Action} by {this}");
+				log.Warning($"can't perform {terraform.Name} by {this}");
 				return;
 			}
 			WorkerJob = terraform;
-			setWorkerJobAnimation(terraform.Action);
+
+			if (terraform.Animation is AnimatedAction animation)
+				animate(animation, AnimationEnding.Repeat);
+
 			wake();
 			_ = PerformBusyAction();
 		}
@@ -707,30 +708,6 @@ namespace C7GameData {
 			WorkerJob = null;
 			WorkerProgressTowardsJob = 0;
 			animate(MapUnit.AnimatedAction.BLANK, AnimationEnding.Repeat);
-		}
-
-		private void setWorkerJobAnimation(UnitAction action) {
-			switch (action) {
-				case UnitAction.Irrigate:
-					animate(MapUnit.AnimatedAction.IRRIGATE, AnimationEnding.Repeat);
-					return;
-				case UnitAction.BuildMine:
-					animate(MapUnit.AnimatedAction.MINE, AnimationEnding.Repeat);
-					return;
-				case UnitAction.BuildRailroad:
-				case UnitAction.BuildRoad:
-					animate(MapUnit.AnimatedAction.ROAD, AnimationEnding.Repeat);
-					return;
-				case UnitAction.ClearForest:
-					animate(MapUnit.AnimatedAction.FOREST, AnimationEnding.Repeat);
-					return;
-				case UnitAction.ClearWetlands:
-					animate(MapUnit.AnimatedAction.JUNGLE, AnimationEnding.Repeat);
-					return;
-				default:
-					// do nothing;
-					return;
-			}
 		}
 
 		public bool canAutomate() {
@@ -786,6 +763,42 @@ namespace C7GameData {
 			// Do nothing after an error so control returns to the player, and
 			// nothing after an progress result, so that next turn continues the
 			// AI action.
+		}
+
+		public List<Terraform> GetAvailableTerraforms() {
+			return EngineStorage.gameData.Terraforms.Where(canPerformTerraformAction).ToList();
+		}
+
+		/**
+		 * Helper function to get the available actions for a unit
+		 * based on what terrain it is on.
+		 **/
+		public List<UnitAction> GetAvailableActions() {
+			List<UnitAction> result = new();
+
+			// Eventually, we should look this up somewhere to see what all actions we have (and mods might add more)
+			// For now, this is still an improvement over the last iteration.
+			UnitAction[] implementedActions = { UnitAction.Hold, UnitAction.Wait, UnitAction.Fortify, UnitAction.Disband, UnitAction.Goto, UnitAction.Bombard };
+			foreach (UnitAction action in implementedActions) {
+				if (unitType.actions.Contains(action)) {
+					result.Add(action);
+				}
+			}
+
+			if (canBuildCity()) {
+				result.Add(UnitAction.BuildCity);
+			}
+			if (canExplore()) {
+				result.Add(UnitAction.Explore);
+			}
+			if (canAutomate()) {
+				result.Add(UnitAction.Automate);
+			}
+
+			// Eventually we will have advanced actions too, whose availability will rely on their base actions' availability.
+			// unit.availableActions.Add("rename");
+
+			return result;
 		}
 	}
 }

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -263,7 +263,7 @@ namespace C7GameData.Save {
 		}
 
 		private void ConvertUnits(GameData data) {
-			data.unitPrototypes = UnitPrototypes.ConvertAll(prototype => new UnitPrototype(prototype));
+			data.unitPrototypes = UnitPrototypes.ConvertAll(prototype => new UnitPrototype(prototype, data.Terraforms));
 
 			var techDict = data.techs.ToDictionary(t => t.id);
 			var unitPrototypeDict = data.unitPrototypes.ToDictionary(b => b.name);

--- a/C7Engine/C7GameData/Save/SaveTerraform.cs
+++ b/C7Engine/C7GameData/Save/SaveTerraform.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using C7Engine;
 
 namespace C7GameData.Save;
 
@@ -9,7 +11,6 @@ public class SaveTerraform {
 	public int TurnsToComplete;
 	public ID RequiredTech;
 	public List<string> RequiredResources = [];
-	public UnitAction Action;
 
 	// Optional: a Terrain Improvement associated with the Terraform
 	public string Improvement;
@@ -17,4 +18,90 @@ public class SaveTerraform {
 	// Lua functions
 	public List<string> Validators = [];
 	public List<string> Effects = [];
+
+	public MapUnit.AnimatedAction? Animation;
+
+	public string UIAction;
+	public string ButtonTexture;
+
+	public void SetUpByTerraformKey(TerraformKey tfKey) {
+		Improvement = TerraformKeyToTerrainImprovement(tfKey);
+		UIAction = TerraformKeyToUIAction(tfKey);
+		ButtonTexture = TerraformKeyToButtonTexture(tfKey);
+		Animation = TerraformKeyToAnimation(tfKey);
+		LoadLuaFunctions(tfKey);
+	}
+
+	private static MapUnit.AnimatedAction? TerraformKeyToAnimation(TerraformKey tfKey) {
+		return tfKey switch {
+			TerraformKey.BuildRoad => MapUnit.AnimatedAction.ROAD,
+			TerraformKey.BuildRailroad => MapUnit.AnimatedAction.ROAD,
+			TerraformKey.BuildMine => MapUnit.AnimatedAction.MINE,
+			TerraformKey.BuildFortress => MapUnit.AnimatedAction.FORTRESS,
+			TerraformKey.BuildBarricade => MapUnit.AnimatedAction.FORTRESS,
+			TerraformKey.Irrigate => MapUnit.AnimatedAction.IRRIGATE,
+			TerraformKey.ClearWetlands => MapUnit.AnimatedAction.JUNGLE,
+			TerraformKey.ClearForest => MapUnit.AnimatedAction.FOREST,
+			TerraformKey.PlantForest => MapUnit.AnimatedAction.PLANT,
+			_ => null
+		};
+	}
+
+	private static string TerraformKeyToUIAction(TerraformKey tfKey) {
+		return tfKey switch {
+			TerraformKey.BuildRoad => C7Action.UnitBuildRoad,
+			TerraformKey.BuildRailroad => C7Action.UnitBuildRailroad,
+			TerraformKey.BuildMine => C7Action.UnitBuildMine,
+			TerraformKey.BuildFortress => C7Action.UnitBuildFortress,
+			TerraformKey.ClearDamage => C7Action.UnitClearDamage,
+			TerraformKey.BuildAirfield => C7Action.UnitBuildAirfield,
+			TerraformKey.BuildRadarTower => C7Action.UnitBuildRadarTower,
+			TerraformKey.BuildOutpost => C7Action.UnitBuildOutpost,
+			TerraformKey.BuildBarricade => C7Action.UnitBuildBarricade,
+			TerraformKey.Irrigate => C7Action.UnitIrrigate,
+			TerraformKey.ClearWetlands => C7Action.UnitClearWetlands,
+			TerraformKey.ClearForest => C7Action.UnitClearForest,
+			TerraformKey.PlantForest => C7Action.UnitPlantForest,
+			_ => throw new ArgumentOutOfRangeException(nameof(tfKey), tfKey, null)
+		};
+	}
+
+	private static string TerraformKeyToButtonTexture(TerraformKey tfKey) {
+		return "ui.unit_control." + TerraformKeyToUIAction(tfKey);
+	}
+
+	private static string TerraformKeyToTerrainImprovement(TerraformKey tfKey) {
+		return tfKey switch {
+			TerraformKey.BuildMine => "mine",
+			TerraformKey.Irrigate => "irrigation",
+			TerraformKey.BuildFortress => "fortress",
+			TerraformKey.BuildBarricade => "barricade",
+			TerraformKey.BuildRoad => "road",
+			TerraformKey.BuildRailroad => "railroad",
+			_ => null,
+		};
+	}
+
+	private void LoadLuaFunctions(TerraformKey tfKey) {
+		string actionPath = tfKey switch {
+			TerraformKey.BuildMine => "mine",
+			TerraformKey.Irrigate => "irrigate",
+			TerraformKey.ClearWetlands => "clear_wetlands",
+			TerraformKey.ClearForest => "clear_forest",
+			_ => null,
+		};
+
+		if (actionPath == null)
+			return;
+
+		Validators.Add($"terraforms.{actionPath}.validator");
+
+		// Add effect
+		switch (tfKey) {
+			case TerraformKey.ClearWetlands:
+			case TerraformKey.ClearForest:
+				Effects.Add($"terraforms.{actionPath}.effect");
+				break;
+		}
+	}
 }

--- a/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
+++ b/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
@@ -31,6 +31,8 @@ namespace C7GameData.Save {
 
 		public HashSet<string> requiredResources = [];
 
+		public HashSet<ID> terraformActions = [];
+
 		public SaveUnitPrototype() { }
 
 		public SaveUnitPrototype(UnitPrototype proto) {
@@ -57,6 +59,7 @@ namespace C7GameData.Save {
 			attributes = new HashSet<string>(proto.attributes);
 
 			requiredResources = proto.requiredResources.Select(r => r.Key).ToHashSet();
+			terraformActions = proto.terraformActions.Select(r => r.Id).ToHashSet();
 		}
 	}
 }

--- a/C7Engine/C7GameData/Terraform.cs
+++ b/C7Engine/C7GameData/Terraform.cs
@@ -18,7 +18,6 @@ public class Terraform {
 	public string CivilopediaEntry;
 	public int TurnsToComplete;
 	public ID RequiredTech;
-	public UnitAction Action;
 
 	public List<Resource> RequiredResources = [];
 
@@ -26,6 +25,14 @@ public class Terraform {
 
 	private Action<ScriptContext> Effect;
 	private List<Func<ScriptContext, bool>> ActionValidators = [];
+
+	public readonly MapUnit.AnimatedAction? Animation;
+
+	// Key of the UI action associated with the Terraform
+	public readonly string UIAction;
+
+	// Path to the texture definition in the texture config
+	public readonly string ButtonTexture;
 
 	private SaveTerraform dataSource;
 
@@ -35,7 +42,9 @@ public class Terraform {
 		CivilopediaEntry = saveTerraform.CivilopediaEntry;
 		TurnsToComplete = saveTerraform.TurnsToComplete;
 		RequiredTech = saveTerraform.RequiredTech;
-		Action = saveTerraform.Action;
+		Animation = saveTerraform.Animation;
+		UIAction = saveTerraform.UIAction;
+		ButtonTexture = saveTerraform.ButtonTexture;
 		dataSource = saveTerraform;
 		RequiredResources = saveTerraform.RequiredResources.ConvertAll(resKey => gameData.Resources.Find(res => res.Key == resKey));
 
@@ -82,5 +91,11 @@ public class Terraform {
 
 	public SaveTerraform ToSaveTerraform() {
 		return dataSource;
+	}
+
+	public bool ProvidesRoad() {
+		if (Improvement == null) return false;
+
+		return Improvement.layer == TerrainImprovement.Layer.Roads && Improvement.upgradesFrom == null;
 	}
 }

--- a/C7Engine/C7GameData/TerrainType.cs
+++ b/C7Engine/C7GameData/TerrainType.cs
@@ -17,10 +17,18 @@ namespace C7GameData {
 		public int baseCommerceProduction { get; set; }
 		public int movementCost { get; set; }
 		public bool allowCities { get; set; } = true;
-		public HashSet<UnitAction> allowedWorkerActions = [];
 		public StrengthBonus defenseBonus;
 		public HashSet<string> allowedResources = new();
 		public int height = -1;
+
+		// These enum and field are kept for compatibility with CIV3 saves.
+		public enum Civ3FoliageAction {
+			None,
+			ClearForest,
+			ClearWetlands,
+			PlantForest
+		}
+		public Civ3FoliageAction allowedFoliageAction = Civ3FoliageAction.None;
 
 		//some stuff about graphics would probably make sense, too
 
@@ -61,7 +69,7 @@ namespace C7GameData {
 					description = civ3Terrain.Name,
 					amount = civ3Terrain.DefenseBonus / 100.0
 				},
-				allowedWorkerActions = LoadWorkerActions(civ3Terrain).ToHashSet(),
+				allowedFoliageAction = LoadFoliageAction(civ3Terrain),
 			};
 
 			if (c7Terrain.Key == "mountains" || c7Terrain.Key == "volcano") {
@@ -79,10 +87,12 @@ namespace C7GameData {
 			return c7Terrain;
 		}
 
-		private static IEnumerable<UnitAction> LoadWorkerActions(TERR civ3Terrain) {
-			if (civ3Terrain.CanChopForest) yield return UnitAction.ClearForest;
-			if (civ3Terrain.CanClearWetlands) yield return UnitAction.ClearWetlands;
-			if (civ3Terrain.CanPlantForest) yield return UnitAction.PlantForest;
+		private static Civ3FoliageAction LoadFoliageAction(TERR civ3Terrain) {
+			if (civ3Terrain.CanChopForest) return Civ3FoliageAction.ClearForest;
+			if (civ3Terrain.CanClearWetlands) return Civ3FoliageAction.ClearWetlands;
+			if (civ3Terrain.CanPlantForest) return Civ3FoliageAction.PlantForest;
+
+			return Civ3FoliageAction.None;
 		}
 
 		//This only works for Conquests due to the new terrains being added in the middle of the list.

--- a/C7Engine/C7GameData/UnitPrototype.cs
+++ b/C7Engine/C7GameData/UnitPrototype.cs
@@ -8,19 +8,6 @@ namespace C7GameData {
 
 	public enum UnitAction {
 		BuildCity,
-		BuildRoad,
-		BuildRailroad,
-		BuildMine,
-		BuildFortress,
-		ClearDamage,
-		BuildAirfield,
-		BuildRadarTower,
-		BuildOutpost,
-		BuildBarricade,
-		Irrigate,
-		ClearWetlands,
-		ClearForest,
-		PlantForest,
 		Bombard,
 		Hold,
 		Wait,
@@ -64,9 +51,12 @@ namespace C7GameData {
 
 		public HashSet<Resource> requiredResources { get; set; } = [];
 
+		public HashSet<Terraform> terraformActions = [];
+		public bool isWorker => terraformActions.Count > 0;
+
 		public UnitPrototype() { }
 
-		public UnitPrototype(SaveUnitPrototype proto) {
+		public UnitPrototype(SaveUnitPrototype proto, IEnumerable<Terraform> terraforms) {
 			(name, artName, shieldCost, populationCost, attack, defense, bombard, movement, iconIndex, unproducible) =
 			(proto.name, proto.artName, proto.shieldCost, proto.populationCost,
 			 proto.attack, proto.defense, proto.bombard, proto.movement, proto.iconIndex, proto.unproducible);
@@ -74,6 +64,8 @@ namespace C7GameData {
 			categories = new HashSet<string>(proto.categories);
 			actions = proto.actions;
 			attributes = new HashSet<string>(proto.attributes);
+
+			terraformActions = proto.terraformActions.Select(id => terraforms.First(t => t.Id == id)).ToHashSet();
 		}
 
 		public override string ToString() {
@@ -143,12 +135,6 @@ namespace C7GameData {
 			}
 
 			return true;
-		}
-	}
-
-	public static class UnitActionExtension {
-		public static Terraform? ToTerraform(this UnitAction action) {
-			return EngineStorage.gameData.Terraforms.Find(t => t.Action == action);
 		}
 	}
 }

--- a/C7Engine/EntryPoints/UnitInteractions.cs
+++ b/C7Engine/EntryPoints/UnitInteractions.cs
@@ -36,44 +36,6 @@ namespace C7Engine {
 			return MapUnit.NONE;
 		}
 
-		/**
-		 * Helper function to add the available actions to a unit
-		 * based on what terrain it is on.
-		 **/
-		public static List<UnitAction> GetAvailableActions(MapUnit unit) {
-			List<UnitAction> result = new();
-			if (unit == MapUnit.NONE) {
-				return result;
-			}
-
-			// Eventually, we should look this up somewhere to see what all actions we have (and mods might add more)
-			// For now, this is still an improvement over the last iteration.
-			UnitAction[] implementedActions = { UnitAction.Hold, UnitAction.Wait, UnitAction.Fortify, UnitAction.Disband, UnitAction.Goto, UnitAction.Bombard };
-			foreach (UnitAction action in implementedActions) {
-				if (unit.unitType.actions.Contains(action)) {
-					result.Add(action);
-				}
-			}
-
-			result.AddRange(EngineStorage.gameData.Terraforms.Where(unit.canPerformTerraformAction).Select(t => t.Action));
-
-			if (unit.canBuildCity()) {
-				result.Add(UnitAction.BuildCity);
-			}
-			if (unit.canExplore()) {
-				result.Add(UnitAction.Explore);
-			}
-
-			if (unit.canAutomate()) {
-				result.Add(UnitAction.Automate);
-			}
-
-			// Eventually we will have advanced actions too, whose availability will rely on their base actions' availability.
-			// unit.availableActions.Add("rename");
-
-			return result;
-		}
-
 		public static void ClearWaitQueue() {
 			waitQueue.Clear();
 		}

--- a/C7Engine/LuaRulesEngine.cs
+++ b/C7Engine/LuaRulesEngine.cs
@@ -174,10 +174,6 @@ public class LuaRulesEngine {
 			log.Debug("Registering type: {typeName}", type.FullName);
 			UserData.RegisterType(type);
 		}
-
-		// TODO: is there a way to detect and register generic types
-		// in the fields of C7GameData classes automatically?
-		UserData.RegisterType<HashSet<UnitAction>>();
 	}
 
 	void RegisterEnums() {


### PR DESCRIPTION
This PR continues the work on making worker jobs more modular (#786). 

Previously, there were two entities that described worker jobs: the UnitAction enum, which included worker jobs among other actions, and the Terraform class, which described data on worker jobs loaded from a JSON save. This PR makes Terraform the only entity responsible for worker jobs, and removes worker jobs from UnitAction.

The old code relied on hard-coded UnitAction values to retrieve unit animations and button textures for worker jobs, and to associate them with UI actions. Now, all these parameters are specified as part of the Terraform class, and so can be defined directly in a JSON save. 

As a side effect, this PR allows building fortresses and barricades. It's not really a complete feature yet: for now the defense bonuses of terrain improvements don't count when calculating the defense score, and these improvements are allowed to be built anywhere, since data on which terrain types they can be built is not yet imported from CIV3 saves.