### PR TITLE
Lower right info box improvements

### DIFF
--- a/C7/Animations/AnimationManager.cs
+++ b/C7/Animations/AnimationManager.cs
@@ -40,6 +40,13 @@ public partial class AnimationManager {
 		return AnimationKey(BaseAnimationKey(unit, action), direction);
 	}
 
+	public static readonly Dictionary<string, ImageTexture> AnimationThumbnails = new();
+	public static readonly Dictionary<string, ImageTexture> AnimationTintThumbnails = new();
+
+	private const int thumbnailFrame = 0;
+	private const TileDirection thumbnailDirection = TileDirection.SOUTHEAST;
+	private const MapUnit.AnimatedAction thumbnailAction = MapUnit.AnimatedAction.DEFAULT;
+
 	private AudioStreamPlayer audioPlayer;
 
 	public SpriteFrames spriteFrames;
@@ -60,6 +67,33 @@ public partial class AnimationManager {
 			iniDatas.Add(pathKey, tr);
 		}
 		return tr;
+	}
+
+	public static string GetUnitDefaultThumbnailKey(UnitPrototype unit) {
+		return  $"{unit.artName}_{thumbnailDirection}_{thumbnailAction}_{thumbnailFrame}";
+	}
+
+	public (ImageTexture baseFrame, ImageTexture tintFrame) GetAnimationFrameAndTintTextures(UnitPrototype unit) {
+
+		string key = GetUnitDefaultThumbnailKey(unit);
+
+		if(AnimationThumbnails.TryGetValue(key, out ImageTexture baseImage)
+		   && AnimationTintThumbnails.TryGetValue(key, out ImageTexture tintImage))
+		{
+			return (baseImage, tintImage);
+		}
+
+		string filepath = getUnitFlicFilepath(unit, thumbnailAction);
+
+		Flic flic = Util.LoadFlic(filepath);
+
+		byte[] rawFrame = flic.Images[flicAnimationDirectionToRow(thumbnailDirection), thumbnailFrame];
+		// This actually doesn't return the tint frame with the civ color applied. The shader still needs to be applied.
+		(ImageTexture baseFrame, ImageTexture tintFrame) = Util.LoadTextureFromFlicData(rawFrame, flic.Palette, flic.Width, flic.Height);
+		AnimationThumbnails[key] = baseFrame;
+		AnimationTintThumbnails[key] = tintFrame;
+
+		return (baseFrame, tintFrame);
 	}
 
 	// Looks up the name of the flic file associated with a given action in an animation INI. If there is no flic file listed for the action,
