### PR TITLE
World Size Options for New Games Added

### DIFF
--- a/C7/UIElements/NewGame/PlayerSetup.cs
+++ b/C7/UIElements/NewGame/PlayerSetup.cs
@@ -35,9 +35,6 @@ public partial class PlayerSetup : Control {
 	SaveGame save;
 	GameSetup gameSetup = new();
 
-	// TODO: read this from the rules based on the world size
-	const int NUM_OPPONENTS = 7;
-
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
 		save = GetSave();
@@ -106,7 +103,9 @@ public partial class PlayerSetup : Control {
 
 	private void AddOpponentSelectors() {
 		// TODO: The number of opponents should come from the rule set.
-		for (int i = 0; i < NUM_OPPONENTS; ++i) {
+		int num_opponents = GetNode<GlobalSingleton>("/root/GlobalSingleton").WorldCharacteristics.worldSize.numberOfCivs - 1;
+
+		for (int i = 0; i < num_opponents; ++i) {
 			OptionButton optionButton = new();
 			StyleBoxFlat styleBox = new() {
 				BorderColor = Color.Color8(150, 150, 150, 220),
@@ -134,7 +133,7 @@ public partial class PlayerSetup : Control {
 			opponentListContainer.AddChild(container);
 			container.AddChild(optionButton);
 
-			container.CustomMinimumSize = new Vector2(312.0f / opponentListContainer.Columns, 315.0f / NUM_OPPONENTS);
+			container.CustomMinimumSize = new Vector2(312.0f / opponentListContainer.Columns, 315.0f / num_opponents);
 			optionButton.CustomMinimumSize = new Vector2(290.0f / opponentListContainer.Columns, optionButton.CustomMinimumSize.Y);
 
 			foreach (Civilization civ in save.Civilizations) {

--- a/C7/UIElements/NewGame/WorldSetup.cs
+++ b/C7/UIElements/NewGame/WorldSetup.cs
@@ -322,15 +322,6 @@ public partial class WorldSetup : Control {
 		billion4Large.Visible = true;
 		billion4.ButtonPressed = true;
 
-		// TODO: handle different map sizes properly (including loading the
-		// optimal city number, etc)
-		tinySize.Visible = true;
-		smallSize.Visible = true;
-		standardSize.Visible = true;
-		largeSize.Visible = true;
-		hugeSize.Visible = true;
-		randomSize.Visible = true;
-
 		tinySize.Pressed += () => {
 			sizeSelected = 0;
 		};

--- a/C7/UIElements/NewGame/WorldSetup.cs
+++ b/C7/UIElements/NewGame/WorldSetup.cs
@@ -1,6 +1,7 @@
 using Godot;
 using System;
 using System.Threading;
+using System.Collections.Generic;
 using C7GameData;
 using C7Engine;
 using C7GameData.Save;
@@ -75,6 +76,60 @@ public partial class WorldSetup : Control {
 	WorldCharacteristics.Age age = WorldCharacteristics.Age.Billion_4;
 	WorldCharacteristics.Temperature temp = WorldCharacteristics.Temperature.Temperate;
 	WorldCharacteristics.Climate clim = WorldCharacteristics.Climate.Normal;
+
+	// Maybe we refactor all this data later into a separate JSON/config file?
+	// I wasn't sure if it fit well into the MapGenerator.cs enum-style since it's a lot of integer data to store
+
+	private int sizeSelected = 2; // Correlates to standard size being default
+	private readonly Random sizeRandomizer = new Random();
+	private readonly List<WorldSize> sizeOptions = new List<WorldSize>
+	{
+		// Tiny, index 0
+		new WorldSize() {
+				width = 60,
+				height = 60,
+				numberOfCivs = 4,
+				distanceBetweenCivs = 11,
+				techRate = 160,
+				optimalNumberOfCities = 14,
+			},
+		// Small, index 1
+		new WorldSize() {
+				width = 80,
+				height = 80,
+				numberOfCivs = 6,
+				distanceBetweenCivs = 11,
+				techRate = 200,
+				optimalNumberOfCities = 17,
+			},
+		// Standard, index 2
+		new WorldSize() {
+				width = 100,
+				height = 100,
+				numberOfCivs = 8,
+				distanceBetweenCivs = 12,
+				techRate = 240,
+				optimalNumberOfCities = 20,
+			},
+		// Large, index 3
+		new WorldSize() {
+				width = 130,
+				height = 130,
+				numberOfCivs = 12,
+				distanceBetweenCivs = 18,
+				techRate = 320,
+				optimalNumberOfCities = 28,
+			},
+		// Huge, index 4
+		new WorldSize() {
+				width = 160,
+				height = 160,
+				numberOfCivs = 16,
+				distanceBetweenCivs = 24,
+				techRate = 400,
+				optimalNumberOfCities = 36,
+			},
+	};
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
@@ -269,12 +324,37 @@ public partial class WorldSetup : Control {
 
 		// TODO: handle different map sizes properly (including loading the
 		// optimal city number, etc)
-		tinySize.Visible = false;
-		smallSize.Visible = false;
-		standardSize.Visible = false;
-		largeSize.Visible = false;
-		hugeSize.Visible = false;
-		randomSize.Visible = false;
+		tinySize.Visible = true;
+		smallSize.Visible = true;
+		standardSize.Visible = true;
+		largeSize.Visible = true;
+		hugeSize.Visible = true;
+		randomSize.Visible = true;
+
+		tinySize.Pressed += () => {
+			sizeSelected = 0;
+		};
+
+		smallSize.Pressed += () => {
+			sizeSelected = 1;
+		};
+
+		standardSize.Pressed += () => {
+			sizeSelected = 2;
+		};
+
+		largeSize.Pressed += () => {
+			sizeSelected = 3;
+		};
+
+		hugeSize.Pressed += () => {
+			sizeSelected = 4;
+		};
+
+		randomSize.Pressed += () => {
+			sizeSelected = sizeRandomizer.Next(sizeOptions.Count);
+		};
+
 	}
 
 	private void ResetLandformGraphics() {
@@ -322,14 +402,7 @@ public partial class WorldSetup : Control {
 			age = age,
 			climate = clim,
 			temperature = temp,
-			worldSize = new WorldSize() {
-				width = 100,
-				height = 100,
-				numberOfCivs = 8,
-				distanceBetweenCivs = 12,
-				techRate = 240,
-				optimalNumberOfCities = 20,
-			},
+			worldSize = sizeOptions[sizeSelected],
 			terrainTypes = save.TerrainTypes,
 			resources = save.Resources,
 			defaultGovernment = save.Governments.Find(x => x.defaultType),

--- a/C7/UIElements/NewGame/world_setup.tscn
+++ b/C7/UIElements/NewGame/world_setup.tscn
@@ -112,7 +112,7 @@ text = "WORLD SIZE"
 horizontal_alignment = 1
 
 [node name="TinySize" type="CheckButton" parent="Background"]
-visible = false
+visible = true
 layout_mode = 0
 offset_left = 167.0
 offset_top = 115.0
@@ -130,7 +130,7 @@ text = "Tiny"
 alignment = 2
 
 [node name="SmallSize" type="CheckButton" parent="Background"]
-visible = false
+visible = true
 layout_mode = 0
 offset_left = 160.0
 offset_top = 137.0
@@ -148,7 +148,7 @@ text = "Small"
 alignment = 2
 
 [node name="StandardSize" type="CheckButton" parent="Background"]
-visible = false
+visible = true
 layout_mode = 0
 offset_left = 136.0
 offset_top = 159.0
@@ -167,7 +167,7 @@ text = "Standard"
 alignment = 2
 
 [node name="LargeSize" type="CheckButton" parent="Background"]
-visible = false
+visible = true
 layout_mode = 0
 offset_left = 162.0
 offset_top = 183.0
@@ -185,7 +185,7 @@ text = "Large"
 alignment = 2
 
 [node name="HugeSize" type="CheckButton" parent="Background"]
-visible = false
+visible = true
 layout_mode = 0
 offset_left = 163.0
 offset_top = 208.0
@@ -203,7 +203,7 @@ text = "Huge"
 alignment = 2
 
 [node name="RandomSize" type="CheckButton" parent="Background"]
-visible = false
+visible = true
 layout_mode = 0
 offset_left = 140.0
 offset_top = 231.0


### PR DESCRIPTION
UI looks a little clunky for the world size buttons + the list of potential civs when you select "Huge", that part will need some extra help.

The linking of loading map size info from original Civ 3 files has NOT been touched. If I could get some pointers on what needs to be done with the QueryCiv3 tools I'd be happy to work on that too.

Happy to refactor the WorldSize object data into a separate file if that would be cleaner than putting it all in WorldSetup.cs, lmk.