### PR TITLE
Fix unit position on tile and animation speed - Issue #826

### DIFF
--- a/C7/Animations/AnimationManager.cs
+++ b/C7/Animations/AnimationManager.cs
@@ -232,7 +232,14 @@ public partial class C7Animation {
 
 	public double getDuration() {
 		Util.FlicSheet flicSheet = getFlicSheet();
-		double frameCount = flicSheet.indices.GetWidth() / flicSheet.spriteWidth;
-		return frameCount / 20.0; // Civ 3 anims often run at 20 FPS   TODO: Do they all? How could we tell? Is it exactly 20 FPS?
+		return flicSheet.animationSpeed * flicSheet.framesPerAnimation;
+	}
+
+	public Vector2I GetFlicAnimationOffset() {
+		return new Vector2I(getFlicSheet().offsetLeft, getFlicSheet().offsetTop);
+	}
+
+	public Vector2I GetFlicAnimationOriginalSize() {
+		return new Vector2I(getFlicSheet().spriteOriginalWidth, getFlicSheet().spriteOriginalHeight);
 	}
 }

--- a/C7/Animations/AnimationTracker.cs
+++ b/C7/Animations/AnimationTracker.cs
@@ -1,10 +1,7 @@
-
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Linq;
 using C7GameData;
-using Godot;
 
 public partial class AnimationTracker {
 	private AnimationManager civ3AnimData;
@@ -29,7 +26,7 @@ public partial class AnimationTracker {
 
 	private void startAnimation(ID id, C7Animation anim, Action completionEvent, AnimationEnding ending) {
 		long currentTimeMS = getCurrentTimeMS();
-		long animDurationMS = (long)(1000.0 * anim.getDuration());
+		long animDurationMS = (long)(anim.getDuration());
 
 		ActiveAnimation aa;
 		if (activeAnims.TryGetValue(id, out aa)) {

--- a/C7/Map/UnitLayer.cs
+++ b/C7/Map/UnitLayer.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Collections.Generic;
 using C7GameData;
-using C7Engine;
-using ConvertCiv3Media;
 using Godot;
 
 public partial class UnitLayer : LooseLayer {
@@ -116,13 +113,14 @@ public partial class UnitLayer : LooseLayer {
 
 	public void drawUnitAnimFrame(LooseView looseView, MapUnit unit, MapUnit.Appearance appearance, Vector2 tileCenter) {
 		AnimationInstance inst = getBlankAnimationInstance(looseView);
-		looseView.mapView.game.animationController.civ3AnimData.forUnit(unit.unitType, appearance.action).loadSpriteAnimation();
+		C7Animation unitAnimation = looseView.mapView.game.animationController.civ3AnimData.forUnit(unit.unitType, appearance.action);
+		unitAnimation.loadSpriteAnimation();
+
 		string animName = AnimationManager.AnimationKey(unit.unitType, appearance.action, appearance.direction);
 
-		// Need to move the sprites upward a bit so that their feet are at the center of the tile. I don't know if spriteHeight/4 is the right
-		var animOffset = MapView.cellSize * new Vector2(appearance.offsetX, appearance.offsetY);
-		Vector2 position = tileCenter + animOffset - new Vector2(0, inst.FrameSize(animName).Y / 4);
-		inst.SetPosition(position);
+		Vector2 framePosition = GetFramePosition(appearance, unitAnimation, inst, animName, tileCenter);
+
+		inst.SetPosition(framePosition);
 
 		Color civColor = TextureLoader.LoadColor(unit.owner.colorIndex);
 		int nextFrame = inst.GetNextFrameByProgress(animName, appearance.progress);
@@ -131,6 +129,34 @@ public partial class UnitLayer : LooseLayer {
 		inst.SetAnimation(animName);
 		inst.SetFrame(nextFrame);
 		inst.Show();
+	}
+
+	private Vector2 GetFramePosition(MapUnit.Appearance appearance, C7Animation unitAnimation, AnimationInstance inst, string animName, Vector2 tileCenter) {
+		// 1. Place unit in the center of the tile.
+		//	  This places the *center* of the sprite frame at the center point of the tile.
+		//
+		// 2. Apply animation offset.
+		//    This applies the offset of the animation when a unit moves from one tile to another, it "follows" the movement
+		//    it's pretty much a noop for the default or other animations that stay in the same tile.
+		//
+		// 3. Apply the offsets from the flic file to place them correctly in a 240x240 rect
+		//    (which starts at the center of the tile extending to the right and bottom).
+		//    The offsets we read from the flic file represent the offsets from the top left corner of the frame,
+		//    so this is why here we need to add half the width and height since the transforms
+		//    in our frames are applied at the center of the image
+		//
+		// 4. Offset the frame by half the width and height of the original size of the animation (which is usually 240x240 in pixels)
+		//    to place it correctly on the tile.
+		//
+		// 5. Finally add (or subtract if negative in .ini) any custom offset from the ini file
+
+		Vector2 animOffset = MapView.cellSize * new Vector2(appearance.offsetX, appearance.offsetY);
+		Vector2I flicOffset = unitAnimation.GetFlicAnimationOffset();
+		Vector2 flicOffsetWithAlignedFrame = new ((inst.FrameSize(animName).X / 2) + flicOffset.X,
+												  (inst.FrameSize(animName).Y / 2) + flicOffset.Y);
+		Vector2I flicOriginalSize = unitAnimation.GetFlicAnimationOriginalSize();
+
+		return tileCenter + animOffset + flicOffsetWithAlignedFrame - (flicOriginalSize / 2);
 	}
 
 	public void drawEffectAnimFrame(LooseView looseView, C7Animation anim, float progress, Vector2 tileCenter) {

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -128,7 +128,7 @@ public partial class Util {
 			}
 		}
 
-		// Next, before trying the base Civ paths, see if we have it packaged 
+		// Next, before trying the base Civ paths, see if we have it packaged
 		// with C7 and are in standalone mode.
 		string c7Path = FileExistsIgnoringCase(getProjectDirectoryPath(), mediaPath);
 		if (C7Settings.UseStandaloneMode()) {
@@ -226,7 +226,11 @@ public partial class Util {
 	// A FlicSheet is a sprite sheet created from a Flic file, with each frame of the animation as its own sprite
 	public struct FlicSheet {
 		public ImageTexture palette, indices;
+		public int spriteOriginalWidth, spriteOriginalHeight;
 		public int spriteWidth, spriteHeight;
+		public int offsetLeft, offsetTop;
+		public int framesPerAnimation, numberOfAnimations;
+		public int animationSpeed, animationTime;
 	}
 
 	// Loads a Flic and also converts it into a sprite sheet
@@ -255,7 +259,20 @@ public partial class Util {
 		var imgIndices = Image.CreateFromData(countColumns * flic.Width, countRows * flic.Height, false, Image.Format.R8, allIndices);
 		ImageTexture texIndices = ImageTexture.CreateFromImage(imgIndices);
 
-		return (new FlicSheet { palette = texPalette, indices = texIndices, spriteWidth = flic.Width, spriteHeight = flic.Height }, flic);
+		return (new FlicSheet {
+			palette = texPalette,
+			indices = texIndices,
+			spriteOriginalWidth = flic.OriginalWidth,
+			spriteOriginalHeight = flic.OriginalHeight,
+			spriteWidth = flic.Width,
+			spriteHeight = flic.Height,
+			offsetLeft = flic.OffsetLeft,
+			offsetTop = flic.OffsetTop,
+			framesPerAnimation = flic.FramesPerAnimation,
+			numberOfAnimations = flic.NumAnimations,
+			animationSpeed = flic.AnimationSpeed,
+			animationTime = flic.AnimationTime
+		}, flic);
 	}
 
 	// Like LoadWAVFromDisk, but the path is a relative path, not the result of

--- a/ConvertCiv3Media/ReadFlic.cs
+++ b/ConvertCiv3Media/ReadFlic.cs
@@ -5,7 +5,11 @@ using Serilog;
 namespace ConvertCiv3Media {
 	// Under construction
 	// Not intended to be a generalized/universal Flic reader
-	// Implementing from description at https://www.drdobbs.com/windows/the-flic-file-format/184408954
+	// [BROKEN LINK] Implementing from description at https://www.drdobbs.com/windows/the-flic-file-format/184408954
+	//
+	// The link above is broken at the time of writing this 28/10/2025
+	// The link below probably is the same article as above, on another site
+	// https://jacobfilipp.com/DrDobbs/articles/DDJ/1993/9303/9303a/9303a.htm#00af_0005
 	public class Flic {
 		private static ILogger log = Log.ForContext<Flic>();
 		// Images is an array of animations,images, each of which is a byte array of palette indexes
@@ -13,10 +17,16 @@ namespace ConvertCiv3Media {
 		// All animations/images have same palette, height, and width
 		// Palette is 256 colors in red, green, blue order
 		public byte[,] Palette = new byte[256,3];
+		public int OriginalWidth = 0;
+		public int OriginalHeight = 0;
 		public int Width = 0;
 		public int Height = 0;
+		public int OffsetLeft = 0;
+		public int OffsetTop = 0;
 		public int NumAnimations = 0;
 		public int FramesPerAnimation = 0;
+		public int AnimationTime = 0;
+		public int AnimationSpeed = 0;
 
 		private string path;
 
@@ -40,6 +50,19 @@ namespace ConvertCiv3Media {
 			int NumFrames = BitConverter.ToUInt16(FlicBytes, 6);
 			this.Width = BitConverter.ToUInt16(FlicBytes, 8);
 			this.Height = BitConverter.ToUInt16(FlicBytes, 10);
+
+			this.AnimationSpeed = BitConverter.ToInt32(FlicBytes, 16);
+
+			this.OffsetLeft = BitConverter.ToUInt16(FlicBytes, 100);
+			this.OffsetTop = BitConverter.ToUInt16(FlicBytes, 102);
+
+			// Disclaimer! I don't know if the width & height order is correct here
+			// but since the game always assumes a 240x240 size, maybe it doesn't matter
+			this.OriginalWidth = BitConverter.ToUInt16(FlicBytes, 104);
+			this.OriginalHeight = BitConverter.ToUInt16(FlicBytes, 106);
+
+			this.AnimationTime = BitConverter.ToUInt16(FlicBytes, 108);
+
 			int ImageLength = this.Width * this.Height;
 
 			// Civ3-specific values


### PR DESCRIPTION
1. Read offsets and animation info from .flic file
2. Calculate units' positions taking into account these offsets
3. Apply animation speed based on the .flic file

Issue #826