### PR TITLE
Terrain improvements enchancements

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -797,11 +797,24 @@ public partial class Game : Node {
 
 		Terraform terraform = C7Action.ToTerraform(currentAction);
 
-		if (terraform != null
-			&& CurrentlySelectedUnit != MapUnit.NONE
-			&& CurrentlySelectedUnit.canPerformTerraformAction(terraform)) {
-			new MsgStartWorkerJob(CurrentlySelectedUnit?.id, terraform).send();
+		if (CurrentlySelectedUnit == MapUnit.NONE || CurrentlySelectedUnit == null
+			|| terraform == null || !CurrentlySelectedUnit.canPerformTerraformAction(terraform))
+			return;
+
+		TerrainImprovement currentImprovement = CurrentlySelectedUnit.location.overlays.ImprovementAtLayer(terraform);
+		if (currentImprovement != null && terraform.Improvement.upgradesFrom != currentImprovement) {
+			popupOverlay.ShowPopup(
+				new ConfirmationPopup(
+					$"A previous terrain enhancement ({currentImprovement.key.Capitalize()}) will be replaced \nby this operation. Do you wish to continue?",
+					"Continue.",
+					"Cancel action.",
+					() => {
+						new MsgStartWorkerJob(CurrentlySelectedUnit.id, terraform).send();
+					}),
+				PopupOverlay.PopupCategory.Advisor);
+			return;
 		}
+		new MsgStartWorkerJob(CurrentlySelectedUnit.id, terraform).send();
 	}
 
 	private void setGotoMode(bool isOn) {

--- a/C7Engine/C7GameData/TerrainImprovement.cs
+++ b/C7Engine/C7GameData/TerrainImprovement.cs
@@ -84,5 +84,12 @@ namespace C7GameData {
 
 			return 0;
 		}
+
+		public bool CanBeReplacedBy(TerrainImprovement replacement) {
+			if (this.key == replacement.key) return false;       // mine-mine
+			if (this.upgradesFrom == replacement) return false;  // railroad upgrades from road so road cannot replace railroad
+			if (replacement.upgradesFrom == this) return true;   // railroad upgrades from road so railroad can replace road
+			return this.layer == replacement.layer;              // irrigation can replace mine and vice versa, an outpost a radar tower, etc
+		}
 	}
 }

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -772,6 +772,12 @@ namespace C7GameData {
 			return ti;
 		}
 
+		public TerrainImprovement ImprovementAtLayer(Terraform terraform) {
+			TerrainImprovement.Layer currentLayer = terraform.Improvement.layer;
+			terrainImprovementByLayer.TryGetValue(currentLayer, out TerrainImprovement ti);
+			return ti;
+		}
+
 		public bool HasImprovement(TerrainImprovement improvement) {
 			return terrainImprovementByLayer.TryGetValue(improvement.layer, out TerrainImprovement val) && val == improvement;
 		}
@@ -787,10 +793,7 @@ namespace C7GameData {
 			if (!terrainImprovementByLayer.TryGetValue(improvement.layer, out var current))
 				return improvement.upgradesFrom == null;
 
-			if (current == improvement || current.upgradesFrom == improvement)
-				return false;
-
-			return improvement.upgradesFrom == current;
+			return current.CanBeReplacedBy(improvement);
 		}
 
 		public bool HasRoad() {


### PR DESCRIPTION
1. Terrain Improvements of the same type can replace each other, but no downgrades are allowed.
2. Ask for confirmation when we are about to replace an improvement