### PR TITLE
Add basic tooltips to the unit buttons 

### DIFF
--- a/C7/UIElements/Popups/TemporaryPopup.cs
+++ b/C7/UIElements/Popups/TemporaryPopup.cs
@@ -9,14 +9,19 @@ public partial class TemporaryPopup : Label {
 		Text = text;
 		this.durationInMillis = (int)(durationInSec * 1000);
 
+		AddThemeStyleboxOverride("normal", PopupStyleBox());
+		AddThemeColorOverride("font_color", Colors.White);
+	}
+
+	// A stylebox that works well for temporary popups or tooltips in game.
+	public static StyleBoxFlat PopupStyleBox() {
 		StyleBoxFlat styleBox = new();
 		styleBox.ContentMarginLeft = 5;
 		styleBox.ContentMarginRight = 5;
 		styleBox.ContentMarginTop = 2;
 		styleBox.ContentMarginBottom = 2;
 		styleBox.BgColor = Color.FromHtml("1C1C1C");
-		AddThemeStyleboxOverride("normal", styleBox);
-		AddThemeColorOverride("font_color", Colors.White);
+		return styleBox;
 	}
 
 	public async void ShowPopup() {

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -85,22 +85,6 @@ public partial class UnitButtons : VBoxContainer {
 		}
 	}
 
-
-	public static string ActionToTooltipText(string input) {
-		// Strip off the "unit_" from actions like "unit_build_city"
-		const string prefix = "unit_";
-		string result = input;
-		if (result.StartsWith(prefix)) {
-			result = result.Substring(prefix.Length);
-		}
-
-		// Turn "build_city" into "build city"
-		result = result.Replace('_', ' ');
-
-		// Turn "build city" into "Build City"
-		return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(result);
-	}
-
 	private void AddNewButton(HBoxContainer row, string action) {
 		TextureButton button = new();
 		TextureLoader.SetButtonTextures(button, "ui.unit_control." + action);
@@ -108,12 +92,15 @@ public partial class UnitButtons : VBoxContainer {
 
 		// Add a tooltip to the button to explain what it does, and ensure that
 		// the tooltip is readable.
-		button.TooltipText = ActionToTooltipText(action);
+		string? tooltipText = C7Action.ToTooltip(action);
+		if (tooltipText != null) {
+			button.TooltipText = tooltipText;
 
-		var customTheme = new Theme();
-		customTheme.SetStylebox("panel", "TooltipPanel", TemporaryPopup.PopupStyleBox());
-		customTheme.SetColor("font_color", "TooltipLabel", Colors.White);
-		button.Theme = customTheme;
+			var customTheme = new Theme();
+			customTheme.SetStylebox("panel", "TooltipPanel", TemporaryPopup.PopupStyleBox());
+			customTheme.SetColor("font_color", "TooltipLabel", Colors.White);
+			button.Theme = customTheme;
+		}
 
 		row.AddChild(button);
 		buttonMap[action] = button;

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -4,6 +4,7 @@ using C7Engine;
 using C7GameData;
 using Serilog;
 using System.Linq;
+using System.Globalization;
 
 /*
  UnitButtons contains the buttons at the bottom of the game UI when viewing the
@@ -84,10 +85,35 @@ public partial class UnitButtons : VBoxContainer {
 		}
 	}
 
+
+	public static string ActionToTooltipText(string input) {
+		// Strip off the "unit_" from actions like "unit_build_city"
+		const string prefix = "unit_";
+		string result = input;
+		if (result.StartsWith(prefix)) {
+			result = result.Substring(prefix.Length);
+		}
+
+		// Turn "build_city" into "build city"
+		result = result.Replace('_', ' ');
+
+		// Turn "build city" into "Build City"
+		return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(result);
+	}
+
 	private void AddNewButton(HBoxContainer row, string action) {
 		TextureButton button = new();
 		TextureLoader.SetButtonTextures(button, "ui.unit_control." + action);
 		button.Pressed += () => { EmitSignal(SignalName.ActionRequested, action); };
+
+		// Add a tooltip to the button to explain what it does, and ensure that
+		// the tooltip is readable.
+		button.TooltipText = ActionToTooltipText(action);
+
+		var customTheme = new Theme();
+		customTheme.SetStylebox("panel", "TooltipPanel", TemporaryPopup.PopupStyleBox());
+		customTheme.SetColor("font_color", "TooltipLabel", Colors.White);
+		button.Theme = customTheme;
 
 		row.AddChild(button);
 		buttonMap[action] = button;

--- a/C7Engine/Actions.cs
+++ b/C7Engine/Actions.cs
@@ -56,6 +56,33 @@ public static class C7Action {
 		[UnitAutomate] = UnitAction.Automate
 	};
 
+	private static readonly Dictionary<string, string> toTooltip = new() {
+		[UnitBombard] = "Bombard",
+		[UnitBuildCity] = "Build City",
+		[UnitBuildRoad] = "Build Road",
+		[UnitBuildMine] = "Build Mine",
+		[UnitIrrigate] = "Irrigate",
+		[UnitBuildRailroad] = "Build Railroad",
+		[UnitBuildFortress] = "Build Fortress",
+		[UnitPlantForest] = "Plant Forest",
+		[UnitClearForest] = "Clear Forest",
+		[UnitClearWetlands] = "Clear Wetlands",
+		[UnitClearDamage] = "Clear Damage",
+		[UnitBuildAirfield] = "Build Airfield",
+		[UnitBuildRadarTower] = "Build Radar Tower",
+		[UnitBuildOutpost] = "Build Outpost",
+		[UnitBuildBarricade] = "Build Barricade",
+		[UnitAutomate] = "Automate",
+		[UnitDisband] = "Disband",
+		[UnitExplore] = "Explore",
+		[UnitFortify] = "Fortify",
+		[UnitGoto] = "Goto",
+		[UnitHold] = "Hold",
+		[UnitSentry] = "Sentry",
+		[UnitSentryEnemyOnly] = "Sentry Enemy Only",
+		[UnitWait] = "Wait",
+	};
+
 	public static UnitAction? ToUnitAction(string action) {
 		return toUnitAction.TryGetValue(action, out var result) ? result : null;
 	}
@@ -82,5 +109,9 @@ public static class C7Action {
 
 	public static Terraform? ToTerraform(string action) {
 		return EngineStorage.gameData.Terraforms.FirstOrDefault(tf => tf.UIAction == action);
+	}
+
+	public static string? ToTooltip(string action) {
+		return toTooltip.TryGetValue(action, out var result) ? result : null;
 	}
 }


### PR DESCRIPTION
I'd like to get the turn count for worker moves next.

<img width="318" height="129" alt="image" src="https://github.com/user-attachments/assets/3e248ed1-969c-4c00-adc7-bf074dfd51a6" />
