### PR TITLE
Fix unit action buttons bugs

### DIFF
--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -123,6 +123,7 @@ public partial class UnitButtons : VBoxContainer {
 	}
 
 	private void UpdateButtons(MapUnit unit) {
+		if (!unit.CanBeActive()) return;
 		// Reset the visibility and tooltip whenever the unit changes.
 		foreach (ButtonAndTooltip btt in buttonMap.Values) {
 			btt.button.Visible = false;

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -773,9 +773,7 @@ namespace C7GameData {
 		}
 
 		public TerrainImprovement ImprovementAtLayer(Terraform terraform) {
-			TerrainImprovement.Layer currentLayer = terraform.Improvement.layer;
-			terrainImprovementByLayer.TryGetValue(currentLayer, out TerrainImprovement ti);
-			return ti;
+			return terraform.Improvement == null ? null : ImprovementAtLayer(terraform.Improvement.layer);
 		}
 
 		public bool HasImprovement(TerrainImprovement improvement) {


### PR DESCRIPTION
This PR aims to fix 2 bugs that affect the UI and parts of the gameplay. They were introduced int this PR https://github.com/C7-Game/Prototype/pull/833

1. Fix unit buttons
(Mostly) Because of the asynchronicity of the units, the unit action buttons would update while a selected unit was idle. So if a warrior just spawned in the capital, and was waiting to do something, an automated worker, or another warrior auto-moving in the background would cause the buttons to switch to that unit, and then, because "technically" we already have a unit selected, they wouldn't switch back to that unit's actions.
Also the button would flicker for the busy/automated units if there was nothing to move and just pressed the end turn button.

2. Fix NPE when a terraform doesn't have an improvement
The second bug, I again introduced with the relevant previous commit, where if there was no improvement on a tile, actions like Clear Forest had broken. A null pointer exception was thrown in the background but gameplay would continue normally. 
This is because I was trying to access the current improvement to open the advisor pop up and ask if the player wants to override the previous improvement, which in this case it was null and not properly checked for.