### PR TITLE
Terraform AI scoring

### DIFF
--- a/C7/Lua/rules/civ3/terraforms.lua
+++ b/C7/Lua/rules/civ3/terraforms.lua
@@ -1,40 +1,102 @@
-local UnitAction = ENUMS.UnitAction
 local YieldType = ENUMS.Tile_YieldType
+local ResourceCategory = ENUMS.ResourceCategory
 local Civ3FoliageAction = ENUMS.TerrainType_Civ3FoliageAction
 
-local terraforms = {
-  mine = {
-    validator = function(context)
-      local mine = context.terraform.Improvement
-      return mine:GetYieldBonus(context.tile.overlayTerrainType, YieldType.Production) > 0
-    end,
-  },
+local terraforms = {}
 
-  irrigate = {
-    validator = function(context)
-      local irrigation = context.terraform.Improvement
-      return context.tile:CanBeIrrigated(irrigation, context.player)
-    end,
-  },
-
-  clear_wetlands = {
-    validator = function(context)
-      return context.tile.overlayTerrainType.allowedFoliageAction == Civ3FoliageAction.ClearWetlands
-    end,
-    effect = function(context)
-      context.tile:ClearTerrainOverlay()
-    end,
-  },
-
-  clear_forest = {
-    validator = function(context)
-      return context.tile.overlayTerrainType.allowedFoliageAction == Civ3FoliageAction.ClearForest
-    end,
-    effect = function(context)
-      context.tile:MaybeAwardForestClearingShields()
-      context.tile:ClearTerrainOverlay()
-    end,
-  },
+terraforms.validators = {
+  mine = function(context)
+    local mine = context.terraform.Improvement
+    return mine:GetYieldBonus(context.tile.overlayTerrainType, YieldType.Production) > 0
+  end,
+  irrigate = function(context)
+    local irrigation = context.terraform.Improvement
+    return context.tile:CanBeIrrigated(irrigation, context.player)
+  end,
+  clear_wetlands = function(context)
+    return context.tile.overlayTerrainType.allowedFoliageAction == Civ3FoliageAction.ClearWetlands
+  end,
+  clear_forest = function(context)
+    return context.tile.overlayTerrainType.allowedFoliageAction == Civ3FoliageAction.ClearForest
+  end,
 }
+
+terraforms.effects = {
+  clear_wetlands = function(context)
+    context.tile:ClearTerrainOverlay()
+  end,
+  clear_forest = function(context)
+    context.tile:MaybeAwardForestClearingShields()
+    context.tile:ClearTerrainOverlay()
+  end,
+}
+
+terraforms.ai_score = {}
+
+local commerce_points = 1
+local shield_points = 3
+local food_points = 5
+
+local resource_points = 20
+local clear_forest_points = 2
+local clear_wetlands_points = 3
+
+-- placeholder
+function terraforms.ai_score.default(_)
+  return 0
+end
+
+function terraforms.ai_score.clear_wetlands(context)
+  return clear_wetlands_points
+end
+
+function terraforms.ai_score.clear_forest(context)
+  if context.tile.hasHadForestCleared then
+    return 0
+  end
+
+  -- TODO: Take the city's current production into account.
+  -- There is no sense in chopping the forest, if the chopping bonus would be lost to overflow
+  return clear_forest_points
+end
+
+function terraforms.ai_score.yield_improvement(context)
+  local terrain_type = context.tile.overlayTerrainType
+  local improvement = context.terraform.Improvement
+  local player = context.player
+
+  -- Player is in despotism. Apply "mine green, irrigate brown" heuristics
+  if player.government.hasTilePenalty then
+    if terrain_type.Key == "grassland" and improvement.key == "irrigation" then
+      return 0
+    end
+    if terrain_type.Key == "plains" and improvement.key == "mine" then
+      return 0
+    end
+  end
+
+  local commerce_diff = improvement.GetYieldBonus(terrain_type, YieldType.Commerce)
+  local shield_diff = improvement.GetYieldBonus(terrain_type, YieldType.Production)
+  local food_diff = improvement.GetYieldBonus(terrain_type, YieldType.Food)
+
+  return commerce_diff * commerce_points + shield_diff * shield_points + food_diff * food_points
+end
+
+function terraforms.ai_score.road(context)
+  local base_score = terraforms.ai_score.yield_improvement(context)
+
+  -- Provide an additional bonus for roading resources
+  local resource = context.tile.Resource
+  local category = resource.Category
+
+  local important_resource = category == ResourceCategory.LUXURY or category == ResourceCategory.STRATEGIC
+  local knows_about_resource = context.player.KnowsAboutResource(resource)
+
+  if important_resource and knows_about_resource then
+    base_score = base_score + resource_points
+  end
+
+  return base_score
+end
 
 return terraforms

--- a/C7/Lua/rules/civ3/terraforms.lua
+++ b/C7/Lua/rules/civ3/terraforms.lua
@@ -40,6 +40,7 @@ local food_points = 5
 local resource_points = 20
 local clear_forest_points = 2
 local clear_wetlands_points = 3
+local railroad_transport_points = 10
 
 -- placeholder
 function terraforms.ai_score.default(_)
@@ -48,6 +49,10 @@ end
 
 function terraforms.ai_score.clear_wetlands(context)
   return clear_wetlands_points
+end
+
+function terraforms.ai_score.railroad(context)
+  return railroad_transport_points
 end
 
 function terraforms.ai_score.clear_forest(context)
@@ -93,7 +98,7 @@ function terraforms.ai_score.road(context)
   local knows_about_resource = context.player.KnowsAboutResource(resource)
 
   if important_resource and knows_about_resource then
-    base_score = base_score + resource_points
+    return base_score + resource_points
   end
 
   return base_score

--- a/C7/Text/c7-static-map-save-standalone.json
+++ b/C7/Text/c7-static-map-save-standalone.json
@@ -74765,7 +74765,7 @@
         "Coal"
       ],
       "improvement": "railroad",
