### PR TITLE
Research improvements

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -318,10 +318,14 @@ public partial class Game : Node {
 			// once they have a city.
 			if (controller.cities.Count > 0
 					&& controller.currentlyResearchedTech == null
-					&& controller.GetAvailableTechsToResearch(gameData).Count > 0) {
+					&& controller.GetAvailableTechsToResearch(gameData.techs).Count > 0) {
 				popupOverlay.ShowPopup(
 						new ScienceSelection(controller),
 						PopupOverlay.PopupCategory.Info);
+
+				if (controller.currentlyResearchedTech == null && controller.GetAvailableTechsToResearch(gameData.techs).Count > 0) {
+					PlayerAI.MaybePickTechToResearch(controller, gameData.techs);
+				}
 			}
 
 			// Allow fast forwarding in observer mode.

--- a/C7/UIElements/Advisors/ScienceAdvisor.cs
+++ b/C7/UIElements/Advisors/ScienceAdvisor.cs
@@ -38,10 +38,10 @@ public partial class ScienceAdvisor : TextureRect {
 		this.CreateUI();
 
 		EngineStorage.ReadGameData((GameData gameData) => {
-			List<Tech> techs = gameData.techs;
+			List<Tech> allTechs = gameData.techs;
 			Player player = gameData.GetFirstHumanPlayer();
 			eraName = string.IsNullOrEmpty(lastOpenedEra) ? player.eraCivilopediaName : lastOpenedEra;
-			this.DrawTechTree(eraName, player, techs, player.GetAvailableTechsToResearch(gameData));
+			this.DrawTechTree(eraName, player, allTechs, player.GetAvailableTechsToResearch(allTechs));
 		});
 	}
 
@@ -205,12 +205,12 @@ public partial class ScienceAdvisor : TextureRect {
 		techBoxes.Clear();
 
 		EngineStorage.ReadGameData((GameData gameData) => {
-			List<Tech> techs = gameData.techs;
+			List<Tech> allTechs = gameData.techs;
 			Player player = gameData.GetFirstHumanPlayer();
 			eraName = string.IsNullOrEmpty(lastOpenedEra)
 				? EraIndexToEra(GetEraIndex(eraName) + delta)
 				: EraIndexToEra(GetEraIndex(lastOpenedEra) + delta);
-			DrawTechTree(eraName, player, techs, player.GetAvailableTechsToResearch(gameData));
+			DrawTechTree(eraName, player, allTechs, player.GetAvailableTechsToResearch(allTechs));
 		});
 	}
 

--- a/C7/UIElements/Popups/ScienceSelection.cs
+++ b/C7/UIElements/Popups/ScienceSelection.cs
@@ -79,7 +79,7 @@ public partial class ScienceSelection : Popup {
 				AddItem(gameData, player.ResearchQueue.Peek(), optionButton);
 			}
 			// then the rest
-			foreach (Tech tech in player.GetAvailableTechsToResearch(gameData)) {
+			foreach (Tech tech in player.GetAvailableTechsToResearch(gameData.techs)) {
 				if (!options.Contains(tech)) {
 					AddItem(gameData, tech, optionButton);
 				}

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -68,17 +68,20 @@ namespace C7Engine {
 			}
 		}
 
-		private static void MaybePickTechToResearch(Player player, List<Tech> techs) {
-			while (player.currentlyResearchedTech == null) {
-				Tech toResearch = PickTechToResearch(player, techs);
+		public static void MaybePickTechToResearch(Player player, List<Tech> techs) {
+			while (player.currentlyResearchedTech == null || player.knownTechs.Contains(player.currentlyResearchedTech)) {
+				Tech toResearch = player.GetAvailableTechsToResearch(techs).FirstOrDefault();
 				if (toResearch == null) {
 					log.Information($"Player {player.civilization.name} has no techs available to research.");
 					player.SetCurrentlyResearchedTech(null);
 					break;
-				} else {
-					log.Information($"Player {player.civilization.name} is researching {toResearch.Name}.");
-					player.SetCurrentlyResearchedTech(toResearch.id);
 				}
+
+				if (player.ResearchQueue.Count <= 0) {
+					player.AddTechItemToResearchQueue(toResearch);
+				}
+				player.SetCurrentlyResearchedTech(player.ResearchQueue.Peek().id);
+				log.Information($"Player {player.civilization.name} is researching {player.ResearchQueue.Peek().Name}.");
 			}
 		}
 
@@ -266,39 +269,6 @@ namespace C7Engine {
 				return new CombatAI(caid);
 			}
 			return null;
-		}
-
-		private static Tech PickTechToResearch(Player player, List<Tech> techs) {
-			List<Tech> possibleTechs = new();
-
-			// Figure out what techs we're allowed to research.
-			foreach (Tech tech in techs) {
-				if (tech.EraCivilopediaName != player.eraCivilopediaName) {
-					continue;
-				}
-				if (player.knownTechs.Contains(tech.id)) {
-					continue;
-				}
-
-				bool prereqsKnown = true;
-				foreach (Tech prereq in tech.Prerequisites) {
-					if (!player.knownTechs.Contains(prereq.id)) {
-						prereqsKnown = false;
-						break;
-					}
-				}
-				if (!prereqsKnown) {
-					continue;
-				}
-				possibleTechs.Add(tech);
-			}
-
-			if (possibleTechs.Count == 0) {
-				return null;
-			}
-
-			// Details on how Civ3 does it: https://forums.civfanatics.com/threads/what-will-the-ai-research-next.45559/
-			return possibleTechs[(int)GameData.rng.NextInt64(possibleTechs.Count)];
 		}
 
 		private static async Task AttemptTrading(Player us) {

--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -106,6 +106,10 @@ namespace C7GameData {
 			return players.Find(p => p.id == id);
 		}
 
+		public Tech GetTech(ID id) {
+			return techs.Find(p => p.id == id);
+		}
+
 		public ExperienceLevel GetExperienceLevelAfter(ExperienceLevel experienceLevel) {
 			int n = experienceLevels.IndexOf(experienceLevel);
 			if (n + 1 < experienceLevels.Count)

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -142,7 +142,7 @@ namespace C7GameData {
 
 				Tech tech = EngineStorage.gameData.techs.Find(x => x.id == id);
 				log.Information($"Awarding {tech.Name} to player {this}");
-				CompleteResearchingTech(EngineStorage.gameData, tech);
+				CompleteResearchAndBeginNew(EngineStorage.gameData, tech);
 				return;
 			}
 
@@ -363,13 +363,8 @@ namespace C7GameData {
 				other.gold -= theirOffer.gold.Value;
 			}
 
-			foreach (Tech t in ourOffer.techs) {
-				other.knownTechs.Add(t.id);
-			}
-
-			foreach (Tech t in theirOffer.techs) {
-				this.knownTechs.Add(t.id);
-			}
+			other.CompleteResearchAndBeginNew(gameData, ourOffer.techs);
+			this.CompleteResearchAndBeginNew(gameData, theirOffer.techs);
 		}
 
 		public int EstimateTurnsToResearch(GameData gameData, Tech tech) {
@@ -444,9 +439,7 @@ namespace C7GameData {
 				return new Queue<Tech>();
 			}
 
-			// TODO: maybe sort these on some other score, perhaps the order the AI would have picked them
-			// Right now the tech with the highest cost comes first
-			List<Tech> requiredTechs = tech.Prerequisites.OrderBy(t => t.Cost).ToList();
+			List<Tech> requiredTechs = OrderTechs(tech.Prerequisites).ToList();
 
 			// first, add the tech the user clicked
 			if (!tempQueue.Contains(tech)) {
@@ -473,9 +466,14 @@ namespace C7GameData {
 			return tempQueue;
 		}
 
-		public HashSet<Tech> GetAvailableTechsToResearch(GameData gameData) {
+		/// <summary>
+		/// Takes all the techs in the game and keeps only what could be researched next at a particular point in the game.
+		/// </summary>
+		/// <param name="allTechs"></param>
+		/// <returns></returns>
+		public HashSet<Tech> GetAvailableTechsToResearch(List<Tech> allTechs) {
 			HashSet<Tech> result = new();
-			foreach (Tech tech in gameData.techs) {
+			foreach (Tech tech in allTechs) {
 				if (knownTechs.Contains(tech.id)) {
 					continue;
 				}
@@ -494,7 +492,17 @@ namespace C7GameData {
 					result.Add(tech);
 				}
 			}
-			return result;
+			return OrderTechs(result.ToList());
+		}
+
+		// Placeholder ordering of techs
+		private HashSet<Tech> OrderTechs(List<Tech> techs) {
+			if (techs == null || techs.Count == 0) {
+				return new HashSet<Tech>();
+			}
+			// TODO: We would want to eventually order them based on how the AI would do it
+			// Details on how Civ3 does it: https://forums.civfanatics.com/threads/what-will-the-ai-research-next.45559/
+			return techs.OrderBy(t => t.Cost).ToHashSet();
 		}
 
 		public List<Government> GetAvailableGovernments(GameData gameData) {
@@ -679,7 +687,18 @@ namespace C7GameData {
 				return;
 			}
 
+			CompleteResearchAndBeginNew(gameData, tech);
+		}
+
+		private void CompleteResearchAndBeginNew(GameData gameData, IEnumerable<Tech> techs) {
+			foreach (Tech tech in techs) {
+				CompleteResearchingTech(gameData, tech);
+			}
+			PlayerAI.MaybePickTechToResearch(this, gameData.techs);
+		}
+		private void CompleteResearchAndBeginNew(GameData gameData, Tech tech) {
 			CompleteResearchingTech(gameData, tech);
+			PlayerAI.MaybePickTechToResearch(this, gameData.techs);
 		}
 
 		private void CompleteResearchingTech(GameData gameData, Tech tech) {


### PR DESCRIPTION
1. When trading techs, register incoming techs as known and auto assign a new research
2. When asked by the science advisor to select what to research and bypass it without selecting a tech, one is auto-assigned for the player
3. Minor refactor to remove duplications and keep one way of handling research related functionality