### PR TITLE
Issue #424 - Fixed city name cycling

### DIFF
--- a/C7/Text/c7-static-map-save-standalone.json
+++ b/C7/Text/c7-static-map-save-standalone.json
@@ -71322,7 +71322,6 @@
       "hasPlayedCurrentTurn": false,
       "defeated": false,
       "civilization": "A Barbarian Chiefdom",
-      "cityNameIndex": 0,
       "turnsUntilPriorityReevaluation": 0,
       "luxuryRate": 0,
       "scienceRate": 5,
@@ -71340,7 +71339,6 @@
       "hasPlayedCurrentTurn": false,
       "defeated": false,
       "civilization": "Netherlands",
-      "cityNameIndex": 0,
       "tileKnowledge": [
         {
           "x": 57,
@@ -71417,7 +71415,6 @@
       "hasPlayedCurrentTurn": false,
       "defeated": false,
       "civilization": "America",
-      "cityNameIndex": 0,
       "tileKnowledge": [
         {
           "x": 64,
@@ -71494,7 +71491,6 @@
       "hasPlayedCurrentTurn": false,
       "defeated": false,
       "civilization": "Aztecs",
-      "cityNameIndex": 0,
       "tileKnowledge": [
         {
           "x": 59,
@@ -71567,7 +71563,6 @@
       "hasPlayedCurrentTurn": false,
       "defeated": false,
       "civilization": "Inca",
-      "cityNameIndex": 0,
       "tileKnowledge": [
         {
           "x": 76,
@@ -71644,7 +71639,6 @@
       "hasPlayedCurrentTurn": false,
       "defeated": false,
       "civilization": "Persia",
-      "cityNameIndex": 0,
       "tileKnowledge": [
         {
           "x": 30,
@@ -71725,7 +71719,6 @@
       "hasPlayedCurrentTurn": false,
       "defeated": false,
       "civilization": "Maya",
-      "cityNameIndex": 0,
       "tileKnowledge": [
         {
           "x": 9,
@@ -71802,7 +71795,6 @@
       "hasPlayedCurrentTurn": false,
       "defeated": false,
       "civilization": "Iroquois",
-      "cityNameIndex": 0,
       "tileKnowledge": [
         {
           "x": 46,

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -73895,7 +73895,6 @@
       "hasPlayedCurrentTurn": false,
       "defeated": false,
       "civilization": "A Barbarian Chiefdom",
-      "cityNameIndex": 0,
       "turnsUntilPriorityReevaluation": 0,
       "luxuryRate": 0,
       "scienceRate": 5,
@@ -73913,7 +73912,6 @@
       "hasPlayedCurrentTurn": false,
       "defeated": false,
       "civilization": "Netherlands",
-      "cityNameIndex": 0,
       "tileKnowledge": [
         {
           "x": 57,
@@ -73990,7 +73988,6 @@
       "hasPlayedCurrentTurn": false,
       "defeated": false,
       "civilization": "America",
-      "cityNameIndex": 0,
       "tileKnowledge": [
         {
           "x": 64,
@@ -74067,7 +74064,6 @@
       "hasPlayedCurrentTurn": false,
       "defeated": false,
       "civilization": "Aztecs",
-      "cityNameIndex": 0,
       "tileKnowledge": [
         {
           "x": 59,
@@ -74140,7 +74136,6 @@
       "hasPlayedCurrentTurn": false,
       "defeated": false,
       "civilization": "Inca",
-      "cityNameIndex": 0,
       "tileKnowledge": [
         {
           "x": 76,
@@ -74217,7 +74212,6 @@
       "hasPlayedCurrentTurn": false,
       "defeated": false,
       "civilization": "Persia",
-      "cityNameIndex": 0,
       "tileKnowledge": [
         {
           "x": 30,
@@ -74298,7 +74292,6 @@
       "hasPlayedCurrentTurn": false,
       "defeated": false,
       "civilization": "Maya",
-      "cityNameIndex": 0,
       "tileKnowledge": [
         {
           "x": 9,
@@ -74375,7 +74368,6 @@
       "hasPlayedCurrentTurn": false,
       "defeated": false,
       "civilization": "Iroquois",
-      "cityNameIndex": 0,
       "tileKnowledge": [
         {
           "x": 46,

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -406,7 +406,6 @@ namespace C7GameData {
 				save.Players.Add(MakeSavePlayerFromCiv(save.Civilizations[i],
 									   isBarbarian: i == 0,
 									   isHuman: false,
-									   cityNameIndex: 0,
 									   era: ""));
 
 				// Set a government for players not associated with LEAD.
@@ -465,7 +464,6 @@ namespace C7GameData {
 				SavePlayer player = MakeSavePlayerFromCiv(civ,
 										  isBarbarian: i == 0,
 										  isHuman: i == 1,
-										  cityNameIndex: leader.FoundedCities,
 										  era: theBiq.Eras[leader.Era].CivilopediaEntry);
 
 				// Record what the player is currently researching.
@@ -769,7 +767,7 @@ namespace C7GameData {
 			}
 		}
 
-		private SavePlayer MakeSavePlayerFromCiv(Civilization civ, bool isBarbarian, bool isHuman, int cityNameIndex, string era) {
+		private SavePlayer MakeSavePlayerFromCiv(Civilization civ, bool isBarbarian, bool isHuman, string era) {
 			return new SavePlayer {
 				id = ids.CreateID("player"),
 				colorIndex = civ.colorIndex,
@@ -779,7 +777,6 @@ namespace C7GameData {
 				// Never let barbarians play before a real player.
 				hasPlayedCurrentTurn = isBarbarian,
 
-				cityNameIndex = cityNameIndex,
 				eraCivilopediaName = era,
 			};
 		}

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -157,18 +157,34 @@ namespace C7GameData {
 			ResearchQueue.Enqueue(tech);
 		}
 
+		private IEnumerable<string> cityNameGenerator() {
+			List<String> cityNames = civilization.cityNames;
+			int loopCounter = 0;
+
+			// Perpetual generator expression to yield all city names lazily
+			while (true) {
+				foreach (string city in cityNames) {
+					if (loopCounter == 0) yield return city;
+					else if (loopCounter == 1) yield return $"New {city}";
+					else {
+						if (loopCounter % 2 == 0) yield return $"{city} {(loopCounter / 2) + 1}";
+						else yield return $"New {city} {(loopCounter / 2) + 1}";
+					}
+				}
+				loopCounter++;
+			}
+		}
+
 		public string GetNextCityName() {
-			string name = civilization.cityNames[cityNameIndex % civilization.cityNames.Count];
-			int bonusLoops = cityNameIndex / civilization.cityNames.Count;
-			if (bonusLoops % 2 == 1) {
-				name = "New " + name;
+			// Convert to hashset for faster lookups
+			HashSet<String> cityNameHashSet = cities.Select(city => city.name).ToHashSet();
+
+			foreach (string city in cityNameGenerator()) {
+				if (!cityNameHashSet.Contains(city)) return city;
 			}
-			int suffix = (bonusLoops / 2) + 1;
-			if (suffix > 1) {
-				name = name + " " + suffix; //e.g. for bonusLoops = 2, we'll have "Athens 2"
-			}
-			cityNameIndex++;
-			return name;
+
+			// Dummy return value so compiler is happy
+			return "";
 		}
 
 		public Player() {

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -23,7 +23,6 @@ namespace C7GameData {
 		public bool defeated = false;
 
 		public Civilization civilization;
-		internal int cityNameIndex = 0;
 
 		public List<MapUnit> units = new List<MapUnit>();
 		public List<City> cities = new List<City>();
@@ -157,8 +156,8 @@ namespace C7GameData {
 			ResearchQueue.Enqueue(tech);
 		}
 
-		private IEnumerable<string> cityNameGenerator() {
-			List<String> cityNames = civilization.cityNames;
+		private IEnumerable<string> CityNameGenerator() {
+			List<string> cityNames = civilization.cityNames;
 			int loopCounter = 0;
 
 			// Perpetual generator expression to yield all city names lazily
@@ -177,14 +176,9 @@ namespace C7GameData {
 
 		public string GetNextCityName() {
 			// Convert to hashset for faster lookups
-			HashSet<String> cityNameHashSet = cities.Select(city => city.name).ToHashSet();
+			HashSet<string> cityNameHashSet = cities.Select(city => city.name).ToHashSet();
 
-			foreach (string city in cityNameGenerator()) {
-				if (!cityNameHashSet.Contains(city)) return city;
-			}
-
-			// Dummy return value so compiler is happy
-			return "";
+			return CityNameGenerator().First(x => !cityNameHashSet.Contains(x));
 		}
 
 		public Player() {

--- a/C7Engine/C7GameData/Save/SavePlayer.cs
+++ b/C7Engine/C7GameData/Save/SavePlayer.cs
@@ -11,7 +11,6 @@ namespace C7GameData.Save {
 		public bool defeated = false;
 
 		public string civilization;
-		public int cityNameIndex = 0;
 
 		public List<TileLocation> tileKnowledge = new List<TileLocation>();
 
@@ -68,7 +67,6 @@ namespace C7GameData.Save {
 				defeated = defeated,
 				colorIndex = colorIndex,
 				civilization = civilization is not null ? civilizations.Find(civ => civ.name == civilization) : null,
-				cityNameIndex = cityNameIndex,
 				knownTechs = knownTechs,
 				eraCivilopediaName = eraCivilopediaName,
 				luxuryRate = luxuryRate,
@@ -118,7 +116,6 @@ namespace C7GameData.Save {
 			civilization = player.civilization?.name;
 			// TODO: this should be computed by looking at cities defined in the save
 			// so that adding cities in the save structure doesn't require updating this value
-			cityNameIndex = player.cityNameIndex;
 			tileKnowledge = player.tileKnowledge.AllKnownTiles().ConvertAll(tile => new TileLocation(tile));
 			turnsUntilPriorityReevaluation = player.turnsUntilPriorityReevaluation;
 			knownTechs = player.knownTechs;


### PR DESCRIPTION
City names will be reused now if player prompted a plant but cancelled. The proposed city name will now be the earliest entry in a civilization's city names that is not currently used by a city, following Civ 3 naming conventions for new loops over the cities (i.e. Athens, New Athens, Athens 2, New Athens 2, etc)

The property `int cityNameIndex` is no longer used in the `Player` class (or anywhere else from what I could tell), but I left in since there appear to be many references throughout the codebase assigning cityNameIndex when instantiating Player objects, and I didn't want to do anything destructive at this time.