### PR TITLE
Fix SaveTest when certain scenario filenames are present

### DIFF
--- a/EngineTests/GameData/SaveTest.cs
+++ b/EngineTests/GameData/SaveTest.cs
@@ -278,17 +278,7 @@ public class SaveTests {
 		string is_on_github = System.Environment.GetEnvironmentVariable("CI");
 		if (is_on_github != null) { return; }
 
-		// Only bother running one turn of the newer scenarios, just to keep the
-		// tests faster.
-		CheckScenariosInCiv3Subfolder("Conquests/Conquests", runOneTurn: true);
-		CheckScenariosInCiv3Subfolder("Conquests/Scenarios", runOneTurn: false);
-	}
-
-	private void CheckScenariosInCiv3Subfolder(string subfolder, bool runOneTurn) {
-		string conquests = Path.Join(Civ3Location.GetCiv3Path(), subfolder);
-		DirectoryInfo directoryInfo = new DirectoryInfo(conquests);
-		// skip all scenarios whose file names aren't explicitly listed here
-		string[] scenarioNamesToTest = {
+		string[] singleplayerScenarios = {
 			"1 Mesopotamia.biq",
 			"2 Rise of Rome.biq",
 			"3 Fall of Rome.biq",
@@ -300,8 +290,31 @@ public class SaveTests {
 			"8 Napoleonic Europe.biq",
 			"9 WWII in the Pacific.biq",
 		};
-		IEnumerable<FileInfo> saveFiles = directoryInfo.EnumerateFiles().Where(fi =>
-			scenarioNamesToTest.Contains(fi.Name)
+		string[] multiplayerScenarios = {
+			"1 MP Mesopotamia.biq",
+			"2 MP Rise of Rome.biq",
+			"3 MP Fall of Rome.biq",
+			"4 MP Middle Ages.biq",
+			"5 MP Mesoamerica.biq",
+			"6 MP Age of Discovery.biq",
+			// skip for now because BIQ parsing fails
+			// "7 MP Sengoku - Sword of the Shogun.biq",
+			"8 MP Napoleonic Europe.biq",
+			"9 MP WWII in the Pacific.biq",
+		};
+		// Only bother running one turn of the newer scenarios, just to keep the
+		// tests faster.
+		CheckScenariosInCiv3Subfolder("Conquests/Conquests", singleplayerScenarios, runOneTurn: true);
+		CheckScenariosInCiv3Subfolder("Conquests/Scenarios", multiplayerScenarios, runOneTurn: false);
+	}
+
+	private void CheckScenariosInCiv3Subfolder(string subfolder, string[] scenarioNamesToTest, bool runOneTurn) {
+		string conquests = Path.Join(Civ3Location.GetCiv3Path(), subfolder);
+		DirectoryInfo directoryInfo = new DirectoryInfo(conquests);
+		IEnumerable<FileInfo> saveFiles = directoryInfo.EnumerateFiles().Where(fi => scenarioNamesToTest.Contains(fi.Name));
+		Assert.True(
+			scenarioNamesToTest.Count() == saveFiles.Count(),
+			$"Expected {scenarioNamesToTest.Count()} files but got {saveFiles.Count()}"
 		);
 		foreach (FileInfo saveFileInfo in saveFiles) {
 			string name = saveFileInfo.Name;

--- a/EngineTests/GameData/SaveTest.cs
+++ b/EngineTests/GameData/SaveTest.cs
@@ -287,15 +287,22 @@ public class SaveTests {
 	private void CheckScenariosInCiv3Subfolder(string subfolder, bool runOneTurn) {
 		string conquests = Path.Join(Civ3Location.GetCiv3Path(), subfolder);
 		DirectoryInfo directoryInfo = new DirectoryInfo(conquests);
-		IEnumerable<FileInfo> saveFiles = directoryInfo.EnumerateFiles().Where(fi => {
-			// currently only test 1 Mesopotamia.biq -> 9 WWII in the Pacific.biq:
-			int prefix = fi.Name[0];
-			if (prefix == '7') {
-				// skip 7 Sengoku - Sword of the Shogun.biq for now because biq parsing fails
-				return false;
-			}
-			return fi.Extension.EndsWith(".biq", true, null) && char.IsAsciiDigit(fi.Name[0]);
-		});
+		// skip all scenarios whose file names aren't explicitly listed here
+		string[] scenarioNamesToTest = {
+			"1 Mesopotamia.biq",
+			"2 Rise of Rome.biq",
+			"3 Fall of Rome.biq",
+			"4 Middle Ages.biq",
+			"5 Mesoamerica.biq",
+			"6 Age of Discovery.biq",
+			// skip for now because BIQ parsing fails
+			// "7 Sengoku - Sword of the Shogun.biq",
+			"8 Napoleonic Europe.biq",
+			"9 WWII in the Pacific.biq",
+		};
+		IEnumerable<FileInfo> saveFiles = directoryInfo.EnumerateFiles().Where(fi =>
+			scenarioNamesToTest.Contains(fi.Name)
+		);
 		foreach (FileInfo saveFileInfo in saveFiles) {
 			string name = saveFileInfo.Name;
 			SaveGame game = null;

--- a/EngineTests/GameData/SaveTest.cs
+++ b/EngineTests/GameData/SaveTest.cs
@@ -304,11 +304,11 @@ public class SaveTests {
 		};
 		// Only bother running one turn of the newer scenarios, just to keep the
 		// tests faster.
-		CheckScenariosInCiv3Subfolder("Conquests/Conquests", singleplayerScenarios, runOneTurn: true);
-		CheckScenariosInCiv3Subfolder("Conquests/Scenarios", multiplayerScenarios, runOneTurn: false);
+		CheckScenariosInCiv3Subfolder("Conquests/Conquests", singleplayerScenarios, runOneTurn: true, "singleplayer");
+		CheckScenariosInCiv3Subfolder("Conquests/Scenarios", multiplayerScenarios, runOneTurn: false, "multiplayer");
 	}
 
-	private void CheckScenariosInCiv3Subfolder(string subfolder, string[] scenarioNamesToTest, bool runOneTurn) {
+	private void CheckScenariosInCiv3Subfolder(string subfolder, string[] scenarioNamesToTest, bool runOneTurn, string basename) {
 		string conquests = Path.Join(Civ3Location.GetCiv3Path(), subfolder);
 		DirectoryInfo directoryInfo = new DirectoryInfo(conquests);
 		IEnumerable<FileInfo> saveFiles = directoryInfo.EnumerateFiles().Where(fi => scenarioNamesToTest.Contains(fi.Name));
@@ -387,7 +387,7 @@ public class SaveTests {
 				}
 			}
 
-			game.Save(Path.Combine(testDirectory, "data", "output", $"conquest_{name[0]}.json"));
+			game.Save(Path.Combine(testDirectory, "data", "output", $"{basename}_{name[0]}.json"));
 
 			// Finally, ensure we can run the first turn of the scenario.
 			if (runOneTurn) {


### PR DESCRIPTION
# Changes

- Replace the existing logic in `SaveTest.cs` for enumerating scenario files with an explicit list of scenario filenames
  - Scenarios whose filenames aren't in the list are skipped
  - Scenarios in the list whose files are missing are also skipped
  - Always skip scenario 7 because parsing is currently broken

Closes #849 

# Test Plan

1. Create an empty file in `$CIV3_HOME/Conquests/Conquests/` with a name that starts with a number, such as `1vsAll.biq`
1. Check out `Development` and run the `EngineTests`
1. Verify that `EngineTests.GameData.SaveTests.LoadAllConquestScenarios` fails to parse the empty file created above; this confirms that the test tried to load a scenario file that it shouldn't have
1. Checkout this PR's branch and re-run the tests
1. Verify that all tests now pass