### PR TITLE
Refactor: terrain improvement replacement logic

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -809,11 +809,11 @@ public partial class Game : Node {
 			|| terraform == null || !CurrentlySelectedUnit.canPerformTerraformAction(terraform))
 			return;
 
-		TerrainImprovement currentImprovement = CurrentlySelectedUnit.location.overlays.ImprovementAtLayer(terraform);
-		if (currentImprovement != null && terraform.Improvement.upgradesFrom != currentImprovement) {
+		TerrainImprovement replacementTarget = CurrentlySelectedUnit.location.overlays.GetReplacementTarget(terraform);
+		if (replacementTarget != null) {
 			popupOverlay.ShowPopup(
 				new ConfirmationPopup(
-					$"A previous terrain enhancement ({currentImprovement.key.Capitalize()}) will be replaced \nby this operation. Do you wish to continue?",
+					$"A previous terrain enhancement ({replacementTarget.key.Capitalize()}) will be replaced \nby this operation. Do you wish to continue?",
 					"Continue.",
 					"Cancel action.",
 					() => {

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -772,8 +772,19 @@ namespace C7GameData {
 			return ti;
 		}
 
-		public TerrainImprovement ImprovementAtLayer(Terraform terraform) {
-			return terraform.Improvement == null ? null : ImprovementAtLayer(terraform.Improvement.layer);
+		// Returns an existing improvement that would be replaced by the given terraform.
+		// Returns null if there is no such improvement,
+		// or the new improvement upgrades from the existing one (upgrades don't count as replacements)
+		public TerrainImprovement GetReplacementTarget(Terraform terraform) {
+			var newImp = terraform.Improvement;
+			if (newImp == null)
+				return null;
+
+			var current = ImprovementAtLayer(newImp.layer);
+			if (current == null)
+				return null;
+
+			return newImp.upgradesFrom != current ? current : null;
 		}
 
 		public bool HasImprovement(TerrainImprovement improvement) {


### PR DESCRIPTION
Previously, the code assumed that every terraform had a terrain improvement associated with it. As a result, it caused NullReferenceException when executing terraforms for chopping forest and clearing wetlands.

This commit fixes the logic for replacement checking and separates it into a helper method in the TileOverlays class.