### PR TITLE
Use ReadOnlySpan<byte> comparison with WAV loading

### DIFF
--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -293,15 +293,15 @@ public partial class Util {
 	static public AudioStreamWav LoadWAVFromDisk(string path) {
 		FileAccess file = FileAccess.Open(path, FileAccess.ModeFlags.Read);
 
-		string riffString = System.Text.Encoding.UTF8.GetString(file.GetBuffer(4));
-		if (riffString != "RIFF") {
-			throw new Exception("Unsupported file");
+		byte[] riffBytes = file.GetBuffer(4);
+		if (!riffBytes.SequenceEqual("RIFF"u8)) {
+			throw new Exception("Unsupported file, missing 'RIFF' tag");
 		}
 		uint fileSize = file.Get32();   //minus 8 bytes
 
-		string waveString = System.Text.Encoding.UTF8.GetString(file.GetBuffer(4));
-		if (waveString != "WAVE") {
-			throw new Exception("Unsupported file");
+		byte[] waveBytes = file.GetBuffer(4);
+		if (!waveBytes.SequenceEqual("WAVE"u8)) {
+			throw new Exception("Unsupported file, missing 'WAVE' tag");
 		}
 
 		bool formatFound = false;
@@ -310,7 +310,7 @@ public partial class Util {
 		AudioStreamWav wav = new AudioStreamWav();
 
 		while (!file.EofReached()) {
-			string chunk = System.Text.Encoding.UTF8.GetString(file.GetBuffer(4));
+			byte[] chunkBytes = file.GetBuffer(4);
 			uint chunkSize = file.Get32();
 			ulong position = file.GetPosition();
 
@@ -319,7 +319,7 @@ public partial class Util {
 				break;
 			}
 
-			if (chunk == "fmt ")    //format chunk
+			if (chunkBytes.SequenceEqual("fmt "u8))    //format chunk
 			{
 				//There is some disagreement between the C++ and GDScript sources
 				//as to which compression codes Godot supports.  The C++ has a comment
@@ -355,7 +355,7 @@ public partial class Util {
 					throw new Exception("Format bits must be a multiple of 8");
 				}
 				formatFound = true;
-			} else if (chunk == "data") {
+			} else if (chunkBytes.SequenceEqual("data"u8)) {
 				byte[] allTheData = file.GetBuffer(chunkSize);
 				wav.Data = allTheData;
 				dataFound = true;

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -294,13 +294,13 @@ public partial class Util {
 		FileAccess file = FileAccess.Open(path, FileAccess.ModeFlags.Read);
 
 		byte[] riffBytes = file.GetBuffer(4);
-		if (!riffBytes.SequenceEqual("RIFF"u8)) {
+		if (!"RIFF"u8.SequenceEqual(riffBytes)) {
 			throw new Exception("Unsupported file, missing 'RIFF' tag");
 		}
 		uint fileSize = file.Get32();   //minus 8 bytes
 
 		byte[] waveBytes = file.GetBuffer(4);
-		if (!waveBytes.SequenceEqual("WAVE"u8)) {
+		if (!"WAVE"u8.SequenceEqual(waveBytes)) {
 			throw new Exception("Unsupported file, missing 'WAVE' tag");
 		}
 
@@ -319,7 +319,7 @@ public partial class Util {
 				break;
 			}
 
-			if (chunkBytes.SequenceEqual("fmt "u8))    //format chunk
+			if ("fmt "u8.SequenceEqual(chunkBytes))    //format chunk
 			{
 				//There is some disagreement between the C++ and GDScript sources
 				//as to which compression codes Godot supports.  The C++ has a comment
@@ -355,7 +355,7 @@ public partial class Util {
 					throw new Exception("Format bits must be a multiple of 8");
 				}
 				formatFound = true;
-			} else if (chunkBytes.SequenceEqual("data"u8)) {
+			} else if ("data"u8.SequenceEqual(chunkBytes)) {
 				byte[] allTheData = file.GetBuffer(chunkSize);
 				wav.Data = allTheData;
 				dataFound = true;


### PR DESCRIPTION
No need to create strings when doing just simple text comparison. 

Also improve exception texts in case someone actually tries to load incorrect files.