-      "aiScore": "terraforms.ai_score.default",
+      "aiScore": "terraforms.ai_score.railroad",
       "animation": "road",
       "uiAction": "unit_build_railroad",
       "buttonTexture": "ui.unit_control.unit_build_railroad"

--- a/C7/Text/c7-static-map-save-standalone.json
+++ b/C7/Text/c7-static-map-save-standalone.json
@@ -74710,8 +74710,9 @@
       "turnsToComplete": 12,
       "improvement": "mine",
       "validators": [
-        "terraforms.mine.validator"
+        "terraforms.validators.mine"
       ],
+      "aiScore": "terraforms.ai_score.yield_improvement",
       "animation": "mine",
       "uiAction": "unit_build_mine",
       "buttonTexture": "ui.unit_control.unit_build_mine"
@@ -74723,8 +74724,9 @@
       "turnsToComplete": 8,
       "improvement": "irrigation",
       "validators": [
-        "terraforms.irrigate.validator"
+        "terraforms.validators.irrigate"
       ],
+      "aiScore": "terraforms.ai_score.yield_improvement",
       "animation": "irrigate",
       "uiAction": "unit_irrigate",
       "buttonTexture": "ui.unit_control.unit_irrigate"
@@ -74736,6 +74738,7 @@
       "turnsToComplete": 16,
       "requiredTech": "tech-21",
       "improvement": "fortress",
+      "aiScore": "terraforms.ai_score.default",
       "animation": "fortress",
       "uiAction": "unit_build_fortress",
       "buttonTexture": "ui.unit_control.unit_build_fortress"
@@ -74746,6 +74749,7 @@
       "civilopediaEntry": "TFRM_Road",
       "turnsToComplete": 6,
       "improvement": "road",
+      "aiScore": "terraforms.ai_score.road",
       "animation": "road",
       "uiAction": "unit_build_road",
       "buttonTexture": "ui.unit_control.unit_build_road"
@@ -74761,6 +74765,7 @@
         "Coal"
       ],
       "improvement": "railroad",
+      "aiScore": "terraforms.ai_score.default",
       "animation": "road",
       "uiAction": "unit_build_railroad",
       "buttonTexture": "ui.unit_control.unit_build_railroad"
