### PR TITLE
Improved Science advisor UI and functionality - Issue #797

### DIFF
--- a/C7/Lua/texture_configs/civ3.lua
+++ b/C7/Lua/texture_configs/civ3.lua
@@ -78,75 +78,6 @@ textures.advisors = {
   },
 }
 
-function add_tables(t1, t2)
-	result = {}
-	for i = 1, math.min(#t1, #t2) do
-		result[i] = t1[i] + t2[i]
-	end
-	return result
-end
-
-tech_boxes_texture = ADVISORS .. "techboxes.pcx"
-
--- different era boxes have slightly different sizes in pcx files
--- this is the max size they could be
--- seeing where the "Not required" sign renders in the original as well
--- this is probably how they did it originally
-tbl_small = { 1, 1, 106, 82 }
-tbl_medium = { 1, 84, 163, 82 }
-tbl_large = { 1, 167, 163, 106 }
-tbl_long = { 1, 274, 188, 82 }
-
-local function create_entry(offset)
-	local entry = {
-		small = {
-			path = tech_boxes_texture,
-			crop_region = add_tables(tbl_small, offset),
-		},
-		medium = {
-			path = tech_boxes_texture,
-			crop_region = add_tables(tbl_medium, offset),
-		},
-		large = {
-			path = tech_boxes_texture,
-			crop_region = add_tables(tbl_large, offset),
-		},
-		long = {
-			path = tech_boxes_texture,
-			crop_region = add_tables(tbl_long, offset),
-		},
-	}
-	return entry
-end
-
-textures.tech_box = {
-	known = {
-		ancient = create_entry({0, 0, 0, 0}),
-		middle = create_entry({0, 356, 0, 0}),
-		industrial = create_entry({0, 712, 0, 0}),
-		modern = create_entry({0, 1068, 0, 0}),
-	},
-	in_progress = {
-		ancient = create_entry({189, 0, 0, 0}),
-		middle = create_entry({189, 356, 0, 0}),
-		industrial = create_entry({189, 712, 0, 0}),
-		modern = create_entry({189, 1068, 0, 0}),
-	},
-	possible = {
-		ancient = create_entry({378, 0, 0, 0}),
-		middle = create_entry({378, 356, 0, 0}),
-		industrial = create_entry({378, 712, 0, 0}),
-		modern = create_entry({378, 1068, 0, 0}),
-	},
-	blocked = {
-		ancient = create_entry({567, 0, 0, 0}),
-		middle = create_entry({567, 356, 0, 0}),
-		industrial = create_entry({567, 712, 0, 0}),
-		modern = create_entry({567, 1068, 0, 0}),
-	},
-	non_required = ADVISORS .. "non_required.pcx",
-}
-
 textures.ui = {
   button = {
     inactive = {
@@ -526,6 +457,7 @@ textures.civ_colors = require "civ3.civ_colors"
 textures.unit_icons = require "civ3.unit_icons"
 textures.building_icons = require "civ3.building_icons"
 textures.tech_icons = require "civ3.tech_icons"
+textures.tech_boxes = require "civ3.tech_boxes"
 textures.leader_heads = require "civ3.leader_heads"
 textures.borders = require "civ3.borders"
 

--- a/C7/Lua/texture_configs/civ3.lua
+++ b/C7/Lua/texture_configs/civ3.lua
@@ -78,24 +78,73 @@ textures.advisors = {
   },
 }
 
+function add_tables(t1, t2)
+	result = {}
+	for i = 1, math.min(#t1, #t2) do
+		result[i] = t1[i] + t2[i]
+	end
+	return result
+end
+
+tech_boxes_texture = ADVISORS .. "techboxes.pcx"
+
+-- different era boxes have slightly different sizes in pcx files
+-- this is the max size they could be
+-- seeing where the "Not required" sign renders in the original as well
+-- this is probably how they did it originally
+tbl_small = { 1, 1, 106, 82 }
+tbl_medium = { 1, 84, 163, 82 }
+tbl_large = { 1, 167, 163, 106 }
+tbl_long = { 1, 274, 188, 82 }
+
+local function create_entry(offset)
+	local entry = {
+		small = {
+			path = tech_boxes_texture,
+			crop_region = add_tables(tbl_small, offset),
+		},
+		medium = {
+			path = tech_boxes_texture,
+			crop_region = add_tables(tbl_medium, offset),
+		},
+		large = {
+			path = tech_boxes_texture,
+			crop_region = add_tables(tbl_large, offset),
+		},
+		long = {
+			path = tech_boxes_texture,
+			crop_region = add_tables(tbl_long, offset),
+		},
+	}
+	return entry
+end
+
 textures.tech_box = {
-  known = {
-    path = ADVISORS .. "techboxes.pcx",
-    crop_region = { 1, 1, 180, 80 },
-  },
-  in_progress = {
-    path = ADVISORS .. "techboxes.pcx",
-    crop_region = { 192, 1, 180, 80 },
-  },
-  possible = {
-    path = ADVISORS .. "techboxes.pcx",
-    crop_region = { 381, 1, 180, 80 },
-  },
-  blocked = {
-    path = ADVISORS .. "techboxes.pcx",
-    crop_region = { 568, 1, 180, 80 },
-  },
-  non_required = ADVISORS .. "non_required.pcx",
+	known = {
+		ancient = create_entry({0, 0, 0, 0}),
+		middle = create_entry({0, 356, 0, 0}),
+		industrial = create_entry({0, 712, 0, 0}),
+		modern = create_entry({0, 1068, 0, 0}),
+	},
+	in_progress = {
+		ancient = create_entry({189, 0, 0, 0}),
+		middle = create_entry({189, 356, 0, 0}),
+		industrial = create_entry({189, 712, 0, 0}),
+		modern = create_entry({189, 1068, 0, 0}),
+	},
+	possible = {
+		ancient = create_entry({378, 0, 0, 0}),
+		middle = create_entry({378, 356, 0, 0}),
+		industrial = create_entry({378, 712, 0, 0}),
+		modern = create_entry({378, 1068, 0, 0}),
+	},
+	blocked = {
+		ancient = create_entry({567, 0, 0, 0}),
+		middle = create_entry({567, 356, 0, 0}),
+		industrial = create_entry({567, 712, 0, 0}),
+		modern = create_entry({567, 1068, 0, 0}),
+	},
+	non_required = ADVISORS .. "non_required.pcx",
 }
 
 textures.ui = {

--- a/C7/Lua/texture_configs/civ3/tech_boxes.lua
+++ b/C7/Lua/texture_configs/civ3/tech_boxes.lua
@@ -1,0 +1,82 @@
+﻿local tech_boxes = {}
+
+local ADVISORS = "Art/Advisors/"
+
+local tech_boxes_texture = ADVISORS .. "techboxes.pcx"
+local non_required_texture = ADVISORS .. "non_required.pcx"
+
+-- different era boxes have slightly different sizes in pcx files
+-- this is the max size they could be
+-- seeing where the "Not required" sign renders in the original as well
+-- this is probably how they did it originally
+local table_small = { 1, 1, 106, 82 }
+local table_medium = { 1, 84, 163, 82 }
+local table_large = { 1, 167, 163, 106 }
+local table_long = { 1, 274, 188, 82 }
+
+-- Add the x, y, width, height variables of two different rectangles,
+-- to allow us to avoid repeating the sizes of each tech box.
+--
+-- `offset` is assumed to be a crop_region with a width and height
+--   of 0.
+--
+-- Returns a crop region table.
+local function combine_offset_with_crop_region(crop_region, offset)
+	local result = {}
+	for i = 1, math.min(#crop_region, #offset) do
+		result[i] = crop_region[i] + offset[i]
+	end
+	return result
+end
+
+local function create_entry(offset)
+	local entry = {
+		small = {
+			path = tech_boxes_texture,
+			crop_region = combine_offset_with_crop_region(table_small, offset),
+		},
+		medium = {
+			path = tech_boxes_texture,
+			crop_region = combine_offset_with_crop_region(table_medium, offset),
+		},
+		large = {
+			path = tech_boxes_texture,
+			crop_region = combine_offset_with_crop_region(table_large, offset),
+		},
+		long = {
+			path = tech_boxes_texture,
+			crop_region = combine_offset_with_crop_region(table_long, offset),
+		},
+	}
+	return entry
+end
+
+tech_boxes = {
+	known = {
+		ancient = create_entry({0, 0, 0, 0}),
+		middle = create_entry({0, 356, 0, 0}),
+		industrial = create_entry({0, 712, 0, 0}),
+		modern = create_entry({0, 1068, 0, 0}),
+	},
+	in_progress = {
+		ancient = create_entry({189, 0, 0, 0}),
+		middle = create_entry({189, 356, 0, 0}),
+		industrial = create_entry({189, 712, 0, 0}),
+		modern = create_entry({189, 1068, 0, 0}),
+	},
+	possible = {
+		ancient = create_entry({378, 0, 0, 0}),
+		middle = create_entry({378, 356, 0, 0}),
+		industrial = create_entry({378, 712, 0, 0}),
+		modern = create_entry({378, 1068, 0, 0}),
+	},
+	blocked = {
+		ancient = create_entry({567, 0, 0, 0}),
+		middle = create_entry({567, 356, 0, 0}),
+		industrial = create_entry({567, 712, 0, 0}),
+		modern = create_entry({567, 1068, 0, 0}),
+	},
+	non_required = non_required_texture
+}
+
+return tech_boxes

--- a/C7/UIElements/Advisors/ScienceAdvisor.cs
+++ b/C7/UIElements/Advisors/ScienceAdvisor.cs
@@ -1,8 +1,10 @@
 using C7Engine;
 using C7GameData;
 using Godot;
-using System;
 using System.Collections.Generic;
+using System.Linq;
+using static C7Engine.MsgChooseResearch;
+using static C7GameData.EraUtils;
 
 public partial class ScienceAdvisor : TextureRect {
 	private ImageTexture AncientBackground;
@@ -17,6 +19,21 @@ public partial class ScienceAdvisor : TextureRect {
 	// Stored separately so we can modify this without mutating the player.
 	private string eraName;
 
+	// store the last opened era window so next time we open the advisor, it opens at the same era window
+	private static string lastOpenedEra = string.Empty;
+
+	private string advisorTitleString;
+
+	private FontFile regularFont = new();
+	private Theme regularBigFontTheme = new();
+	// private Theme regularMediumFontTheme = new();
+
+	private int bigFontSize = 26;
+	// private int middleFontSize = 20;
+
+	private int bigFontGlyphSpacing = 14;
+	private int bigFontGlyphSpaceSpacing = 22;
+
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
 		this.CreateUI();
@@ -24,12 +41,19 @@ public partial class ScienceAdvisor : TextureRect {
 		EngineStorage.ReadGameData((GameData gameData) => {
 			List<Tech> techs = gameData.techs;
 			Player player = gameData.GetFirstHumanPlayer();
-			eraName = player.eraCivilopediaName;
+			eraName = string.IsNullOrEmpty(lastOpenedEra) ? player.eraCivilopediaName : lastOpenedEra;
 			this.DrawTechTree(eraName, player, techs, player.GetAvailableTechsToResearch(gameData));
 		});
 	}
 
 	private void CreateUI() {
+
+		regularFont = ResourceLoader.Load<FontFile>("res://Fonts/NotoSans-Regular.ttf");
+		// regularMediumFontTheme.DefaultFont = regularFont;
+		regularBigFontTheme.DefaultFont = regularFont;
+		regularBigFontTheme.SetFontSize("font_size", "Label", bigFontSize);
+		// regularMediumFontTheme.SetFontSize("font_size", "Label", middleFontSize);
+
 		// science_industrial_new is used as the industrial tech tree is
 		// different from vanilla civ3.
 		AncientBackground = TextureLoader.Load("advisors.science.background.ancient");
@@ -40,6 +64,36 @@ public partial class ScienceAdvisor : TextureRect {
 		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Science, AdvisorHead.Mood.Happy, eraIndex: 0);
 		advisorHead.SetPosition(new Vector2(851, 0));
 		AddChild(advisorHead);
+
+		// Advisor Label
+		advisorTitleString = GetAdvisorName();
+
+		FontVariation fontVariation = new FontVariation
+		{
+			BaseFont = regularFont,
+			SpacingGlyph = bigFontGlyphSpacing,
+			SpacingSpace = bigFontGlyphSpaceSpacing,
+		};
+
+		Theme regularThemeWithCustomSpacing = new Theme();
+		regularThemeWithCustomSpacing.SetFont("font", "Label", fontVariation);
+		regularThemeWithCustomSpacing.SetFontSize("font_size", "Label", bigFontSize);
+
+		float containerWidth = AncientBackground.GetWidth();
+
+		float advisorTitleStringWidth = GetStringSizeWithCustomSpacing(regularFont, advisorTitleString, bigFontSize,
+			bigFontGlyphSpacing, bigFontGlyphSpaceSpacing).X;
+
+		float advisorTitleOffsetLeft = (containerWidth / 2.0f) - (advisorTitleStringWidth) / 2.0f;
+
+		Label advisorTitle = new() {
+			Text = advisorTitleString,
+			OffsetLeft = advisorTitleOffsetLeft,
+			OffsetTop = 15,
+			Theme = regularThemeWithCustomSpacing,
+		};
+		AddChild(advisorTitle);
+
 
 		ImageTexture DialogBoxTexture = TextureLoader.Load("advisors.dialog_box");
 		TextureButton DialogBox = new TextureButton();
@@ -100,15 +154,19 @@ public partial class ScienceAdvisor : TextureRect {
 		previousEra.Show();
 		nextEra.Show();
 
+		lastOpenedEra = eraName;
+
+		Queue<Tech> queue = player.ResearchQueue;
+
 		// Set the tech background based on the player's era.
-		if (eraName == "ERAS_Ancient_Times") {
+		if (eraName == ANCIENT_TIMES_CVLPD) {
 			previousEra.Hide();
 			this.Texture = AncientBackground;
-		} else if (eraName == "ERAS_Middle_Ages") {
+		} else if (eraName == MIDDLE_AGES_CVLPD) {
 			this.Texture = MiddleBackground;
-		} else if (eraName == "ERAS_Industrial_Age") {
+		} else if (eraName == INDUSTRIAL_AGE_CVLPD) {
 			this.Texture = IndustrialBackground;
-		} else if (eraName == "ERAS_Modern_Era") {
+		} else if (eraName == MODERN_ERA_CVLPD) {
 			this.Texture = ModernBackground;
 			nextEra.Hide();
 		}
@@ -124,16 +182,21 @@ public partial class ScienceAdvisor : TextureRect {
 				techState = TechBox.TechState.kKnown;
 			} else if (player.currentlyResearchedTech == tech.id) {
 				techState = TechBox.TechState.kInProgress;
+			} else if (queue.Count > 0 && queue.Contains(tech)) {
+				techState = TechBox.TechState.kQueued;
 			} else if (availableTechsToResearch.Contains(tech)) {
 				techState = TechBox.TechState.kPossible;
 			} else {
 				techState = TechBox.TechState.kBlocked;
 			}
 
-			TechBox techButton = new(tech, techState);
+			int queueNumber = queue.ToList().IndexOf(tech) + 1;
+
+			TechBox techButton = new(tech, techState, queueNumber);
 			techButton.SetPosition(new Vector2(tech.X, tech.Y));
 			techButton.Pressed += () => {
-				new MsgChooseResearch(tech.id, showAdvisor: true).send();
+				SelectionMode selection = Input.IsKeyPressed(Key.Shift) ? SelectionMode.Multi : SelectionMode.Single;
+				new MsgChooseResearch(tech, AdvisorState.Show, selection).send();
 			};
 			AddChild(techButton);
 			techBoxes.Add(techButton);
@@ -150,12 +213,35 @@ public partial class ScienceAdvisor : TextureRect {
 		EngineStorage.ReadGameData((GameData gameData) => {
 			List<Tech> techs = gameData.techs;
 			Player player = gameData.GetFirstHumanPlayer();
-			eraName = Player.EraIndexToEra(Player.EraIndex(eraName) + delta);
+			eraName = string.IsNullOrEmpty(lastOpenedEra)
+				? EraIndexToEra(GetEraIndex(eraName) + delta)
+				: EraIndexToEra(GetEraIndex(lastOpenedEra) + delta);
 			DrawTechTree(eraName, player, techs, player.GetAvailableTechsToResearch(gameData));
 		});
 	}
 
 	private void ReturnToMenu() {
 		GetParent<Advisors>().Hide();
+	}
+
+	private string GetAdvisorName() {
+		return string.Concat(this.GetType().Name.Select(x => char.IsUpper(x) ? " " + x : x.ToString())).Trim().ToUpper();
+	}
+
+	private Vector2 GetStringSizeWithCustomSpacing(Font font, string input, int fontSize = 16, int glyphSpacing = 0, int glyphSpaceSpacing = 0) {
+
+		float extraSpacing = 0.0f;
+		for (int i = 0; i < input.Length; i++) {
+			if (i < input.Length - 1) {
+				if (char.IsWhiteSpace(input[i]) && glyphSpaceSpacing > 0) {
+					extraSpacing += glyphSpaceSpacing;
+				} else {
+					extraSpacing += glyphSpacing;
+				}
+			}
+		}
+
+		Vector2 originalSize = font.GetStringSize(input, fontSize: fontSize);
+		return new Vector2(originalSize.X + extraSpacing, originalSize.Y);
 	}
 }

--- a/C7/UIElements/Advisors/ScienceAdvisor.cs
+++ b/C7/UIElements/Advisors/ScienceAdvisor.cs
@@ -22,11 +22,10 @@ public partial class ScienceAdvisor : TextureRect {
 	// store the last opened era window so next time we open the advisor, it opens at the same era window
 	private static string lastOpenedEra = string.Empty;
 
-	private string advisorTitleString;
+	private string advisorTitleString = "SCIENCE ADVISOR";
 
 	private FontFile regularFont = new();
 	private Theme regularBigFontTheme = new();
-	// private Theme regularMediumFontTheme = new();
 
 	private int bigFontSize = 26;
 	// private int middleFontSize = 20;
@@ -49,10 +48,8 @@ public partial class ScienceAdvisor : TextureRect {
 	private void CreateUI() {
 
 		regularFont = ResourceLoader.Load<FontFile>("res://Fonts/NotoSans-Regular.ttf");
-		// regularMediumFontTheme.DefaultFont = regularFont;
 		regularBigFontTheme.DefaultFont = regularFont;
 		regularBigFontTheme.SetFontSize("font_size", "Label", bigFontSize);
-		// regularMediumFontTheme.SetFontSize("font_size", "Label", middleFontSize);
 
 		// science_industrial_new is used as the industrial tech tree is
 		// different from vanilla civ3.
@@ -64,9 +61,6 @@ public partial class ScienceAdvisor : TextureRect {
 		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Science, AdvisorHead.Mood.Happy, eraIndex: 0);
 		advisorHead.SetPosition(new Vector2(851, 0));
 		AddChild(advisorHead);
-
-		// Advisor Label
-		advisorTitleString = GetAdvisorName();
 
 		FontVariation fontVariation = new FontVariation
 		{
@@ -222,10 +216,6 @@ public partial class ScienceAdvisor : TextureRect {
 
 	private void ReturnToMenu() {
 		GetParent<Advisors>().Hide();
-	}
-
-	private string GetAdvisorName() {
-		return string.Concat(this.GetType().Name.Select(x => char.IsUpper(x) ? " " + x : x.ToString())).Trim().ToUpper();
 	}
 
 	private Vector2 GetStringSizeWithCustomSpacing(Font font, string input, int fontSize = 16, int glyphSpacing = 0, int glyphSpaceSpacing = 0) {

--- a/C7/UIElements/Advisors/TechBox.cs
+++ b/C7/UIElements/Advisors/TechBox.cs
@@ -1,11 +1,34 @@
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using C7Engine;
 using C7GameData;
 using Godot;
+using static C7GameData.EraUtils;
 
 public partial class TechBox : TextureButton {
 	private Tech tech;
 	private TechState techState;
+
+	private readonly Dictionary<ID, List<Building>> Buildings = new();
+	private readonly Dictionary<ID, List<Building>> ObsoleteBuildings = new();
+	private readonly Dictionary<ID, List<Terraform>> Terraforms = new();
+	private readonly Dictionary<ID, List<UnitPrototype>> Units = new();
+
+	private static readonly Dictionary<string, ImageTexture> CachedObsoleteBuildingTextures = new();
+
+	private static readonly Dictionary<string, string> TruncatedToFullTechTextMap = new();
+
+	private FontFile smallFont = new();
+	private Theme smallFontTheme = new();
+	private int smallFontSize = 11;
+
+	private Label techNameLabel;
+
+	private int queueNumber;
 
 	public enum TechState {
 		// This tech is known to the player.
@@ -17,54 +40,306 @@ public partial class TechBox : TextureButton {
 		// The player needs to research the prerequisites before this tech can
 		// be researched.
 		kBlocked,
+		// The player has queued this tech for research.
+		kQueued,
 	}
 
-	public TechBox(Tech tech, TechState techState) {
+	public TechBox(Tech tech, TechState techState, int queueNumber = 0) {
 		this.tech = tech;
 		this.techState = techState;
+		this.queueNumber = queueNumber;
 	}
 
 	public override void _Ready() {
-		// TODO: Figure out how to pick which of the different sized tech boxes
-		// we should use for a given tech.
-		//
-		// NOTE: this pcx has 16 rows, 4 per era, with different sizes.
-		//
-		// NOTE: the X coordinates of each column were found via guess+check.
-		ImageTexture knownTechBox = TextureLoader.Load("tech_box.known");
-		ImageTexture inProgressTechBox = TextureLoader.Load("tech_box.in_progress");
-		ImageTexture possibleTechBox = TextureLoader.Load("tech_box.possible");
-		ImageTexture blockedTechBox = TextureLoader.Load("tech_box.blocked");
+
+		smallFont = ResourceLoader.Load<FontFile>("res://Fonts/NotoSans-Regular.ttf");
+
+		if (!tech.RequiredForEraAdvancement)
+			smallFont = ResourceLoader.Load<FontFile>("res://Fonts/NotoSans-Italic.ttf");
+
+		if (tech.id == EngineStorage.gameData.GetFirstHumanPlayer().currentlyResearchedTech)
+			smallFont = ResourceLoader.Load<FontFile>("res://Fonts/NotoSans-Bold.ttf");
+
+		smallFontTheme.DefaultFont = smallFont;
+		smallFontTheme.SetColor("font_color", "Label", Colors.Black);
+		smallFontTheme.SetFontSize("font_size", "Label", smallFontSize);
+
+
+		int techBoxSizeCost = CalculateTechBoxSizeCost(EngineStorage.gameData);
+		string techBoxSize = CostToStringKey(techBoxSizeCost);
+		string era = CalculateTechEraTexture(tech.EraCivilopediaName);
+
+		ImageTexture knownTechBox = TextureLoader.Load($"tech_box.known.{era}.{techBoxSize}");
+		ImageTexture inProgressTechBox = TextureLoader.Load($"tech_box.in_progress.{era}.{techBoxSize}");
+		ImageTexture possibleTechBox = TextureLoader.Load($"tech_box.possible.{era}.{techBoxSize}");
+		ImageTexture blockedTechBox = TextureLoader.Load($"tech_box.blocked.{era}.{techBoxSize}");
 
 		TextureNormal = techState switch {
 			TechState.kKnown => knownTechBox,
 			TechState.kInProgress => inProgressTechBox,
 			TechState.kPossible => possibleTechBox,
 			TechState.kBlocked => blockedTechBox,
+			TechState.kQueued => inProgressTechBox,
 			_ => throw new ArgumentOutOfRangeException("Invalid tech state")
 		};
 
-		ImageTexture iconTexture = TextureLoader.Load("tech_icons.small", tech, useCache: true);
-		TextureRect icon = new() {
-			Texture = iconTexture
-		};
+		ImageTexture techIconTexture = TextureLoader.Load("tech_icons.small", tech, useCache: true);
+		TextureRect icon = new() { Texture = techIconTexture };
 		icon.SetPosition(new Vector2(12, 32));
 		AddChild(icon);
 
-		// TODO: Have the name trail off if it is too large for the box.
-		Label techName = new() {
-			Text = tech.Name,
+		// we could be calculating this every time based on the font size,
+		// but I don't think it's worth the computation cost
+		// a larger char length, means a smaller Tech name (more chars will be truncated)
+		float averageCharLength = 6.0f;
+		int boxBorderWidth = 16;
+		int charLimitOfCurrentBox = (int)((TextureNormal.GetWidth() - boxBorderWidth) / averageCharLength);
+
+		int estimatedTurns = EngineStorage.gameData.GetFirstHumanPlayer().EstimateTurnsToResearch(EngineStorage.gameData, tech);
+		string estimatedTurnsString = estimatedTurns > 50 ? $"(-- turns)" : $"({estimatedTurns} turns)";
+
+		string techName = tech.Name;
+		string prepend = techState is TechState.kInProgress or TechState.kQueued ? $"{queueNumber}." : "";
+
+		if (techState is TechState.kInProgress) {
+			techName = $"{prepend} {tech.Name} {estimatedTurnsString}";
+		} else if (techState is TechState.kQueued) {
+			techName = $"{prepend} {tech.Name}";
+		} else if (techState is TechState.kPossible) {
+			techName = $"{tech.Name} {estimatedTurnsString}";
+		}
+
+		UpdateLabelTheme();
+
+		techNameLabel = new() {
+			Text = TruncateAndCacheName(techName, charLimitOfCurrentBox),
 			OffsetLeft = 12,
-			OffsetTop = 12
+			OffsetTop = 13,
+			Theme = smallFontTheme,
 		};
-		AddChild(techName);
+
+		this.MouseEntered += ShowTooltip;
+		this.MouseExited += UpdateLabelTheme;
+
+		int offsetX = techIconTexture.GetWidth() + 7;
+		int offsetY = 0;
+		int counter = 0;
+
+		// TODO : would be nice to figure out a way to cache these textures.
+		// A simple static dict won't work because of changes in scenarios etc
+		// because, if you Retire from one game, and into a new one,
+		// the textures will be from another set of rules
+		List<ImageTexture> techEffects = TechEffectTextures();
+
+		for (int i = 0; i < techEffects.Count; i++) {
+			TextureRect tr = new() { Texture = techEffects.ElementAt(i), };
+			tr.SetPosition(new Vector2(12 + offsetX, 32 + offsetY));
+			AddChild(tr);
+
+			if (techBoxSizeCost > 4) {
+				if (i == 2) {
+					offsetX = 7;
+					offsetY += techIconTexture.GetHeight() + 1;
+				}
+			}
+
+			offsetX += (int)tr.GetSize().X + 1;
+		}
+
+		AddChild(techNameLabel);
 
 		if (!tech.RequiredForEraAdvancement) {
-			TextureRect notRequired = new() {
-				Texture = TextureLoader.Load("tech_box.non_required"),
-			};
-			notRequired.SetPosition(new Vector2(85, 0));
+			TextureRect notRequired = new() { Texture = TextureLoader.Load("tech_box.non_required"), };
+			notRequired.SetPosition(new Vector2(TextureNormal.GetWidth() - 20, 0));
 			AddChild(notRequired);
+		}
+	}
+
+	private void ShowTooltip() {
+		smallFontTheme.SetColor("font_color", "Label", new Color(0.71f, 0.35f, 0.13f));
+
+		var customTheme = new Theme();
+		customTheme.SetStylebox("panel", "TooltipPanel", TemporaryPopup.PopupTechStyleBox());
+		customTheme.SetColor("font_color", "TooltipLabel", Colors.Black);
+		customTheme.SetFontSize("font_size", "TooltipLabel", 12);
+		this.Theme = customTheme;
+		if (TruncatedToFullTechTextMap.TryGetValue(tech.Name, out string fullText))
+			this.TooltipText = $"{fullText}";
+	}
+
+	private void UpdateLabelTheme() {
+
+		Color color = Colors.Black;
+
+		bool isTechEraBeyondPlayerEra = GetEraIndex(tech.EraCivilopediaName) > GetEraIndex(EngineStorage.gameData.GetFirstHumanPlayer().eraCivilopediaName);
+
+		if (techState is TechState.kKnown)
+			color = Colors.MediumBlue;
+		else if (techState is TechState.kQueued or TechState.kInProgress)
+			color = Colors.RoyalBlue;
+		else if (techState is TechState.kPossible)
+			color = Colors.DarkOliveGreen;
+		else if (isTechEraBeyondPlayerEra)
+			color = Colors.DimGray;
+
+		smallFontTheme.SetColor("font_color", "Label", color);
+	}
+
+	private string TruncateAndCacheName(string input, int limit) {
+
+		if (input.Length > limit) {
+
+			if (TruncatedToFullTechTextMap.ContainsKey(tech.Name)) {
+				TruncatedToFullTechTextMap[tech.Name] = input;
+			} else {
+				TruncatedToFullTechTextMap.TryAdd(tech.Name, input);
+			}
+
+			return $"{input.Trim().Substring(0, limit - 1)}...";
+		}
+
+		TruncatedToFullTechTextMap.Remove(tech.Name);
+
+		return input;
+	}
+
+	// TODO: When we figure out how to load the data, load the correct textures
+	private List<ImageTexture> TechEffectTextures() {
+
+		List<ImageTexture> textures = new ();
+
+		// Units
+		foreach (UnitPrototype unit in Units[tech.id]) {
+			// TODO : load the correct textures
+			// ImageTexture texture = ...
+			// textures.Add(texture);
+		}
+
+		// Buildings
+		foreach (Building building in Buildings[tech.id]) {
+			// TODO : load the correct textures
+			// ImageTexture texture = ...
+			// textures.Add(texture);
+		}
+
+		// Terraforms
+		foreach (Terraform terraform in Terraforms[tech.id]) {
+			textures.Add(TextureLoader.Load($"{terraform.ButtonTexture}.normal"));
+		}
+
+		// Obsolete buildings
+		foreach (Building building in ObsoleteBuildings[tech.id]) {
+			// if (cachedObsoleteBuildingTextures.TryGetValue(building.name, out ImageTexture texture)) {
+			// 	textures.Add(texture);
+			// } else {
+			// 	// TODO : load the correct textures
+			// 	// Image rawImage = ...
+			// 	// Image xMarkedImage = DrawXOnImage(rawImage, new Color(1, 0, 0), 1);
+			// 	// ImageTexture obsoleteBuilding = ImageTexture.CreateFromImage(xMarkedImage);
+			// 	// cachedObsoleteBuildingTextures.TryAdd(building.name, obsoleteBuilding);
+			// 	// textures.Add(texture);
+			// }
+		}
+
+		return textures;
+	}
+
+	private int CalculateTechBoxSizeCost(GameData gameData) {
+
+		int cost = 0;
+
+		// List of building that require this tech to be built
+		List<Building> buildings = gameData.Buildings.Where(b => b.requiredTech == tech).ToList();
+		Buildings.TryAdd(tech.id, buildings);
+		cost += buildings.Count;
+
+		// List of Great Wonders this tech renders obsolete
+		List<Building> obsoleteGrWonders = gameData.Buildings.Where(b => b.renderedObsoleteBy == tech).ToList();
+		ObsoleteBuildings.TryAdd(tech.id, obsoleteGrWonders);
+		cost += obsoleteGrWonders.Count;
+
+		List<UnitPrototype> units = new();
+		// List of units that require this tech to be built, taking into account that some are unique
+		List<UnitPrototype> unitsRequiringTech = gameData.unitPrototypes.Where(u => u.requiredTech == tech).ToList();
+		HashSet<string> replacements = new();
+
+		// Filter out all the units that are getting replaced
+		// e.x. Numidian Mercenary replaces Spearman
+		foreach (UnitPrototype u in unitsRequiringTech) {
+			if (u.unique != null && EngineStorage.gameData.GetFirstHumanPlayer().civilization == u.unique.civilization) {
+				if (u.unique.replace != null)
+					replacements.Add(u.unique.replace.name);
+			}
+		}
+
+		// Then add the correct units to the list
+		foreach (UnitPrototype u in unitsRequiringTech) {
+			if (u.unique == null && !replacements.Contains(u.name)) {
+				units.Add(u);
+			}
+			if (u.unique != null && EngineStorage.gameData.GetFirstHumanPlayer().civilization == u.unique.civilization) {
+				units.Add(u);
+			}
+		}
+
+		Units.TryAdd(tech.id, units);
+		cost += units.Count;
+
+		// List of terraform actions that require this tech to be done
+		List<Terraform> terraforms = gameData.Terraforms.Where(t => t.RequiredTech == tech.id).ToList();
+		Terraforms.TryAdd(tech.id, terraforms);
+		cost += terraforms.Count;
+
+		return cost;
+	}
+
+	private string CostToStringKey(int cost) {
+		// at best the large container fits 6 items
+		if (cost is > 4 and <= 6) {
+			return "large";
+		} else if (cost > 3) {
+			return "long";
+		} else if (cost > 1) {
+			return "medium";
+		} else {
+			return "small";
+		}
+	}
+
+	private string CalculateTechEraTexture(string techEra) {
+		return techEra switch {
+			ANCIENT_TIMES_CVLPD => "ancient",
+			MIDDLE_AGES_CVLPD => "middle",
+			INDUSTRIAL_AGE_CVLPD => "industrial",
+			MODERN_ERA_CVLPD => "modern",
+			_ => "ancient"
+		};
+	}
+
+	private Image DrawXOnImage(Image image, Color color, int thickness) {
+		// draw line from top left, to bottom right  ╲
+		DrawLineOnImage(image, new Vector2I(0, 0), new Vector2I(image.GetSize().X, image.GetSize().Y), color, thickness);
+		// draw line from top right, to bottom left  ╱
+		DrawLineOnImage(image, new Vector2I(image.GetSize().X, 0), new Vector2I(0, image.GetSize().Y), color, thickness);
+		return image;
+	}
+
+	private void DrawLineOnImage(Image img, Vector2I start, Vector2I end, Color color, int thickness) {
+		Vector2 direction = new Vector2(end.X - start.X, end.Y - start.Y).Normalized();
+		float distance = start.DistanceTo(end);
+
+		for (int i = 0; i < distance; i++) {
+			Vector2 pos = new Vector2(start.X, start.Y) + direction * i;
+			Vector2I point = new Vector2I(Mathf.RoundToInt(pos.X), Mathf.RoundToInt(pos.Y));
+
+			for (int dx = -thickness / 2; dx <= thickness / 2; dx++) {
+				for (int dy = -thickness / 2; dy <= thickness / 2; dy++) {
+					Vector2I pixel = point + new Vector2I(dx, dy);
+					if (pixel.X >= 0 && pixel.X < img.GetWidth() && pixel.Y >= 0 && pixel.Y < img.GetHeight()) {
+						img.SetPixel(pixel.X, pixel.Y, color);
+					}
+				}
+			}
 		}
 	}
 }

--- a/C7/UIElements/Advisors/TechBox.cs
+++ b/C7/UIElements/Advisors/TechBox.cs
@@ -18,9 +18,8 @@ public partial class TechBox : TextureButton {
 	private readonly Dictionary<ID, List<Terraform>> Terraforms = new();
 	private readonly Dictionary<ID, List<UnitPrototype>> Units = new();
 
-	private static readonly Dictionary<string, ImageTexture> CachedObsoleteBuildingTextures = new();
-
 	private static readonly Dictionary<string, string> TruncatedToFullTechTextMap = new();
+	private static readonly Dictionary<string, ImageTexture> CachedObsoleteBuildingTextures = new();
 
 	private FontFile smallFont = new();
 	private Theme smallFontTheme = new();
@@ -51,7 +50,6 @@ public partial class TechBox : TextureButton {
 	}
 
 	public override void _Ready() {
-
 		smallFont = ResourceLoader.Load<FontFile>("res://Fonts/NotoSans-Regular.ttf");
 
 		if (!tech.RequiredForEraAdvancement)
@@ -69,10 +67,10 @@ public partial class TechBox : TextureButton {
 		string techBoxSize = CostToStringKey(techBoxSizeCost);
 		string era = CalculateTechEraTexture(tech.EraCivilopediaName);
 
-		ImageTexture knownTechBox = TextureLoader.Load($"tech_box.known.{era}.{techBoxSize}");
-		ImageTexture inProgressTechBox = TextureLoader.Load($"tech_box.in_progress.{era}.{techBoxSize}");
-		ImageTexture possibleTechBox = TextureLoader.Load($"tech_box.possible.{era}.{techBoxSize}");
-		ImageTexture blockedTechBox = TextureLoader.Load($"tech_box.blocked.{era}.{techBoxSize}");
+		ImageTexture knownTechBox = TextureLoader.Load($"tech_boxes.known.{era}.{techBoxSize}");
+		ImageTexture inProgressTechBox = TextureLoader.Load($"tech_boxes.in_progress.{era}.{techBoxSize}");
+		ImageTexture possibleTechBox = TextureLoader.Load($"tech_boxes.possible.{era}.{techBoxSize}");
+		ImageTexture blockedTechBox = TextureLoader.Load($"tech_boxes.blocked.{era}.{techBoxSize}");
 
 		TextureNormal = techState switch {
 			TechState.kKnown => knownTechBox,
@@ -88,7 +86,10 @@ public partial class TechBox : TextureButton {
 		icon.SetPosition(new Vector2(12, 32));
 		AddChild(icon);
 
-		// we could be calculating this every time based on the font size,
+		// Figure out how many characters can fit in the tech box's width.
+		// We use this for truncation when creating the label below.
+		//
+		// We could be calculating this every time based on the font size,
 		// but I don't think it's worth the computation cost
 		// a larger char length, means a smaller Tech name (more chars will be truncated)
 		float averageCharLength = 6.0f;
@@ -125,10 +126,6 @@ public partial class TechBox : TextureButton {
 		int offsetY = 0;
 		int counter = 0;
 
-		// TODO : would be nice to figure out a way to cache these textures.
-		// A simple static dict won't work because of changes in scenarios etc
-		// because, if you Retire from one game, and into a new one,
-		// the textures will be from another set of rules
 		List<ImageTexture> techEffects = TechEffectTextures();
 
 		for (int i = 0; i < techEffects.Count; i++) {
@@ -149,7 +146,7 @@ public partial class TechBox : TextureButton {
 		AddChild(techNameLabel);
 
 		if (!tech.RequiredForEraAdvancement) {
-			TextureRect notRequired = new() { Texture = TextureLoader.Load("tech_box.non_required"), };
+			TextureRect notRequired = new() { Texture = TextureLoader.Load("tech_boxes.non_required"), };
 			notRequired.SetPosition(new Vector2(TextureNormal.GetWidth() - 20, 0));
 			AddChild(notRequired);
 		}
@@ -163,14 +160,13 @@ public partial class TechBox : TextureButton {
 		customTheme.SetColor("font_color", "TooltipLabel", Colors.Black);
 		customTheme.SetFontSize("font_size", "TooltipLabel", 12);
 		this.Theme = customTheme;
+
 		if (TruncatedToFullTechTextMap.TryGetValue(tech.Name, out string fullText))
 			this.TooltipText = $"{fullText}";
 	}
 
 	private void UpdateLabelTheme() {
-
 		Color color = Colors.Black;
-
 		bool isTechEraBeyondPlayerEra = GetEraIndex(tech.EraCivilopediaName) > GetEraIndex(EngineStorage.gameData.GetFirstHumanPlayer().eraCivilopediaName);
 
 		if (techState is TechState.kKnown)
@@ -186,26 +182,20 @@ public partial class TechBox : TextureButton {
 	}
 
 	private string TruncateAndCacheName(string input, int limit) {
-
 		if (input.Length > limit) {
-
 			if (TruncatedToFullTechTextMap.ContainsKey(tech.Name)) {
 				TruncatedToFullTechTextMap[tech.Name] = input;
 			} else {
 				TruncatedToFullTechTextMap.TryAdd(tech.Name, input);
 			}
-
 			return $"{input.Trim().Substring(0, limit - 1)}...";
 		}
-
 		TruncatedToFullTechTextMap.Remove(tech.Name);
-
 		return input;
 	}
 
 	// TODO: When we figure out how to load the data, load the correct textures
 	private List<ImageTexture> TechEffectTextures() {
-
 		List<ImageTexture> textures = new ();
 
 		// Units
@@ -245,7 +235,6 @@ public partial class TechBox : TextureButton {
 	}
 
 	private int CalculateTechBoxSizeCost(GameData gameData) {
-
 		int cost = 0;
 
 		// List of building that require this tech to be built

--- a/C7/UIElements/Popups/ScienceSelection.cs
+++ b/C7/UIElements/Popups/ScienceSelection.cs
@@ -1,10 +1,8 @@
 using Godot;
-using System;
-using System.Diagnostics;
 using C7GameData;
 using C7Engine;
-using Serilog;
 using System.Collections.Generic;
+using static C7Engine.MsgChooseResearch;
 
 public partial class ScienceSelection : Popup {
 	Player player;
@@ -41,7 +39,7 @@ public partial class ScienceSelection : Popup {
 		optionButton.SetPosition(new Vector2(25, 190));
 
 		AddButton("OK. Sounds good.", 235, () => {
-			new MsgChooseResearch(options[optionButton.Selected].id, showAdvisor: false).send();
+			new MsgChooseResearch(options[optionButton.Selected], AdvisorState.DontShow).send();
 			GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
 		});
 		AddButton("What's the big picture?", 265, () => {
@@ -50,7 +48,7 @@ public partial class ScienceSelection : Popup {
 		});
 
 		AddConfirmButton(new Vector2(width - 40, height - 40), () => {
-			new MsgChooseResearch(options[optionButton.Selected].id, showAdvisor: false).send();
+			new MsgChooseResearch(options[optionButton.Selected], AdvisorState.DontShow).send();
 			GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
 		});
 	}
@@ -76,11 +74,15 @@ public partial class ScienceSelection : Popup {
 		popup.AddThemeStyleboxOverride("panel", styleBox);
 
 		EngineStorage.ReadGameData((GameData gameData) => {
+			// first suggest the next item in the queue
+			if (player.ResearchQueue.Count > 0) {
+				AddItem(gameData, player.ResearchQueue.Peek(), optionButton);
+			}
+			// then the rest
 			foreach (Tech tech in player.GetAvailableTechsToResearch(gameData)) {
-				int turns = player.EstimateTurnsToResearch(gameData, tech);
-				string turnsStr = turns == int.MaxValue ? "--" : $"{turns}";
-				optionButton.AddItem($"{tech.Name} ({turnsStr} turns)");
-				options.Add(tech);
+				if (!options.Contains(tech)) {
+					AddItem(gameData, tech, optionButton);
+				}
 			}
 
 			for (int i = 0; i < popup.ItemCount; ++i) {
@@ -90,5 +92,12 @@ public partial class ScienceSelection : Popup {
 		});
 
 		return optionButton;
+	}
+
+	private void AddItem(GameData gameData, Tech tech, OptionButton optionButton) {
+		int turns = player.EstimateTurnsToResearch(gameData, tech);
+		string turnsStr = turns == int.MaxValue ? "--" : $"{turns}";
+		optionButton.AddItem($"{tech.Name} ({turnsStr} turns)");
+		options.Add(tech);
 	}
 }

--- a/C7/UIElements/Popups/TemporaryPopup.cs
+++ b/C7/UIElements/Popups/TemporaryPopup.cs
@@ -24,6 +24,21 @@ public partial class TemporaryPopup : Label {
 		return styleBox;
 	}
 
+	public static StyleBoxFlat PopupTechStyleBox() {
+		StyleBoxFlat styleBox = new();
+		styleBox.ContentMarginLeft = 5;
+		styleBox.ContentMarginRight = 5;
+		styleBox.ContentMarginTop = 2;
+		styleBox.ContentMarginBottom = 2;
+		styleBox.BorderColor = Colors.Black;
+		styleBox.BorderWidthBottom = 1;
+		styleBox.BorderWidthTop = 1;
+		styleBox.BorderWidthLeft = 1;
+		styleBox.BorderWidthRight = 1;
+		styleBox.BgColor = Color.FromHtml("F8F8F8");
+		return styleBox;
+	}
+
 	public async void ShowPopup() {
 		// Wait until we hit our duration then destroy ourself.
 		await Task.Delay(durationInMillis);

--- a/C7Engine/C7GameData/EraUtils.cs
+++ b/C7Engine/C7GameData/EraUtils.cs
@@ -1,0 +1,77 @@
+namespace C7GameData;
+
+public static class EraUtils {
+
+	public const string ANCIENT_TIMES_CVLPD = "ERAS_Ancient_Times";
+	public const string MIDDLE_AGES_CVLPD = "ERAS_Middle_Ages";
+	public const string INDUSTRIAL_AGE_CVLPD = "ERAS_Industrial_Age";
+	public const string MODERN_ERA_CVLPD = "ERAS_Modern_Era";
+
+	public const string ANCIENT_TIMES = "Ancient Times";
+	public const string MIDDLE_AGES = "Middle Ages";
+	public const string INDUSTRIAL_AGE = "Industrial Age";
+	public const string MODERN_ERA = "Modern Era";
+
+	public static int GetEraIndex(string era) {
+		if (era == ANCIENT_TIMES_CVLPD) {
+			return 0;
+		} else if (era == MIDDLE_AGES_CVLPD) {
+			return 1;
+		} else if (era == INDUSTRIAL_AGE_CVLPD) {
+			return 2;
+		} else if (era == MODERN_ERA_CVLPD) {
+			return 3;
+		}
+		return -1;
+	}
+
+	public static string EraIndexToEra(int index) {
+		if (index <= 0) {
+			return ANCIENT_TIMES_CVLPD;
+		} else if (index == 1) {
+			return MIDDLE_AGES_CVLPD;
+		} else if (index == 2) {
+			return INDUSTRIAL_AGE_CVLPD;
+		} else {
+			return MODERN_ERA_CVLPD;
+		}
+	}
+
+	public static string GetNiceEraName(string era) {
+		if (era == ANCIENT_TIMES_CVLPD) {
+			return ANCIENT_TIMES;
+		} else if (era == MIDDLE_AGES_CVLPD) {
+			return MIDDLE_AGES;
+		} else if (era == INDUSTRIAL_AGE_CVLPD) {
+			return INDUSTRIAL_AGE;
+		} else if (era == MODERN_ERA_CVLPD) {
+			return MODERN_ERA;
+		}
+		return $"Not A Valid Era: {era}";
+	}
+
+	public static string GetNextEraNiceName(string era) {
+		if (era == ANCIENT_TIMES_CVLPD) {
+			return MIDDLE_AGES;
+		} else if (era == MIDDLE_AGES_CVLPD) {
+			return INDUSTRIAL_AGE;
+		}
+		return MODERN_ERA;
+	}
+
+	public static string GetPreviousEraNiceName(string era) {
+		if (era == MODERN_ERA_CVLPD) {
+			return INDUSTRIAL_AGE;
+		} else if (era == INDUSTRIAL_AGE_CVLPD) {
+			return MIDDLE_AGES;
+		}
+		return ANCIENT_TIMES;
+	}
+
+	public static string GetNextEraNameByIndex(int index) {
+		return EraIndexToEra(index + 1);
+	}
+	public static string GetPreviousEraNameByIndex(int index) {
+		return EraIndexToEra(index - 1);
+	}
+}

--- a/C7Engine/C7GameData/EraUtils.cs
+++ b/C7Engine/C7GameData/EraUtils.cs
@@ -2,6 +2,7 @@ namespace C7GameData;
 
 public static class EraUtils {
 
+	// The civilopedia (CVLPD) version for each of the era names
 	public const string ANCIENT_TIMES_CVLPD = "ERAS_Ancient_Times";
 	public const string MIDDLE_AGES_CVLPD = "ERAS_Middle_Ages";
 	public const string INDUSTRIAL_AGE_CVLPD = "ERAS_Industrial_Age";

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -478,6 +478,12 @@ namespace C7GameData {
 					}
 				}
 
+				// Populate player's research queue
+				for (int t = 0; t < savData.LeadTechQueue[i].Length; ++t) {
+					int techItem = savData.LeadTechQueue[i][t];
+					player.researchQueue.Add(save.Techs[techItem].id);
+				}
+
 				player.gold = leader.Gold;
 				player.beakers = leader.Beakers;
 				player.turnsResearched = leader.TurnsResearched;

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -46,6 +46,10 @@ namespace C7GameData {
 		public ID currentlyResearchedTech { get; private set; }
 
 		// A queue of technologies the player has specified they want to research
+		//
+		// TODO: save the research queue (see SavePlayer.cs)
+		//
+		// TODO: be able to import the research queue in ImportCiv3.cs
 		public Queue<Tech> ResearchQueue { get; private set; } = new();
 
 		// The civilopedia name of the era this player is in.

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using C7Engine.AI.StrategicAI;
 using C7GameData.Save;
-using C7Engine.Pathing;
 using C7Engine;
 using Serilog;
+using static C7GameData.EraUtils;
 
 namespace C7GameData {
 	public class Player {
@@ -44,6 +44,9 @@ namespace C7GameData {
 
 		// The tech the player is currently researching.
 		public ID currentlyResearchedTech { get; private set; }
+
+		// A queue of technologies the player has specified they want to research
+		public Queue<Tech> ResearchQueue { get; private set; } = new();
 
 		// The civilopedia name of the era this player is in.
 		//
@@ -98,7 +101,7 @@ namespace C7GameData {
 		public int freeTechsRemaining = 0;
 
 		public int EraIndex() {
-			return EraIndex(eraCivilopediaName);
+			return GetEraIndex(eraCivilopediaName);
 		}
 
 		public static int EraIndex(string era) {
@@ -394,13 +397,78 @@ namespace C7GameData {
 			return $"{tech.Name} ({turns} turns)";
 		}
 
+		// Get a fresh research queue that overrides any current or previous queues.
+		// This queue is being reversed in the end, to provide the actual queue
+		// that the player would go through
+		public void CalculateFreshTechQueueAndAssignNewCurrent(Tech tech) {
+			ResearchQueue.Clear();
+			IEnumerable<Tech> techQueue = GetResearchQueueFor(tech, ResearchQueue).Reverse();
+			ResearchQueue = new Queue<Tech>(techQueue);
+
+			if (ResearchQueue.Count > 0)
+				SetCurrentlyResearchedTech(ResearchQueue.Peek().id);
+		}
+
+		// Append a new queue at the tail end of the current queue
+		public void CalculateTechQueueAndAppendToCurrentQueue(Tech tech) {
+			IEnumerable<Tech> techQueue = GetResearchQueueFor(tech, new Queue<Tech>()).Reverse();
+			foreach (Tech t in techQueue) {
+				if (!ResearchQueue.Contains(t)) {
+					ResearchQueue.Enqueue(t);
+				}
+			}
+		}
+
+		/// <summary>
+		/// This produces a queue, but in reverse order, going from the last tech to the first.
+		/// We can't reverse when returning from this method, because of its recursive nature,
+		/// so this must be done from the caller method.
+		/// </summary>
+		/// <param name="gameData"></param>
+		/// <param name="tech"></param>
+		/// <returns></returns>
+		private Queue<Tech> GetResearchQueueFor(Tech tech, Queue<Tech> tempQueue) {
+
+			if (tech == null) {
+				return new Queue<Tech>();
+			}
+
+			// TODO: maybe sort these on some other score, perhaps the order the AI would have picked them
+			// Right now the tech with the highest cost comes first
+			List<Tech> requiredTechs = tech.Prerequisites.OrderBy(t => t.Cost).ToList();
+
+			// first, add the tech the user clicked
+			if (!tempQueue.Contains(tech)) {
+				tempQueue.Enqueue(tech);
+			}
+
+			// second, get the direct required techs
+			foreach (Tech t in requiredTechs) {
+				if (!knownTechs.Contains(t.id)) {
+					if (!tempQueue.Contains(t)) {
+						tempQueue.Enqueue(t);
+					}
+				}
+			}
+
+			// last, recursively get the required techs of these required techs
+			foreach (Tech t in requiredTechs) {
+				if (!knownTechs.Contains(t.id)) {
+					if (t.Prerequisites.Count > 0) {
+						GetResearchQueueFor(t, tempQueue);
+					}
+				}
+			}
+			return tempQueue;
+		}
+
 		public HashSet<Tech> GetAvailableTechsToResearch(GameData gameData) {
 			HashSet<Tech> result = new();
 			foreach (Tech tech in gameData.techs) {
 				if (knownTechs.Contains(tech.id)) {
 					continue;
 				}
-				if (EraIndex(tech.EraCivilopediaName) > EraIndex()) {
+				if (GetEraIndex(tech.EraCivilopediaName) > EraIndex()) {
 					continue;
 				}
 
@@ -621,8 +689,13 @@ namespace C7GameData {
 			knownTechs.Add(tech.id);
 			SetCurrentlyResearchedTech(null);
 
+			// remove completed tech from the current research queue
+			if (ResearchQueue.Count > 0) {
+				ResearchQueue.Dequeue();
+			}
+
 			if (CanAdvanceToNextEra(gameData)) {
-				eraCivilopediaName = EraIndexToEra(EraIndex() + 1);
+				eraCivilopediaName = GetNextEraNameByIndex(EraIndex());
 			}
 		}
 

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -46,10 +46,6 @@ namespace C7GameData {
 		public ID currentlyResearchedTech { get; private set; }
 
 		// A queue of technologies the player has specified they want to research
-		//
-		// TODO: save the research queue (see SavePlayer.cs)
-		//
-		// TODO: be able to import the research queue in ImportCiv3.cs
 		public Queue<Tech> ResearchQueue { get; private set; } = new();
 
 		// The civilopedia name of the era this player is in.
@@ -155,6 +151,10 @@ namespace C7GameData {
 			// Clear out previous progress.
 			beakers = 0;
 			turnsResearched = 0;
+		}
+
+		public void AddTechItemToResearchQueue(Tech tech) {
+			ResearchQueue.Enqueue(tech);
 		}
 
 		public string GetNextCityName() {
@@ -418,7 +418,7 @@ namespace C7GameData {
 			IEnumerable<Tech> techQueue = GetResearchQueueFor(tech, new Queue<Tech>()).Reverse();
 			foreach (Tech t in techQueue) {
 				if (!ResearchQueue.Contains(t)) {
-					ResearchQueue.Enqueue(t);
+					AddTechItemToResearchQueue(t);
 				}
 			}
 		}

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -105,8 +105,10 @@ namespace C7GameData.Save {
 
 			ConvertTerrainImprovements(data);
 			ConvertTerraforms(data);
-			ConvertMapAndPlayers(data);
+			// convert technologies earlier than the player data,
+			// because we need to fill in current research and research queues
 			ConvertTechnologies(data);
+			ConvertMapAndPlayers(data);
 			ConvertBuildings(data);
 			ConvertUnits(data);
 			ConvertCities(data);
@@ -179,7 +181,7 @@ namespace C7GameData.Save {
 			data.map = Map.ToGameMap(data);
 
 			// players need game map to populate tile knowledge
-			data.players = Players.ConvertAll(player => player.ToPlayer(data.map, Civilizations, data.governments, data.rules));
+			data.players = Players.ConvertAll(player => player.ToPlayer(data.map, Civilizations, data.governments, data.techs, data.rules));
 		}
 
 		private void ConvertTerrainImprovements(GameData gameData) {

--- a/C7Engine/C7GameData/Save/SavePlayer.cs
+++ b/C7Engine/C7GameData/Save/SavePlayer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace C7GameData.Save {
 	// A class holding all the state of the relationship between two civs.
@@ -40,6 +41,9 @@ namespace C7GameData.Save {
 		// The tech the player is currently researching.
 		public ID currentlyResearchedTech;
 
+		// The tech queue the player is currently researching.
+		public List<ID> researchQueue = new();
+
 		// The civilopedia name of the era this player is in.
 		//
 		// The civilopedia name is what is used for art lookups, not the actual
@@ -73,7 +77,7 @@ namespace C7GameData.Save {
 		// The current government of the player.
 		public ID governmentId;
 
-		public Player ToPlayer(GameMap map, List<Civilization> civilizations, List<Government> governments, Rules rules) {
+		public Player ToPlayer(GameMap map, List<Civilization> civilizations, List<Government> governments, List<Tech> techs, Rules rules) {
 			Player player = new Player{
 				id = id,
 				isBarbarians = barbarian,
@@ -113,6 +117,11 @@ namespace C7GameData.Save {
 			player.beakers = beakers;
 			player.turnsResearched = turnsResearched;
 
+			foreach (ID techId in researchQueue) {
+				Tech tech = techs.Find(x => x.id == techId);
+				player.AddTechItemToResearchQueue(tech);
+			}
+
 			return player;
 		}
 
@@ -133,6 +142,7 @@ namespace C7GameData.Save {
 			turnsUntilPriorityReevaluation = player.turnsUntilPriorityReevaluation;
 			knownTechs = player.knownTechs;
 			currentlyResearchedTech = player.currentlyResearchedTech;
+			researchQueue = new List<ID>(player.ResearchQueue.Select(t => t.id));
 			eraCivilopediaName = player.eraCivilopediaName;
 			luxuryRate = player.luxuryRate;
 			scienceRate = player.scienceRate;

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -166,32 +166,48 @@ namespace C7Engine {
 	}
 
 	public class MsgChooseResearch : MessageToEngine {
-		private ID techId;
-		private bool showAdvisor;
-		public MsgChooseResearch(ID techId, bool showAdvisor) {
-			this.techId = techId;
-			this.showAdvisor = showAdvisor;
+		private Tech tech;
+		private AdvisorState advisorState;
+		private SelectionMode selectionMode;
+
+		public enum AdvisorState : byte {
+			DontShow,
+			Show,
+		}
+		public enum SelectionMode : byte {
+			Single,
+			Multi,
+		}
+
+		public MsgChooseResearch(Tech tech, AdvisorState advisorState, SelectionMode selectionMode = SelectionMode.Single) {
+			this.tech = tech;
+			this.advisorState = advisorState;
+			this.selectionMode = selectionMode;
 		}
 
 		public override void process() {
 			Player player = EngineStorage.gameData.GetFirstHumanPlayer();
-			if (player.currentlyResearchedTech == techId) {
+
+			bool isTechEraBeyondPlayerEra = EraUtils.GetEraIndex(tech.EraCivilopediaName) > EraUtils.GetEraIndex(player.eraCivilopediaName);
+			if (isTechEraBeyondPlayerEra)
+				return;
+			if (player.currentlyResearchedTech == tech.id && player.ResearchQueue.Count == 1) {
 				return;
 			}
-			Tech requestedTech = EngineStorage.gameData.techs.Find(t => t.id == techId);
 
-			// Ensure this is an eligible tech to research.
-			//
-			// TODO: do a topological sort to allow a queue of techs to study.
-			foreach (Tech prereq in requestedTech.Prerequisites) {
-				if (!player.knownTechs.Contains(prereq.id)) {
-					return;
-				}
+			// Start the tech queueing process
+			// and start researching the first tech in the queue
+			// or append a new queue to the current one if it's a multiselection process
+			if (selectionMode == SelectionMode.Single) {
+				player.CalculateFreshTechQueueAndAssignNewCurrent(tech);
+			} else {
+				player.CalculateTechQueueAndAppendToCurrentQueue(tech);
+
 			}
 
-			// Start researching this tech and update the UI.
-			player.SetCurrentlyResearchedTech(requestedTech.id);
-			if (showAdvisor) {
+			// update the UI
+			if (advisorState == AdvisorState.Show) {
+
 				new MsgShowScienceAdvisor().send();
 			}
 		}

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -189,7 +189,7 @@ namespace C7Engine {
 			Player player = EngineStorage.gameData.GetFirstHumanPlayer();
 
 			bool isTechEraBeyondPlayerEra = EraUtils.GetEraIndex(tech.EraCivilopediaName) > EraUtils.GetEraIndex(player.eraCivilopediaName);
-			if (isTechEraBeyondPlayerEra)
+			if (player.knownTechs.Contains(tech.id) || isTechEraBeyondPlayerEra)
 				return;
 			if (player.currentlyResearchedTech == tech.id && player.ResearchQueue.Count == 1) {
 				return;


### PR DESCRIPTION
1. Added size and era appropriate textures for tech boxes.
2. Added tech multiselection/queue functionality
3. Era helper class, should come handy in the future
4. White pop up tooltip for techs
5. Advisor name (probably temp way)

I had gone way further than that, pulling unit and building images with era and culture variations, extended the biq and pediaicons classes, but since there is an ongoing discussion as to how we will structure the data, I removed all that, leaving what I think will stay unaffected.