### PR TITLE
Apllied shadows to resources' textures

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -60,7 +60,7 @@ public partial class Game : Node {
 	private Vector2 OldPosition;
 
 	Stopwatch loadTimer = new Stopwatch();
-	GlobalSingleton Global;
+	public GlobalSingleton Global { get; private set; }
 
 	[Export]
 	private PopupOverlay popupOverlay;

--- a/C7/Lua/texture_configs/civ3/resources.lua
+++ b/C7/Lua/texture_configs/civ3/resources.lua
@@ -25,6 +25,27 @@ function resources.large:map_object_to_sprite(resource)
   }
 end
 
+resources.shadows = {
+  extra_data = {
+    path = "Art/resources_shadows.pcx",
+  },
+}
+
+function resources.shadows:map_object_to_sprite(resource)
+  if resource:GetType().Name ~= "Resource" then
+    error "Expected a Resource object"
+  end
+
+  local icon = resource.Icon
+  local row = math.floor(icon / 6)
+  local col = icon % 6
+
+  return {
+    path = self.extra_data.path,
+    crop_region = { col * RESOURCE_SIZE,  row * RESOURCE_SIZE, RESOURCE_SIZE, RESOURCE_SIZE },
+  }
+end
+
 resources.small = {
   extra_data = {
     path = "Art/city screen/luxuryicons_small.pcx",

--- a/C7/Map/ResourceLayer.cs
+++ b/C7/Map/ResourceLayer.cs
@@ -19,8 +19,12 @@ namespace C7.Map {
 				return;
 			}
 
-			var texture = TextureLoader.Load("resources.large", resource, useCache: true);
+			if (!looseView.mapView.game.Global.ModernGraphicsActive) {
+				ImageTexture shadows = TextureLoader.Load("resources.shadows", resource, useCache: true);
+				looseView.DrawTexture(shadows, tileCenter - 0.5f * shadows.GetSize());
+			}
 
+			ImageTexture texture = TextureLoader.Load("resources.large", resource, useCache: true);
 			looseView.DrawTexture(texture, tileCenter - 0.5f * texture.GetSize());
 		}
 

--- a/C7/Textures/PCXToGodot.cs
+++ b/C7/Textures/PCXToGodot.cs
@@ -215,7 +215,9 @@ public partial class PCXToGodot : GodotObject {
 
 		if (colorOptions.shadows) {
 			for (int i = 240; i < 256; i++) {
-				ColorData[i] = ((MAX_COLOR - i) * 16) << ALPHA_BITSHIFT;
+				if (!colorOptions.transparentColorIndexes.Contains(i)) {
+					ColorData[i] = ((MAX_COLOR - i) * 16) << ALPHA_BITSHIFT;
+				}
 			}
 		}
 


### PR DESCRIPTION
Basically what the title says.

An alternative way of doing this that I tested, instead of exposing a public getter for **ModernGraphicsActive** and checking it in the ResourceLayer, would be to add an empty texture so Lua doesn't freak out, and render a cropped region of nothing (since newer graphics can simply contain their shadows in the same image) when the new graphics are enabled, which I didn't like, it's just wasted draw calls.

Maybe a boolean in Lua like "Civ3Exclusive" would be helpful, but then the Texture.Load() would have to return null or something that doesn't break everything and can be checked by the caller merhod in order to skip the draw call.

Let me know what you think.