@@ -74771,6 +74776,7 @@
       "civilopediaEntry": "TFRM_Plant_Forest",
       "turnsToComplete": 18,
       "requiredTech": "tech-24",
+      "aiScore": "terraforms.ai_score.default",
       "animation": "plant",
       "uiAction": "unit_plant_forest",
       "buttonTexture": "ui.unit_control.unit_plant_forest"
@@ -74781,11 +74787,12 @@
       "civilopediaEntry": "TFRM_Clear_Forest",
       "turnsToComplete": 4,
       "validators": [
-        "terraforms.clear_forest.validator"
+        "terraforms.validators.clear_forest"
       ],
       "effects": [
-        "terraforms.clear_forest.effect"
+        "terraforms.effects.clear_forest"
       ],
+      "aiScore": "terraforms.ai_score.clear_forest",
       "animation": "forest",
       "uiAction": "unit_clear_forest",
       "buttonTexture": "ui.unit_control.unit_clear_forest"
@@ -74796,11 +74803,12 @@
       "civilopediaEntry": "TFRM_Clear_Wetlands",
       "turnsToComplete": 16,
       "validators": [
-        "terraforms.clear_wetlands.validator"
+        "terraforms.validators.clear_wetlands"
       ],
       "effects": [
-        "terraforms.clear_wetlands.effect"
+        "terraforms.effects.clear_wetlands"
       ],
+      "aiScore": "terraforms.ai_score.clear_wetlands",
       "animation": "jungle",
       "uiAction": "unit_clear_wetlands",
       "buttonTexture": "ui.unit_control.unit_clear_wetlands"
@@ -74810,6 +74818,7 @@
       "name": "Clear Damage",
       "civilopediaEntry": "TFRM_Clear_Damage",
       "turnsToComplete": 24,
+      "aiScore": "terraforms.ai_score.default",
       "uiAction": "unit_clear_damage",
       "buttonTexture": "ui.unit_control.unit_clear_damage"
     },
@@ -74819,6 +74828,7 @@
       "civilopediaEntry": "TFRM_Airfield",
       "turnsToComplete": 1,
       "requiredTech": "tech-59",
+      "aiScore": "terraforms.ai_score.default",
       "uiAction": "unit_build_airfield",
       "buttonTexture": "ui.unit_control.unit_build_airfield"
     },
@@ -74828,6 +74838,7 @@
       "civilopediaEntry": "TFRM_Radar_Tower",
       "turnsToComplete": 1,
       "requiredTech": "tech-64",
+      "aiScore": "terraforms.ai_score.default",
       "uiAction": "unit_build_radar_tower",
       "buttonTexture": "ui.unit_control.unit_build_radar_tower"
     },
@@ -74837,6 +74848,7 @@
       "civilopediaEntry": "TFRM_Outpost",
       "turnsToComplete": 1,
       "requiredTech": "tech-2",
+      "aiScore": "terraforms.ai_score.default",
       "uiAction": "unit_build_outpost",
       "buttonTexture": "ui.unit_control.unit_build_outpost"
     },
@@ -74847,6 +74859,7 @@
       "turnsToComplete": 16,
       "requiredTech": "tech-21",
       "improvement": "barricade",
+      "aiScore": "terraforms.ai_score.default",
       "animation": "fortress",
       "uiAction": "unit_build_barricade",
       "buttonTexture": "ui.unit_control.unit_build_barricade"

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -77283,8 +77283,9 @@
       "turnsToComplete": 12,
       "improvement": "mine",
       "validators": [
-        "terraforms.mine.validator"
+        "terraforms.validators.mine"
       ],
+      "aiScore": "terraforms.ai_score.yield_improvement",
       "animation": "mine",
       "uiAction": "unit_build_mine",
       "buttonTexture": "ui.unit_control.unit_build_mine"
@@ -77296,8 +77297,9 @@
       "turnsToComplete": 8,
       "improvement": "irrigation",
       "validators": [
-        "terraforms.irrigate.validator"
+        "terraforms.validators.irrigate"
       ],
