### PR TITLE
Main menu improvements for Dutch

### DIFF
--- a/C7/UIElements/MainMenu/MainMenu.cs
+++ b/C7/UIElements/MainMenu/MainMenu.cs
@@ -9,7 +9,7 @@ public partial class MainMenu : Node {
 	[Export]
 	Civ3FileDialog LoadDialog;
 	[Export]
-	Button SetCiv3Home;
+	Control NoCiv3Options;
 	[Export]
 	FileDialog SetCiv3HomeDialog;
 	[Export]
@@ -18,14 +18,12 @@ public partial class MainMenu : Node {
 	MenuButtonContainer ButtonContainer;
 	[Export]
 	AudioStreamPlayer player;
-	[Export] Button UseStandaloneMode;
 
 	GlobalSingleton Global;
 
 	public override void _Ready() {
 		log = LogManager.ForContext<MainMenu>();
 		log.Debug("enter MainMenu._Ready");
-		UseStandaloneMode.Pressed += UseStandaloneModePressed;
 
 		DisplayServer.WindowSetTitle("C7 - Godot 4");
 
@@ -74,9 +72,8 @@ public partial class MainMenu : Node {
 			ButtonContainer.ToggleGraphics.Visible = false;
 		}
 
-		// Hide select home folder if valid path is present as proven by reaching this point in code
-		SetCiv3Home.Visible = false;
-		UseStandaloneMode.Visible = false;
+		// Hide if valid path is present as proven by reaching this point in code
+		NoCiv3Options.Visible = false;
 	}
 
 	private void SetToggleGraphicsText() {

--- a/C7/UIElements/MainMenu/main_menu.tscn
+++ b/C7/UIElements/MainMenu/main_menu.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=9 format=3 uid="uid://gnt0y3og7nk6"]
+[gd_scene load_steps=10 format=3 uid="uid://gnt0y3og7nk6"]
 
 [ext_resource type="Script" uid="uid://dgpuse88jc2hc" path="res://UIElements/MainMenu/MainMenu.cs" id="1_akneh"]
 [ext_resource type="Texture2D" uid="uid://s55xvcaini8h" path="res://title-screen.png" id="2_erxyj"]
 [ext_resource type="Script" uid="uid://ca14gkdccjfcg" path="res://UIElements/MainMenu/MenuButtonContainer.cs" id="3_t1nuq"]
+[ext_resource type="FontFile" uid="uid://b1xkj8g82jbx5" path="res://Fonts/NotoSans-BoldItalic.ttf" id="3_x68dx"]
 [ext_resource type="Script" uid="uid://dauceqein40wj" path="res://UIElements/MainMenu/MainMenuMusicPlayer.cs" id="4_tqr50"]
 [ext_resource type="PackedScene" uid="uid://bvncm1bgcii5e" path="res://UIElements/civ3_file_dialog.tscn" id="5_rw2g7"]
 
@@ -12,15 +13,14 @@
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_gmerc"]
 
-[node name="MainMenu" type="Node" node_paths=PackedStringArray("LoadDialog", "SetCiv3Home", "SetCiv3HomeDialog", "LoadScenarioDialog", "ButtonContainer", "player", "UseStandaloneMode")]
+[node name="MainMenu" type="Node" node_paths=PackedStringArray("LoadDialog", "NoCiv3Options", "SetCiv3HomeDialog", "LoadScenarioDialog", "ButtonContainer", "player")]
 script = ExtResource("1_akneh")
 LoadDialog = NodePath("LoadDialog")
-SetCiv3Home = NodePath("SetCiv3Home")
+NoCiv3Options = NodePath("Control/NoCiv3Options")
 SetCiv3HomeDialog = NodePath("SetCiv3HomeDialog")
 LoadScenarioDialog = NodePath("LoadScenarioDialog")
 ButtonContainer = NodePath("Control/MainMenuContainer")
 player = NodePath("SoundEffectPlayer")
-UseStandaloneMode = NodePath("UseStandaloneMode")
 
 [node name="Control" type="Control" parent="."]
 layout_mode = 3
@@ -47,6 +47,19 @@ texture = ExtResource("2_erxyj")
 expand_mode = 3
 stretch_mode = 4
 
+[node name="RichTextLabel" type="RichTextLabel" parent="Control/Background"]
+layout_mode = 0
+offset_left = 20.0
+offset_top = 5.0
+offset_right = 660.0
+offset_bottom = 65.0
+theme_override_colors/default_color = Color(1, 0.25098, 0, 1)
+theme_override_fonts/normal_font = ExtResource("3_x68dx")
+theme_override_font_sizes/normal_font_size = 36
+text = "OpenCiv3 v0.3 Dutch Preview 1"
+deselect_on_focus_loss_enabled = false
+drag_and_drop_selection_enabled = false
+
 [node name="MainMenuContainer" type="VBoxContainer" parent="Control"]
 layout_mode = 1
 anchors_preset = -1
@@ -61,46 +74,36 @@ grow_horizontal = 2
 theme_override_constants/separation = 15
 script = ExtResource("3_t1nuq")
 
-[node name="MainMenuMusicPlayer" type="AudioStreamPlayer" parent="."]
-script = ExtResource("4_tqr50")
+[node name="NoCiv3Options" type="VBoxContainer" parent="Control"]
+layout_mode = 0
+offset_left = 260.0
+offset_top = 100.0
+offset_right = 580.0
+offset_bottom = 400.0
+theme_override_constants/separation = 15
 
-[node name="SoundEffectPlayer" type="AudioStreamPlayer" parent="."]
+[node name="NoCiv3Prompt" type="Label" parent="Control/NoCiv3Options"]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 12
+text = "An installation of Civilization III was not found.
+You may provide the location of game files, OR play in standalone mode to use OpenCiv3 files only"
+autowrap_mode = 2
 
-[node name="SetCiv3Home" type="Button" parent="."]
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -157.0
-offset_top = -33.0
-offset_right = 157.0
-offset_bottom = 33.0
-grow_horizontal = 2
-grow_vertical = 2
-size_flags_horizontal = 4
-size_flags_vertical = 4
+[node name="SetCiv3Home" type="Button" parent="Control/NoCiv3Options"]
+custom_minimum_size = Vector2(320, 60)
+layout_mode = 2
 theme_override_constants/h_separation = 50
 theme_override_font_sizes/font_size = 24
 theme_override_styles/hover = SubResource("StyleBoxFlat_vbij8")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_e20w6")
 theme_override_styles/normal = SubResource("StyleBoxFlat_gmerc")
-text = "Select Civ3 Home Folder"
+text = "Locate Civilization III files"
 
-[node name="UseStandaloneMode" type="Button" parent="."]
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -157.0
-offset_top = 54.0
-offset_right = 157.0
-offset_bottom = 120.0
-grow_horizontal = 2
-grow_vertical = 2
-size_flags_horizontal = 4
-size_flags_vertical = 4
+[node name="UseStandaloneMode" type="Button" parent="Control/NoCiv3Options"]
+custom_minimum_size = Vector2(320, 60)
+layout_mode = 2
 theme_override_constants/h_separation = 50
 theme_override_font_sizes/font_size = 24
 theme_override_styles/hover = SubResource("StyleBoxFlat_vbij8")
@@ -108,14 +111,19 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_e20w6")
 theme_override_styles/normal = SubResource("StyleBoxFlat_gmerc")
 text = "Play in standalone mode"
 
-[node name="Label" type="Label" parent="UseStandaloneMode"]
+[node name="Label" type="Label" parent="Control/NoCiv3Options/UseStandaloneMode"]
 layout_mode = 0
-offset_top = 48.0
+offset_top = 42.0
 offset_right = 314.0
-offset_bottom = 68.0
+offset_bottom = 62.0
 theme_override_font_sizes/font_size = 11
-text = "Warning: AI was used for some placeholder art"
+text = "Notice: standalone mode makes use of AI placeholder art"
 horizontal_alignment = 1
+
+[node name="MainMenuMusicPlayer" type="AudioStreamPlayer" parent="."]
+script = ExtResource("4_tqr50")
+
+[node name="SoundEffectPlayer" type="AudioStreamPlayer" parent="."]
 
 [node name="SetCiv3HomeDialog" type="FileDialog" parent="."]
 mode = 3
@@ -132,5 +140,6 @@ visible = false
 [node name="LoadScenarioDialog" parent="." instance=ExtResource("5_rw2g7")]
 visible = false
 
-[connection signal="pressed" from="SetCiv3Home" to="." method="_on_SetCiv3Home_pressed"]
+[connection signal="pressed" from="Control/NoCiv3Options/SetCiv3Home" to="." method="_on_SetCiv3Home_pressed"]
+[connection signal="pressed" from="Control/NoCiv3Options/UseStandaloneMode" to="." method="UseStandaloneModePressed"]
 [connection signal="dir_selected" from="SetCiv3HomeDialog" to="." method="_on_SetCiv3HomeDialog_dir_selected"]


### PR DESCRIPTION
My first new Godot work in far too long :)

Added a placeholder title node on the main menu (orange of course). The title banner should be shown here once we have one, but it would be good to keep the text label to display a detailed version and/or build number.

Reworked the controls for when Civ3 is not found, including more descriptive text. The whole thing is now under a single node that can be hidden similar to the real menu.

<img width="1152" height="768" alt="image" src="https://github.com/user-attachments/assets/e7b92ea3-118f-4506-88df-08f22a456f9a" />
