### PR TITLE
Hotkey and UI fixes

### DIFF
--- a/C7/Animations/AnimationController.cs
+++ b/C7/Animations/AnimationController.cs
@@ -49,9 +49,6 @@ public partial class AnimationController : Node {
 					mSEA.markCompleted();
 				}
 				break;
-			case MsgStartStopAllAnimations mSSAA:
-				animTracker.endAllImmediately = !mSSAA.animationsEnabled;
-				break;
 		}
 	}
 
@@ -67,9 +64,11 @@ public partial class AnimationController : Node {
 
 	public void ToggleAnimationsEnabled() {
 		new MsgToggleAnimationsEnabled().send();
+		animTracker.endAllImmediately = !animTracker.endAllImmediately;
 	}
 
 	public void SetAnimationsEnabled(bool enabled) {
 		new MsgSetAnimationsEnabled(enabled).send();
+		animTracker.endAllImmediately = !enabled;
 	}
 }

--- a/C7/Animations/AnimationController.cs
+++ b/C7/Animations/AnimationController.cs
@@ -1,4 +1,3 @@
-using System;
 using C7Engine;
 using C7GameData;
 using Godot;
@@ -50,6 +49,9 @@ public partial class AnimationController : Node {
 					mSEA.markCompleted();
 				}
 				break;
+			case MsgStartStopAllAnimations mSSAA:
+				animTracker.endAllImmediately = !mSSAA.animationsEnabled;
+				break;
 		}
 	}
 
@@ -63,8 +65,11 @@ public partial class AnimationController : Node {
 		animTracker.update();
 	}
 