+      "aiScore": "terraforms.ai_score.yield_improvement",
       "animation": "irrigate",
       "uiAction": "unit_irrigate",
       "buttonTexture": "ui.unit_control.unit_irrigate"
@@ -77309,6 +77311,7 @@
       "turnsToComplete": 16,
       "requiredTech": "tech-21",
       "improvement": "fortress",
+      "aiScore": "terraforms.ai_score.default",
       "animation": "fortress",
       "uiAction": "unit_build_fortress",
       "buttonTexture": "ui.unit_control.unit_build_fortress"
@@ -77319,6 +77322,7 @@
       "civilopediaEntry": "TFRM_Road",
       "turnsToComplete": 6,
       "improvement": "road",
+      "aiScore": "terraforms.ai_score.road",
       "animation": "road",
       "uiAction": "unit_build_road",
       "buttonTexture": "ui.unit_control.unit_build_road"
@@ -77334,6 +77338,7 @@
         "Coal"
       ],
       "improvement": "railroad",
+      "aiScore": "terraforms.ai_score.default",
       "animation": "road",
       "uiAction": "unit_build_railroad",
       "buttonTexture": "ui.unit_control.unit_build_railroad"
@@ -77344,6 +77349,7 @@
       "civilopediaEntry": "TFRM_Plant_Forest",
       "turnsToComplete": 18,
       "requiredTech": "tech-24",
+      "aiScore": "terraforms.ai_score.default",
       "animation": "plant",
       "uiAction": "unit_plant_forest",
       "buttonTexture": "ui.unit_control.unit_plant_forest"
@@ -77354,11 +77360,12 @@
       "civilopediaEntry": "TFRM_Clear_Forest",
       "turnsToComplete": 4,
       "validators": [
-        "terraforms.clear_forest.validator"
+        "terraforms.validators.clear_forest"
       ],
       "effects": [
-        "terraforms.clear_forest.effect"
+        "terraforms.effects.clear_forest"
       ],
+      "aiScore": "terraforms.ai_score.clear_forest",
       "animation": "forest",
       "uiAction": "unit_clear_forest",
       "buttonTexture": "ui.unit_control.unit_clear_forest"
@@ -77369,11 +77376,12 @@
       "civilopediaEntry": "TFRM_Clear_Wetlands",
       "turnsToComplete": 16,
       "validators": [
-        "terraforms.clear_wetlands.validator"
+        "terraforms.validators.clear_wetlands"
       ],
       "effects": [
-        "terraforms.clear_wetlands.effect"
+        "terraforms.effects.clear_wetlands"
       ],
+      "aiScore": "terraforms.ai_score.clear_wetlands",
       "animation": "jungle",
       "uiAction": "unit_clear_wetlands",
       "buttonTexture": "ui.unit_control.unit_clear_wetlands"
@@ -77383,6 +77391,7 @@
       "name": "Clear Damage",
       "civilopediaEntry": "TFRM_Clear_Damage",
       "turnsToComplete": 24,
+      "aiScore": "terraforms.ai_score.default",
       "uiAction": "unit_clear_damage",
       "buttonTexture": "ui.unit_control.unit_clear_damage"
     },
@@ -77392,6 +77401,7 @@
       "civilopediaEntry": "TFRM_Airfield",
       "turnsToComplete": 1,
       "requiredTech": "tech-59",
+      "aiScore": "terraforms.ai_score.default",
       "uiAction": "unit_build_airfield",
       "buttonTexture": "ui.unit_control.unit_build_airfield"
     },
@@ -77401,6 +77411,7 @@
       "civilopediaEntry": "TFRM_Radar_Tower",
       "turnsToComplete": 1,
       "requiredTech": "tech-64",
+      "aiScore": "terraforms.ai_score.default",
       "uiAction": "unit_build_radar_tower",
       "buttonTexture": "ui.unit_control.unit_build_radar_tower"
     },
@@ -77410,6 +77421,7 @@
       "civilopediaEntry": "TFRM_Outpost",
       "turnsToComplete": 1,
       "requiredTech": "tech-2",