@@ -102,6 +136,20 @@ public partial class AnimationManager {
 		// TODO: I wanted to add a TileDirection.INVALID enum value when implementing this,
 		// but adding an INVALID value broke stuff: https://github.com/C7-Game/Prototype/issues/397
 		return TileDirection.NORTH;
+	}
+
+	private static int flicAnimationDirectionToRow(TileDirection tileDirection) {
+		switch (tileDirection) {
+			case TileDirection.SOUTHWEST: return 0;
+			case TileDirection.SOUTH: return 1;
+			case TileDirection.SOUTHEAST: return 2;
+			case TileDirection.EAST: return 3;
+			case TileDirection.NORTHEAST: return 4;
+			case TileDirection.NORTH: return 5;
+			case TileDirection.NORTHWEST: return 6;
+			case TileDirection.WEST: return 7;
+		}
+		return 2;
 	}
 
 	public static void loadFlicAnimation(string path, string name, ref SpriteFrames frames, ref SpriteFrames tint) {

--- a/C7/Animations/AnimationManager.cs
+++ b/C7/Animations/AnimationManager.cs
@@ -70,16 +70,15 @@ public partial class AnimationManager {
 	}
 
 	public static string GetUnitDefaultThumbnailKey(UnitPrototype unit) {
-		return  $"{unit.artName}_{thumbnailDirection}_{thumbnailAction}_{thumbnailFrame}";
+		return $"{unit.artName}_{thumbnailDirection}_{thumbnailAction}_{thumbnailFrame}";
 	}
 
 	public (ImageTexture baseFrame, ImageTexture tintFrame) GetAnimationFrameAndTintTextures(UnitPrototype unit) {
 
 		string key = GetUnitDefaultThumbnailKey(unit);
 
-		if(AnimationThumbnails.TryGetValue(key, out ImageTexture baseImage)
-		   && AnimationTintThumbnails.TryGetValue(key, out ImageTexture tintImage))
-		{
+		if (AnimationThumbnails.TryGetValue(key, out ImageTexture baseImage)
+		   && AnimationTintThumbnails.TryGetValue(key, out ImageTexture tintImage)) {
 			return (baseImage, tintImage);
 		}
 

--- a/C7/Animations/AnimationManager.cs
+++ b/C7/Animations/AnimationManager.cs
@@ -217,6 +217,11 @@ public partial class AnimationManager {
 	public C7Animation forEffect(AnimatedEffect effect) {
 		return new C7Animation(this, effect);
 	}
+
+	public static void ClearCache() {
+		AnimationThumbnails.Clear();
+		AnimationTintThumbnails.Clear();
+	}
 }
 
 public partial class C7Animation {

--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -240,6 +240,8 @@ visible = false
 [connection signal="ShowCityScreen" from="." to="CanvasLayer/CityScreen" method="OnShowCityScreen"]
 [connection signal="ShowSpecificAdvisor" from="." to="CanvasLayer/Advisor" method="OnShowSpecificAdvisor"]
 [connection signal="TurnEnded" from="." to="CanvasLayer/Control/GameStatus/LowerRightInfoBox" method="StopToggling"]
+[connection signal="UnitMoved" from="." to="CanvasLayer/Control/UnitButtons" method="OnUnitMoved"]
+[connection signal="UnitMoved" from="." to="CanvasLayer/Control/GameStatus/LowerRightInfoBox" method="OnUnitMoved"]
 [connection signal="NewAutoselectedUnit" from="UnitSelector" to="CanvasLayer/Control/UnitButtons" method="OnNewUnitSelected"]
 [connection signal="NewAutoselectedUnit" from="UnitSelector" to="CanvasLayer/Control/GameStatus/LowerRightInfoBox" method="OnNewUnitSelected"]
 [connection signal="NoMoreAutoselectableUnits" from="UnitSelector" to="CanvasLayer/Control/UnitButtons" method="OnNoMoreAutoselectableUnits"]

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -15,8 +15,9 @@ public partial class Game : Node {
 
 	[Signal] public delegate void PlayerTurnStartEventHandler();
 	[Signal] public delegate void PlayerTurnEndEventHandler();
-
 	[Signal] public delegate void GameInitializedEventHandler();
+
+	[Signal] public delegate void UnitMovedEventHandler();
 
 	private ILogger log = LogManager.ForContext<Game>();
 
@@ -269,6 +270,9 @@ public partial class Game : Node {
 				popup.SetPosition(mapView.screenLocationOfTile(mSTP.location, true) + new Vector2(0, -64));
 				AddChild(popup);
 				popup.ShowPopup();
+				break;
+			case MsgUnitMoved mUUAAB:
+				EmitSignal(SignalName.UnitMoved, new ParameterWrapper<MapUnit>(mUUAAB.Unit));
 				break;
 		}
 	}

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -554,7 +554,7 @@ public partial class MapView : Node2D {
 
 	public Game game;
 
-	public MapView(){}
+	public MapView() { }
 
 	public int mapWidth { get; private set; }
 	public int mapHeight { get; private set; }

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -3,11 +3,9 @@ using System;
 using System.Linq;
 using C7.Map;
 using Godot;
-using ConvertCiv3Media;
 using C7GameData;
 using C7Engine;
 using Serilog;
-using Serilog.Events;
 using System.Diagnostics;
 
 // Loose layers are for drawing things on the map on a per-tile basis. (Historical aside: There used to be another kind of layer called a TileLayer
@@ -556,6 +554,8 @@ public partial class MapView : Node2D {
 
 	public Game game;
 
+	public MapView(){}
+
 	public int mapWidth { get; private set; }
 	public int mapHeight { get; private set; }
 	public bool wrapHorizontally { get; private set; }
@@ -597,6 +597,16 @@ public partial class MapView : Node2D {
 
 	const float MIN_SCALE = 0.1f;
 	const float MAX_SCALE = 4.0f;
+
+	private LowerRightInfoBox lowerRightInfoBox;
+	public override void _Ready() {
+		lowerRightInfoBox = GetNode<LowerRightInfoBox>("/root/C7Game/CanvasLayer/Control/GameStatus/LowerRightInfoBox");
+		lowerRightInfoBox.CenterCameraOnActiveUnit += OnCenterCameraOnUnit;
+	}
+
+	public override void _ExitTree() {
+		lowerRightInfoBox.CenterCameraOnActiveUnit -= OnCenterCameraOnUnit;
+	}
 
 	public MapView(Game game, int mapWidth, int mapHeight, bool wrapHorizontally, bool wrapVertically) {
 		this.game = game;
@@ -803,5 +813,12 @@ public partial class MapView : Node2D {
 	public void centerCameraOnTile(Tile t) {
 		var tileCenter = new Vector2(t.XCoordinate + 1, t.YCoordinate + 1) * scaledCellSize;
 		setCameraLocation(tileCenter - (float)0.5 * getVisibleAreaSize());
+	}
+
+	public void OnCenterCameraOnUnit() {
+		MapUnit currentlySelectedUnit = game.CurrentlySelectedUnit;
+		if (currentlySelectedUnit == MapUnit.NONE || currentlySelectedUnit == null)
+			return;
+		centerCameraOnTile(currentlySelectedUnit.location);
 	}
 }

--- a/C7/Textures/TextureLoader.cs
+++ b/C7/Textures/TextureLoader.cs
@@ -76,6 +76,7 @@ public static class TextureLoader {
 	private static Dictionary<string, Pcx> PcxCache = [];
 	private static Dictionary<string, Image> PngCache = [];
 	private static Dictionary<string, Color> colorCache = [];
+	private static Dictionary<int, ShaderMaterial> materialCache = [];
 
 	private static Dictionary<string, ImageTexture> configKeyCache = [];
 	private static Dictionary<(string configKey, object obj), ImageTexture> objectMappingCache = [];
@@ -458,6 +459,18 @@ public static class TextureLoader {
 		return png;
 	}
 
+	public static ShaderMaterial GetShaderMaterialForUnit(int civIndex) {
+		if (materialCache.TryGetValue(civIndex, out ShaderMaterial material)) {
+			return material;
+		}
+		material = new();
+		material.Shader = GD.Load<Shader>("res://UnitTint.gdshader");
+		Color civColor = LoadColor(civIndex);
+		material.SetShaderParameter("tintColor", new Vector3(civColor.R, civColor.G, civColor.B));
+		materialCache[civIndex] = material;
+		return material;
+	}
+
 	public static void ClearCache() {
 		PcxCache.Clear();
 		PngCache.Clear();
@@ -466,5 +479,6 @@ public static class TextureLoader {
 		objectMappingCache.Clear();
 		animationCache.Clear();
 		colorCache.Clear();
+		materialCache.Clear();
 	}
 }

--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -594,25 +594,9 @@ public partial class CityScreen : Control {
 		}
 
 		if (city.itemBeingProduced is UnitPrototype up) {
-			// Get the flic data for the unit we're producing.
-			string path = new AnimationManager(null).getUnitFlicFilepath(up, MapUnit.AnimatedAction.DEFAULT);
-			ConvertCiv3Media.Flic flic = Util.LoadFlic(path);
-
-			// Set up a shader we can use to color the "tint" portion of the
-			// animation frame below.
-			ShaderMaterial material = new();
-			material.Shader = GD.Load<Shader>("res://UnitTint.gdshader");
-			Color civColor = TextureLoader.LoadColor(city.owner.colorIndex);
-			material.SetShaderParameter("tintColor", new Vector3(civColor.R, civColor.G, civColor.B));
-
-			// See flicRowToAnimationDirection for the mapping, row 2 is facing
-			// southeast, and we're just grabbing frame 0.
-			byte[] frame = flic.Images[2, 0];
-
-			// Each frame is split in two parts, the base image, and the "tint"
-			// of the image, which is the part of the unit that has civ-specific
-			// colors.
-			(ImageTexture baseImage, ImageTexture imageTint) = Util.LoadTextureFromFlicData(frame, flic.Palette, flic.Width, flic.Height);
+			AnimationManager animationManager = mapView.game.animationController.civ3AnimData.forUnit(up, MapUnit.AnimatedAction.DEFAULT).animationManager;
+			ShaderMaterial material = TextureLoader.GetShaderMaterialForUnit(city.owner.colorIndex);
+			(ImageTexture baseImage, ImageTexture imageTint) = animationManager.GetAnimationFrameAndTintTextures(up);
 
 			// Add the base sprite.
 			Sprite2D baseImageSprite = new();

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -256,9 +256,9 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 	}
 
 	private void UpdateUnitGraphic(MapUnit unit) {
-		if(this.GetChildren().Contains(unitPlaceholder))
+		if (this.GetChildren().Contains(unitPlaceholder))
 			this.RemoveChild(unitPlaceholder);
-		if(this.GetChildren().Contains(unitTintPlaceholder))
+		if (this.GetChildren().Contains(unitTintPlaceholder))
 			this.RemoveChild(unitTintPlaceholder);
 
 		if (unit == MapUnit.NONE || unit == null) {
@@ -282,7 +282,7 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 
 		// Add the tint sprite, hooking up the shader.
 		unitTintPlaceholder = new Sprite2D();
-		unitTintPlaceholder.Texture =  tintFrame;
+		unitTintPlaceholder.Texture = tintFrame;
 		unitTintPlaceholder.Material = material;
 		unitTintPlaceholder.Position = unitPlaceholder.Position;
 		this.AddChild(unitTintPlaceholder);

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -12,8 +12,6 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 	private const float offsetUnitThumbnailX = 14;
 	private const float offsetUnitThumbnailY = 16;
 
-	private MapUnit activeUnit;
-
 	private TextureRect boxRightRectangle = new();
 	private TextureButton boxRightRectangleButton = new();
 
@@ -240,16 +238,10 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 		});
 
 		base._Process(delta);
-
-		if (activeUnit == MapUnit.NONE || activeUnit == null)
-			return;
-
-		UpdateUnitInfo(activeUnit, activeUnit.location.overlayTerrainType);
 	}
 
 	private void OnNewUnitSelected(ParameterWrapper<MapUnit> wrappedMapUnit) {
 		MapUnit unit = wrappedMapUnit.Value;
-		activeUnit = unit;
 		log.Information("Selected unit: " + unit + " at " + unit.location);
 		UpdateUnitGraphic(unit);
 		UpdateUnitInfo(unit, unit.location.overlayTerrainType);
@@ -262,7 +254,6 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 			this.RemoveChild(unitTintPlaceholder);
 
 		if (unit == MapUnit.NONE || unit == null) {
-			activeUnit = MapUnit.NONE;
 			return;
 		}
 
@@ -296,5 +287,10 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 		}
 		// Otherwise we can center the camera to the unit currently active
 		EmitSignal(SignalName.CenterCameraOnActiveUnit);
+	}
+
+	private void OnUnitMoved(ParameterWrapper<MapUnit> wrappedMapUnit) {
+		MapUnit unit = wrappedMapUnit.Value;
+		UpdateUnitInfo(unit, unit.location.overlayTerrainType);
 	}
 }

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -1,5 +1,4 @@
 using Godot;
-using ConvertCiv3Media;
 using C7GameData;
 using Serilog;
 using C7Engine;
@@ -9,34 +8,67 @@ using C7Engine;
 public partial class LowerRightInfoBox : Civ3TextureRect {
 	private ILogger log = LogManager.ForContext<LowerRightInfoBox>();
 
-	TextureButton nextTurnButton = new TextureButton();
-	ImageTexture nextTurnOnTexture;
-	ImageTexture nextTurnOffTexture;
-	ImageTexture nextTurnBlinkTexture;
+	private const int fontSize = 12;
+	private const float offsetUnitThumbnailX = 14;
+	private const float offsetUnitThumbnailY = 16;
 
-	Label civAndGovt = new();
-	Label lblUnitSelected = new Label();
-	Label attackDefenseMovement = new Label();
-	Label terrainType = new Label();
-	Label yearAndGold = new Label();
-	Label scienceProgress = new();
+	private MapUnit activeUnit;
 
-	Timer blinkingTimer = new Timer();
-	bool timerStarted = false;  //This "isStopped" returns false if it's never been started.  So we need this to know if we've ever started it.
+	private TextureRect boxRightRectangle = new();
+	private TextureButton boxRightRectangleButton = new();
+
+	private TextureButton nextTurnButton = new();
+	private ImageTexture nextTurnOnTexture;
+	private ImageTexture nextTurnOffTexture;
+	private ImageTexture nextTurnBlinkTexture;
+
+	private Label unitRank = new();
+	private Label unitType = new();
+	private Label attackDefenseMovement = new();
+	private Label terrainType = new();
+
+	private Label civAndGovt = new();
+	private Label yearAndGold = new();
+	private Label scienceProgress = new();
+
+	private Label suggestion = new();
+
+	private Sprite2D unitPlaceholder = new();
+	private Sprite2D unitTintPlaceholder = new();
+
+	private Timer blinkingTimer = new Timer();
+	private bool timerStarted = false;  //This "isStopped" returns false if it's never been started.  So we need this to know if we've ever started it.
 
 	[Signal] public delegate void BlinkyEndTurnButtonPressedEventHandler();
+	[Signal] public delegate void CenterCameraOnActiveUnitEventHandler();
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
+		unitRank.AddThemeFontSizeOverride("font_size", fontSize);
+		unitType.AddThemeFontSizeOverride("font_size", fontSize);
+		attackDefenseMovement.AddThemeFontSizeOverride("font_size", fontSize);
+		terrainType.AddThemeFontSizeOverride("font_size", fontSize);
+		civAndGovt.AddThemeFontSizeOverride("font_size", fontSize);
+		yearAndGold.AddThemeFontSizeOverride("font_size", fontSize);
+		scienceProgress.AddThemeFontSizeOverride("font_size", fontSize);
+		suggestion.AddThemeFontSizeOverride("font_size", fontSize);
+
 		this.CreateUI();
 	}
 
 	private void CreateUI() {
 		ImageTexture boxRight = TextureLoader.Load("lower_right_infobox.box");
-		TextureRect boxRightRectangle = new TextureRect();
+		boxRightRectangle = new TextureRect();
 		boxRightRectangle.Texture = boxRight;
 		boxRightRectangle.SetPosition(new Vector2(0, 0));
 		AddChild(boxRightRectangle);
+
+		// An "invisible" button covering the inside area of the box so we can register the click
+		// and center the camera on the unit or end the turn
+		boxRightRectangleButton.SetSize(new Vector2(228, 108));
+		boxRightRectangleButton.SetPosition(new Vector2(40, 17));
+		AddChild(boxRightRectangleButton);
+		boxRightRectangleButton.Pressed += HandleBoxClick;
 
 		nextTurnOffTexture = TextureLoader.Load("lower_right_infobox.next_turn.off");
 		nextTurnOnTexture = TextureLoader.Load("lower_right_infobox.next_turn.on");
@@ -49,39 +81,55 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 		nextTurnButton.Pressed += turnEnded;
 
 
-		//Labels and whatnot in this text box
-		lblUnitSelected.Text = "Settler";
-		lblUnitSelected.HorizontalAlignment = HorizontalAlignment.Right;
-		lblUnitSelected.SetPosition(new Vector2(0, 20));
-		lblUnitSelected.AnchorRight = 1.0f;
-		lblUnitSelected.OffsetRight = -30;
-		boxRightRectangle.AddChild(lblUnitSelected);
+		// Unit info
+		unitType.Text = "Settler";
+		unitType.HorizontalAlignment = HorizontalAlignment.Right;
+		unitType.SetPosition(new Vector2(0, 18));
+		unitType.AnchorRight = 1.0f;
+		unitType.OffsetRight = -35;
+		boxRightRectangle.AddChild(unitType);
+
+		unitRank.Text = "Regular";
+		unitRank.HorizontalAlignment = HorizontalAlignment.Right;
+		unitRank.SetPosition(new Vector2(0, 32));
+		unitRank.AnchorRight = 1.0f;
+		unitRank.OffsetRight = -35;
+		unitRank.Visible = false;
+		boxRightRectangle.AddChild(unitRank);
 
 		attackDefenseMovement.Text = "0.0. 1/1";
 		attackDefenseMovement.HorizontalAlignment = HorizontalAlignment.Right;
-		attackDefenseMovement.SetPosition(new Vector2(0, 35));
+		attackDefenseMovement.SetPosition(new Vector2(0, 32));
 		attackDefenseMovement.AnchorRight = 1.0f;
-		attackDefenseMovement.OffsetRight = -30;
+		attackDefenseMovement.OffsetRight = -35;
 		boxRightRectangle.AddChild(attackDefenseMovement);
 
 		terrainType.Text = "Grassland";
 		terrainType.HorizontalAlignment = HorizontalAlignment.Right;
-		terrainType.SetPosition(new Vector2(0, 50));
+		terrainType.SetPosition(new Vector2(0, 46));
 		terrainType.AnchorRight = 1.0f;
-		terrainType.OffsetRight = -30;
+		terrainType.OffsetRight = -35;
 		boxRightRectangle.AddChild(terrainType);
 
-		civAndGovt.SetPosition(new Vector2(0, 75));
+		// Player info
+		civAndGovt.SetPosition(new Vector2(0, 80));
 		boxRightRectangle.AddChild(civAndGovt);
 		civAndGovt.SetTextAndCenterLabel("Carthage - Despotism (5.5.0)");
 
-		yearAndGold.SetPosition(new Vector2(0, 90));
+		yearAndGold.SetPosition(new Vector2(0, 94));
 		boxRightRectangle.AddChild(yearAndGold);
 		yearAndGold.SetTextAndCenterLabel("Turn 0  10 Gold (+0 per turn)");
 
-		scienceProgress.SetPosition(new Vector2(0, 105));
+		scienceProgress.SetPosition(new Vector2(0, 108));
 		boxRightRectangle.AddChild(scienceProgress);
 		scienceProgress.SetTextAndCenterLabel("");
+
+		// End of turn suggestions
+		suggestion.HorizontalAlignment = HorizontalAlignment.Right;
+		suggestion.SetPosition(new Vector2(0, 25));
+		suggestion.AnchorRight = 1.0f;
+		suggestion.OffsetRight = -45;
+		boxRightRectangle.AddChild(suggestion);
 
 		//Setup up, but do not start, the timer.
 		blinkingTimer.OneShot = false;
@@ -91,7 +139,11 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 	}
 
 	private void SetEndOfTurnStatus() {
-		lblUnitSelected.Text = "ENTER or SPACEBAR for next turn";
+		UpdateUnitGraphic(MapUnit.NONE);
+		suggestion.Text = "ENTER or SPACEBAR for next turn";
+		suggestion.Visible = true;
+		unitRank.Visible = false;
+		unitType.Visible = false;
 		attackDefenseMovement.Visible = false;
 		terrainType.Visible = false;
 
@@ -108,17 +160,17 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 	private void toggleEndTurnButton() {
 		if (nextTurnButton.TextureNormal == nextTurnOnTexture) {
 			nextTurnButton.TextureNormal = nextTurnBlinkTexture;
-			lblUnitSelected.Visible = true;
+			suggestion.Visible = true;
 		} else {
 			nextTurnButton.TextureNormal = nextTurnOnTexture;
-			lblUnitSelected.Visible = false;
+			suggestion.Visible = false;
 		}
 	}
 
 	private void StopToggling() {
 		nextTurnButton.TextureNormal = nextTurnOffTexture;
-		lblUnitSelected.Text = "Please wait...";
-		lblUnitSelected.Visible = true;
+		suggestion.Text = "Please wait...";
+		suggestion.Visible = true;
 		blinkingTimer.Stop();
 		timerStarted = false;
 	}
@@ -128,19 +180,33 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 		EmitSignal(SignalName.BlinkyEndTurnButtonPressed);
 	}
 
-	private void UpdateUnitInfo(MapUnit NewUnit, TerrainType terrain) {
+	private void UpdateUnitInfo(MapUnit unit, TerrainType terrain) {
 		StopToggling();
 
 		terrainType.Text = terrain.DisplayName;
-		terrainType.Visible = true;
-		lblUnitSelected.Text = NewUnit.unitType.name;
-		lblUnitSelected.Visible = true;
-		string movementPointsRemaining = NewUnit.movementPoints.canMove ? "" + $"{(NewUnit.movementPoints.getMixedNumber())}" : "0";
-		string bombardText = "";
-		if (NewUnit.unitType.bombard > 0) {
-			bombardText = $"({NewUnit.unitType.bombard})";
+		if (unit.location.HasCity && unit.owner == unit.location.cityAtTile.owner) {
+			terrainType.Text = unit.location.cityAtTile.name;
 		}
-		attackDefenseMovement.Text = $"{NewUnit.unitType.attack}{bombardText}.{NewUnit.unitType.defense} {movementPointsRemaining}/{NewUnit.unitType.movement}";
+		if (unit.unitType.attack > 0 || unit.unitType.defense > 0) {
+			unitRank.Visible = true;
+			unitRank.Text = unit.experienceLevel.displayName;
+			attackDefenseMovement.SetPosition(new Vector2(0, 46));
+			terrainType.SetPosition(new Vector2(0, 60));
+		} else {
+			unitRank.Visible = false;
+			attackDefenseMovement.SetPosition(new Vector2(0, 32));
+			terrainType.SetPosition(new Vector2(0, 46));
+		}
+		suggestion.Visible = false;
+		terrainType.Visible = true;
+		unitType.Text = unit.unitType.name;
+		unitType.Visible = true;
+		string movementPointsRemaining = unit.movementPoints.canMove ? "" + $"{(unit.movementPoints.getMixedNumber())}" : "0";
+		string bombardText = "";
+		if (unit.unitType.bombard > 0) {
+			bombardText = $"({unit.unitType.bombard})";
+		}
+		attackDefenseMovement.Text = $"{unit.unitType.attack}{bombardText}.{unit.unitType.defense} {movementPointsRemaining}/{unit.unitType.movement}";
 		attackDefenseMovement.Visible = true;
 	}
 
@@ -174,11 +240,61 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 		});
 
 		base._Process(delta);
+
+		if (activeUnit == MapUnit.NONE || activeUnit == null)
+			return;
+
+		UpdateUnitInfo(activeUnit, activeUnit.location.overlayTerrainType);
 	}
 
 	private void OnNewUnitSelected(ParameterWrapper<MapUnit> wrappedMapUnit) {
-		MapUnit newUnit = wrappedMapUnit.Value;
-		log.Information("Selected unit: " + newUnit + " at " + newUnit.location);
-		UpdateUnitInfo(newUnit, newUnit.location.overlayTerrainType);
+		MapUnit unit = wrappedMapUnit.Value;
+		activeUnit = unit;
+		log.Information("Selected unit: " + unit + " at " + unit.location);
+		UpdateUnitGraphic(unit);
+		UpdateUnitInfo(unit, unit.location.overlayTerrainType);
+	}
+
+	private void UpdateUnitGraphic(MapUnit unit) {
+		if(this.GetChildren().Contains(unitPlaceholder))
+			this.RemoveChild(unitPlaceholder);
+		if(this.GetChildren().Contains(unitTintPlaceholder))
+			this.RemoveChild(unitTintPlaceholder);
+
+		if (unit == MapUnit.NONE || unit == null) {
+			activeUnit = MapUnit.NONE;
+			return;
+		}
+
+		string key = AnimationManager.GetUnitDefaultThumbnailKey(unit.unitType);
+		ImageTexture baseFrame = AnimationManager.AnimationThumbnails[key];
+		ImageTexture tintFrame = AnimationManager.AnimationTintThumbnails[key];
+
+		ShaderMaterial material = TextureLoader.GetShaderMaterialForUnit(unit.owner.colorIndex);
+
+		// Add the base sprite.
+		unitPlaceholder = new Sprite2D();
+		unitPlaceholder.Texture = baseFrame;
+		unitPlaceholder.Position = new Vector2(
+			boxRightRectangle.Texture.GetWidth() / 2f - offsetUnitThumbnailX,
+			boxRightRectangle.Texture.GetHeight() / 2f - offsetUnitThumbnailY);
+		this.AddChild(unitPlaceholder);
+
+		// Add the tint sprite, hooking up the shader.
+		unitTintPlaceholder = new Sprite2D();
+		unitTintPlaceholder.Texture =  tintFrame;
+		unitTintPlaceholder.Material = material;
+		unitTintPlaceholder.Position = unitPlaceholder.Position;
+		this.AddChild(unitTintPlaceholder);
+	}
+
+	private void HandleBoxClick() {
+		// When the turn can be ended, the click on the box is like clicking on the blinky button
+		if (timerStarted) {
+			turnEnded();
+			return;
+		}
+		// Otherwise we can center the camera to the unit currently active
+		EmitSignal(SignalName.CenterCameraOnActiveUnit);
 	}
 }

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -122,8 +122,7 @@ public partial class UnitButtons : VBoxContainer {
 		UpdateButtons(wrappedMapUnit.Value);
 	}
 
-	private void UpdateButtons(MapUnit unit)
-	{
+	private void UpdateButtons(MapUnit unit) {
 		// Reset the visibility and tooltip whenever the unit changes.
 		foreach (ButtonAndTooltip btt in buttonMap.Values) {
 			btt.button.Visible = false;

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -115,8 +115,15 @@ public partial class UnitButtons : VBoxContainer {
 	}
 
 	private void OnNewUnitSelected(ParameterWrapper<MapUnit> wrappedMapUnit) {
-		MapUnit unit = wrappedMapUnit.Value;
+		UpdateButtons(wrappedMapUnit.Value);
+	}
 
+	private void OnUnitMoved(ParameterWrapper<MapUnit> wrappedMapUnit) {
+		UpdateButtons(wrappedMapUnit.Value);
+	}
+
+	private void UpdateButtons(MapUnit unit)
+	{
 		// Reset the visibility and tooltip whenever the unit changes.
 		foreach (ButtonAndTooltip btt in buttonMap.Values) {
 			btt.button.Visible = false;

--- a/C7/UnitSelector.cs
+++ b/C7/UnitSelector.cs
@@ -103,6 +103,7 @@ public partial class UnitSelector : Node {
 		if (CurrentlySelectedUnit != MapUnit.NONE) {
 			NoMoreAutoselectableUnitsEmitted = false;
 			ParameterWrapper<MapUnit> wrappedUnit = new(CurrentlySelectedUnit);
+			PreLoadUnitAnimationThumbnail(wrappedUnit.Value.unitType);
 			EmitSignal(SignalName.NewAutoselectedUnit, wrappedUnit);
 			return true;
 		}
@@ -113,5 +114,9 @@ public partial class UnitSelector : Node {
 		}
 
 		return false;
+	}
+
+	private void PreLoadUnitAnimationThumbnail(UnitPrototype unit) {
+		game.animationController.civ3AnimData.GetAnimationFrameAndTintTextures(unit);
 	}
 }

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -392,5 +392,6 @@ public partial class Util {
 	public static void ClearCaches() {
 		flicCache.Clear();
 		TextureLoader.ClearCache();
+		AnimationManager.ClearCache();
 	}
 }

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -157,12 +157,14 @@ namespace C7GameData {
 		}
 
 		public async Task animateAsync(MapUnit.AnimatedAction action, AnimationEnding ending = AnimationEnding.Stop) {
-			if (!EngineStorage.animationsEnabled) return;
+			if (EngineStorage.animationsEnabled) {
+				var msg = new MsgStartUnitAnimation(this, action, ending);
+				msg.send();
 
-			var msg = new MsgStartUnitAnimation(this, action, ending);
-			msg.send();
-
-			await EngineStorage.WaitForAnimationFinished(msg.animationId);
+				await EngineStorage.WaitForAnimationFinished(msg.animationId);
+			}
+			if(this.owner.isHuman)
+				new MsgUnitMoved(this).send();
 		}
 
 		public void animate(MapUnit.AnimatedAction action, AnimationEnding ending = AnimationEnding.Stop) {

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -163,7 +163,7 @@ namespace C7GameData {
 
 				await EngineStorage.WaitForAnimationFinished(msg.animationId);
 			}
-			if(this.owner.isHuman)
+			if (this.owner.isHuman)
 				new MsgUnitMoved(this).send();
 		}
 

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -141,4 +141,11 @@ namespace C7Engine {
 			this.aiGive = aiGive;
 		}
 	}
+
+	public class MsgUnitMoved : MessageToUI {
+		public MapUnit Unit;
+		public MsgUnitMoved(MapUnit unit) {
+			this.Unit = unit;
+		}
+	}
 }


### PR DESCRIPTION
1. Added unit thumbnail in the lower right info box
2. Now it also displays the unit's rank, and also if the unit is in a city, the name of the city instead of the underlying terrain info
3. Clicking on it will center on the currently active unit
4. Clicking on it at the end of the turn will end the turn

To be honest this one felt a bit "hacky",  for lack of a better word. If you have any suggestions as to how to improve it, let me know.