### PR TITLE
Issue #293 - Min barb distance

### DIFF
--- a/C7Engine/MapGenerator.cs
+++ b/C7Engine/MapGenerator.cs
@@ -1388,7 +1388,7 @@ namespace C7Engine {
 						continue;
 					}
 
-					if (TileIsTooCloseToOtherStarts(t, startingLocations, wc.worldSize.distanceBetweenCivs, attempt)) {
+					if (TileIsTooCloseToOtherStarts(t, m, startingLocations, wc.worldSize.distanceBetweenCivs, attempt)) {
 						continue;
 					}
 
@@ -1443,13 +1443,17 @@ namespace C7Engine {
 			return startsOnContinent < luxuriesOnContinent;
 		}
 
-		private static bool TileIsTooCloseToOtherStarts(Tile t, List<Tile> startingLocations, int minDistance, int attempt) {
+		private static bool TileIsTooCloseToOtherStarts(Tile t, GameMap m, List<Tile> startingLocations, int minDistance, int attempt) {
+			
+			// Minimum barb camp distance is 10 tiles away, scaling down to 5 based on # of attempts
+			int minBarbDistance = Math.Max(10 - attempt, 5);
+			
 			if (attempt > 2) {
 				minDistance /= 2;
 			}
 
 			foreach (Tile start in startingLocations) {
-				if (start.continent == t.continent && start.distanceTo(t) < minDistance) {
+				if (start.continent == t.continent && start.distanceTo(t) < minDistance && m.barbarianCamps.All(x => start.distanceTo(x) < minBarbDistance)) {
 					return true;
 				}
 			}

--- a/C7Engine/MapGenerator.cs
+++ b/C7Engine/MapGenerator.cs
@@ -122,7 +122,7 @@ namespace C7Engine {
 
 			// TODO: Goody huts, barbarian camps.
 
-			
+
 
 			// Last step: Assign the terrain file and image ids to each tile so
 			// we know which texture to use when displaying them.
@@ -1453,7 +1453,6 @@ namespace C7Engine {
 		}
 
 		private static bool TileIsTooCloseToOtherStarts(Tile t, List<Tile> startingLocations, int minDistance, int attempt) {
-			
 			if (attempt > 2) {
 				minDistance /= 2;
 			}

--- a/C7Engine/MapGenerator.cs
+++ b/C7Engine/MapGenerator.cs
@@ -110,13 +110,19 @@ namespace C7Engine {
 			// for resources.
 			AddBonusGrasslands(wc, gameMap);
 
-			// Step 10: Add barb camps. We do this towards the end to make sure
+			// Step 10: Place player starting locations
+			// Placing this before barb camps so barbs don't spawn <5 tiles away from players
+			// Tried placing barbs then players, but caused all players to spawn together
+			DetermineStartingLocations(wc, gameMap);
+
+			// Step 11: Add barb camps. We do this towards the end to make sure
 			// that we don't have barb camps on top of resources.
+			// Previously step 10
 			AddBarbarianCamps(wc, gameMap);
 
 			// TODO: Goody huts, barbarian camps.
 
-			DetermineStartingLocations(wc, gameMap);
+			
 
 			// Last step: Assign the terrain file and image ids to each tile so
 			// we know which texture to use when displaying them.
@@ -1339,6 +1345,9 @@ namespace C7Engine {
 				}
 			}
 
+			// No barbarian camps less than 6 tiles away from a player
+			if (m.startingLocations.Any(x => t.distanceTo(x) < 6)) return false;
+
 			return true;
 		}
 
@@ -1388,7 +1397,7 @@ namespace C7Engine {
 						continue;
 					}
 
-					if (TileIsTooCloseToOtherStarts(t, m, startingLocations, wc.worldSize.distanceBetweenCivs, attempt)) {
+					if (TileIsTooCloseToOtherStarts(t, startingLocations, wc.worldSize.distanceBetweenCivs, attempt)) {
 						continue;
 					}
 
@@ -1443,17 +1452,14 @@ namespace C7Engine {
 			return startsOnContinent < luxuriesOnContinent;
 		}
 
-		private static bool TileIsTooCloseToOtherStarts(Tile t, GameMap m, List<Tile> startingLocations, int minDistance, int attempt) {
-			
-			// Minimum barb camp distance is 10 tiles away, scaling down to 5 based on # of attempts
-			int minBarbDistance = Math.Max(10 - attempt, 5);
+		private static bool TileIsTooCloseToOtherStarts(Tile t, List<Tile> startingLocations, int minDistance, int attempt) {
 			
 			if (attempt > 2) {
 				minDistance /= 2;
 			}
 
 			foreach (Tile start in startingLocations) {
-				if (start.continent == t.continent && start.distanceTo(t) < minDistance && m.barbarianCamps.All(x => start.distanceTo(x) < minBarbDistance)) {
+				if (start.continent == t.continent && start.distanceTo(t) < minDistance) {
 					return true;
 				}
 			}


### PR DESCRIPTION
Swapped the map generation order from place barbs -> place players to place players -> place barbs. Added control flow gate to invalidate any barbarian spawn candidate that's less than 6 tiles away from an already placed player location.

Waiting to finalize PR until older PR's are good to go (i.e. the world size option update)