### PR TITLE
Bugfix: Prohibit to contact barbarians

### DIFF
--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -193,14 +193,15 @@ public partial class RightClickTileMenu : RightClickMenu {
 				foreach (MapUnit unit in nonPlayerUnits) {
 					AddItem($"{unit.owner.civilization.noun} {unit.Describe()}", null);
 				}
-				AddItem($"Contact {nonPlayerUnits[0].owner.civilization.name}", contactCiv);
 			} else {
 				// TODO: This isn't necessarily the top unit, get that code to an accessible
 				// location and then use it here.
 				MapUnit unit = nonPlayerUnits[0];
 				AddItem($"{unit.owner.civilization.noun} {unit.Describe()}", null);
-				AddItem($"Contact {unit.owner.civilization.name}", contactCiv);
 			}
+
+			if (!nonPlayerUnits[0].owner.isBarbarians)
+				AddItem($"Contact {nonPlayerUnits[0].owner.civilization.name}", contactCiv);
 		}
 	}
 

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -186,6 +186,9 @@ namespace C7GameData {
 		}
 
 		public void EnsureRelationshipExists(Player other) {
+			if (isBarbarians || other.isBarbarians)
+				return;
+
 			if (!playerRelationships.ContainsKey(other.id)) {
 				playerRelationships.Add(other.id, new PlayerRelationship());
 			}


### PR DESCRIPTION
This PR prohibits contacting barbarians both through the right-click menu and the diplomacy panel. Previously, it was possible to open a diplomacy screen with barbarians, which led to a game freeze due to missing textures.