### PR TITLE
Fix a bug with worker speed

### DIFF
--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -588,8 +588,8 @@ namespace C7GameData {
 		private float SumWorkerProgress(Tile tile, Terraform workerJob) {
 			float result = 0;
 			foreach (MapUnit unit in tile.unitsOnTile) {
-				if (WorkerJob == workerJob) {
-					result += WorkerProgressTowardsJob;
+				if (unit.WorkerJob == workerJob) {
+					result += unit.WorkerProgressTowardsJob;
 				}
 			}
 			return result;


### PR DESCRIPTION
Previously worker moves were finishing too fast because we weren't looking at each unit's worker progress, meaning that non-workers on the same tile could "help" with worker moves