+      "aiScore": "terraforms.ai_score.default",
       "uiAction": "unit_build_outpost",
       "buttonTexture": "ui.unit_control.unit_build_outpost"
     },
@@ -77420,6 +77432,7 @@
       "turnsToComplete": 16,
       "requiredTech": "tech-21",
       "improvement": "barricade",
+      "aiScore": "terraforms.ai_score.default",
       "animation": "fortress",
       "uiAction": "unit_build_barricade",
       "buttonTexture": "ui.unit_control.unit_build_barricade"

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -77338,7 +77338,7 @@
         "Coal"
       ],
       "improvement": "railroad",
-      "aiScore": "terraforms.ai_score.default",
+      "aiScore": "terraforms.ai_score.railroad",
       "animation": "road",
       "uiAction": "unit_build_railroad",
       "buttonTexture": "ui.unit_control.unit_build_railroad"

--- a/C7Engine/AI/UnitAI/WorkerAI.cs
+++ b/C7Engine/AI/UnitAI/WorkerAI.cs
@@ -104,50 +104,15 @@ namespace C7Engine {
 				return buildRoad;
 			}
 
-			int initialCommerce = t.commerceYield(player).yield;
-			int initialShields = t.productionYield(player).yield;
-			int initialFood = t.foodYield(player).yield;
+			var best = (
+				from at in accessibleTerraforms
+				let aiScore = at.CalculateAIScore(player, t)
+				where aiScore > 0
+				orderby aiScore descending, at.TurnsToComplete
+				select at
+			).FirstOrDefault();
 
