### PR TITLE
Go-to line, AI pathfinding modifications

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -852,7 +852,7 @@ public partial class Game : Node {
 			// different than the tile the unit is on, calculate the path to move there.
 			MapUnit unit = tile == null ? null : gameData.GetUnit(CurrentlySelectedUnit.id);
 			if (unit != null && unit.location != tile) {
-				result.path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, tile);
+				result.path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, tile, unit);
 				result.moveCost =
 					result.path.PathCost(unit.owner, unit.location, unit.unitType.movement, unit.movementPoints.remaining);
 				result.pathCoords = result.path.GetPathCoords();

--- a/C7/Map/GotoLayer.cs
+++ b/C7/Map/GotoLayer.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using C7GameData;
-using C7Engine;
-using ConvertCiv3Media;
 using Godot;
 
 // The layer responsible for drawing the cursor when the player is selecting a
@@ -16,7 +14,7 @@ public partial class GotoLayer : LooseLayer {
 		//
 		// We use FixedSize so Godot can calculate the width of the text for centering.
 		gotoLabelFont = ResourceLoader.Load<FontFile>("res://Fonts/NotoSans-Regular.ttf", null, ResourceLoader.CacheMode.Ignore);
-		gotoLabelFont.FixedSize = 25;
+		gotoLabelFont.FixedSize = 20;
 
 		whiteFontTheme.DefaultFont = gotoLabelFont;
 		whiteFontTheme.SetColor("font_color", "Label", Colors.White);
@@ -29,41 +27,45 @@ public partial class GotoLayer : LooseLayer {
 
 	// The GoTo cursor and label fields.
 	private AnimatedSprite2D gotoCursorSprite = null;
+	private TextureRect staticCursorRect = null;
+	private ImageTexture staticCursor = null;
 	private Label gotoLabel = null;
 	Theme whiteFontTheme = new();
 	Theme redFontTheme = new();
 	FontFile gotoLabelFont = new();
 
-	public void drawGotoCursor(LooseView looseView, Vector2 position, int moves, bool attackingMove) {
-		// Initialize cursor if necessary
-		if (gotoCursorSprite == null) {
-			gotoCursorSprite = new AnimatedSprite2D();
-			gotoCursorSprite.SpriteFrames = TextureLoader.LoadAnimation("animations.cursor", "cursor");
-			gotoCursorSprite.Animation = "cursor";
+	public void DrawStaticGoToCursor(LooseView looseView, Vector2 position, int moves, bool attackingMove) {
+		gotoCursorSprite?.Hide();
+		gotoLabel?.Hide();
+		staticCursorRect?.Hide();
+		if (staticCursor == null) {
+			staticCursor = (ImageTexture)TextureLoader.LoadAnimation("animations.cursor", "cursor").GetFrameTexture("cursor", 1);
+			TextureRect tr = new() { Texture = staticCursor};
+			staticCursorRect = tr;
 
 			gotoLabel = new() {
 				Theme = whiteFontTheme
 			};
 
+			looseView.AddChild(staticCursorRect);
 			looseView.AddChild(gotoLabel);
-			looseView.AddChild(gotoCursorSprite);
-			gotoCursorSprite.Play("cursor");
 		}
 
+		staticCursorRect.Position = position - new Vector2(staticCursor.GetWidth(), staticCursor.GetHeight()) / 2;
+
 		gotoLabel.Theme = attackingMove ? redFontTheme : whiteFontTheme;
-		gotoLabel.Text = moves.ToString();
+		gotoLabel.Text = moves > 0 ? moves.ToString() : " ";
 		Vector2 labelSize = gotoLabelFont.GetStringSize(gotoLabel.Text);
 		gotoLabel.Position = position - labelSize / 2;
-		gotoCursorSprite.Position = position;
 
-		// Now that we're positioned our objects, we can display them again.
-		gotoCursorSprite.Show();
+		staticCursorRect.Show();
 		gotoLabel.Show();
 	}
 
 	public override void onBeginDraw(LooseView looseView, GameData gameData) {
 		// Hide the cursor if it has been initialized
 		gotoCursorSprite?.Hide();
+		staticCursorRect?.Hide();
 		gotoLabel?.Hide();
 
 		looseView.mapView.game.animationController.updateAnimations();
@@ -73,15 +75,49 @@ public partial class GotoLayer : LooseLayer {
 		if (looseView.mapView.game.gotoInfo == null) {
 			return;
 		}
-		Game.GotoInfo gotoInfo = looseView.mapView.game.gotoInfo;
 
-		// We set the move cost to -1 in Game.cs if the move is invalid for some reason.
-		if (gotoInfo.destinationTile == tile && gotoInfo.moveCost >= 0) {
-			drawGotoCursor(looseView, tileCenter, gotoInfo.moveCost, gotoInfo.attackingMove);
-		} else if (gotoInfo.pathCoords
-				?.Contains(new System.Numerics.Vector2(tile.XCoordinate, tile.YCoordinate)) == true) {
-			// If this tile is part of the path, draw a little dot to represent that.
-			looseView.DrawCircle(tileCenter, 5, Colors.White);
+		Game.GotoInfo gotoInfo = looseView.mapView.game.gotoInfo;
+		MapUnit unit = looseView.mapView.game.CurrentlySelectedUnit;
+		Tile unitOriginTile = unit.location;
+
+		if (gotoInfo.destinationTile == tile){
+			DrawStaticGoToCursor(looseView, tileCenter,0,true );
+		}
+
+		if (gotoInfo.path != null && unit.CanEnterTile(gotoInfo.destinationTile, true ,true)) {
+			List<Tile> tiles = new List<Tile>();
+			tiles.Add(unitOriginTile);
+			tiles.AddRange(gotoInfo.path.path);
+
+			for (int i = 0; i < tiles.Count - 1; i++) {
+				Tile currentTile = tiles[i];
+				Tile nextTile = tiles[i + 1];
+
+				// Variable width of the line to account for various camera zoom levels.
+				// The end result should look pretty much the same to the player on any zoom level.
+				float lineWidth = Math.Max(1f / looseView.mapView.cameraZoom, 1f);
+
+				// We draw only the lines between tiles that are in our visible area
+				// with one or two tile buffer on both axis. How many is determined in the MapView
+				// by the getVisibleRegion().
+				// This is not only saving draw calls which is great, but there is a bigger reason.
+				// Imagine just loading the game, not moving the camera at all
+				// and press G to instruct a unit to move somewhere.
+				// The path is precomputed by another module, so we know the route to our destination.
+				// But if the path goes outside the visible area + the buffer, there is an issue.
+				// The visible region is only what you see at the screen plus the tiny buffer.
+				// These are the only tiles the player has seen and calculated the centers of, so far.
+				// If we try to draw lines between tiles that are outside this visible region, we will
+				// get an error because we don't know yet what these centers are. We either have to move the camera
+				// and calculate them, or precompute a huge buffer of tiles which is not practical at all.
+				if (looseView.tileCenters.TryGetValue(currentTile, out Vector2 currentTileCenter)
+				    && looseView.tileCenters.TryGetValue(nextTile, out Vector2 nextTileCenter)) {
+					staticCursorRect?.Hide();
+					looseView.DrawLine(currentTileCenter, nextTileCenter, Colors.Red, width: lineWidth);
+					// drawGotoCursor(looseView, nextTileCenter, gotoInfo.moveCost, gotoInfo.attackingMove);
+					DrawStaticGoToCursor(looseView, nextTileCenter, gotoInfo.moveCost, gotoInfo.attackingMove);
+				}
+			}
 		}
 	}
 }

--- a/C7/Map/GotoLayer.cs
+++ b/C7/Map/GotoLayer.cs
@@ -72,12 +72,13 @@ public partial class GotoLayer : LooseLayer {
 	}
 
 	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
-		if (looseView.mapView.game.gotoInfo == null) {
+		MapUnit unit = looseView.mapView.game.CurrentlySelectedUnit;
+		// When no unit is selected, at the end of a turn for example, we don't need to draw anything
+		if (looseView.mapView.game.gotoInfo == null || unit == MapUnit.NONE || unit == null) {
 			return;
 		}
 
 		Game.GotoInfo gotoInfo = looseView.mapView.game.gotoInfo;
-		MapUnit unit = looseView.mapView.game.CurrentlySelectedUnit;
 		Tile unitOriginTile = unit.location;
 
 		if (gotoInfo.destinationTile == tile) {
@@ -114,7 +115,6 @@ public partial class GotoLayer : LooseLayer {
 					&& looseView.tileCenters.TryGetValue(nextTile, out Vector2 nextTileCenter)) {
 					staticCursorRect?.Hide();
 					looseView.DrawLine(currentTileCenter, nextTileCenter, Colors.Red, width: lineWidth);
-					// drawGotoCursor(looseView, nextTileCenter, gotoInfo.moveCost, gotoInfo.attackingMove);
 					DrawStaticGoToCursor(looseView, nextTileCenter, gotoInfo.moveCost, gotoInfo.attackingMove);
 				}
 			}

--- a/C7/Map/GotoLayer.cs
+++ b/C7/Map/GotoLayer.cs
@@ -80,11 +80,11 @@ public partial class GotoLayer : LooseLayer {
 		MapUnit unit = looseView.mapView.game.CurrentlySelectedUnit;
 		Tile unitOriginTile = unit.location;
 
-		if (gotoInfo.destinationTile == tile){
-			DrawStaticGoToCursor(looseView, tileCenter,0,true );
+		if (gotoInfo.destinationTile == tile) {
+			DrawStaticGoToCursor(looseView, tileCenter, 0, true);
 		}
 
-		if (gotoInfo.path != null && unit.CanEnterTile(gotoInfo.destinationTile, true ,true)) {
+		if (gotoInfo.path != null && unit.CanEnterTile(gotoInfo.destinationTile, true, true)) {
 			List<Tile> tiles = new List<Tile>();
 			tiles.Add(unitOriginTile);
 			tiles.AddRange(gotoInfo.path.path);
@@ -111,7 +111,7 @@ public partial class GotoLayer : LooseLayer {
 				// get an error because we don't know yet what these centers are. We either have to move the camera
 				// and calculate them, or precompute a huge buffer of tiles which is not practical at all.
 				if (looseView.tileCenters.TryGetValue(currentTile, out Vector2 currentTileCenter)
-				    && looseView.tileCenters.TryGetValue(nextTile, out Vector2 nextTileCenter)) {
+					&& looseView.tileCenters.TryGetValue(nextTile, out Vector2 nextTileCenter)) {
 					staticCursorRect?.Hide();
 					looseView.DrawLine(currentTileCenter, nextTileCenter, Colors.Red, width: lineWidth);
 					// drawGotoCursor(looseView, nextTileCenter, gotoInfo.moveCost, gotoInfo.attackingMove);

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -445,11 +445,15 @@ public partial class LooseView : Node2D {
 	public List<LooseLayer> layers = new List<LooseLayer>();
 	private static ILogger log = Log.ForContext<LooseView>();
 
+	protected List<VisibleTile> visibleKnownTiles;
+	protected List<VisibleTile> visibleUnKnownTiles;
+	public Dictionary<Tile, Vector2> tileCenters { get; private set; } = new Dictionary<Tile, Vector2>();
+
 	public LooseView(MapView mapView) {
 		this.mapView = mapView;
 	}
 
-	private struct VisibleTile {
+	protected struct VisibleTile {
 		public Tile tile;
 		public Vector2 tileCenter;
 	}
@@ -461,26 +465,24 @@ public partial class LooseView : Node2D {
 			// Iterating over visible tiles is unfortunately pretty expensive. Assemble a list of Tile references and centers first so we don't
 			// have to reiterate for each layer. Doing this improves framerate significantly.
 			MapView.VisibleRegion visRegion = mapView.getVisibleRegion();
-			List<VisibleTile> visibleTiles = new List<VisibleTile>();
-			for (int Y = visRegion.upperLeftY; Y < visRegion.lowerRightY; Y++) {
-				if (gD.map.isRowAt(Y)) {
-					for (int X = visRegion.getRowStartX(Y); X < visRegion.lowerRightX; X += 2) {
-						Tile tile = gD.map.tileAt(X, Y);
-						if (IsTileKnown(tile, gD)) {
-							visibleTiles.Add(new VisibleTile {
-								tile = tile,
-								tileCenter = MapView.cellSize * new Vector2(X + 1, Y + 1)
-							});
-						}
-					}
-				}
-			}
+			visibleKnownTiles = new List<VisibleTile>();
+			visibleUnKnownTiles = new List<VisibleTile>();
+			GetVisibleTiles(visRegion, gD);
 
 			Stopwatch stopwatch = new Stopwatch();
 			stopwatch.Start();
-			foreach (LooseLayer layer in layers.FindAll(L => L.visible && !(L is FogOfWarLayer))) {
+			foreach (LooseLayer layer in layers.FindAll(L => L.visible && !(L is FogOfWarLayer) && !(L is GridLayer))) {
 				layer.onBeginDraw(this, gD);
-				foreach (VisibleTile vT in visibleTiles) {
+				foreach (VisibleTile vT in visibleKnownTiles) {
+					layer.drawObject(this, gD, vT.tile, vT.tileCenter);
+				}
+
+				layer.onEndDraw(this, gD);
+			}
+
+			foreach (GridLayer layer in layers.Where(layer => layer.visible && layer is GridLayer).Cast<GridLayer>()) {
+				layer.onBeginDraw(this, gD);
+				foreach (VisibleTile vT in visibleKnownTiles.Concat(visibleUnKnownTiles)) {
 					layer.drawObject(this, gD, vT.tile, vT.tileCenter);
 				}
 
@@ -493,8 +495,8 @@ public partial class LooseView : Node2D {
 
 			if (!gD.observerMode) {
 				foreach (FogOfWarLayer layer in layers.Where(layer => layer is FogOfWarLayer).Cast<FogOfWarLayer>()) {
-					for (int Y = visRegion.upperLeftY; Y < visRegion.lowerRightY; Y++)
-						if (gD.map.isRowAt(Y))
+					for (int Y = visRegion.upperLeftY; Y < visRegion.lowerRightY; Y++) {
+						if (gD.map.isRowAt(Y)) {
 							for (int X = visRegion.getRowStartX(Y); X < visRegion.lowerRightX; X += 2) {
 								Tile tile = gD.map.tileAt(X, Y);
 								if (tile != Tile.NONE) {
@@ -505,10 +507,37 @@ public partial class LooseView : Node2D {
 									layer.drawObject(this, gD, tile, invisibleTile.tileCenter);
 								}
 							}
+						}
+					}
 				}
 			}
 		});
 	}
+
+	private void GetVisibleTiles(MapView.VisibleRegion visRegion, GameData gD)
+	{
+		for (int Y = visRegion.upperLeftY; Y < visRegion.lowerRightY; Y++) {
+			if (gD.map.isRowAt(Y)) {
+				for (int X = visRegion.getRowStartX(Y); X < visRegion.lowerRightX; X += 2) {
+					Tile tile = gD.map.tileAt(X, Y);
+					Vector2 tileCenter = MapView.cellSize * new Vector2(X + 1, Y + 1);
+					if (IsTileKnown(tile, gD)) {
+						visibleKnownTiles.Add(new VisibleTile {
+							tile = tile,
+							tileCenter = tileCenter
+						});
+					} else {
+						visibleUnKnownTiles.Add(new VisibleTile {
+							tile = tile,
+							tileCenter = tileCenter
+						});
+					}
+					tileCenters[tile] = tileCenter;
+				}
+			}
+		}
+	}
+
 	private static bool IsTileKnown(Tile tile, GameData gameData) {
 		if (gameData.observerMode) {
 			return true;
@@ -604,10 +633,6 @@ public partial class MapView : Node2D {
 		this.cityLayer = new();
 		cityView.layers.Add(this.cityLayer);
 
-		LooseView unitView = new(this);
-		unitView.layers.Add(new UnitLayer());
-		unitView.layers.Add(new GotoLayer());
-
 		LooseView tileAssignmentView = new(this);
 		this.tileAssignmentLayer = new();
 		tileAssignmentView.layers.Add(this.tileAssignmentLayer);
@@ -615,20 +640,27 @@ public partial class MapView : Node2D {
 		LooseView fogOfWarView = new(this);
 		fogOfWarView.layers.Add(new FogOfWarLayer());
 
+		LooseView unitView = new(this);
+		unitView.layers.Add(new GotoLayer());
+		LooseView otherView = new(this);
+		otherView.layers.Add(new UnitLayer());
+
 		AddChild(terrainView);
 		looseViews.Add(terrainView);
 
 		AddChild(cityView);
 		looseViews.Add(cityView);
 
-		AddChild(unitView);
-		looseViews.Add(unitView);
-
 		AddChild(tileAssignmentView);
 		looseViews.Add(tileAssignmentView);
 
 		AddChild(fogOfWarView);
 		looseViews.Add(fogOfWarView);
+
+		AddChild(unitView);
+		looseViews.Add(unitView);
+		AddChild(otherView);
+		looseViews.Add(otherView);
 	}
 
 	public override void _Process(double delta) {

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -514,8 +514,7 @@ public partial class LooseView : Node2D {
 		});
 	}
 
-	private void GetVisibleTiles(MapView.VisibleRegion visRegion, GameData gD)
-	{
+	private void GetVisibleTiles(MapView.VisibleRegion visRegion, GameData gD) {
 		for (int Y = visRegion.upperLeftY; Y < visRegion.lowerRightY; Y++) {
 			if (gD.map.isRowAt(Y)) {
 				for (int X = visRegion.getRowStartX(Y); X < visRegion.lowerRightX; X += 2) {

--- a/C7Engine/AI/Pathing/AStarAlgorithm.cs
+++ b/C7Engine/AI/Pathing/AStarAlgorithm.cs
@@ -129,26 +129,26 @@ namespace C7Engine.Pathing {
 			if (current.IsWater() && neighbor.IsWater()) {
 				// current:east -> neighbor:west case
 				if (current.neighbors[TileDirection.WEST] == neighbor
-				    && current.neighbors[TileDirection.SOUTHWEST].IsLand()
-				    && current.neighbors[TileDirection.NORTHWEST].IsLand()) {
+					&& current.neighbors[TileDirection.SOUTHWEST].IsLand()
+					&& current.neighbors[TileDirection.NORTHWEST].IsLand()) {
 					return true;
 				}
 				// current:west -> neighbor:east case
 				if (current.neighbors[TileDirection.EAST] == neighbor
-				    && current.neighbors[TileDirection.SOUTHEAST].IsLand()
-				    && current.neighbors[TileDirection.NORTHEAST].IsLand()) {
+					&& current.neighbors[TileDirection.SOUTHEAST].IsLand()
+					&& current.neighbors[TileDirection.NORTHEAST].IsLand()) {
 					return true;
 				}
 				// current:south -> neighbor:north case
 				if (current.neighbors[TileDirection.NORTH] == neighbor
-				    && current.neighbors[TileDirection.NORTHWEST].IsLand()
-				    && current.neighbors[TileDirection.NORTHEAST].IsLand()) {
+					&& current.neighbors[TileDirection.NORTHWEST].IsLand()
+					&& current.neighbors[TileDirection.NORTHEAST].IsLand()) {
 					return true;
 				}
 				// current:north -> neighbor:south case
 				if (current.neighbors[TileDirection.SOUTH] == neighbor
-				    && current.neighbors[TileDirection.SOUTHWEST].IsLand()
-				    && current.neighbors[TileDirection.SOUTHEAST].IsLand()) {
+					&& current.neighbors[TileDirection.SOUTHWEST].IsLand()
+					&& current.neighbors[TileDirection.SOUTHEAST].IsLand()) {
 					return true;
 				}
 			}

--- a/C7Engine/AI/Pathing/AStarAlgorithm.cs
+++ b/C7Engine/AI/Pathing/AStarAlgorithm.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System;
 using C7GameData;
+using Serilog;
 
 namespace C7Engine.Pathing {
 	public class TileAndCost : IComparable<TileAndCost> {
@@ -38,17 +39,15 @@ namespace C7Engine.Pathing {
 		}
 
 		public override TilePath PathFrom(Tile start, Tile destination, MapUnit unit) {
-			// Exit early if we're starting and ending on land, and we're on
+			// Exit early if AI is starting and ending on land, and it's on
 			// different continents. Don't waste time checking every tile on the
 			// continent just to discover the path is impossible.
-			if (!unit.owner.isHuman || unit.owner.HasExploredTile(destination)) {
-				if (unit.IsLandUnit() && start.IsLand() && destination.IsLand() && start.continent != destination.continent) {
+			if (!unit.owner.isHuman) {
+				if (start.IsLand() && destination.IsLand() && start.continent != destination.continent) {
 					return TilePath.EmptyPath(destination);
 				}
-				// Avoid trying to calculate an impossible path, for example, from the sea to a lake
-				if (unit.IsWaterUnit() && start.IsWater() && destination.IsWater() && start.continent != destination.continent) {
-					return TilePath.EmptyPath(destination);
-				}
+				// TODO: We can add more restrictions to avoid calculations,
+				// especially for the water AI units, but requires careful planning/testing
 			}
 			// The set of tiles to explore next, ordered by their cumulative cost
 			// so far and the estimate of the cost to the goal.
@@ -83,7 +82,9 @@ namespace C7Engine.Pathing {
 
 					// TODO: the possibility here is to create a building/improvement/tech effect like "canal"
 					// (much like what the Panama canal is irl) that allows that kind of movement
-					if (unit.IsWaterUnit() && IsLandStrip(current, neighbor)) continue;
+					if (unit.IsWaterUnit()
+						&& (unit.owner.HasExploredTile(destination) || !unit.owner.isHuman)
+						&& GameMap.IsLandStrip(current, neighbor)) continue;
 
 					if (!isPassable(neighbor, destination)) {
 						continue;
@@ -106,53 +107,6 @@ namespace C7Engine.Pathing {
 			}
 
 			return TilePath.EmptyPath(destination);
-		}
-
-		private bool IsLandStrip(Tile current, Tile neighbor) {
-			// Account for small strips of land(visually) that water units must go around.
-			// These are coast tiles that bridge land tiles, and that a sea unit couldn't go through
-			// because otherwise that would make them islands of sorts.
-			// But in reality they are sea tiles with the coast texture, right next to each other,
-			// and nothing was preventing a sea unit to just cross from one to the other.
-			//
-			// Because of the isometric nature of the tiles, it seems that
-			// tiles that have a different relationship other than W<->E and N<->S
-			// like NW<->SE and NE<->SW can't possibly have the same issues
-			// because the never meet in a corner, but rather an edge.
-			//
-			//  east<->west case       north<->south case
-			//
-			//        <L>                    <S>
-			//      <S> <S>       or       <L> <L>
-			//        <L>                    <S>
-			//
-			if (current.IsWater() && neighbor.IsWater()) {
-				// current:east -> neighbor:west case
-				if (current.neighbors[TileDirection.WEST] == neighbor
-					&& current.neighbors[TileDirection.SOUTHWEST].IsLand()
-					&& current.neighbors[TileDirection.NORTHWEST].IsLand()) {
-					return true;
-				}
-				// current:west -> neighbor:east case
-				if (current.neighbors[TileDirection.EAST] == neighbor
-					&& current.neighbors[TileDirection.SOUTHEAST].IsLand()
-					&& current.neighbors[TileDirection.NORTHEAST].IsLand()) {
-					return true;
-				}
-				// current:south -> neighbor:north case
-				if (current.neighbors[TileDirection.NORTH] == neighbor
-					&& current.neighbors[TileDirection.NORTHWEST].IsLand()
-					&& current.neighbors[TileDirection.NORTHEAST].IsLand()) {
-					return true;
-				}
-				// current:north -> neighbor:south case
-				if (current.neighbors[TileDirection.SOUTH] == neighbor
-					&& current.neighbors[TileDirection.SOUTHWEST].IsLand()
-					&& current.neighbors[TileDirection.SOUTHEAST].IsLand()) {
-					return true;
-				}
-			}
-			return false;
 		}
 
 		private static TilePath makePath(Dictionary<Tile, Tile> cameFrom, Tile current) {

--- a/C7Engine/AI/Pathing/AStarAlgorithm.cs
+++ b/C7Engine/AI/Pathing/AStarAlgorithm.cs
@@ -37,14 +37,19 @@ namespace C7Engine.Pathing {
 			this.isPassable = isPassable;
 		}
 
-		public override TilePath PathFrom(Tile start, Tile destination) {
+		public override TilePath PathFrom(Tile start, Tile destination, MapUnit unit) {
 			// Exit early if we're starting and ending on land, and we're on
 			// different continents. Don't waste time checking every tile on the
 			// continent just to discover the path is impossible.
-			if (start.IsLand() && destination.IsLand() && start.continent != destination.continent) {
-				return TilePath.EmptyPath(destination);
+			if (!unit.owner.isHuman || unit.owner.HasExploredTile(destination)) {
+				if (unit.IsLandUnit() && start.IsLand() && destination.IsLand() && start.continent != destination.continent) {
+					return TilePath.EmptyPath(destination);
+				}
+				// Avoid trying to calculate an impossible path, for example, from the sea to a lake
+				if (unit.IsWaterUnit() && start.IsWater() && destination.IsWater() && start.continent != destination.continent) {
+					return TilePath.EmptyPath(destination);
+				}
 			}
-
 			// The set of tiles to explore next, ordered by their cumulative cost
 			// so far and the estimate of the cost to the goal.
 			BinaryMinHeap<TileAndCost> openSet = new();
@@ -76,6 +81,10 @@ namespace C7Engine.Pathing {
 				foreach (Edge<Tile> neighborEdge in edgeWalker.getEdges(current)) {
 					Tile neighbor = neighborEdge.current;
 
+					// TODO: the possibility here is to create a building/improvement/tech effect like "canal"
+					// (much like what the Panama canal is irl) that allows that kind of movement
+					if (unit.IsWaterUnit() && IsLandStrip(current, neighbor)) continue;
+
 					if (!isPassable(neighbor, destination)) {
 						continue;
 					}
@@ -97,6 +106,53 @@ namespace C7Engine.Pathing {
 			}
 
 			return TilePath.EmptyPath(destination);
+		}
+
+		private bool IsLandStrip(Tile current, Tile neighbor) {
+			// Account for small strips of land(visually) that water units must go around.
+			// These are coast tiles that bridge land tiles, and that a sea unit couldn't go through
+			// because otherwise that would make them islands of sorts.
+			// But in reality they are sea tiles with the coast texture, right next to each other,
+			// and nothing was preventing a sea unit to just cross from one to the other.
+			//
+			// Because of the isometric nature of the tiles, it seems that
+			// tiles that have a different relationship other than W<->E and N<->S
+			// like NW<->SE and NE<->SW can't possibly have the same issues
+			// because the never meet in a corner, but rather an edge.
+			//
+			//  east<->west case       north<->south case
+			//
+			//        <L>                    <S>
+			//      <S> <S>       or       <L> <L>
+			//        <L>                    <S>
+			//
+			if (current.IsWater() && neighbor.IsWater()) {
+				// current:east -> neighbor:west case
+				if (current.neighbors[TileDirection.WEST] == neighbor
+				    && current.neighbors[TileDirection.SOUTHWEST].IsLand()
+				    && current.neighbors[TileDirection.NORTHWEST].IsLand()) {
+					return true;
+				}
+				// current:west -> neighbor:east case
+				if (current.neighbors[TileDirection.EAST] == neighbor
+				    && current.neighbors[TileDirection.SOUTHEAST].IsLand()
+				    && current.neighbors[TileDirection.NORTHEAST].IsLand()) {
+					return true;
+				}
+				// current:south -> neighbor:north case
+				if (current.neighbors[TileDirection.NORTH] == neighbor
+				    && current.neighbors[TileDirection.NORTHWEST].IsLand()
+				    && current.neighbors[TileDirection.NORTHEAST].IsLand()) {
+					return true;
+				}
+				// current:north -> neighbor:south case
+				if (current.neighbors[TileDirection.SOUTH] == neighbor
+				    && current.neighbors[TileDirection.SOUTHWEST].IsLand()
+				    && current.neighbors[TileDirection.SOUTHEAST].IsLand()) {
+					return true;
+				}
+			}
+			return false;
 		}
 
 		private static TilePath makePath(Dictionary<Tile, Tile> cameFrom, Tile current) {

--- a/C7Engine/AI/Pathing/EdgeWalker.cs
+++ b/C7Engine/AI/Pathing/EdgeWalker.cs
@@ -25,9 +25,9 @@ namespace C7Engine.Pathing {
 				if (!unit.owner.HasExploredTile(neighbor)) {
 					isPassable = true;
 				} else {
-					if(unit.IsLandUnit())
+					if (unit.IsLandUnit())
 						isPassable = neighbor.IsLand();
-					else if(unit.IsWaterUnit())
+					else if (unit.IsWaterUnit())
 						isPassable = neighbor.IsWater() || neighborHasCityWithSameOwner;
 				}
 

--- a/C7Engine/AI/Pathing/EdgeWalker.cs
+++ b/C7Engine/AI/Pathing/EdgeWalker.cs
@@ -22,7 +22,7 @@ namespace C7Engine.Pathing {
 
 				bool isPassable = false;
 
-				if (!unit.owner.HasExploredTile(neighbor)) {
+				if (unit.owner.isHuman && !unit.owner.HasExploredTile(neighbor)) {
 					isPassable = true;
 				} else {
 					if (unit.IsLandUnit())

--- a/C7Engine/AI/Pathing/EdgeWalker.cs
+++ b/C7Engine/AI/Pathing/EdgeWalker.cs
@@ -14,23 +14,24 @@ namespace C7Engine.Pathing {
 		}
 
 		public override IEnumerable<Edge<Tile>> getEdges(Tile node) {
-			bool landUnit = unit.IsLandUnit();
-
 			List<Edge<Tile>> result = new List<Edge<Tile>>();
 			foreach (KeyValuePair<TileDirection, Tile> pair in node.neighbors) {
 				TileDirection direction = pair.Key;
 				Tile neighbor = pair.Value;
 				bool neighborHasCityWithSameOwner = neighbor.cityAtTile != null && neighbor.cityAtTile.owner == unit.owner;
 
+				bool isPassable = false;
 
-				// Land units can only go on to land.
-				if (landUnit && !neighbor.IsLand()) {
-					continue;
+				if (!unit.owner.HasExploredTile(neighbor)) {
+					isPassable = true;
+				} else {
+					if(unit.IsLandUnit())
+						isPassable = neighbor.IsLand();
+					else if(unit.IsWaterUnit())
+						isPassable = neighbor.IsWater() || neighborHasCityWithSameOwner;
 				}
 
-				// Water units can only go on water or coastal cities with the
-				// same owner (to support canals).
-				if (!landUnit && !(neighbor.IsWater() || neighborHasCityWithSameOwner)) {
+				if (!isPassable) {
 					continue;
 				}
 

--- a/C7Engine/AI/Pathing/PathingAlgorithm.cs
+++ b/C7Engine/AI/Pathing/PathingAlgorithm.cs
@@ -4,7 +4,7 @@ using C7GameData;
 
 namespace C7Engine.Pathing {
 	public abstract class PathingAlgorithm {
-		public abstract TilePath PathFrom(Tile start, Tile destination);
+		public abstract TilePath PathFrom(Tile start, Tile destination, MapUnit unit);
 
 		// Should not be public
 		public TilePath ConstructPath(Tile destination, Dictionary<Tile, Tile> predecessors) {

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -261,7 +261,7 @@ namespace C7Engine {
 				caid.destination = closestBarbCamp;
 
 				PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
-				caid.path = algorithm.PathFrom(unit.location, closestBarbCamp);
+				caid.path = algorithm.PathFrom(unit.location, closestBarbCamp, unit);
 				log.Information($"Set unit {unit} to take out barb camp at {closestBarbCamp}");
 				return new CombatAI(caid);
 			}

--- a/C7Engine/AI/UnitAI/CombatAI.cs
+++ b/C7Engine/AI/UnitAI/CombatAI.cs
@@ -143,7 +143,7 @@ namespace C7Engine.AI.UnitAI {
 			foreach (KeyValuePair<Tile, float> p in sortedScoredTiles) {
 				CombatAIData result = new();
 				result.destination = p.Key;
-				result.path = algorithm.PathFrom(unit.location, result.destination);
+				result.path = algorithm.PathFrom(unit.location, result.destination, unit);
 
 				// If we can't reach the destination, go to the next candidate.
 				if ((result.path?.PathLength() ?? -1) == -1) {
@@ -188,8 +188,8 @@ namespace C7Engine.AI.UnitAI {
 
 				foreach (Tile neighbor in t.neighbors.Values) {
 					// Units next to our cities are an even bigger threat. Note
-					// that it is possible for an enemy unit to be next to a 
-					// city but not in our borders if two cities are very close 
+					// that it is possible for an enemy unit to be next to a
+					// city but not in our borders if two cities are very close
 					// together.
 					if (neighbor.cityAtTile != null && neighbor.cityAtTile.owner == player) {
 						score += 3 * defender.unitType.attack;

--- a/C7Engine/AI/UnitAI/DefenderAI.cs
+++ b/C7Engine/AI/UnitAI/DefenderAI.cs
@@ -34,7 +34,7 @@ namespace C7Engine.AI.UnitAI {
 			ai.goal = DefenderAIData.DefenderGoal.DEFEND_CITY;
 
 			PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
-			ai.pathToDestination = algorithm.PathFrom(unit.location, ai.destination);
+			ai.pathToDestination = algorithm.PathFrom(unit.location, ai.destination, unit);
 
 			log.Information($"Unit {unit} tasked with defending {cityToDefend.name}");
 			return ai;
@@ -66,7 +66,7 @@ namespace C7Engine.AI.UnitAI {
 		/**
 		 * Finds a nearby city that could use extra defenders.
 		 *
-		 * This is not a brilliant method, with many flaws such as whether the 
+		 * This is not a brilliant method, with many flaws such as whether the
 		 * city needs more defenders, or if the units present are defenders.
 		 */
 		private static City FindAtRiskCityToDefend(MapUnit unit, Player player, int minDefenders) {

--- a/C7Engine/AI/UnitAI/EscortAI.cs
+++ b/C7Engine/AI/UnitAI/EscortAI.cs
@@ -79,7 +79,7 @@ namespace C7Engine {
 			}
 
 			// Move to the unit we're escorting.
-			TilePath path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, data.unitToEscort.location);
+			TilePath path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, data.unitToEscort.location, unit);
 			result = this.TryToMoveAlongPath(unit, ref path, allowCombat: false);
 			if (result != UnitAI.Result.InProgress) {
 				return result;

--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -101,14 +101,14 @@ namespace C7Engine {
 				int score = numUnknownNeighbors;
 				score *= numUnknownNeighbors;
 
-				// But penalize tiles that are far away from our cities, to 
+				// But penalize tiles that are far away from our cities, to
 				// encourate semi-local exploration. Without this we won't know
 				// city sites.
 				if (player.cities.Count > 0) {
 					score -= DistanceToNearestCity(player, t);
 				}
 
-				// Similarly with tiles that are far away from us. We use 
+				// Similarly with tiles that are far away from us. We use
 				// distanceTo as a quick heuristic to avoid expensive
 				// pathfinding.
 				score -= unit.location.distanceTo(t);
@@ -137,7 +137,7 @@ namespace C7Engine {
 			foreach (KeyValuePair<Tile, float> p in orderedScores) {
 				ExplorerAIData result = new ();
 				result.destination = p.Key;
-				result.pathToDestination = algorithm.PathFrom(unit.location, result.destination);
+				result.pathToDestination = algorithm.PathFrom(unit.location, result.destination, unit);
 
 				// If we can't reach the destination, go to the next candidate.
 				if ((result.pathToDestination?.PathLength() ?? -1) == -1) {

--- a/C7Engine/AI/UnitAI/SettlerAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerAI.cs
@@ -26,7 +26,7 @@ namespace C7Engine {
 					log.Information($"Set AI for unit {unit.id} of {unit.owner.civilization.name} to JOIN_CITY due to lack of locations to settle");
 				} else {
 					PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
-					settlerAiData.pathToDestination = algorithm.PathFrom(unit.location, settlerAiData.destination);
+					settlerAiData.pathToDestination = algorithm.PathFrom(unit.location, settlerAiData.destination, unit);
 					log.Information($"Set AI for unit {unit.id} of {unit.owner.civilization.name} to BUILD_CITY with destination of " + settlerAiData.destination);
 				}
 

--- a/C7Engine/AI/UnitAI/WorkerAI.cs
+++ b/C7Engine/AI/UnitAI/WorkerAI.cs
@@ -176,7 +176,7 @@ namespace C7Engine {
 					log.Information($"Set AI for unit at {unit.location} to {improvement} with destination of " + result.destination);
 
 					PathingAlgorithm algorithm = PathingAlgorithmChooser.GetAlgorithm(unit);
-					result.pathToDestination = algorithm.PathFrom(unit.location, result.destination);
+					result.pathToDestination = algorithm.PathFrom(unit.location, result.destination, unit);
 
 					return result;
 				}

--- a/C7Engine/AI/UnitAiExtension.cs
+++ b/C7Engine/AI/UnitAiExtension.cs
@@ -22,7 +22,7 @@ namespace C7Engine {
 				log.Information($"Attempting to repath {unit} from {unit.location} to {path.destination}");
 				// Attempt to repath. If we succeed, return inprogress so we get
 				// called again.
-				path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, path.destination);
+				path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, path.destination, unit);
 				if ((path?.PathLength() ?? -1) == -1 || path.PeekNext() == Tile.NONE || !unit.CanEnterTile(path.PeekNext(), allowCombat)) {
 					return UnitAI.Result.Error;
 				}

--- a/C7Engine/C7GameData/AIData/TilePath.cs
+++ b/C7Engine/C7GameData/AIData/TilePath.cs
@@ -91,7 +91,7 @@ namespace C7GameData {
 		public static float GetMovementCost(Player player, Tile from, TileDirection dir, Tile newLocation) {
 			// If the player hasn't yet explored a tile, assume it's a generic tile
 			// and give back a generic cost, since we don't know yet what it is.
-			if(player.isHuman && !player.HasExploredTile(newLocation))
+			if (player.isHuman && !player.HasExploredTile(newLocation))
 				return 1f;
 
 			// River crossings disrupt roads, so check that first.

--- a/C7Engine/C7GameData/AIData/TilePath.cs
+++ b/C7Engine/C7GameData/AIData/TilePath.cs
@@ -89,6 +89,10 @@ namespace C7GameData {
 		}
 
 		public static float GetMovementCost(Player player, Tile from, TileDirection dir, Tile newLocation) {
+			// If the player hasn't yet explored a tile, assume it's a generic tile
+			// and give back a generic cost, since we don't know yet what it is.
+			if(player.isHuman && !player.HasExploredTile(newLocation))
+				return 1f;
 
 			// River crossings disrupt roads, so check that first.
 			if (from.HasRiverCrossing(dir)) {
@@ -100,7 +104,6 @@ namespace C7GameData {
 			if (!Player.CanMoveFreely(player, from, newLocation)) {
 				return newLocation.MovementCost();
 			}
-
 
 			// Special case: if we are a water unit, traveling from the water into
 			// a city, it doesn't matter if the city is on hills or on grassland,

--- a/C7Engine/C7GameData/GameMap.cs
+++ b/C7Engine/C7GameData/GameMap.cs
@@ -1,3 +1,5 @@
+using Serilog;
+
 namespace C7GameData {
 	using System;
 	using System.Linq;
@@ -180,7 +182,7 @@ namespace C7GameData {
 					currentContinent.Add(x);
 
 					foreach (Tile n in x.neighbors.Values) {
-						if (!seen.Contains(n) && n.IsLand() == x.IsLand()) {
+						if (!seen.Contains(n) && n.IsLand() == x.IsLand() && !IsLandStrip(x, n)) {
 							seen.Add(n);
 							toCheck.Enqueue(n);
 						}
@@ -210,6 +212,65 @@ namespace C7GameData {
 					}
 				}
 			}
+		}
+
+		public static bool IsLandStrip(Tile current, Tile neighbor) {
+			// Account for small strips of land(visually) that water units must go around.
+			// These are coast tiles that bridge land tiles, and that a sea unit couldn't go through
+			// because otherwise that would make them islands of sorts.
+			// But in reality they are sea tiles with the coast texture, right next to each other,
+			// and nothing was preventing a sea unit to just cross from one to the other.
+			//
+			// Because of the isometric nature of the tiles, it seems that
+			// tiles that have a different relationship other than W<->E and N<->S
+			// like NW<->SE and NE<->SW can't possibly have the same issues
+			// because the never meet in a corner, but rather an edge.
+			//
+			//  east<->west case       north<->south case
+			//
+			//        <L>                    <S>
+			//      <S> <S>       or       <L> <L>
+			//        <L>                    <S>
+			//
+			if (current.IsWater() && neighbor.IsWater()) {
+				// current:east -> neighbor:west case
+				if (current.neighbors.TryGetValue(TileDirection.WEST, out Tile westNeighbor)
+					&& westNeighbor == neighbor
+					&& current.neighbors.TryGetValue(TileDirection.SOUTHWEST, out Tile eastWest_southWestTile)
+					&& eastWest_southWestTile.IsLand()
+					&& current.neighbors.TryGetValue(TileDirection.NORTHWEST, out Tile eastWest_NorthWestTile)
+					&& eastWest_NorthWestTile.IsLand()) {
+					return true;
+				}
+				// current:west -> neighbor:east case
+				if (current.neighbors.TryGetValue(TileDirection.EAST, out Tile eastNeighbor)
+					&& eastNeighbor == neighbor
+					&& current.neighbors.TryGetValue(TileDirection.SOUTHEAST, out Tile westEast_SouthEastTile)
+					&& westEast_SouthEastTile.IsLand()
+					&& current.neighbors.TryGetValue(TileDirection.NORTHEAST, out Tile westEast_NorthEastTile)
+					&& westEast_NorthEastTile.IsLand()) {
+					return true;
+				}
+				// current:south -> neighbor:north case
+				if (current.neighbors.TryGetValue(TileDirection.NORTH, out Tile northNeighbor)
+					&& northNeighbor == neighbor
+					&& current.neighbors.TryGetValue(TileDirection.NORTHWEST, out Tile southNorth_NorthWestTile)
+					&& southNorth_NorthWestTile.IsLand()
+					&& current.neighbors.TryGetValue(TileDirection.NORTHEAST, out Tile southNorth_NorthEastTile)
+					&& southNorth_NorthEastTile.IsLand()) {
+					return true;
+				}
+				// current:north -> neighbor:south case
+				if (current.neighbors.TryGetValue(TileDirection.SOUTH, out Tile southNeighbor)
+					&& southNeighbor == neighbor
+					&& current.neighbors.TryGetValue(TileDirection.SOUTHWEST, out Tile northSouth_SouthWestTile)
+					&& northSouth_SouthWestTile.IsLand()
+					&& current.neighbors.TryGetValue(TileDirection.SOUTHEAST, out Tile northSouth_SouthEastTile)
+					&& northSouth_SouthEastTile.IsLand()) {
+					return true;
+				}
+			}
+			return false;
 		}
 	}
 }

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -66,6 +66,9 @@ namespace C7GameData {
 		public bool IsLandUnit() {
 			return this.unitType.categories.Contains("Land");
 		}
+		public bool IsWaterUnit() {
+			return this.unitType.categories.Contains("Sea");
+		}
 
 		public bool CanDefendOnLand() {
 			return IsLandUnit() && unitType.defense > 0;
@@ -487,13 +490,25 @@ namespace C7GameData {
 		// Like above, but allows specifying that we want to handle the case
 		// where a war declaration could be made before the move.
 		public bool CanEnterTile(Tile tile, bool allowCombat, bool allowWarDeclaration) {
+			if (this.owner.isHuman && !this.owner.HasExploredTile(tile))
+				return true;
+
+			// TODO: Add sea/ocean restrictions for water units
+			// Check if the player has the appropriate tech or wonder to move freely.
+			// Civ3 seems to not allow to set a destination on sea/ocean without tech/wonder
+			// (even if you can actually go there using the keyboard keys)
+			// but it will go through it if it's just a shortcut to an allowed tile.
+
 			// Keep land units on land and sea units on water
-			if (unitType.categories.Contains("Sea") && tile.IsLand()) {
+			if (this.IsWaterUnit() && tile.IsLand()) {
 				if (tile.HasCity && tile.cityAtTile.owner == owner) {
 					return true;
 				}
 				return false;
-			} else if (unitType.categories.Contains("Land") && !tile.IsLand())
+			}
+			// TODO: to be modified to allow boarding on ships,
+			// that have the capacity and can take units of this kind
+			if (this.IsLandUnit() && !tile.IsLand())
 				return false;
 
 			// If we allow declaring war on this move, then it doesn't matter if
@@ -503,19 +518,30 @@ namespace C7GameData {
 				return true;
 			}
 
-			// Check for units belonging to other civs
-			foreach (MapUnit other in tile.unitsOnTile) {
-				if (other.owner != owner) {
-					if (!other.owner.IsAtPeaceWith(owner))
-						return allowCombat && unitType.attack > 0;
-					else
+			// Allow AI to "see" human/other AI units even if they are in an unexplored or inactive tile
+			// from their perspective, but allow humans to set a course if the tile
+			// is unknown or not active, aka, the human player shouldn't know what's on the tile
+			// if the tile is not active, or they haven't  discovered it yet.
+			//
+			// If we don't want to have the AI have this advantage over the human player
+			// we can simply remove the !isHuman() condition. This can also be tied to
+			// AI difficulty level, or be made moddable somehow, etc...
+			if (!this.owner.isHuman || this.owner.tileKnowledge.isActiveTile(tile)) {
+				// Check for units belonging to other civs
+				foreach (MapUnit other in tile.unitsOnTile) {
+					if (other.owner != owner) {
+						if (!other.owner.IsAtPeaceWith(owner))
+							return allowCombat && unitType.attack > 0;
 						return false;
+					}
 				}
 			}
 
 			// Check for cities belonging to other civs.
 			if (tile.cityAtTile != null && tile.cityAtTile.owner != owner) {
-				return allowCombat;
+				if(!this.owner.isHuman || this.owner.tileKnowledge.isActiveTile(tile))
+					return allowCombat;
+				return false;
 			}
 
 			return true;

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -539,7 +539,7 @@ namespace C7GameData {
 
 			// Check for cities belonging to other civs.
 			if (tile.cityAtTile != null && tile.cityAtTile.owner != owner) {
-				if(!this.owner.isHuman || this.owner.tileKnowledge.isActiveTile(tile))
+				if (!this.owner.isHuman || this.owner.tileKnowledge.isActiveTile(tile))
 					return allowCombat;
 				return false;
 			}

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -175,6 +175,10 @@ namespace C7GameData {
 			tileKnowledge = new TileKnowledge(this);
 		}
 
+		public bool HasExploredTile(Tile tile) {
+			return this.tileKnowledge.knownTiles.Contains(tile);
+		}
+
 		public bool IsAtPeaceWith(Player other) {
 			// Evaluate this before checking for barbarians so barbarians don't
 			// attack themselves.
@@ -263,6 +267,9 @@ namespace C7GameData {
 		}
 
 		public static bool CanMoveFreely(Player player, Tile sourceTile, Tile targetTile) {
+			if (!player.HasExploredTile(targetTile))
+				return true;
+
 			Player targetTileOwner = targetTile.OwningPlayer();
 			Player sourceTileOwner = sourceTile.OwningPlayer();
 

--- a/EngineTests/AI/Pathing/AStarPathFindingTest.cs
+++ b/EngineTests/AI/Pathing/AStarPathFindingTest.cs
@@ -1,0 +1,454 @@
+using C7Engine.Pathing;
+using C7GameData;
+using C7GameData.Save;
+using EngineTests.Utils;
+using Xunit;
+
+namespace EngineTests.AI.Pathing;
+
+public sealed class AStarPathFindingLandUnitTest : MapBase {
+
+	[Fact]
+	private void TestHumanLandUnitCanEnterUnknownCoastTiles() {
+		InitilizeStartTile(MakeHillTile(), new TileLocation(50, 50));
+		var north1 = AddNeighborsAndUpdateMap(startTile, MakeCoastTile(), TileDirection.NORTH);
+		var north2 = AddNeighborsAndUpdateMap(north1, MakeCoastTile(), TileDirection.NORTH);
+
+		MapUnit unit = MakeLandUnit();
+
+		// make player human, so that they can't see unknown tiles
+		unit.owner.isHuman = true;
+
+		AStarAlgorithm aStarAlgorithm = PathingAlgorithmChooser.GetAlgorithm(unit) as AStarAlgorithm;
+		TilePath tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
+
+		// Human land unit can calculate a path that contains coast tiles because it doesn't know yet
+		Assert.NotEmpty(tilePath.path);
+		Assert.True(tilePath.path.Count == 2);
+		Assert.True(tilePath.path.Contains(north1));
+		Assert.True(tilePath.path.Contains(north2));
+	}
+
+	[Fact]
+	private void TestAILandUnitCannotEnterUnknownCoastTiles() {
+		InitilizeStartTile(MakeHillTile(), new TileLocation(50, 50));
+		var north1 = AddNeighborsAndUpdateMap(startTile, MakeCoastTile(), TileDirection.NORTH);
+		var north2 = AddNeighborsAndUpdateMap(north1, MakeCoastTile(), TileDirection.NORTH);
+
+		MapUnit unit = MakeLandUnit();
+
+		unit.owner.isHuman = false;
+
+		AStarAlgorithm aStarAlgorithm = PathingAlgorithmChooser.GetAlgorithm(unit) as AStarAlgorithm;
+		TilePath tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
+
+		// AI land unit will not calculate a path that contains coast tiles because it can see them
+		// even if they are unexplored yet; i.e. the AI is cheating
+		Assert.Empty(tilePath.path);
+	}
+
+	[Fact]
+	private void TestHumanLandUnitCannotEnterKnownCoastTile() {
+		InitilizeStartTile(MakeHillTile(), new TileLocation(50, 50));
+		var north1 = AddNeighborsAndUpdateMap(startTile, MakeCoastTile(), TileDirection.NORTH);
+		var north2 = AddNeighborsAndUpdateMap(north1, MakeCoastTile(), TileDirection.NORTH);
+
+		MapUnit unit = MakeLandUnit();
+
+		// make player human, so that they can't see unknown tiles
+		unit.owner.isHuman = true;
+		unit.owner.tileKnowledge.knownTiles.Add(north1);
+		unit.owner.tileKnowledge.knownTiles.Add(north2);
+
+		AStarAlgorithm aStarAlgorithm = PathingAlgorithmChooser.GetAlgorithm(unit) as AStarAlgorithm;
+		TilePath tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
+
+		// Human land unit will ignore known coast tiles
+		Assert.Empty(tilePath.path);
+	}
+
+	[Fact]
+	private void TestLandUnitCanEnterDifferentContinentUnknownTile() {
+		InitilizeStartTile(MakeHillTile(), new TileLocation(50, 50));
+		startTile.continent = 1;
+		var coast = AddNeighborsAndUpdateMap(startTile, MakeCoastTile(), TileDirection.NORTH);
+		coast.continent = 0;
+		var otherContinentTile = AddNeighborsAndUpdateMap(coast, MakePlainsTile(), TileDirection.NORTH);
+		otherContinentTile.continent = 2;
+
+		MapUnit unit = MakeLandUnit();
+
+		AStarAlgorithm aStarAlgorithm = PathingAlgorithmChooser.GetAlgorithm(unit) as AStarAlgorithm;
+		TilePath tilePath = aStarAlgorithm.PathFrom(startTile, otherContinentTile, unit);
+
+		// Test 1
+		// The AI won't attempt to find a path to another continent's tile
+		Assert.Empty(tilePath.path);
+
+		// Test 2
+		unit.owner.isHuman = true;
+
+		tilePath = aStarAlgorithm.PathFrom(startTile, otherContinentTile, unit);
+
+		// The Human doesn't know what the tile is, even more so that's in a different continent and it can't ever reach it
+		Assert.NotEmpty(tilePath.path);
+		Assert.True(tilePath.path.Count == 2);
+		Assert.True(tilePath.path.Contains(otherContinentTile));
+		Assert.True(tilePath.path.Contains(coast));
+	}
+}
+
+public sealed class AStarPathFindingWaterUnitTest : MapBase {
+
+	[Fact]
+	private void TestWaterUnitCanEnterWaterTile() {
+		InitilizeStartTile(MakeCoastTile(), new TileLocation(50, 50));
+		var north1 = AddNeighborsAndUpdateMap(startTile, MakeCoastTile(), TileDirection.NORTH);
+		var north2 = AddNeighborsAndUpdateMap(north1, MakeCoastTile(), TileDirection.NORTH);
+
+		MapUnit unit = MakeWaterUnit();
+
+		AStarAlgorithm aStarAlgorithm = PathingAlgorithmChooser.GetAlgorithm(unit) as AStarAlgorithm;
+		TilePath tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
+
+		// Test 1
+		// AI can find the path
+		Assert.True(tilePath.path.Count == 2);
+		Assert.True(tilePath.path.Contains(north1));
+		Assert.True(tilePath.path.Contains(north2));
+
+		// Test 2
+		// Human can find the path, while tiles are unknown
+		unit.owner.isHuman = true;
+
+		tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
+
+		Assert.True(tilePath.path.Count == 2);
+		Assert.True(tilePath.path.Contains(north1));
+		Assert.True(tilePath.path.Contains(north2));
+
+		// Test 3
+		// Human can find the path, while having knowledge of the tiles
+		unit.owner.tileKnowledge.knownTiles.Add(north1);
+		unit.owner.tileKnowledge.knownTiles.Add(north2);
+
+		ComputeAllNeighbors(unit.owner.tileKnowledge.knownTiles);
+
+		tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
+
+		Assert.True(tilePath.path.Count == 2);
+		Assert.True(tilePath.path.Contains(north1));
+		Assert.True(tilePath.path.Contains(north2));
+	}
+
+	[Fact]
+	private void TestWaterUnitCanEnterWaterTileFromCity() {
+		InitilizeStartTile(MakeHillTile(), new TileLocation(50, 50));
+		var north1 = AddNeighborsAndUpdateMap(startTile, MakeCoastTile(), TileDirection.NORTH);
+		var north2 = AddNeighborsAndUpdateMap(north1, MakeCoastTile(), TileDirection.NORTH);
+
+
+		MapUnit unit = MakeWaterUnit();
+		startTile.cityAtTile = new City(north1, unit.owner, "Canal City", ID.None(""));
+
+		AStarAlgorithm aStarAlgorithm = PathingAlgorithmChooser.GetAlgorithm(unit) as AStarAlgorithm;
+		TilePath tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
+
+		// Test 1
+		// AI can find the path
+		Assert.True(tilePath.path.Count == 2);
+		Assert.True(tilePath.path.Contains(north1));
+		Assert.True(tilePath.path.Contains(north2));
+
+		// Test 2
+		// Human can find the path, while tiles are unknown
+		unit.owner.isHuman = true;
+
+		tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
+
+		Assert.True(tilePath.path.Count == 2);
+		Assert.True(tilePath.path.Contains(north1));
+		Assert.True(tilePath.path.Contains(north2));
+
+		// Test 3
+		// Human can find the path, while having knowledge of the tiles
+		unit.owner.tileKnowledge.knownTiles.Add(north1);
+		unit.owner.tileKnowledge.knownTiles.Add(north2);
+
+		ComputeAllNeighbors(unit.owner.tileKnowledge.knownTiles);
+
+		tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
+
+		Assert.True(tilePath.path.Count == 2);
+		Assert.True(tilePath.path.Contains(north1));
+		Assert.True(tilePath.path.Contains(north2));
+	}
+
+	[Fact]
+	private void TestHumanWaterUnitCanEnterUnknownLandTilesFromWater() {
+		InitilizeStartTile(MakeCoastTile(), new TileLocation(50, 50));
+		var north1 = AddNeighborsAndUpdateMap(startTile, MakePlainsTile(), TileDirection.NORTH);
+		var north2 = AddNeighborsAndUpdateMap(north1, MakePlainsTile(), TileDirection.NORTH);
+
+		MapUnit unit = MakeWaterUnit();
+
+		// make player human, so that they can't see unknown tiles
+		unit.owner.isHuman = true;
+
+		AStarAlgorithm aStarAlgorithm = PathingAlgorithmChooser.GetAlgorithm(unit) as AStarAlgorithm;
+		TilePath tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
+
+		// Test 1
+		// Human water unit can calculate a path that contains land tiles because it doesn't know yet
+		Assert.NotEmpty(tilePath.path);
+		Assert.True(tilePath.path.Count == 2);
+		Assert.True(tilePath.path.Contains(north1));
+		Assert.True(tilePath.path.Contains(north2));
+
+		// Test 2
+		// AI land unit will not calculate a path from a water tile to a land tile
+		// because it can see them even if they are unexplored yet; i.e. the AI is cheating
+		unit.owner.isHuman = false;
+
+		tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
+
+		Assert.Empty(tilePath.path);
+	}
+
+	[Fact]
+	private void TestHumanWaterUnitCanEnterUnknownLandTilesFromCity() {
+		InitilizeStartTile(MakePlainsTile(), new TileLocation(50, 50));
+		var north1 = AddNeighborsAndUpdateMap(startTile, MakePlainsTile(), TileDirection.NORTH);
+		var north2 = AddNeighborsAndUpdateMap(north1, MakePlainsTile(), TileDirection.NORTH);
+
+		MapUnit unit = MakeWaterUnit();
+
+		// make player human, so that they can't see unknown tiles
+		unit.owner.isHuman = true;
+		startTile.cityAtTile = new City(startTile, unit.owner, "Canal City", ID.None(""));
+
+		AStarAlgorithm aStarAlgorithm = PathingAlgorithmChooser.GetAlgorithm(unit) as AStarAlgorithm;
+		TilePath tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
+
+		// Test 1
+		// Human water unit can calculate a path that contains land tiles because it doesn't know yet
+		Assert.NotEmpty(tilePath.path);
+		Assert.True(tilePath.path.Count == 2);
+		Assert.True(tilePath.path.Contains(north1));
+		Assert.True(tilePath.path.Contains(north2));
+
+		// Test 2
+		// AI land unit will not calculate a path from a water tile to a land tile
+		// because it can see them even if they are unexplored yet; i.e. the AI is cheating
+		unit.owner.isHuman = false;
+
+		tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
+
+		Assert.Empty(tilePath.path);
+	}
+
+	[Fact]
+	private void TestWaterUnitCanEnterCityTile() {
+		InitilizeStartTile(MakeCoastTile(), new TileLocation(50, 50));
+		var north1 = AddNeighborsAndUpdateMap(startTile, MakePlainsTile(), TileDirection.NORTH);
+		var north2 = AddNeighborsAndUpdateMap(north1, MakeCoastTile(), TileDirection.NORTH);
+
+		MapUnit unit = MakeWaterUnit();
+
+		north1.cityAtTile = new City(north1, unit.owner, "Canal City", ID.None(""));
+
+		AStarAlgorithm aStarAlgorithm = PathingAlgorithmChooser.GetAlgorithm(unit) as AStarAlgorithm;
+		TilePath tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
+
+		// Test 1
+		// Water unit can enter a land tile that has a city, if they have the same owner
+		Assert.NotEmpty(tilePath.path);
+		Assert.True(tilePath.path.Count == 2);
+		Assert.True(tilePath.path.Contains(north1));
+		Assert.True(tilePath.path.Contains(north2));
+
+		// Test 2
+		// But cannot enter city with different owner
+		Player otherPlayer = new Player();
+
+		north1.cityAtTile = new City(north1, otherPlayer, "Canal City", ID.None(""));
+
+		tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
+
+		// Any water unit cannot enter a land tile that has a city if they have different owners
+		Assert.Empty(tilePath.path);
+	}
+
+	[Fact]
+	private void TestWaterUnitCanReachLakeNextToOcean() {
+		// "ocean"
+		InitilizeStartTile(MakeSeaTile(), new TileLocation(50, 50));
+		var coast1 = AddNeighborsAndUpdateMap(startTile, MakeSeaTile(), TileDirection.NORTH);
+		// land borders
+		var land1 =  AddNeighborsAndUpdateMap(coast1, MakePlainsTile(), TileDirection.NORTHWEST);
+		var land2 =  AddNeighborsAndUpdateMap(coast1, MakePlainsTile(), TileDirection.NORTHEAST);
+		// "Lake"
+		var lake1 = AddNeighborsAndUpdateMap(coast1, MakeLakeTile(), TileDirection.NORTH);
+		lake1.isFreshWater = true;
+		var lake2 = AddNeighborsAndUpdateMap(lake1, MakeLakeTile(), TileDirection.NORTHWEST);
+		var lake3 = AddNeighborsAndUpdateMap(lake1, MakeLakeTile(), TileDirection.NORTHEAST);
+		// destination
+		var lake4 = AddNeighborsAndUpdateMap(lake1, MakeLakeTile(), TileDirection.NORTH);
+
+		MapUnit unit = MakeWaterUnit();
+
+		AStarAlgorithm aStarAlgorithm = PathingAlgorithmChooser.GetAlgorithm(unit) as AStarAlgorithm;
+		TilePath tilePath = aStarAlgorithm.PathFrom(startTile, lake4, unit);
+
+		// Test 1
+		// Fist test the AI
+		Assert.Empty(tilePath.path);
+
+		// Test 2
+		// Then the human
+		unit.owner.isHuman = true;
+		unit.owner.tileKnowledge.knownTiles.Add(startTile);
+		unit.owner.tileKnowledge.knownTiles.Add(coast1);
+		unit.owner.tileKnowledge.knownTiles.Add(land1);
+		unit.owner.tileKnowledge.knownTiles.Add(land2);
+		unit.owner.tileKnowledge.knownTiles.Add(lake1);
+		unit.owner.tileKnowledge.knownTiles.Add(lake2);
+		unit.owner.tileKnowledge.knownTiles.Add(lake3);
+		unit.owner.tileKnowledge.knownTiles.Add(lake4);
+
+		ComputeAllNeighbors(unit.owner.tileKnowledge.knownTiles);
+
+		tilePath = aStarAlgorithm.PathFrom(startTile, lake4, unit);
+
+		Assert.Empty(tilePath.path);
+
+		//Test 3
+		// Go through city
+		land1.cityAtTile = new City(land1, unit.owner, "Canal City", ID.None(""));
+		tilePath = aStarAlgorithm.PathFrom(startTile, lake4, unit);
+
+		Assert.True(tilePath.path.Count == 4);
+		Assert.True(tilePath.path.Contains(coast1));
+		Assert.True(tilePath.path.Contains(land1));
+		Assert.True(tilePath.path.Contains(lake2));
+		Assert.True(tilePath.path.Contains(lake4));
+	}
+
+	[Fact]
+	private void TestWaterUnitCannotGoThroughLandStrip() {
+		InitilizeStartTile(MakeCoastTile(), new TileLocation(50, 50));
+		var destination = AddNeighborsAndUpdateMap(startTile, MakeCoastTile(), TileDirection.NORTH);
+		var west = AddNeighborsAndUpdateMap(startTile, MakePlainsTile(), TileDirection.NORTHWEST);
+		var east = AddNeighborsAndUpdateMap(startTile, MakePlainsTile(), TileDirection.NORTHEAST);
+
+		MapUnit unit = MakeWaterUnit();
+
+		AStarAlgorithm aStarAlgorithm = PathingAlgorithmChooser.GetAlgorithm(unit) as AStarAlgorithm;
+		TilePath tilePath = aStarAlgorithm.PathFrom(startTile, destination, unit);
+
+		// Test 1
+		// Fist test the AI
+		Assert.Empty(tilePath.path);
+
+		// Test 2
+		// Then the human
+		unit.owner.isHuman = true;
+
+		tilePath = aStarAlgorithm.PathFrom(startTile, destination, unit);
+
+		Assert.Single(tilePath.path);
+		Assert.True(tilePath.path.Contains(destination));
+	}
+
+	[Fact]
+	private void TestWaterUnitHasToGoAroundLandStrip() {
+		// Tile location here doesn't have a special meaning, I just had a map example to work off of
+		InitilizeStartTile(MakeCoastTile(), new TileLocation(88, 12));
+		var east = AddNeighborsAndUpdateMap(startTile, MakeCoastTile(), TileDirection.EAST);
+		var destination = AddNeighborsAndUpdateMap(east, MakeCoastTile(), TileDirection.EAST);
+
+		var land1 = AddNeighborsAndUpdateMap(east, MakePlainsTile(), TileDirection.SOUTHEAST);
+		var land2 = AddNeighborsAndUpdateMap(east, MakePlainsTile(), TileDirection.NORTHEAST);
+
+		var north = AddNeighborsAndUpdateMap(east, MakeCoastTile(), TileDirection.NORTH);
+		var northEast = AddNeighborsAndUpdateMap(north, MakeCoastTile(), TileDirection.NORTHEAST);
+		var southEast = AddNeighborsAndUpdateMap(northEast, MakeCoastTile(), TileDirection.SOUTHEAST);
+
+
+		MapUnit unit = MakeWaterUnit();
+		unit.owner.isHuman = true;
+
+		// Test 1
+		// First we will try to path to the destination blind as a human
+		unit.owner.tileKnowledge.knownTiles.Add(startTile);
+
+		ComputeAllNeighbors(unit.owner.tileKnowledge.knownTiles);
+
+		AStarAlgorithm aStarAlgorithm = PathingAlgorithmChooser.GetAlgorithm(unit) as AStarAlgorithm;
+		TilePath tilePath = aStarAlgorithm.PathFrom(startTile, destination, unit);
+
+		Assert.True(tilePath.path.Count == 2);
+		Assert.True(tilePath.path.Contains(east));
+		Assert.True(tilePath.path.Contains(destination));
+
+		// Test 2
+		// Update human player knowledge and recompute for the actual path now that we have "seen" the tiles
+		unit.owner.tileKnowledge.knownTiles.Add(east);
+		unit.owner.tileKnowledge.knownTiles.Add(destination);
+		unit.owner.tileKnowledge.knownTiles.Add(land1);
+		unit.owner.tileKnowledge.knownTiles.Add(land2);
+		unit.owner.tileKnowledge.knownTiles.Add(north);
+		unit.owner.tileKnowledge.knownTiles.Add(northEast);
+		unit.owner.tileKnowledge.knownTiles.Add(southEast);
+
+		ComputeAllNeighbors(unit.owner.tileKnowledge.knownTiles);
+
+		tilePath = aStarAlgorithm.PathFrom(startTile, destination, unit);
+
+		// path should be
+		Assert.True(tilePath.path.Count == 4);
+		Assert.True(tilePath.path.Contains(east));
+		Assert.True(tilePath.path.Contains(north));
+		Assert.True(tilePath.path.Contains(southEast));
+		Assert.True(tilePath.path.Contains(destination));
+
+		// Test 3
+		// Now add a city tile in one of the land tiles and unit should go through that
+		land1.cityAtTile = new City(land1, unit.owner, "Canal City", ID.None(""));
+		tilePath = aStarAlgorithm.PathFrom(startTile, destination, unit);
+
+		Assert.True(tilePath.path.Count == 3);
+		Assert.True(tilePath.path.Contains(east));
+		Assert.True(tilePath.path.Contains(land1));
+		Assert.True(tilePath.path.Contains(destination));
+
+		// Test 4
+		// Make the city another player's city, should ignore it
+		land1.cityAtTile = new City(land1, new Player(), "Canal City", ID.None(""));
+		tilePath = aStarAlgorithm.PathFrom(startTile, destination, unit);
+
+		Assert.True(tilePath.path.Count == 4);
+		Assert.False(tilePath.path.Contains(land1));
+		Assert.True(tilePath.path.Contains(east));
+		Assert.True(tilePath.path.Contains(north));
+		Assert.True(tilePath.path.Contains(southEast));
+		Assert.True(tilePath.path.Contains(destination));
+
+		// Test 5
+		// Then remove the tile knowledge & city and try as AI and should get the same results
+		unit.owner.isHuman = false;
+		land1.cityAtTile = null;
+		foreach (Tile tile in unit.owner.tileKnowledge.knownTiles)
+			unit.owner.tileKnowledge.knownTiles.Remove(tile);
+
+		ComputeAllNeighbors(unit.owner.tileKnowledge.knownTiles);
+
+		tilePath = aStarAlgorithm.PathFrom(startTile, destination, unit);
+
+		Assert.True(tilePath.path.Count == 4);
+		Assert.True(tilePath.path.Contains(east));
+		Assert.True(tilePath.path.Contains(north));
+		Assert.True(tilePath.path.Contains(southEast));
+		Assert.True(tilePath.path.Contains(destination));
+	}
+}

--- a/EngineTests/AI/Pathing/BinaryMinHeapTest.cs
+++ b/EngineTests/AI/Pathing/BinaryMinHeapTest.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using C7Engine.Pathing;
 using Xunit;
 
-namespace EngineTests {
+namespace EngineTests.AI.Pathing {
 	public class BinaryMinHeapTest {
 		private void checkBunchInsert<T>(List<T> list) where T : IComparable<T> {
 			BinaryMinHeap<T> heap = new BinaryMinHeap<T>();

--- a/EngineTests/AI/Pathing/EdgeWalkerTest.cs
+++ b/EngineTests/AI/Pathing/EdgeWalkerTest.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using C7Engine.Pathing;
 using C7GameData;
+using C7GameData.Save;
 using EngineTests.Utils;
 using Xunit;
 
@@ -9,29 +10,28 @@ namespace EngineTests.AI.Pathing {
 	public sealed class WalkerOnLandTest : MapBase {
 		[Fact]
 		private void TestHumanPlayerLandUnitIgnoresKnownWater() {
-			Tile start = hill;
+			InitilizeStartTile(MakeHillTile(), new TileLocation(50, 50));
 
-			// Add 3 neighbors, one of which is water.
-			start.neighbors[TileDirection.NORTH] = coast;
-			start.neighbors[TileDirection.SOUTH] = mountain;
-			start.neighbors[TileDirection.WEST] = plains;
+			var coast = AddNeighborsAndUpdateMap(startTile, MakeCoastTile(), TileDirection.NORTH);
+			var mountain = AddNeighborsAndUpdateMap(startTile, MakeMountainTile(), TileDirection.SOUTH);
+			var plains = AddNeighborsAndUpdateMap(startTile, MakePlainsTile(), TileDirection.WEST);
 
 			float movementPoints = 2.0f;
-			MapUnit landUnit =  MakeLandUnit((int)movementPoints);
+			MapUnit unit =  MakeLandUnit((int)movementPoints);
 
 			// make player human, so that they can't see unknown tiles
-			landUnit.owner.isHuman = true;
+			unit.owner.isHuman = true;
 
 			// Add tiles to Player's known tiles
-			landUnit.owner.tileKnowledge.knownTiles.Add(start);
-			landUnit.owner.tileKnowledge.knownTiles.Add(coast);
-			landUnit.owner.tileKnowledge.knownTiles.Add(mountain);
-			landUnit.owner.tileKnowledge.knownTiles.Add(plains);
+			unit.owner.tileKnowledge.knownTiles.Add(startTile);
+			unit.owner.tileKnowledge.knownTiles.Add(coast);
+			unit.owner.tileKnowledge.knownTiles.Add(mountain);
+			unit.owner.tileKnowledge.knownTiles.Add(plains);
 
-			UnitWalker unitWalker = new(landUnit);
+			UnitWalker unitWalker = new(unit);
 
 			// The water tile should be ignored, and the costs should be correct.
-			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(start);
+			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(startTile);
 			Assert.Equal(2, edges.Count());
 
 			Assert.Contains(edges, item => item.current == mountain && item.distanceToCurrent == 1);
@@ -40,26 +40,25 @@ namespace EngineTests.AI.Pathing {
 
 		[Fact]
 		private void TestHumanPlayerLandUnitIncludesUnknownWater() {
-			Tile start = hill;
+			InitilizeStartTile(MakeHillTile(), new TileLocation(50, 50));
 
-			// Add 3 neighbors, one of which is water.
-			start.neighbors[TileDirection.NORTH] = coast;
-			start.neighbors[TileDirection.SOUTH] = mountain;
-			start.neighbors[TileDirection.WEST] = plains;
+			var coast = AddNeighborsAndUpdateMap(startTile, MakeCoastTile(), TileDirection.NORTH);
+			var mountain = AddNeighborsAndUpdateMap(startTile, MakeMountainTile(), TileDirection.SOUTH);
+			var plains = AddNeighborsAndUpdateMap(startTile, MakePlainsTile(), TileDirection.WEST);
 
 			float movementPoints = 2.0f;
-			MapUnit landUnit =  MakeLandUnit((int)movementPoints);
-			landUnit.owner.isHuman = true;
+			MapUnit unit =  MakeLandUnit((int)movementPoints);
+			unit.owner.isHuman = true;
 
 			// Add tiles to Player's known tiles
-			landUnit.owner.tileKnowledge.knownTiles.Add(start);
-			landUnit.owner.tileKnowledge.knownTiles.Add(mountain);
-			landUnit.owner.tileKnowledge.knownTiles.Add(plains);
+			unit.owner.tileKnowledge.knownTiles.Add(startTile);
+			unit.owner.tileKnowledge.knownTiles.Add(mountain);
+			unit.owner.tileKnowledge.knownTiles.Add(plains);
 
-			UnitWalker unitWalker = new(landUnit);
+			UnitWalker unitWalker = new(unit);
 
 			// The water tile should not be ignored, and the costs should be correct.
-			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(start);
+			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(startTile);
 			Assert.Equal(3, edges.Count());
 
 			Assert.Contains(edges, item => item.current == mountain && item.distanceToCurrent == 1);
@@ -70,23 +69,22 @@ namespace EngineTests.AI.Pathing {
 
 		[Fact]
 		private void TestAiPlayerLandUnitIgnoresUnknownWater() {
-			Tile start = hill;
+			InitilizeStartTile(MakeHillTile(), new TileLocation(50, 50));
 
-			// Add 3 neighbors, one of which is water.
-			start.neighbors[TileDirection.NORTH] = coast;
-			start.neighbors[TileDirection.SOUTH] = mountain;
-			start.neighbors[TileDirection.WEST] = plains;
+			var coast = AddNeighborsAndUpdateMap(startTile, MakeCoastTile(), TileDirection.NORTH);
+			var mountain = AddNeighborsAndUpdateMap(startTile, MakeMountainTile(), TileDirection.SOUTH);
+			var plains = AddNeighborsAndUpdateMap(startTile, MakePlainsTile(), TileDirection.WEST);
 
 			float movementPoints = 2.0f;
-			MapUnit landUnit =  MakeLandUnit((int)movementPoints);
+			MapUnit unit =  MakeLandUnit((int)movementPoints);
 
 			// make player human, so that they can't see unknown tiles
-			landUnit.owner.isHuman = false;
+			unit.owner.isHuman = false;
 
-			UnitWalker unitWalker = new(landUnit);
+			UnitWalker unitWalker = new(unit);
 
 			// The water tile should be ignored, even if it's unexplored because player is AI, and the costs should be correct.
-			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(start);
+			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(startTile);
 			Assert.Equal(2, edges.Count());
 
 			Assert.Contains(edges, item => item.current == mountain && item.distanceToCurrent == 1);
@@ -95,61 +93,58 @@ namespace EngineTests.AI.Pathing {
 
 		[Fact]
 		private void TestRoadOnDestinationNotOnStart() {
-			Tile start = hill;
+			InitilizeStartTile(MakeHillTile(), new TileLocation(50, 50));
 
 			// Set up a neighbor with a road.
-			Tile end = plains;
-			end.overlays.Add(road);
-			start.neighbors[TileDirection.NORTH] = end;
+			var plains = AddNeighborsAndUpdateMap(startTile, MakePlainsTile(), TileDirection.NORTH);
+			plains.overlays.Add(road);
 
 			float movementPoints = 2.0f;
-			MapUnit landUnit =  MakeLandUnit((int)movementPoints);
+			MapUnit unit =  MakeLandUnit((int)movementPoints);
 
-			UnitWalker unitWalker = new(landUnit);
+			UnitWalker unitWalker = new(unit);
 
 			// The road shouldn't matter, since we don't have a road.
-			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(start);
+			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(startTile);
 			Assert.Single(edges);
 			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1 / 2.0f);
 		}
 
 		[Fact]
 		private void TestRoadOnStartNotOnDestination() {
-			Tile start = hill;
-			start.overlays.Add(road);
+			InitilizeStartTile(MakeHillTile(), new TileLocation(50, 50));
+			startTile.overlays.Add(road);
 
 			// Set up a neighbor without a road.
-			Tile end = plains;
-			start.neighbors[TileDirection.NORTH] = end;
+			var plains = AddNeighborsAndUpdateMap(startTile, MakePlainsTile(), TileDirection.NORTH);
 
 			float movementPoints = 2.0f;
-			MapUnit landUnit =  MakeLandUnit((int)movementPoints);
+			MapUnit unit =  MakeLandUnit((int)movementPoints);
 
-			UnitWalker unitWalker = new(landUnit);
+			UnitWalker unitWalker = new(unit);
 
 			// The road shouldn't matter, since the destination doesn't have a road.
-			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(start);
+			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(startTile);
 			Assert.Single(edges);
 			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1 / 2.0f);
 		}
 
 		[Fact]
 		private void TestRoadOnStartAndDestination() {
-			Tile start = hill;
-			start.overlays.Add(road);
+			InitilizeStartTile(MakeHillTile(), new TileLocation(50, 50));
+			startTile.overlays.Add(road);
 
-			// Set up a neighbor with a road.
-			Tile end = plains;
-			end.overlays.Add(road);
-			start.neighbors[TileDirection.NORTH] = end;
+			// Set up a neighbor without a road.
+			var plains = AddNeighborsAndUpdateMap(startTile, MakePlainsTile(), TileDirection.NORTH);
+			plains.overlays.Add(road);
 
 			float movementPoints = 2.0f;
-			MapUnit landUnit =  MakeLandUnit((int)movementPoints);
+			MapUnit unit =  MakeLandUnit((int)movementPoints);
 
-			UnitWalker unitWalker = new(landUnit);
+			UnitWalker unitWalker = new(unit);
 
 			// The cost should be adjusted because we both have a road.
-			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(start);
+			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(startTile);
 			Assert.Single(edges);
 			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1.0f / 3.0f / 2.0f);
 		}
@@ -158,27 +153,27 @@ namespace EngineTests.AI.Pathing {
 	public sealed class WalkerOnWaterTest : MapBase {
 		[Fact]
 		private void TestHumanWaterUnitIgnoresKnownLand() {
-			Tile start = coast;
+			InitilizeStartTile(MakeCoastTile(), new TileLocation(50, 50));
 
 			// Add 2 neighbors, one of which is land.
-			start.neighbors[TileDirection.NORTH] = hill;
-			start.neighbors[TileDirection.SOUTH] = sea;
+			var hills = AddNeighborsAndUpdateMap(startTile, MakeHillTile(), TileDirection.NORTH);
+			var sea = AddNeighborsAndUpdateMap(startTile, MakeSeaTile(), TileDirection.SOUTH);
 
 			float movementPoints = 2.0f;
-			MapUnit nonLandUnit =  MakeWaterUnit((int)movementPoints);
+			MapUnit unit =  MakeWaterUnit((int)movementPoints);
 
 			// make player human, so that they can't see unknown tiles
-			nonLandUnit.owner.isHuman = true;
+			unit.owner.isHuman = true;
 
 			// Add tiles to Player's known tiles
-			nonLandUnit.owner.tileKnowledge.knownTiles.Add(start);
-			nonLandUnit.owner.tileKnowledge.knownTiles.Add(hill);
-			nonLandUnit.owner.tileKnowledge.knownTiles.Add(sea);
+			unit.owner.tileKnowledge.knownTiles.Add(sea);
+			unit.owner.tileKnowledge.knownTiles.Add(hills);
+			unit.owner.tileKnowledge.knownTiles.Add(sea);
 
-			UnitWalker unitWalker = new(nonLandUnit);
+			UnitWalker unitWalker = new(unit);
 
 			// The land tile should be ignored, and the costs should be correct.
-			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(start);
+			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(startTile);
 			Assert.Single(edges);
 
 			Assert.Contains(edges, item => item.current == sea && item.distanceToCurrent == 1 / movementPoints);
@@ -186,26 +181,26 @@ namespace EngineTests.AI.Pathing {
 
 		[Fact]
 		private void TestHumanWaterUnitDoesNotIgnoreUnknownLand() {
-			Tile start = coast;
+			InitilizeStartTile(MakeCoastTile(), new TileLocation(50, 50));
 
 			// Add 2 neighbors, one of which is land.
-			start.neighbors[TileDirection.NORTH] = hill;
-			start.neighbors[TileDirection.SOUTH] = sea;
+			var hill = AddNeighborsAndUpdateMap(startTile, MakeHillTile(), TileDirection.NORTH);
+			var sea = AddNeighborsAndUpdateMap(startTile, MakeSeaTile(), TileDirection.SOUTH);
 
 			float movementPoints = 2.0f;
-			MapUnit nonLandUnit =  MakeWaterUnit((int)movementPoints);
+			MapUnit unit =  MakeWaterUnit((int)movementPoints);
 
 			// make player human, so that they can't see unknown tiles
-			nonLandUnit.owner.isHuman = true;
+			unit.owner.isHuman = true;
 
 			// Add tiles to Player's known tiles
-			nonLandUnit.owner.tileKnowledge.knownTiles.Add(start);
-			nonLandUnit.owner.tileKnowledge.knownTiles.Add(sea);
+			unit.owner.tileKnowledge.knownTiles.Add(startTile);
+			unit.owner.tileKnowledge.knownTiles.Add(sea);
 
-			UnitWalker unitWalker = new(nonLandUnit);
+			UnitWalker unitWalker = new(unit);
 
 			// The land tile should be ignored, and the costs should be correct.
-			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(start);
+			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(startTile);
 			Assert.Equal(2, edges.Count());
 
 			Assert.Contains(edges, item => item.current == sea && item.distanceToCurrent == 1 / movementPoints);
@@ -214,58 +209,57 @@ namespace EngineTests.AI.Pathing {
 
 		[Fact]
 		private void TestLandIncludedIfItHasCityWithSameOwner() {
-			Tile start = coast;
+			InitilizeStartTile(MakeCoastTile(), new TileLocation(50, 50));
+			var hill = AddNeighborsAndUpdateMap(startTile, MakeHillTile(), TileDirection.NORTH);
 
 			float movementPoints = 2.0f;
-			MapUnit nonLandUnit =  MakeWaterUnit((int)movementPoints);
+			MapUnit unit =  MakeWaterUnit((int)movementPoints);
 
 			// Set up a neighbor on land with a city of the same owner.
-			Tile end = hill;
-			end.cityAtTile = new City(Tile.NONE, nonLandUnit.owner, "", ID.None(""));
-			start.neighbors[TileDirection.NORTH] = end;
+			hill.cityAtTile = new City(Tile.NONE, unit.owner, "", ID.None(""));
 
 			// Add tiles to Player's known tiles
-			nonLandUnit.owner.tileKnowledge.knownTiles.Add(start);
-			nonLandUnit.owner.tileKnowledge.knownTiles.Add(end);
+			unit.owner.tileKnowledge.knownTiles.Add(startTile);
+			unit.owner.tileKnowledge.knownTiles.Add(hill);
 
-			UnitWalker walker = new(nonLandUnit);
+			UnitWalker walker = new(unit);
 
 			// The city tile should be included, to allow for canals, and so
 			// that ships can go back into harbors.
 			//
 			// The cost should be 1, despite the city being on a hill. Land
 			// movement costs don't make sense to apply to ships.
-			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
+			IEnumerable<Edge<Tile>> edges = walker.getEdges(startTile);
 			Assert.Single(edges);
 			Assert.Contains(edges, item => item.current == hill && item.distanceToCurrent == 1 / movementPoints);
 		}
 
 		[Fact]
 		private void TestCityWithDifferentOwnerNotIncluded() {
-			Tile start = coast;
+			InitilizeStartTile(MakeCoastTile(), new TileLocation(50, 50));
+			var hill = AddNeighborsAndUpdateMap(startTile, MakeHillTile(), TileDirection.NORTH);
 
 			float movementPoints = 2.0f;
-			MapUnit nonLandUnit =  MakeWaterUnit((int)movementPoints);
+			MapUnit unit =  MakeWaterUnit((int)movementPoints);
 
 			Player otherPlayer = new Player();
 
 			// Set up a neighbor on land with a city of the same owner.
 			Tile end = hill;
 			end.cityAtTile = new City(Tile.NONE, otherPlayer, "", ID.None(""));
-			start.neighbors[TileDirection.NORTH] = end;
 
 			// Add tiles to Player's known tiles
-			nonLandUnit.owner.tileKnowledge.knownTiles.Add(start);
-			nonLandUnit.owner.tileKnowledge.knownTiles.Add(end);
+			unit.owner.tileKnowledge.knownTiles.Add(startTile);
+			unit.owner.tileKnowledge.knownTiles.Add(end);
 
-			UnitWalker walker = new(nonLandUnit);
+			UnitWalker walker = new(unit);
 
 			// The city tile should be included, to allow for canals, and so
 			// that ships can go back into harbors.
 			//
 			// The cost should be 1, despite the city being on a hill. Land
 			// movement costs don't make sense to apply to ships.
-			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
+			IEnumerable<Edge<Tile>> edges = walker.getEdges(startTile);
 			Assert.Empty(edges);
 		}
 	}

--- a/EngineTests/AI/Pathing/EdgeWalkerTest.cs
+++ b/EngineTests/AI/Pathing/EdgeWalkerTest.cs
@@ -2,61 +2,13 @@ using System.Collections.Generic;
 using System.Linq;
 using C7Engine.Pathing;
 using C7GameData;
+using EngineTests.Utils;
 using Xunit;
 
-namespace EngineTests {
-	public class WalkerOnLandTest {
-		private static MapUnit MakeLandUnit() {
-			MapUnit result = new(ID.None("")) {
-				unitType = new UnitPrototype() {
-					movement = 2,
-				},
-			};
-			result.unitType.categories.Add("Land");
-			return result;
-		}
-
-		private UnitWalker walker = new(MakeLandUnit());
-		private Tile mountain  = new(ID.None("")) {
-			baseTerrainType = new() {
-				Key = "mountains"
-			},
-			overlayTerrainType = new() {
-				Key = "mountains",
-				movementCost = 3
-			}
-		};
-		private Tile hill  = new(ID.None("")) {
-			baseTerrainType = new() {
-				Key = "hills"
-			},
-			overlayTerrainType = new() {
-				Key = "hills",
-				movementCost = 2
-			}
-		};
-		private Tile plains  = new(ID.None("")) {
-			baseTerrainType = new() {
-				Key = "plains"
-			},
-			overlayTerrainType = new() {
-				Key = "plains",
-				movementCost = 1
-			}
-		};
-		private Tile coast  = new(ID.None("")) {
-			baseTerrainType = new() {
-				Key = "coast"
-			},
-			overlayTerrainType = new() {
-				Key = "coast",
-				movementCost = 1
-			}
-		};
-		private TerrainImprovement road = new("road", TerrainImprovement.Layer.Roads, movementCost: 1.0f / 3);
-
+namespace EngineTests.AI.Pathing {
+	public sealed class WalkerOnLandTest : MapBase {
 		[Fact]
-		void testIgnoresWater() {
+		private void TestHumanPlayerLandUnitIgnoresKnownWater() {
 			Tile start = hill;
 
 			// Add 3 neighbors, one of which is water.
@@ -64,16 +16,85 @@ namespace EngineTests {
 			start.neighbors[TileDirection.SOUTH] = mountain;
 			start.neighbors[TileDirection.WEST] = plains;
 
+			float movementPoints = 2.0f;
+			MapUnit landUnit =  MakeLandUnit((int)movementPoints);
+
+			// make player human, so that they can't see unknown tiles
+			landUnit.owner.isHuman = true;
+
+			// Add tiles to Player's known tiles
+			landUnit.owner.tileKnowledge.knownTiles.Add(start);
+			landUnit.owner.tileKnowledge.knownTiles.Add(coast);
+			landUnit.owner.tileKnowledge.knownTiles.Add(mountain);
+			landUnit.owner.tileKnowledge.knownTiles.Add(plains);
+
+			UnitWalker unitWalker = new(landUnit);
+
 			// The water tile should be ignored, and the costs should be correct.
-			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
+			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(start);
 			Assert.Equal(2, edges.Count());
 
 			Assert.Contains(edges, item => item.current == mountain && item.distanceToCurrent == 1);
-			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1 / 2.0f);
+			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1 / movementPoints);
 		}
 
 		[Fact]
-		void testRoadOnDestinationNotOnStart() {
+		private void TestHumanPlayerLandUnitIncludesUnknownWater() {
+			Tile start = hill;
+
+			// Add 3 neighbors, one of which is water.
+			start.neighbors[TileDirection.NORTH] = coast;
+			start.neighbors[TileDirection.SOUTH] = mountain;
+			start.neighbors[TileDirection.WEST] = plains;
+
+			float movementPoints = 2.0f;
+			MapUnit landUnit =  MakeLandUnit((int)movementPoints);
+			landUnit.owner.isHuman = true;
+
+			// Add tiles to Player's known tiles
+			landUnit.owner.tileKnowledge.knownTiles.Add(start);
+			landUnit.owner.tileKnowledge.knownTiles.Add(mountain);
+			landUnit.owner.tileKnowledge.knownTiles.Add(plains);
+
+			UnitWalker unitWalker = new(landUnit);
+
+			// The water tile should not be ignored, and the costs should be correct.
+			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(start);
+			Assert.Equal(3, edges.Count());
+
+			Assert.Contains(edges, item => item.current == mountain && item.distanceToCurrent == 1);
+			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1 / movementPoints);
+			// 1 cost because the human player does not know the nature of the unexplored tile
+			Assert.Contains(edges, item => item.current == coast && item.distanceToCurrent == 1 / movementPoints);
+		}
+
+		[Fact]
+		private void TestAiPlayerLandUnitIgnoresUnknownWater() {
+			Tile start = hill;
+
+			// Add 3 neighbors, one of which is water.
+			start.neighbors[TileDirection.NORTH] = coast;
+			start.neighbors[TileDirection.SOUTH] = mountain;
+			start.neighbors[TileDirection.WEST] = plains;
+
+			float movementPoints = 2.0f;
+			MapUnit landUnit =  MakeLandUnit((int)movementPoints);
+
+			// make player human, so that they can't see unknown tiles
+			landUnit.owner.isHuman = false;
+
+			UnitWalker unitWalker = new(landUnit);
+
+			// The water tile should be ignored, even if it's unexplored because player is AI, and the costs should be correct.
+			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(start);
+			Assert.Equal(2, edges.Count());
+
+			Assert.Contains(edges, item => item.current == mountain && item.distanceToCurrent == 1);
+			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1 / movementPoints);
+		}
+
+		[Fact]
+		private void TestRoadOnDestinationNotOnStart() {
 			Tile start = hill;
 
 			// Set up a neighbor with a road.
@@ -81,14 +102,19 @@ namespace EngineTests {
 			end.overlays.Add(road);
 			start.neighbors[TileDirection.NORTH] = end;
 
+			float movementPoints = 2.0f;
+			MapUnit landUnit =  MakeLandUnit((int)movementPoints);
+
+			UnitWalker unitWalker = new(landUnit);
+
 			// The road shouldn't matter, since we don't have a road.
-			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
+			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(start);
 			Assert.Single(edges);
 			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1 / 2.0f);
 		}
 
 		[Fact]
-		void testRoadOnStartNotOnDestination() {
+		private void TestRoadOnStartNotOnDestination() {
 			Tile start = hill;
 			start.overlays.Add(road);
 
@@ -96,14 +122,19 @@ namespace EngineTests {
 			Tile end = plains;
 			start.neighbors[TileDirection.NORTH] = end;
 
+			float movementPoints = 2.0f;
+			MapUnit landUnit =  MakeLandUnit((int)movementPoints);
+
+			UnitWalker unitWalker = new(landUnit);
+
 			// The road shouldn't matter, since the destination doesn't have a road.
-			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
+			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(start);
 			Assert.Single(edges);
 			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1 / 2.0f);
 		}
 
 		[Fact]
-		void testRoadOnStartAndDestination() {
+		private void TestRoadOnStartAndDestination() {
 			Tile start = hill;
 			start.overlays.Add(road);
 
@@ -112,80 +143,92 @@ namespace EngineTests {
 			end.overlays.Add(road);
 			start.neighbors[TileDirection.NORTH] = end;
 
+			float movementPoints = 2.0f;
+			MapUnit landUnit =  MakeLandUnit((int)movementPoints);
+
+			UnitWalker unitWalker = new(landUnit);
+
 			// The cost should be adjusted because we both have a road.
-			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
+			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(start);
 			Assert.Single(edges);
 			Assert.Contains(edges, item => item.current == plains && item.distanceToCurrent == 1.0f / 3.0f / 2.0f);
 		}
 	}
 
-	public class WalkerOnWaterTest {
-		private static MapUnit MakeWaterUnit() {
-			MapUnit result = new(ID.None("")) {
-				unitType = new UnitPrototype() {
-					movement = 2,
-				},
-			};
-			return result;
-		}
-
-		private Player player = new();
-		private MapUnit nonLandUnit = MakeWaterUnit();
-		private Tile hill  = new(ID.None("")) {
-			baseTerrainType = new() {
-				Key = "hills"
-			},
-			overlayTerrainType = new() {
-				Key = "hills",
-				movementCost = 2
-			}
-		};
-		private Tile coast  = new(ID.None("")) {
-			baseTerrainType = new() {
-				Key = "coast"
-			},
-			overlayTerrainType = new() {
-				Key = "coast",
-				movementCost = 1
-			}
-		};
-		private Tile sea  = new(ID.None("")) {
-			baseTerrainType = new() {
-				Key = "sea"
-			},
-			overlayTerrainType = new() {
-				Key = "sea",
-				movementCost = 1
-			}
-		};
-
+	public sealed class WalkerOnWaterTest : MapBase {
 		[Fact]
-		void testIgnoresLand() {
-			UnitWalker walker = new(nonLandUnit);
+		private void TestHumanWaterUnitIgnoresKnownLand() {
 			Tile start = coast;
 
 			// Add 2 neighbors, one of which is land.
 			start.neighbors[TileDirection.NORTH] = hill;
 			start.neighbors[TileDirection.SOUTH] = sea;
 
+			float movementPoints = 2.0f;
+			MapUnit nonLandUnit =  MakeWaterUnit((int)movementPoints);
+
+			// make player human, so that they can't see unknown tiles
+			nonLandUnit.owner.isHuman = true;
+
+			// Add tiles to Player's known tiles
+			nonLandUnit.owner.tileKnowledge.knownTiles.Add(start);
+			nonLandUnit.owner.tileKnowledge.knownTiles.Add(hill);
+			nonLandUnit.owner.tileKnowledge.knownTiles.Add(sea);
+
+			UnitWalker unitWalker = new(nonLandUnit);
+
 			// The land tile should be ignored, and the costs should be correct.
-			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
+			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(start);
 			Assert.Single(edges);
 
-			Assert.Contains(edges, item => item.current == sea && item.distanceToCurrent == 1 / 2.0f);
+			Assert.Contains(edges, item => item.current == sea && item.distanceToCurrent == 1 / movementPoints);
 		}
 
 		[Fact]
-		void testLandIncludedIfItHasCityWithSameOwner() {
-			UnitWalker walker = new(nonLandUnit);
-			nonLandUnit.owner = player;
-
+		private void TestHumanWaterUnitDoesNotIgnoreUnknownLand() {
 			Tile start = coast;
+
+			// Add 2 neighbors, one of which is land.
+			start.neighbors[TileDirection.NORTH] = hill;
+			start.neighbors[TileDirection.SOUTH] = sea;
+
+			float movementPoints = 2.0f;
+			MapUnit nonLandUnit =  MakeWaterUnit((int)movementPoints);
+
+			// make player human, so that they can't see unknown tiles
+			nonLandUnit.owner.isHuman = true;
+
+			// Add tiles to Player's known tiles
+			nonLandUnit.owner.tileKnowledge.knownTiles.Add(start);
+			nonLandUnit.owner.tileKnowledge.knownTiles.Add(sea);
+
+			UnitWalker unitWalker = new(nonLandUnit);
+
+			// The land tile should be ignored, and the costs should be correct.
+			IEnumerable<Edge<Tile>> edges = unitWalker.getEdges(start);
+			Assert.Equal(2, edges.Count());
+
+			Assert.Contains(edges, item => item.current == sea && item.distanceToCurrent == 1 / movementPoints);
+			Assert.Contains(edges, item => item.current == hill && item.distanceToCurrent == 1 / movementPoints);
+		}
+
+		[Fact]
+		private void TestLandIncludedIfItHasCityWithSameOwner() {
+			Tile start = coast;
+
+			float movementPoints = 2.0f;
+			MapUnit nonLandUnit =  MakeWaterUnit((int)movementPoints);
 
 			// Set up a neighbor on land with a city of the same owner.
 			Tile end = hill;
-			end.cityAtTile = new City(Tile.NONE, player, "", ID.None(""));
+			end.cityAtTile = new City(Tile.NONE, nonLandUnit.owner, "", ID.None(""));
 			start.neighbors[TileDirection.NORTH] = end;
+
+			// Add tiles to Player's known tiles
+			nonLandUnit.owner.tileKnowledge.knownTiles.Add(start);
+			nonLandUnit.owner.tileKnowledge.knownTiles.Add(end);
+
+			UnitWalker walker = new(nonLandUnit);
 
 			// The city tile should be included, to allow for canals, and so
 			// that ships can go back into harbors.
@@ -194,20 +237,28 @@ namespace EngineTests {
 			// movement costs don't make sense to apply to ships.
 			IEnumerable<Edge<Tile>> edges = walker.getEdges(start);
 			Assert.Single(edges);
-			Assert.Contains(edges, item => item.current == hill && item.distanceToCurrent == 1 / 2.0f);
+			Assert.Contains(edges, item => item.current == hill && item.distanceToCurrent == 1 / movementPoints);
 		}
 
 		[Fact]
-		void testCityWithDifferentOwnerNotIncluded() {
-			UnitWalker walker = new(nonLandUnit);
+		private void TestCityWithDifferentOwnerNotIncluded() {
 			Tile start = coast;
-			nonLandUnit.owner = player;
-			Player otherPlayer =new();
+
+			float movementPoints = 2.0f;
+			MapUnit nonLandUnit =  MakeWaterUnit((int)movementPoints);
+
+			Player otherPlayer = new Player();
 
 			// Set up a neighbor on land with a city of the same owner.
 			Tile end = hill;
 			end.cityAtTile = new City(Tile.NONE, otherPlayer, "", ID.None(""));
 			start.neighbors[TileDirection.NORTH] = end;
+
+			// Add tiles to Player's known tiles
+			nonLandUnit.owner.tileKnowledge.knownTiles.Add(start);
+			nonLandUnit.owner.tileKnowledge.knownTiles.Add(end);
+
+			UnitWalker walker = new(nonLandUnit);
 
 			// The city tile should be included, to allow for canals, and so
 			// that ships can go back into harbors.

--- a/EngineTests/GameData/CityTest.cs
+++ b/EngineTests/GameData/CityTest.cs
@@ -1,10 +1,12 @@
 using C7GameData;
 using Xunit;
 
+namespace EngineTests.GameData;
+
 public class CityTest {
 	[Fact]
 	public void CityWith2ProductionPerTurn_ShouldReturn1TurnIf9_of_10ProductionDone() {
-		C7Engine.EngineStorage.InitializeGameDataForTests(new GameData() {
+		C7Engine.EngineStorage.InitializeGameDataForTests(new C7GameData.GameData() {
 			gameDifficulty = new Difficulty(),
 		});
 		Player player = new() {
@@ -62,7 +64,7 @@ public class CityTest {
 
 	[Fact]
 	public void CityShouldShrinkWhenItRunsOutOfFood() {
-		GameData gameData = new();
+		C7GameData.GameData gameData = new();
 		Player player = new();
 		player.government = new Government();
 		player.rules = new() { MaximumLevel1CitySize = 6 };

--- a/EngineTests/GameData/GameMapTest.cs
+++ b/EngineTests/GameData/GameMapTest.cs
@@ -1,0 +1,127 @@
+
+using System.Collections.Generic;
+using System.Linq;
+using C7GameData;
+using C7GameData.Save;
+using EngineTests.Utils;
+using Xunit;
+
+namespace EngineTests.GameData;
+
+public class GameMapTest : MapBase {
+	[Fact]
+	public void TestCorrectContinentCalculation() {
+		// <~ ~ ~ > is sea
+		// <______> is plains
+		// <oooooo> is coast that is freshwater (lake)
+		//
+		//
+		//           <~ ~ ~ ><~ ~ ~ ><~ ~ ~ ><~ ~ ~ ><~ ~ ~ >
+		//       <~ ~ ~ ><~ ~ ~ ><~ ~ ~ ><~ ~ ~ ><~ ~ ~ >
+		//           <~ ~ ~ ><~ ~ ~ ><~ ~ ~ ><~ ~ ~ ><~ ~ ~ >    <---------- sea might not be exact, but the point is there is a block of sea
+		//       <~ ~ ~ ><~ ~ ~ ><~ ~ ~ ><~ ~ ~ ><~ ~ ~ >
+		//                   <~ ~ ~ ><______>
+		//                       <~ ~ ~ ><______>
+		//                   <______><______><______>
+		//               <______><oooooo><oooooo><______>         <---------- first tile on the left here is the starting tile
+		//                   <______><oooooo><______>
+		//                       <______><______>
+		//                           <______>
+
+
+
+		InitilizeStartTile(MakePlainsTile(), new TileLocation(50, 50));
+		Tile x1y1 = AddNeighborsAndUpdateMap(startTile, MakePlainsTile(), TileDirection.SOUTHEAST);
+		Tile x1y2 = AddNeighborsAndUpdateMap(x1y1, MakePlainsTile(), TileDirection.NORTH);
+
+		Tile x2y1 = AddNeighborsAndUpdateMap(x1y1, MakePlainsTile(), TileDirection.SOUTHEAST);
+		Tile x2y2 = AddNeighborsAndUpdateMap(x2y1, MakeCoastTile(), TileDirection.NORTH); // lake
+		Tile x2y3 = AddNeighborsAndUpdateMap(x2y2, MakeCoastTile(), TileDirection.NORTH); // sea
+		Tile x2y4 = AddNeighborsAndUpdateMap(x2y3, MakeCoastTile(), TileDirection.NORTHWEST); // sea
+
+		// extra sea so x2y3 that we actually care to check against the lake
+		// is not calculated as being freshwater, because it's less than 20 tiles
+		Tile s01 = AddNeighborsAndUpdateMap(x2y3, MakeCoastTile(), TileDirection.NORTH); // sea
+		Tile s02 = AddNeighborsAndUpdateMap(s01, MakeCoastTile(), TileDirection.EAST); // sea
+		Tile s03 = AddNeighborsAndUpdateMap(s02, MakeCoastTile(), TileDirection.EAST); // sea
+		Tile s04 = AddNeighborsAndUpdateMap(s01, MakeCoastTile(), TileDirection.WEST); // sea
+		Tile s05 = AddNeighborsAndUpdateMap(s04, MakeCoastTile(), TileDirection.WEST); // sea
+
+		Tile s06 = AddNeighborsAndUpdateMap(s03, MakeCoastTile(), TileDirection.NORTHEAST); // sea
+		Tile s07 = AddNeighborsAndUpdateMap(s06, MakeCoastTile(), TileDirection.EAST); // sea
+		Tile s08 = AddNeighborsAndUpdateMap(s07, MakeCoastTile(), TileDirection.EAST); // sea
+		Tile s09 = AddNeighborsAndUpdateMap(s08, MakeCoastTile(), TileDirection.EAST); // sea
+		Tile s10 = AddNeighborsAndUpdateMap(s09, MakeCoastTile(), TileDirection.EAST); // sea
+
+		Tile s11 = AddNeighborsAndUpdateMap(s06, MakeCoastTile(), TileDirection.NORTHWEST); // sea
+		Tile s12 = AddNeighborsAndUpdateMap(s11, MakeCoastTile(), TileDirection.EAST); // sea
+		Tile s13 = AddNeighborsAndUpdateMap(s12, MakeCoastTile(), TileDirection.EAST); // sea
+		Tile s14 = AddNeighborsAndUpdateMap(s13, MakeCoastTile(), TileDirection.EAST); // sea
+		Tile s15 = AddNeighborsAndUpdateMap(s14, MakeCoastTile(), TileDirection.EAST); // sea
+
+		Tile s16 = AddNeighborsAndUpdateMap(s11, MakeCoastTile(), TileDirection.NORTHEAST); // sea
+		Tile s17 = AddNeighborsAndUpdateMap(s16, MakeCoastTile(), TileDirection.EAST); // sea
+		Tile s18 = AddNeighborsAndUpdateMap(s17, MakeCoastTile(), TileDirection.EAST); // sea
+		Tile s19 = AddNeighborsAndUpdateMap(s18, MakeCoastTile(), TileDirection.EAST); // sea
+		Tile s20 = AddNeighborsAndUpdateMap(s19, MakeCoastTile(), TileDirection.EAST); // sea
+
+		//
+
+		Tile x3y1 = AddNeighborsAndUpdateMap(x2y1, MakePlainsTile(), TileDirection.SOUTHEAST);
+		Tile x3y2 = AddNeighborsAndUpdateMap(x3y1, MakeCoastTile(), TileDirection.NORTH); // lake
+		Tile x3y3 = AddNeighborsAndUpdateMap(x3y2, MakePlainsTile(), TileDirection.NORTH);
+		Tile x3y4 = AddNeighborsAndUpdateMap(x3y3, MakePlainsTile(), TileDirection.NORTH);
+
+		Tile x4y1 = AddNeighborsAndUpdateMap(x3y1, MakePlainsTile(), TileDirection.NORTHEAST);
+		Tile x4y2 = AddNeighborsAndUpdateMap(x4y1, MakeCoastTile(), TileDirection.NORTH); // lake
+		Tile x4y3 = AddNeighborsAndUpdateMap(x4y2, MakePlainsTile(), TileDirection.NORTH);
+
+		Tile x5y1 = AddNeighborsAndUpdateMap(x4y1, MakePlainsTile(), TileDirection.NORTHEAST);
+		Tile x5y2 = AddNeighborsAndUpdateMap(x5y1, MakePlainsTile(), TileDirection.NORTH);
+
+		Tile x6y1 = AddNeighborsAndUpdateMap(x5y1, MakePlainsTile(), TileDirection.NORTHEAST);
+
+		gameMap.tiles = new List<Tile>() {
+			startTile,
+			x1y1, x1y2,
+			x2y1, x2y2, x2y3, x2y4,
+			s01, s02, s03, s04, s05, s06, s07, s08, s09, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20,
+			x3y1, x3y2, x3y3, x3y4,
+			x4y1, x4y2, x4y3,
+			x5y1, x5y2,
+			x5y1, x5y2,
+			x6y1
+		};
+
+		ComputeAllNeighbors(gameMap.tiles.ToHashSet());
+
+		gameMap.recomputeContinents();
+
+		// land is the same continent
+		Assert.Equal(x1y1.continent, x2y1.continent);
+		// land and water are not
+		Assert.NotEqual(x1y1.continent, x2y2.continent);
+		// sea and lake are not
+		Assert.NotEqual(x2y2.continent, x2y3.continent);
+		// all lake tiles are part of the same continent
+		Assert.Equal(x2y2.continent, x3y2.continent);
+		Assert.Equal(x2y2.continent, x4y2.continent);
+		// lake is fresh water
+		Assert.True(x2y2.isFreshWater);
+		Assert.True(x3y2.isFreshWater);
+		Assert.True(x4y2.isFreshWater);
+		// random sea tiles are the same continent
+		Assert.Equal(x2y3.continent, s01.continent);
+		Assert.Equal(s01.continent, s04.continent);
+		Assert.Equal(s04.continent, s08.continent);
+		Assert.Equal(s08.continent, s13.continent);
+		Assert.Equal(s13.continent, s19.continent);
+		// random sea tiles are not fresh water
+		Assert.False(x2y3.isFreshWater);
+		Assert.False(s01.isFreshWater);
+		Assert.False(s05.isFreshWater);
+		Assert.False(s10.isFreshWater);
+		Assert.False(s15.isFreshWater);
+		Assert.False(s20.isFreshWater);
+	}
+}

--- a/EngineTests/GameData/HeightMapTest.cs
+++ b/EngineTests/GameData/HeightMapTest.cs
@@ -1,15 +1,11 @@
-using C7GameData;
-using Xunit;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+using C7GameData;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
+using Xunit;
 
-
-namespace C7GameDataTests;
+namespace EngineTests.GameData;
 
 public class HeightMapTest {
 	public static void SaveNoiseMapAsPng(List<HeightMap> heightMaps, string filePath) {

--- a/EngineTests/GameData/IDFactoryTests.cs
+++ b/EngineTests/GameData/IDFactoryTests.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
-using Xunit;
 using C7GameData;
 using C7GameData.Save;
+using Xunit;
+
+namespace EngineTests.GameData;
 
 public class IDFactoryTests {
 	[Fact]
@@ -59,4 +61,3 @@ public class IDFactoryTests {
 		Assert.Equal("unit-1", id.ToString());
 	}
 }
-

--- a/EngineTests/GameData/MapGeneratorTest.cs
+++ b/EngineTests/GameData/MapGeneratorTest.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace EngineTests.GameData;
 
-public class GameMapTest {
+public class GameMapGeneratorTest {
 	public static void SaveMapsAsWaterLandPng(List<List<GameMap>> maps, string filePath) {
 		int mapWidthPx = maps[0][0].numTilesWide * 2 + 1;
 		int mapHeightPx = maps[0][0].numTilesTall + 1;

--- a/EngineTests/GameData/MapGeneratorTest.cs
+++ b/EngineTests/GameData/MapGeneratorTest.cs
@@ -1,16 +1,12 @@
-using C7GameData;
-using C7Engine;
-using Xunit;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+using C7Engine;
+using C7GameData;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
+using Xunit;
 
-
-namespace C7GameDataTests;
+namespace EngineTests.GameData;
 
 public class GameMapTest {
 	public static void SaveMapsAsWaterLandPng(List<List<GameMap>> maps, string filePath) {

--- a/EngineTests/GameData/SaveTest.cs
+++ b/EngineTests/GameData/SaveTest.cs
@@ -3,16 +3,16 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-
+using C7Engine;
+using C7GameData;
+using C7GameData.Save;
+using Newtonsoft.Json.Linq;
+using QueryCiv3;
 using Xunit;
 
-using C7GameData;
-using C7Engine;
-using C7GameData.Save;
-using QueryCiv3;
-using System.Runtime.InteropServices;
-using Newtonsoft.Json.Linq;
+namespace EngineTests.GameData;
 
 public class SaveTests {
 
@@ -65,7 +65,7 @@ public class SaveTests {
 		SaveGame saveNeverGameData = SaveGame.Load(developerSave, (string unused) => { return unused; });
 
 		saveNeverGameData.Save(outputNeverGameDataPath);
-		GameData gameData = ToGameData(saveNeverGameData);
+		C7GameData.GameData gameData = ToGameData(saveNeverGameData);
 		SaveGame saveWasGameData = SaveGame.FromGameData(gameData);
 		saveWasGameData.Save(outputWasGameDataPath);
 
@@ -113,13 +113,13 @@ public class SaveTests {
 		return CreateGame.createGame(path, luaRulesDir, biqPath, getPediaIconsPath).Result;
 	}
 
-	private GameData ToGameData(SaveGame game) {
+	private C7GameData.GameData ToGameData(SaveGame game) {
 		return game.ToGameData(luaRulesDir);
 	}
 
 	private void CheckAiInvariants() {
-		EngineStorage.ReadGameData((GameData gameData) => {
-			GameData game = gameData;
+		EngineStorage.ReadGameData((C7GameData.GameData gameData) => {
+			C7GameData.GameData game = gameData;
 
 			foreach (Player p in game.players) {
 				foreach (MapUnit u in p.units) {
@@ -169,8 +169,8 @@ public class SaveTests {
 
 		// Make the player a human again so we can save and load the game.
 		human.isHuman = true;
-		GameData game = null;
-		EngineStorage.ReadGameData((GameData gameData) => {
+		C7GameData.GameData game = null;
+		EngineStorage.ReadGameData((C7GameData.GameData gameData) => {
 			game = gameData;
 		});
 		Assert.Equal(50, game.turn);
@@ -181,7 +181,7 @@ public class SaveTests {
 
 		// Load the saved game and save it again.
 		string roundTrippedSavePath = getDataPath("output/headless-game-round-tripped-save.json");
-		GameData roundTrippedGameData = ToGameData(SaveGame.Load(outputDirectSavePath, (string unused) => { return unused; }));
+		C7GameData.GameData roundTrippedGameData = ToGameData(SaveGame.Load(outputDirectSavePath, (string unused) => { return unused; }));
 		SaveGame.FromGameData(roundTrippedGameData).Save(roundTrippedSavePath);
 
 		string[] directSaveLines = File.ReadAllLines(outputDirectSavePath);
@@ -201,8 +201,8 @@ public class SaveTests {
 		Player human = CreateHeadlessGame(developerSave);
 		WaitForStartTurnMessage();
 
-		GameData gd = null;
-		EngineStorage.ReadGameData((GameData gameData) => { gd = gameData; });
+		C7GameData.GameData gd = null;
+		EngineStorage.ReadGameData((C7GameData.GameData gameData) => { gd = gameData; });
 
 		Tile t0 = gd.map.tileAt(97, 33);
 		Tile t1 = gd.map.tileAt(99, 33);
@@ -243,7 +243,7 @@ public class SaveTests {
 		int i = 0;
 		foreach (FileInfo saveFileInfo in saveFiles) {
 			SaveGame game = null;
-			GameData gd = null;
+			C7GameData.GameData gd = null;
 			Console.WriteLine(saveFileInfo.FullName);
 			Exception ex = Record.Exception(() => {
 				game = ImportCiv3.ImportSav(saveFileInfo.FullName, defaultBicPath, (relativeModePath) => {
@@ -294,7 +294,7 @@ public class SaveTests {
 		foreach (FileInfo saveFileInfo in saveFiles) {
 			string name = saveFileInfo.Name;
 			SaveGame game = null;
-			GameData gd = null;
+			C7GameData.GameData gd = null;
 
 			Func<string, string> getPediaIconsPath = (relativeModPath) => {
 				if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
@@ -339,7 +339,7 @@ public class SaveTests {
 				// The human player should always have either a city or a settler.
 				if (player.human) {
 					Assert.True(cityCount + settlerCount > 0,
-								name + " : " + player.civilization);
+						name + " : " + player.civilization);
 				}
 			}
 
@@ -358,7 +358,7 @@ public class SaveTests {
 				// The human player should always have either a city or a settler.
 				if (player.isHuman) {
 					Assert.True(cityCount + settlerCount > 0,
-								name + " : " + player.civilization.name);
+						name + " : " + player.civilization.name);
 				}
 			}
 

--- a/EngineTests/Utils/MapBase.cs
+++ b/EngineTests/Utils/MapBase.cs
@@ -1,9 +1,15 @@
+using System.Collections.Generic;
+using System.Linq;
 using C7GameData;
+using C7GameData.Save;
 
 namespace EngineTests.Utils;
 
 public class MapBase {
-	protected static MapUnit MakeWaterUnit(int movementPoints) {
+	protected GameMap gameMap = new GameMap() { tiles = new List<Tile>()};
+	protected Tile startTile;
+
+	protected static MapUnit MakeWaterUnit(int movementPoints = 2) {
 		MapUnit result = new(ID.None("")) {
 			unitType = new UnitPrototype() {
 				movement = movementPoints,
@@ -14,7 +20,7 @@ public class MapBase {
 		return result;
 	}
 
-	protected static MapUnit MakeLandUnit(int movementPoints) {
+	protected static MapUnit MakeLandUnit(int movementPoints = 1) {
 		MapUnit result = new(ID.None("")) {
 			unitType = new UnitPrototype() {
 				movement = movementPoints,
@@ -25,52 +31,146 @@ public class MapBase {
 		return result;
 	}
 
+	protected void InitilizeStartTile(Tile start, TileLocation tileLocation) {
+		startTile = start;
+		startTile.XCoordinate = tileLocation.X;
+		startTile.YCoordinate = tileLocation.Y;
+	}
+
+	protected Player MakePlayer(bool isHuman = false) {
+		return new Player() { isHuman = isHuman };
+	}
+
+	private TileDirection[] directions = {
+		TileDirection.NORTH,
+		TileDirection.NORTHEAST,
+		TileDirection.NORTHWEST,
+		TileDirection.SOUTH,
+		TileDirection.SOUTHEAST,
+		TileDirection.SOUTHWEST,
+		TileDirection.EAST,
+		TileDirection.WEST,
+	};
+
+	// Probably not the best way to update all he neighbors,
+	// but it's only meant to be used in the unit tests
+	//
+	/// <summary>
+	///This is needed because the unit tests don't have any knowledge of the tile neighbors,
+	/// apart from exactly what we give it ourselves. <br/><br/>
+	/// We might intuitively say that Tile [50,50] neighbors [52,50] in the east,
+	/// but unless we specifically update this relationship in the unit test, it won't take effect,
+	/// and the A* won't work as we would expect
+	/// </summary>
+	/// <param name="tiles"></param>
+	protected void ComputeAllNeighbors(HashSet<Tile> tiles) {
+		foreach (var tile in tiles) {
+			foreach (TileDirection direction in directions) {
+				List<Tile> eligible = tiles.Where(t =>
+					Tile.NeighborCoordinate(new TileLocation(tile.XCoordinate, tile.YCoordinate), direction)
+						.Equals(new TileLocation(t.XCoordinate, t.YCoordinate)) && tiles.Contains(t)).ToList();
+				if (eligible.Count <= 0) continue;
+				foreach (Tile eligibleTile in eligible) {
+					AddNeighborsAndUpdateMap(tile, eligibleTile, direction);
+				}
+			}
+		}
+	}
+
+	protected Tile AddNeighborsAndUpdateMap(Tile tile, Tile neighbor, TileDirection tileDirection) {
+		tile.neighbors[tileDirection] = neighbor;
+		if (gameMap.tiles.Contains(tile)) {
+			gameMap.tiles.Add(tile);
+		}
+		if (gameMap.tiles.Contains(neighbor)) {
+			gameMap.tiles.Add(neighbor);
+		}
+		if (tile.map == null) {
+			tile.map = gameMap;
+		}
+		if (neighbor.map == null) {
+			neighbor.map = gameMap;
+		}
+		if (tileDirection == TileDirection.NORTH) {
+			neighbor.XCoordinate = tile.XCoordinate;
+			neighbor.YCoordinate = tile.YCoordinate - 2;
+		}
+		if (tileDirection == TileDirection.EAST) {
+			neighbor.XCoordinate = tile.XCoordinate + 2;
+			neighbor.YCoordinate = tile.YCoordinate;
+		}
+		if (tileDirection == TileDirection.SOUTH) {
+			neighbor.XCoordinate = tile.XCoordinate;
+			neighbor.YCoordinate = tile.YCoordinate + 2;
+		}
+		if (tileDirection == TileDirection.WEST) {
+			neighbor.XCoordinate = tile.XCoordinate - 2;
+			neighbor.YCoordinate = tile.YCoordinate;
+		}
+		if (tileDirection == TileDirection.NORTHEAST) {
+			neighbor.XCoordinate = tile.XCoordinate + 1;
+			neighbor.YCoordinate = tile.YCoordinate - 1;
+		}
+		if (tileDirection == TileDirection.SOUTHEAST) {
+			neighbor.XCoordinate = tile.XCoordinate + 1;
+			neighbor.YCoordinate = tile.YCoordinate + 1;
+		}
+		if (tileDirection == TileDirection.NORTHWEST) {
+			neighbor.XCoordinate = tile.XCoordinate - 1;
+			neighbor.YCoordinate = tile.YCoordinate - 1;
+		}
+		if (tileDirection == TileDirection.SOUTHWEST) {
+			neighbor.XCoordinate = tile.XCoordinate - 1;
+			neighbor.YCoordinate = tile.YCoordinate + 1;
+		}
+
+		return neighbor;
+	}
+
 	protected TerrainImprovement road = new("road", TerrainImprovement.Layer.Roads, movementCost: 1.0f / 3);
 
-
-	protected Tile mountain  = new(ID.None("")) {
-		baseTerrainType = new() {
-			Key = "mountains"
-		},
-		overlayTerrainType = new() {
-			Key = "mountains",
-			movementCost = 3
-		}
-	};
-	protected Tile hill  = new(ID.None("")) {
-		baseTerrainType = new() {
-			Key = "hills"
-		},
-		overlayTerrainType = new() {
-			Key = "hills",
-			movementCost = 2
-		}
-	};
-	protected Tile plains  = new(ID.None("")) {
-		baseTerrainType = new() {
-			Key = "plains"
-		},
-		overlayTerrainType = new() {
-			Key = "plains",
-			movementCost = 1
-		}
-	};
-	protected Tile coast  = new(ID.None("")) {
-		baseTerrainType = new() {
-			Key = "coast"
-		},
-		overlayTerrainType = new() {
-			Key = "coast",
-			movementCost = 1
-		}
-	};
-	protected Tile sea  = new(ID.None("")) {
-		baseTerrainType = new() {
-			Key = "sea"
-		},
-		overlayTerrainType = new() {
-			Key = "sea",
-			movementCost = 1
-		}
-	};
+	protected Tile MakeMountainTile() {
+		return new(ID.None("")) {
+			baseTerrainType = new() { Key = "mountains" },
+			overlayTerrainType = new() { Key = "mountains", movementCost = 3 }
+		};
+	}
+	protected Tile MakeHillTile() {
+		return new(ID.None("")) {
+			baseTerrainType = new() { Key = "hills" },
+			overlayTerrainType = new() { Key = "hills", movementCost = 2 }
+		};
+	}
+	protected Tile MakePlainsTile() {
+		return new(ID.None("")) {
+			baseTerrainType = new() { Key = "plains" },
+			overlayTerrainType = new() { Key = "plains", movementCost = 1 }
+		};
+	}
+	protected Tile MakeCoastTile() {
+		return new(ID.None("")) {
+			baseTerrainType = new() { Key = "coast" },
+			overlayTerrainType = new() { Key = "coast", movementCost = 1 }
+		};
+	}
+	protected Tile MakeLakeTile() {
+		Tile lakeTile = new(ID.None("")) {
+			baseTerrainType = new() { Key = "coast" },
+			overlayTerrainType = new() { Key = "coast", movementCost = 1 }
+		};
+		lakeTile.isFreshWater = true;
+		return lakeTile;
+	}
+	protected Tile MakeSeaTile() {
+		return new(ID.None("")) {
+			baseTerrainType = new() { Key = "sea" },
+			overlayTerrainType = new() { Key = "sea", movementCost = 1 }
+		};
+	}
+	protected Tile MakeOceanTile() {
+		return new(ID.None("")) {
+			baseTerrainType = new() { Key = "ocean" },
+			overlayTerrainType = new() { Key = "ocean", movementCost = 1 }
+		};
+	}
 }

--- a/EngineTests/Utils/MapBase.cs
+++ b/EngineTests/Utils/MapBase.cs
@@ -1,0 +1,76 @@
+using C7GameData;
+
+namespace EngineTests.Utils;
+
+public class MapBase {
+	protected static MapUnit MakeWaterUnit(int movementPoints) {
+		MapUnit result = new(ID.None("")) {
+			unitType = new UnitPrototype() {
+				movement = movementPoints,
+			},
+			owner = new Player()
+		};
+		result.unitType.categories.Add("Sea");
+		return result;
+	}
+
+	protected static MapUnit MakeLandUnit(int movementPoints) {
+		MapUnit result = new(ID.None("")) {
+			unitType = new UnitPrototype() {
+				movement = movementPoints,
+			},
+			owner = new Player(),
+		};
+		result.unitType.categories.Add("Land");
+		return result;
+	}
+
+	protected TerrainImprovement road = new("road", TerrainImprovement.Layer.Roads, movementCost: 1.0f / 3);
+
+
+	protected Tile mountain  = new(ID.None("")) {
+		baseTerrainType = new() {
+			Key = "mountains"
+		},
+		overlayTerrainType = new() {
+			Key = "mountains",
+			movementCost = 3
+		}
+	};
+	protected Tile hill  = new(ID.None("")) {
+		baseTerrainType = new() {
+			Key = "hills"
+		},
+		overlayTerrainType = new() {
+			Key = "hills",
+			movementCost = 2
+		}
+	};
+	protected Tile plains  = new(ID.None("")) {
+		baseTerrainType = new() {
+			Key = "plains"
+		},
+		overlayTerrainType = new() {
+			Key = "plains",
+			movementCost = 1
+		}
+	};
+	protected Tile coast  = new(ID.None("")) {
+		baseTerrainType = new() {
+			Key = "coast"
+		},
+		overlayTerrainType = new() {
+			Key = "coast",
+			movementCost = 1
+		}
+	};
+	protected Tile sea  = new(ID.None("")) {
+		baseTerrainType = new() {
+			Key = "sea"
+		},
+		overlayTerrainType = new() {
+			Key = "sea",
+			movementCost = 1
+		}
+	};
+}


### PR DESCRIPTION
1. Refactored the go-to layer, to show path lines between tiles.
2. The pathing algorith has been modified, now AI can see the whole map (as before) but the human player can't.
3. Account for narrow land strips in map for water units (see before below)

<img width="564" height="453" alt="c7_sea_travel" src="https://github.com/user-attachments/assets/42f6e4b3-23d2-4233-a69e-fadea6014a8e" />

and afer

<img width="548" height="410" alt="image" src="https://github.com/user-attachments/assets/47c46a08-c8ba-45a5-8fd7-494c063b7258" />


5. Grid layer is now computed by itself, before it was rendering only known tiles, resulting in missing lines etc. The tiles for the grid are already being computed for the other layers, so it's not like we add a huge overhead or something.

I wanted to include a "fixed" cursor animation, but I can't get it to render properly (civil disorder suffers too), and I 've tried for like hours and hours.
I don't know if it's the shadows, or the tint, or the overall way it's being extracted from the flc.
Someone smarter than me can understand it and fix it.