+	public void ToggleAnimationsEnabled() {
+		new MsgToggleAnimationsEnabled().send();
+	}
+
 	public void SetAnimationsEnabled(bool enabled) {
 		new MsgSetAnimationsEnabled(enabled).send();
-		animTracker.endAllImmediately = !enabled;
 	}
 }

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -445,7 +445,9 @@ public partial class Game : Node {
 
 	private void HandleLeftMouseButton(InputEventMouseButton eventMouseButton) {
 		GetViewport().SetInputAsHandled();
-		if (eventMouseButton.IsPressed()) {
+		Control uiHover = GetViewport().GuiGetHoveredControl();
+		// Can't drag the map when the mouse is over a ui element
+		if (eventMouseButton.IsPressed() && uiHover is not TextureButton) {
 			OldPosition = eventMouseButton.Position;
 			IsMovingCamera = true;
 
@@ -583,9 +585,6 @@ public partial class Game : Node {
 		if (eventKeyDown.Keycode == Godot.Key.O && eventKeyDown.ShiftPressed && eventKeyDown.IsCommandOrControlPressed() && eventKeyDown.AltPressed) {
 			ToggleObserverMode();
 		}
-		if (eventKeyDown.Keycode == Godot.Key.G && eventKeyDown.ShiftPressed && eventKeyDown.IsCommandOrControlPressed() && eventKeyDown.AltPressed) {
-			ToggleGridCoordinates();
-		}
 		if (eventKeyDown.Keycode == Godot.Key.T && eventKeyDown.ShiftPressed && eventKeyDown.IsCommandOrControlPressed() && eventKeyDown.AltPressed) {
 			ToggleC7Graphics();
 		}
@@ -608,6 +607,32 @@ public partial class Game : Node {
 			City capital = controller.cities.Find(c => c.IsCapital());
 			if (capital != null) {
 				mapView.centerCameraOnTile(capital.location);
+			}
+		}
+		// For inputs that have the same keys mapped to multiple actions like G
+		// we need to manually handle what is triggered by adding extra conditions.
+		// Otherwise when pressing CTRL + G for example, both the go-to
+		// and the toggle grid actions are triggered, because godot does not distinguish
+		// single key presses from combos, it sends both signals.
+		// Sometimes even worse, when pressing CTRL + G, it only sends the go-to signal.
+		// We continue to map these to an action and not call them directly,
+		// because we could add a button in the ui that does the same and this would call the action too.
+		if (eventKeyDown.Keycode == Godot.Key.G) {
+			// Toggle Coordinates
+			if (eventKeyDown.IsCommandOrControlPressed()
+				&& eventKeyDown.ShiftPressed
+				&& eventKeyDown.AltPressed) {
+				ProcessAction(C7Action.ToggleCoordinates);
+			}
+			// Toggle Grid
+			else if (eventKeyDown.IsCommandOrControlPressed()) {
+				ProcessAction(C7Action.ToggleGrid);
+			}
+			// Trigger Unit go-to
+			else if (!eventKeyDown.IsCommandOrControlPressed()
+					   && !eventKeyDown.ShiftPressed
+					   && !eventKeyDown.AltPressed) {
+				ProcessAction(C7Action.UnitGoto);
 			}
 		}
 	}
@@ -667,7 +692,15 @@ public partial class Game : Node {
 		foreach (StringName action in actions) {
 			if (Input.IsActionJustPressed(action)) {
 				ProcessAction(action.ToString());
+			} else if (Input.IsActionJustReleased(action)) {
+				ProcessOnReleaseAction(action.ToString());
 			}
+		}
+	}
+
+	private void ProcessOnReleaseAction(string currentAction) {
+		if (currentAction == C7Action.EnableTempAnimations) {
+			animationController.SetAnimationsEnabled(true);
 		}
 	}
 
@@ -719,6 +752,10 @@ public partial class Game : Node {
 			this.mapView.gridLayer.visible = !this.mapView.gridLayer.visible;
 		}
 
+		if (currentAction == C7Action.ToggleCoordinates) {
+			ToggleGridCoordinates();
+		}
+
 		if (currentAction == C7Action.Escape && this.gotoInfo == null) {
 			log.Debug("Got request for escape/quit");
 			popupOverlay.ShowPopup(new EscapeQuitPopup(), PopupOverlay.PopupCategory.Info);
@@ -733,9 +770,11 @@ public partial class Game : Node {
 		}
 
 		if (currentAction == C7Action.ToggleAnimations) {
+			animationController.ToggleAnimationsEnabled();
+		}
+
+		if (currentAction == C7Action.EnableTempAnimations) {
 			animationController.SetAnimationsEnabled(false);
-		} else if (Input.IsActionJustReleased(C7Action.ToggleAnimations)) {
-			animationController.SetAnimationsEnabled(true);
 		}
 
 		// actions with unit buttons, which are only relevant during the player
@@ -758,6 +797,9 @@ public partial class Game : Node {
 		}
 
 		if (currentAction == C7Action.UnitDisband) {
+			if (CurrentlySelectedUnit == null || CurrentlySelectedUnit == MapUnit.NONE) {
+				return;
+			}
 			popupOverlay.ShowPopup(
 				new ConfirmationPopup(
 					$"Disband {CurrentlySelectedUnit.unitType.name}? Pardon me but these are OUR people. Do \nyou really want to disband them?",

--- a/C7/project.godot
+++ b/C7/project.godot
@@ -61,8 +61,7 @@ down={
 }
 unit_goto={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":71,"key_label":0,"unicode":103,"location":0,"echo":false,"script":null)
-]
+"events": []
 }
 end_turn={
 "deadzone": 0.5,
@@ -120,9 +119,7 @@ move_unit_southwest={
 }
 toggle_grid={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":true,"pressed":false,"keycode":0,"physical_keycode":71,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":71,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
-]
+"events": []
 }
 escape={
 "deadzone": 0.5,
@@ -136,7 +133,7 @@ toggle_zoom={
 }
 toggle_animations={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194329,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 unit_hold={
@@ -197,6 +194,11 @@ unit_build_mine={
 unit_irrigate={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":73,"key_label":0,"unicode":105,"location":0,"echo":false,"script":null)
+]
+}
+enable_temp_animations={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/C7Engine/Actions.cs
+++ b/C7Engine/Actions.cs
@@ -17,7 +17,9 @@ public static class C7Action {
 	public const string MoveUnitNorth = "move_unit_north";
 	public const string MoveUnitNortheast = "move_unit_northeast";
 	public const string ToggleAnimations = "toggle_animations";
+	public const string EnableTempAnimations = "enable_temp_animations";
 	public const string ToggleGrid = "toggle_grid";
+	public const string ToggleCoordinates = "toggle_coordinates";
 	public const string ToggleZoom = "toggle_zoom";
 	public const string UnitBombard = "unit_bombard";
 	public const string UnitBuildCity = "unit_build_city";

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -326,7 +326,6 @@ namespace C7Engine {
 
 		public override void process() {
 			EngineStorage.animationsEnabled = enabled;
-			new MsgStartStopAllAnimations().send();
 		}
 	}
 
@@ -337,7 +336,6 @@ namespace C7Engine {
 
 		public override void process() {
 			EngineStorage.animationsEnabled = !EngineStorage.animationsEnabled;
-			new MsgStartStopAllAnimations().send();
 		}
 	}
 

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -326,6 +326,18 @@ namespace C7Engine {
 
 		public override void process() {
 			EngineStorage.animationsEnabled = enabled;
+			new MsgStartStopAllAnimations().send();
+		}
+	}
+
+	public class MsgToggleAnimationsEnabled : MessageToEngine {
+
+		public MsgToggleAnimationsEnabled() {
+		}
+
+		public override void process() {
+			EngineStorage.animationsEnabled = !EngineStorage.animationsEnabled;
+			new MsgStartStopAllAnimations().send();
 		}
 	}
 

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -51,6 +51,13 @@ namespace C7Engine {
 		}
 	}
 
+	public class MsgStartStopAllAnimations : AnimationMessage {
+		public bool animationsEnabled;
+		public MsgStartStopAllAnimations() {
+			animationsEnabled = EngineStorage.animationsEnabled;
+		}
+	}
+
 	public class MsgStartTurn : MessageToUI { }
 
 	public class MsgShowScienceAdvisor : MessageToUI { }

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -51,13 +51,6 @@ namespace C7Engine {
 		}
 	}
 
-	public class MsgStartStopAllAnimations : AnimationMessage {
-		public bool animationsEnabled;
-		public MsgStartStopAllAnimations() {
-			animationsEnabled = EngineStorage.animationsEnabled;
-		}
-	}
-
 	public class MsgStartTurn : MessageToUI { }
 
 	public class MsgShowScienceAdvisor : MessageToUI { }


### PR DESCRIPTION
1. Unit animations can be toggled with Caps Lock
2. The map can't be dragged when the mouse is over UI elements.
3. Unit animations can be temporarily be switched on and off by holding down Shift
4. Refactored actions that are mapped to G (single and combo)
5. Fix disband unit throwing an exception when no unit is selected

For caps lock sadly there is no API in Godot (yet, there is a PR I think that fixes that but hasn't been merged) to check if caps lock is on or off. So for now, simple toggling will do.

For holding down shift to disable animations, I had to create a method like ProcessAction, that handles the release of the keys so that we know to stop disabling the animations.

I couldn't find a way to better handle the G presses, as it was triggering both go-to and toggle grid if CTRL+G (or CTRL+SHIFT+ALT+G) was pressed. And after a point it would stop triggering the grid action.
So I removed the mapping that was done inside Godot, and handle the seperate cases manually.