-			int bestScore = 0;
-			Terraform? bestTerraform = null;
-
-			const int CommercePoints = 1;
-			const int ShieldPoints = 3;
-			const int FoodPoints = 5;
-			const int ResourcePoints = 20;
-
-			foreach (Terraform terraform in accessibleTerraforms) {
-				Tile tAfterImprovement = t.Copy();
-				terraform.OnComplete(unit.owner, tAfterImprovement);
-
-				int newCommerce = tAfterImprovement.commerceYield(player).yield;
-				int newShields = tAfterImprovement.productionYield(player).yield;
-				int newFood = tAfterImprovement.foodYield(player).yield;
-
-				int commerceDiff = newCommerce - initialCommerce;
-				int shieldDiff = newShields - initialShields;
-				int foodDiff = newFood - initialFood;
-
-				int currentScore = commerceDiff * CommercePoints +
-						  shieldDiff * ShieldPoints +
-						  foodDiff * FoodPoints;
-
-				// Provide an additional bonus for roading resources. In despotism
-				// some resources may already have 2 commerce, so roading would
-				// seem to have no effect - but we want to encourage hooking up
-				// luxuries.
-				if ((t.Resource.Category == ResourceCategory.LUXURY || t.Resource.Category == ResourceCategory.STRATEGIC)
-					&& terraform.ProvidesRoad() && player.KnowsAboutResource(t.Resource)) {
-					currentScore += ResourcePoints;
-				}
-
-				if (currentScore > bestScore) {
-					bestScore = currentScore;
-					bestTerraform = terraform;
-				}
-			}
-
-			return bestTerraform;
+			return best;
 		}
 
 		private UnitAI.Result PerformWorkerMove(MapUnit unit, Terraform workerMove) {

--- a/C7Engine/C7GameData/Save/SaveTerraform.cs
+++ b/C7Engine/C7GameData/Save/SaveTerraform.cs
@@ -18,6 +18,7 @@ public class SaveTerraform {
 	// Lua functions
 	public List<string> Validators = [];
 	public List<string> Effects = [];
+	public string AIScore;
 
 	public MapUnit.AnimatedAction? Animation;
 
@@ -91,16 +92,34 @@ public class SaveTerraform {
 			_ => null,
 		};
 
-		if (actionPath == null)
-			return;
-
-		Validators.Add($"terraforms.{actionPath}.validator");
+		if (actionPath != null)
+			Validators.Add($"terraforms.validators.{actionPath}");
 
 		// Add effect
 		switch (tfKey) {
 			case TerraformKey.ClearWetlands:
 			case TerraformKey.ClearForest:
-				Effects.Add($"terraforms.{actionPath}.effect");
+				Effects.Add($"terraforms.effects.{actionPath}");
+				break;
+		}
+
+		// Add AI-scoring function
+		switch (tfKey) {
+			case TerraformKey.ClearWetlands:
+				AIScore = "terraforms.ai_score.clear_wetlands";
+				break;
+			case TerraformKey.ClearForest:
+				AIScore = "terraforms.ai_score.clear_forest";
+				break;
+			case TerraformKey.BuildMine:
+			case TerraformKey.Irrigate:
+				AIScore = "terraforms.ai_score.yield_improvement";
+				break;
+			case TerraformKey.BuildRoad:
+				AIScore = "terraforms.ai_score.road";
+				break;
+			default:
+				AIScore = "terraforms.ai_score.default";
 				break;
 		}
 	}

--- a/C7Engine/C7GameData/Terraform.cs
+++ b/C7Engine/C7GameData/Terraform.cs
@@ -25,6 +25,7 @@ public class Terraform {
 
 	private Action<ScriptContext> Effect;
 	private List<Func<ScriptContext, bool>> ActionValidators = [];
+	private Func<ScriptContext, int> AIScore;
 
 	public readonly MapUnit.AnimatedAction? Animation;
 
@@ -66,6 +67,8 @@ public class Terraform {
 		foreach (string functionPath in dataSource.Validators) {
 			ActionValidators.Add(engine.ImportFunc<Func<ScriptContext, bool>>(functionPath));
 		}
+
+		AIScore = engine.ImportFunc<Func<ScriptContext, int>>(dataSource.AIScore);
 	}
 
 	public bool MeetsRequirements(Player player, Tile tile) {
@@ -87,6 +90,10 @@ public class Terraform {
 		if (Improvement != null) {
 			tile.overlays.Add(Improvement);
 		}
+	}
+
+	public int CalculateAIScore(Player player, Tile tile) {
+		return AIScore(new(player, tile, this));
 	}
 
 	public SaveTerraform ToSaveTerraform() {

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -695,12 +695,6 @@ namespace C7GameData {
 		public void ClearTerrainOverlay() {
 			overlayTerrainType = baseTerrainType;
 		}
-
-		public Tile Copy() {
-			Tile clone = (Tile)MemberwiseClone();
-			clone.overlays = new TileOverlays(overlays);
-			return clone;
-		}
 	}
 
 	public enum TileDirection {
@@ -750,11 +744,6 @@ namespace C7GameData {
 
 		public TileOverlays(Tile tile) {
 			this.tile = tile;
-		}
-
-		public TileOverlays(TileOverlays other)
-			: this(other.tile) {
-			terrainImprovementByLayer = new(other.terrainImprovementByLayer);
 		}
 
 		public void Add(TerrainImprovement improvement) {

--- a/C7Engine/LuaRulesEngine.cs
+++ b/C7Engine/LuaRulesEngine.cs
@@ -137,6 +137,8 @@ public class LuaRulesEngine {
 	public T ImportFunc<T>(string functionPath) where T : Delegate {
 		if (script == null || rules == null)
 			throw new InvalidOperationException("Engine is not initialized");
+		if (functionPath == null)
+			throw new InvalidOperationException("Non-null function path expected");
 
 		Closure closure = ResolveFunctionPath(functionPath);
 		Delegate del = LuaDelegateConverter.CreateDelegate(script, closure, typeof(T));


### PR DESCRIPTION
This commit updates the AI for choosing the best worker action (terraform) for a tile.

Previously, the AI scored terraforms by making a copy of a tile, applying a terraform to it and comparing yields of the original tile and its copy. This system had problems. If the terraform had an effect on the world outside of a tile (for example, forest chopping granting shields to the nearest city), these changes were mistakenly applied during the AI score calculations. There was also no way to account for such effects in AI calculations.

This commit fixes that by extending the Terraform class with a new Lua "hook" for AI score calculations. This is a function bound to a terraform that returns its AI points. This way, the effect of the terraform is run only on its completion. This also allows implementing custom AI for new terraforms without modifying the game core.

closes #814 