### PR TITLE
#798 Render specialist' effects

### DIFF
--- a/C7/Lua/texture_configs/civ3.lua
+++ b/C7/Lua/texture_configs/civ3.lua
@@ -187,21 +187,93 @@ textures.icons = {
     path = CITY_SCREEN_ICONS,
     crop_region = { 34, 2, 30, 30 },
   },
-  luxury = {
+  beaker = {
     path = CITY_SCREEN_ICONS,
-    crop_region = { 376, 2, 30, 30 },
+    crop_region = { 34, 2, 29, 29 },
   },
-  food = {
+  good_gold = {
+	  path = CITY_SCREEN_ICONS,
+	  crop_region = { 64, 2, 29, 29 },
+  },
+  commerce = {
     path = CITY_SCREEN_ICONS,
-    crop_region = { 195, 1, 21, 30 },
+    crop_region = { 67, 1, 21, 30 },
+  },
+  wasted_gold = {
+    path = CITY_SCREEN_ICONS,
+    crop_region = { 95, 2, 30, 30 },
+  },
+  good_shield = {
+	  path = CITY_SCREEN_ICONS,
+	  crop_region = { 129, 5, 22, 22 },
   },
   shield = {
     path = CITY_SCREEN_ICONS,
     crop_region = { 133, 1, 16, 30 },
   },
-  commerce = {
+  wasted_shield = {
+	  path = CITY_SCREEN_ICONS,
+	  crop_region = { 160, 5, 22, 22 },
+  },
+  full_food = {
+	  path = CITY_SCREEN_ICONS,
+	  crop_region = { 191, 7, 20, 20 },
+  },
+  food = {
+	  path = CITY_SCREEN_ICONS,
+	  crop_region = { 195, 1, 21, 30 },
+  },
+  eaten_food = {
+	  path = CITY_SCREEN_ICONS,
+	  crop_region = { 223, 7, 20, 20 },
+  },
+  empty_shield = {
+	  path = CITY_SCREEN_ICONS,
+	  crop_region = { 253, 5, 22, 22 },
+  },
+  empty_food = {
+	  path = CITY_SCREEN_ICONS,
+	  crop_region = { 284, 7, 20, 20 },
+  },
+  no_food = {
+	  path = CITY_SCREEN_ICONS,
+	  crop_region = { 315, 7, 20, 20 },
+  },
+  luxury = {
     path = CITY_SCREEN_ICONS,
-    crop_region = { 67, 1, 21, 30 },
+    crop_region = { 376, 2, 30, 30 },
+  },
+  happy_face = {
+	  path = CITY_SCREEN_ICONS,
+	  crop_region = { 373, 2, 29, 29 },
+  },
+  effect_smiley_face = {
+    path = CITY_SCREEN_ICONS,
+    crop_region = { 373, 1, 30, 30 },
+  },
+  effect_shield = {
+    path = CITY_SCREEN_ICONS,
+    crop_region = { 404, 1, 30, 30 },
+  },
+  effect_good_gold = {
+    path = CITY_SCREEN_ICONS,
+    crop_region = { 435, 1, 30, 30 },
+  },
+  effect_beaker = {
+    path = CITY_SCREEN_ICONS,
+    crop_region = { 497, 1, 30, 30 },
+  },
+  effect_wasted_gold = {
+    path = CITY_SCREEN_ICONS,
+    crop_region = { 528, 1, 30, 30 },
+  },
+  content_face = {
+	  path = CITY_SCREEN_ICONS,
+	  crop_region = { 591, 2, 29, 29 },
+  },
+  treasury = {
+	  path = CITY_SCREEN_ICONS,
+	  crop_region = { 746, 2, 29, 29 },
   },
   plus = {
     path = ADVISORS .. "domestic_icons_aux.pcx",
@@ -210,58 +282,6 @@ textures.icons = {
   minus = {
     path = ADVISORS .. "domestic_icons_aux.pcx",
     crop_region = { 51, 1, 22, 22 },
-  },
-  eaten_food = {
-    path = CITY_SCREEN_ICONS,
-    crop_region = { 223, 7, 20, 20 },
-  },
-  full_food = {
-    path = CITY_SCREEN_ICONS,
-    crop_region = { 191, 7, 20, 20 },
-  },
-  no_food = {
-    path = CITY_SCREEN_ICONS,
-    crop_region = { 315, 7, 20, 20 },
-  },
-  empty_food = {
-    path = CITY_SCREEN_ICONS,
-    crop_region = { 284, 7, 20, 20 },
-  },
-  wasted_shield = {
-    path = CITY_SCREEN_ICONS,
-    crop_region = { 160, 5, 22, 22 },
-  },
-  good_shield = {
-    path = CITY_SCREEN_ICONS,
-    crop_region = { 129, 5, 22, 22 },
-  },
-  empty_shield = {
-    path = CITY_SCREEN_ICONS,
-    crop_region = { 253, 5, 22, 22 },
-  },
-  wasted_gold = {
-    path = CITY_SCREEN_ICONS,
-    crop_region = { 95, 2, 29, 29 },
-  },
-  good_gold = {
-    path = CITY_SCREEN_ICONS,
-    crop_region = { 64, 2, 29, 29 },
-  },
-  happy_face = {
-    path = CITY_SCREEN_ICONS,
-    crop_region = { 373, 2, 29, 29 },
-  },
-  content_face = {
-    path = CITY_SCREEN_ICONS,
-    crop_region = { 591, 2, 29, 29 },
-  },
-  beaker = {
-    path = CITY_SCREEN_ICONS,
-    crop_region = { 34, 2, 29, 29 },
-  },
-  treasury = {
-    path = CITY_SCREEN_ICONS,
-    crop_region = { 746, 2, 29, 29 },
   },
   capital_star = {
     path = CITY_ICONS,

--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -1,6 +1,5 @@
 using Godot;
 using System;
-using System.Linq;
 using Serilog;
 using System.Collections.Generic;
 using C7GameData;
@@ -18,6 +17,14 @@ public partial class CityScreen : Control {
 	public MapView mapView;
 	public List<CitizenType> citizenTypes;
 	private List<TextureButton> popHeads = new();
+	private List<TextureRect> popHeadEffects = new();
+
+	private const int POP_HEAD_OFFSET_Y = 433;
+	private const string LUXURIES = "luxuries";
+	private const string TAXES = "taxes";
+	private const string RESEARCH = "research";
+	private const string CORRUPTION = "corruption";
+	private const string CONSTRUCTION = "construction";
 
 	[Export] private TextureRect background;
 	[Export] private VBoxContainer existingBuildings;
@@ -63,6 +70,14 @@ public partial class CityScreen : Control {
 	private ImageTexture emptyFoodTexture;
 	private ImageTexture noFoodTexture;
 	private ImageTexture eatenFoodTexture;
+
+	private ImageTexture smileyFaceTexture;
+	private ImageTexture goodShieldTexture;
+	private ImageTexture beakerTexture;
+	private ImageTexture goodGoldTexture;
+	private ImageTexture wastedGoldTexture;
+
+	private Dictionary<string, ImageTexture> effectIcons = new();
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
@@ -134,6 +149,20 @@ public partial class CityScreen : Control {
 		emptyFoodTexture = TextureLoader.Load("icons.empty_food");
 		noFoodTexture = TextureLoader.Load("icons.no_food");
 		eatenFoodTexture = TextureLoader.Load("icons.eaten_food");
+		// effects
+		smileyFaceTexture = TextureLoader.Load("icons.effect_smiley_face");
+		goodGoldTexture = TextureLoader.Load("icons.effect_good_gold");
+		beakerTexture = TextureLoader.Load("icons.effect_beaker");
+		wastedGoldTexture = TextureLoader.Load("icons.effect_wasted_gold");
+		goodShieldTexture = TextureLoader.Load("icons.effect_shield");
+
+		effectIcons = new() {
+			{LUXURIES,  smileyFaceTexture},
+			{TAXES,  goodGoldTexture},
+			{RESEARCH,  beakerTexture},
+			{CORRUPTION,  wastedGoldTexture},
+			{CONSTRUCTION,  goodShieldTexture}
+		};
 
 		RenderShieldBox(shieldCost: 30, shieldsInBox: 15);
 		RenderShieldRow(goodShields: 10, corruptShields: 3);
@@ -689,7 +718,14 @@ public partial class CityScreen : Control {
 			background.RemoveChild(head);
 			head.QueueFree();
 		}
+		// Reset any old head effects.
+		foreach (TextureRect effect in popHeadEffects) {
+			background.RemoveChild(effect);
+			effect.QueueFree();
+		}
+
 		popHeads.Clear();
+		popHeadEffects.Clear();
 
 		int eraNum = city.owner.EraIndex();
 
@@ -761,7 +797,7 @@ public partial class CityScreen : Control {
 		foreach (CityResident cr in specialists) {
 			TextureButton tb = new();
 			tb.TextureNormal = PopHead.GetTexture(cr, eraNum);
-			tb.SetPosition(new Vector2(xPos, 440));
+			tb.SetPosition(new Vector2(xPos, POP_HEAD_OFFSET_Y));
 
 			List<CitizenType> specialistTypes = null;
 			EngineStorage.ReadGameData((GameData gameData) => { specialistTypes = city.owner.GetKnownSpecialists(gameData); });
@@ -776,6 +812,32 @@ public partial class CityScreen : Control {
 			};
 
 			background.AddChild(tb);
+
+			float iconOffset = 0.0f;
+			foreach (KeyValuePair<string, int> entry in GetSpecialistEffectInfo(cr)) {
+				if (!effectIcons.TryGetValue(entry.Key, out ImageTexture texture)) continue;
+				for (int i = 0; i < entry.Value; i++) {
+					TextureRect icon = new();
+					icon.Texture = texture;
+
+					float iconHalfWidth = icon.Texture.GetWidth() / 2.0f;
+					float iconXPos = tb.Position.X + iconHalfWidth * i + iconOffset;
+					float iconYPos = tb.Position.Y + PopHead.HEAD_SIZE - 10;
+
+					icon.SetPosition(new Vector2(iconXPos, iconYPos));
+					background.AddChild(icon);
+					popHeadEffects.Add(icon);
+
+					// If multiple effects are applicable we need to
+					// calculate the total offset that comes before each type.
+					// The offset is only calculated on the last iteration
+					// because we don't want any extra offset between effects of the same type.
+					if (i == entry.Value - 1) {
+						iconOffset += iconHalfWidth * entry.Value;
+					}
+				}
+			}
+
 			popHeads.Add(tb);
 			xPos += PopHead.HEAD_SIZE;
 		}
@@ -804,9 +866,20 @@ public partial class CityScreen : Control {
 	private int AddDefaultCitizen(CityResident cr, int xPos, int eraNum) {
 		TextureButton tb = new();
 		tb.TextureNormal = PopHead.GetTexture(cr, eraNum);
-		tb.SetPosition(new Vector2(xPos, 440));
+		tb.SetPosition(new Vector2(xPos, POP_HEAD_OFFSET_Y));
 		background.AddChild(tb);
 		popHeads.Add(tb);
 		return xPos + PopHead.HEAD_SIZE;
+	}
+
+	private Dictionary<string, int> GetSpecialistEffectInfo(CityResident cityResident) {
+		Dictionary<string, int> specialistEffectInfo = new();
+		specialistEffectInfo.TryAdd(LUXURIES, cityResident.citizenType.Luxuries);
+		specialistEffectInfo.TryAdd(TAXES, cityResident.citizenType.Taxes);
+		specialistEffectInfo.TryAdd(RESEARCH, cityResident.citizenType.Research);
+		specialistEffectInfo.TryAdd(CORRUPTION, cityResident.citizenType.Corruption);
+		specialistEffectInfo.TryAdd(CONSTRUCTION, cityResident.citizenType.Construction);
+
+		return specialistEffectInfo;
 	}
 }


### PR DESCRIPTION
The original game as far as I understand, uses different icons for the beaker/gold/shield effect icons than the icons that are used in the commerce, shield production, etc.. 

That is because the effect icons are smaller than the other ones, so my guess is they didn't want to scale the icons, as in 30px max size the icons would not render as nicely. 

That is why I updated the civ3.lua file, to get the proper icons for the job. I also rearranged the other CITY_SCREEN_ICONS to be in order, I didn't remove anything. I am aware I added some duplicate icons, but I was hopping we could discuss this and find a unified way to get these icons from the texture files (original or otherwise) since pretty much all of them have different crops and sizes. 

Regarding the implementation of the effects rendering, I made it so that it obviously renders what you would expect from the  original game.

<img width="581" height="351" alt="c7-rendering-specialists'-effects" src="https://github.com/user-attachments/assets/a0145e2e-e1ce-4533-a96a-524dc7c6e005" />

But I had another thought.

Maybe in the future someone modding it, would want for example to have an entertainer's effects during a golden age to be 1 smiley face and 1 tax and 1 science effect. The code accomodates for that, while being "backwards" compatible. 

<img width="591" height="347" alt="Screenshot_12" src="https://github.com/user-attachments/assets/05366bfd-d35b-4902-a594-2a32af98d917" />

I chose the most straight forward way to implement this with the dictionaries and such, because I didn't want to do any refactoring regarding the data structures already provided. But again, I would love a discussion on how this could be done otherwise.

Lastly, I made a change regarding the height of the popheads (and thus the effect icons), so now it's all flush with the original and has more breathing room on the bottom.