### PR TITLE
Ensure that the unit taking a city is not destroyed

### DIFF
--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -649,14 +649,18 @@ namespace C7GameData {
 		/// Eventually, we should also have a method to make relevant units (workers, artillery, etc.) be captured.
 		/// </summary>
 		/// <param name="tile"></param>
-		public void DisbandNonDefendingUnits() {
+		public void DisbandNonDefendingUnits(Player owner) {
 			//There may have been naval units, if so, disband them
 			if (unitsOnTile.Count > 0) {
 				//Copy to a separate array so we don't crash due to concurrent modification exceptions
 				MapUnit[] unitsOnTile = new MapUnit[this.unitsOnTile.Count];
 				this.unitsOnTile.CopyTo(unitsOnTile);
 				foreach (MapUnit destroyedUnit in unitsOnTile) {
-					destroyedUnit.disband();
+					// Ensure we only destroy units of the losing side of the
+					// combat, not the unit entering the city.
+					if (destroyedUnit.owner == owner) {
+						destroyedUnit.disband();
+					}
 				}
 			}
 		}

--- a/C7Engine/EntryPoints/CityInteractions.cs
+++ b/C7Engine/EntryPoints/CityInteractions.cs
@@ -47,8 +47,8 @@ namespace C7Engine {
 
 		public static void DestroyCity(int X, int Y) {
 			Tile tile = EngineStorage.gameData.map.tileAt(X, Y);
-			tile.DisbandNonDefendingUnits();
 			Player owner = tile.cityAtTile.owner;
+			tile.DisbandNonDefendingUnits(owner);
 			tile.cityAtTile.RemoveAllCitizens();
 			tile.cityAtTile.owner.cities.Remove(tile.cityAtTile);
 			EngineStorage.gameData.cities.Remove(tile.cityAtTile);


### PR DESCRIPTION
The previous logic ensured that we destroyed any non-defending units (catapults, boats, workers, etc) but mistakenly destroyed the unit entering the city as well.