### PR TITLE
Fixed bugs in the lower right info box behaviour

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -240,6 +240,7 @@ visible = false
 [connection signal="ShowCityScreen" from="." to="CanvasLayer/CityScreen" method="OnShowCityScreen"]
 [connection signal="ShowSpecificAdvisor" from="." to="CanvasLayer/Advisor" method="OnShowSpecificAdvisor"]
 [connection signal="TurnEnded" from="." to="CanvasLayer/Control/GameStatus/LowerRightInfoBox" method="StopToggling"]
+[connection signal="TurnEnded" from="." to="CanvasLayer/Control/GameStatus/LowerRightInfoBox" method="PleaseWait"]
 [connection signal="UnitMoved" from="." to="CanvasLayer/Control/UnitButtons" method="OnUnitMoved"]
 [connection signal="UnitMoved" from="." to="CanvasLayer/Control/GameStatus/LowerRightInfoBox" method="OnUnitMoved"]
 [connection signal="NewAutoselectedUnit" from="UnitSelector" to="CanvasLayer/Control/UnitButtons" method="OnNewUnitSelected"]

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -138,12 +138,9 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 
 	private void SetEndOfTurnStatus() {
 		UpdateUnitGraphic(MapUnit.NONE);
+		HideUnitInfo();
 		suggestion.Text = "ENTER or SPACEBAR for next turn";
 		suggestion.Visible = true;
-		unitRank.Visible = false;
-		unitType.Visible = false;
-		attackDefenseMovement.Visible = false;
-		terrainType.Visible = false;
 
 		toggleEndTurnButton();
 
@@ -167,10 +164,15 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 
 	private void StopToggling() {
 		nextTurnButton.TextureNormal = nextTurnOffTexture;
-		suggestion.Text = "Please wait...";
-		suggestion.Visible = true;
 		blinkingTimer.Stop();
 		timerStarted = false;
+		suggestion.Visible = false;
+	}
+
+	private void PleaseWait() {
+		HideUnitInfo();
+		suggestion.Text = "Please wait...";
+		suggestion.Visible = true;
 	}
 
 	private void turnEnded() {
@@ -179,33 +181,51 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 	}
 
 	private void UpdateUnitInfo(MapUnit unit, TerrainType terrain) {
-		StopToggling();
+		if (!unit.CanBeActive()) return;
+
+		bool showRank = false;
 
 		terrainType.Text = terrain.DisplayName;
 		if (unit.location.HasCity && unit.owner == unit.location.cityAtTile.owner) {
 			terrainType.Text = unit.location.cityAtTile.name;
 		}
-		if (unit.unitType.attack > 0 || unit.unitType.defense > 0) {
-			unitRank.Visible = true;
+		if (unit.HasRank()) {
+			showRank = true;
 			unitRank.Text = unit.experienceLevel.displayName;
 			attackDefenseMovement.SetPosition(new Vector2(0, 46));
 			terrainType.SetPosition(new Vector2(0, 60));
 		} else {
-			unitRank.Visible = false;
 			attackDefenseMovement.SetPosition(new Vector2(0, 32));
 			terrainType.SetPosition(new Vector2(0, 46));
 		}
-		suggestion.Visible = false;
-		terrainType.Visible = true;
 		unitType.Text = unit.unitType.name;
-		unitType.Visible = true;
 		string movementPointsRemaining = unit.movementPoints.canMove ? "" + $"{(unit.movementPoints.getMixedNumber())}" : "0";
 		string bombardText = "";
 		if (unit.unitType.bombard > 0) {
 			bombardText = $"({unit.unitType.bombard})";
 		}
 		attackDefenseMovement.Text = $"{unit.unitType.attack}{bombardText}.{unit.unitType.defense} {movementPointsRemaining}/{unit.unitType.movement}";
+
+		suggestion.Visible = false;
+
+		ShowUnitInfo(showRank);
+	}
+
+	private void HideUnitInfo() {
+		terrainType.Visible = false;
+		unitType.Visible = false;
+		unitRank.Visible = false;
+		attackDefenseMovement.Visible = false;
+		unitPlaceholder.Visible = false;
+		unitTintPlaceholder.Visible = false;
+	}
+	private void ShowUnitInfo(bool showRank) {
+		terrainType.Visible = true;
+		unitType.Visible = true;
+		unitRank.Visible = showRank;
 		attackDefenseMovement.Visible = true;
+		unitPlaceholder.Visible = true;
+		unitTintPlaceholder.Visible = true;
 	}
 
 	public override void _Process(double delta) {
@@ -243,6 +263,7 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 	private void OnNewUnitSelected(ParameterWrapper<MapUnit> wrappedMapUnit) {
 		MapUnit unit = wrappedMapUnit.Value;
 		log.Information("Selected unit: " + unit + " at " + unit.location);
+		StopToggling();
 		UpdateUnitGraphic(unit);
 		UpdateUnitInfo(unit, unit.location.overlayTerrainType);
 	}

--- a/C7/UnitSelector.cs
+++ b/C7/UnitSelector.cs
@@ -26,7 +26,10 @@ public partial class UnitSelector : Node {
 	private bool NoMoreAutoselectableUnitsEmitted = false;
 
 	public override void _Ready() {
-		game.PlayerTurnEnd += () => { NoMoreAutoselectableUnitsEmitted = false; };
+		game.PlayerTurnEnd += () => {
+			NoMoreAutoselectableUnitsEmitted = false;
+			CurrentlySelectedUnit = MapUnit.NONE;
+		};
 	}
 
 	public override void _Process(double delta) {
@@ -101,6 +104,7 @@ public partial class UnitSelector : Node {
 
 		// Also emit the signal for a new unit being selected, so other areas such as Game Status and Unit Buttons can update
 		if (CurrentlySelectedUnit != MapUnit.NONE) {
+			unit.wake();
 			NoMoreAutoselectableUnitsEmitted = false;
 			ParameterWrapper<MapUnit> wrappedUnit = new(CurrentlySelectedUnit);
 			PreLoadUnitAnimationThumbnail(wrappedUnit.Value.unitType);

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -74,6 +74,14 @@ namespace C7GameData {
 			return IsLandUnit() && unitType.defense > 0;
 		}
 
+		public bool HasRank() {
+			return this.unitType.attack > 0 || this.unitType.defense > 0;
+		}
+
+		public bool CanBeActive() {
+			return !this.IsBusy() && this.movementPoints.canMove;
+		}
+
 		public override string ToString() {
 			if (this != MapUnit.NONE) {
 				return this.owner + " " + unitType.name + " at (" + location.XCoordinate + ", " + location.YCoordinate + ") with " + movementPoints.getMixedNumber() + " MP and " + hitPointsRemaining + " HP, id = " + id;


### PR DESCRIPTION
1. Fixed bugs in the lower right info box behaviour (initial PR https://github.com/C7-Game/Prototype/pull/833) where labels are overlapping and units' info doesn't update as it should in certain scenarios.
2. Units are waken up when selected.
3. When ending the turn the currently selected unit gets reset.

All changes are pretty much concerned with visuals, of how and when the box gets updated, except of course 2 and 3, but they are pretty much 1 line each.

Number 2 and 3 were added so that the box knows if a unit is awake or nothing is selected, instead of adding some hacky behaviour to the box.

A lot of code has moved around, but it's mostly to accomodate the order of operations rather than changing the behaviour.

The only thing I am sceptical about is the waking of a newly selected unit, although I didn't see anything weird.
