### PR TITLE
Adjust tile enter check to allow bombardment as well

### DIFF
--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -541,7 +541,7 @@ namespace C7GameData {
 				foreach (MapUnit other in tile.unitsOnTile) {
 					if (other.owner != owner) {
 						if (!other.owner.IsAtPeaceWith(owner))
-							return allowCombat && unitType.attack > 0;
+							return allowCombat && unitType.CanAttack();
 						return false;
 					}
 				}

--- a/C7Engine/C7GameData/UnitPrototype.cs
+++ b/C7Engine/C7GameData/UnitPrototype.cs
@@ -108,6 +108,10 @@ namespace C7GameData {
 			return categories.Contains("Sea");
 		}
 
+		public bool CanAttack() {
+			return attack > 0 || bombard > 0;
+		}
+
 		// TODO: Consider golden ages when determining whether a unit is obsolete.
 		// If a golden age has not yet been triggered and a unit can trigger one,
 		// it shouldn't be marked as obsolete, even if its upgrade is available.


### PR DESCRIPTION
I got OpenCiv3 running and noticed that the Catapult unit was behaving strangely when attacking a city. Even though I'd been at war with an opponent for some time, I was still being prompted to declare war whenever attacking with a Catapult unit.

I suspect bombardment isn't fully enabled yet, but I tracked this specific issue down to a bug in the engine code that checks whether the moving unit can enter an occupied tile. This code checks for `attack > 0`, which in the case of a bombarding unit is not true.

This fix pushes the "tile entering aggression" logic into the Unit Prototype, and adds a relevant test to allow bombarding units to attack occupied tiles.