### PR TITLE
Fix macOS export crash: resolve data paths relative to executable

### DIFF
--- a/C7/GamePaths.cs
+++ b/C7/GamePaths.cs
@@ -1,12 +1,41 @@
+using Godot;
+using System.IO;
+
 public static class GamePaths {
+	// Base directory for finding data files (Lua/, Text/, Assets/).
+	// In the editor this is "res://". In exports, it's the directory
+	// containing the executable — on macOS, navigated out of the .app bundle.
+	private static string _baseDir;
+	public static string BaseDir {
+		get {
+			if (_baseDir == null) {
+				if (OS.HasFeature("editor")) {
+					_baseDir = "";
+				} else {
+					string exeDir = OS.GetExecutablePath().GetBaseDir();
+					// On macOS the exe is inside *.app/Contents/MacOS/;
+					// data files live alongside the .app bundle.
+					if (exeDir.Contains(".app/Contents/MacOS")) {
+						_baseDir = Path.GetFullPath(Path.Combine(exeDir, "..", "..", "..")) + "/";
+					} else {
+						_baseDir = exeDir + "/";
+					}
+				}
+			}
+			return _baseDir;
+		}
+	}
+
 	// This is the 'static map' used in lieu of terrain generation
 	public static string DefaultGamePath {
 		get =>
-			C7Engine.C7Settings.UseStandaloneMode() ? "./Text/c7-static-map-save-standalone.json" : "./Text/c7-static-map-save.json";
+			C7Engine.C7Settings.UseStandaloneMode()
+				? BaseDir + "Text/c7-static-map-save-standalone.json"
+				: BaseDir + "Text/c7-static-map-save.json";
 	}
 
-	public const string LuaRulesDir = "./Lua/rules/";
-	public const string TextureConfigsDir = "./Lua/texture_configs/";
+	public static string LuaRulesDir => BaseDir + "Lua/rules/";
+	public static string TextureConfigsDir => BaseDir + "Lua/texture_configs/";
 
 	public const string ModernGraphicsConfig = "c7.lua";
 	public const string ClassicGraphicsConfig = "civ3.lua";


### PR DESCRIPTION
GamePaths used `./` relative paths which resolve against the CWD. When launched from Finder or `open`, the CWD is `/`, so Lua/, Text/, and Assets/ directories were not found, causing crashes.

Now resolves paths relative to the executable location, navigating out of the .app/Contents/MacOS/ bundle on macOS.