### PR TITLE
Fix standalone startup handling on macOS and add build instructions doc

### DIFF
--- a/C7/UIElements/MainMenu/MainMenu.cs
+++ b/C7/UIElements/MainMenu/MainMenu.cs
@@ -43,13 +43,15 @@ public partial class MainMenu : Node {
 		LoadScenarioDialog.SetDirectoryForLoading(@"Conquests/Scenarios");
 		LoadScenarioDialog.GoToScenarioSetupAfterLoading = true;
 
-		// If couldn't find the button textures when ButtonContainer._Ready, then
-		// these buttons will be null, so be sure to recreate them if we call
-		// DisplayTitleScreen after picking standalone mode or getting the civ3
-		// home path set.
-		if (ButtonContainer.NewGame == null) {
-			ButtonContainer.CreateButtons();
+		if (!C7Settings.UseStandaloneMode() && !ClassicGraphicsAvailable()) {
+			NoCiv3Options.Visible = true;
+			ButtonContainer.Visible = false;
+			return;
 		}
+
+		ButtonContainer.Visible = true;
+		ButtonContainer.CreateButtons();
+
 		// TODO: enable buttons are features are implemented
 		ButtonContainer.NewGame.Pressed += GoToWorldSetup;
 		ButtonContainer.QuickStart.Pressed += StartGame;
@@ -79,6 +81,22 @@ public partial class MainMenu : Node {
 
 		// Hide if valid path is present as proven by reaching this point in code
 		NoCiv3Options.Visible = false;
+	}
+
+	private bool ClassicGraphicsAvailable() {
+		if (string.IsNullOrEmpty(Util.Civ3Root)) {
+			return false;
+		}
+
+		string[] basePaths = ["Conquests", "civ3PTW", ""];
+		foreach (string basePath in basePaths) {
+			string relPath = string.IsNullOrEmpty(basePath) ? "Art/buttonsFINAL.pcx" : $"{basePath}/Art/buttonsFINAL.pcx";
+			if (Util.FileExistsIgnoringCase(Util.Civ3Root, relPath) != null) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private void SetToggleGraphicsText() {
@@ -151,7 +169,9 @@ public partial class MainMenu : Node {
 	}
 
 	private void UseStandaloneModePressed() {
-		Global.ToggleModernGraphics();
+		if (!Global.ModernGraphicsActive) {
+			Global.ToggleModernGraphics();
+		}
 		C7Settings.SetValue("locations", "useStandaloneMode", "true");
 		C7Settings.SaveSettings();
 		DisplayTitleScreen();

--- a/C7/UIElements/MainMenu/MenuButtonContainer.cs
+++ b/C7/UIElements/MainMenu/MenuButtonContainer.cs
@@ -15,11 +15,24 @@ public partial class MenuButtonContainer : VBoxContainer {
 	public Civ3MenuButton Credits { get; private set; }
 	public Civ3MenuButton Exit { get; private set; }
 
-	public override void _Ready() {
-		CreateButtons();
-	}
-
 	public void CreateButtons() {
+		foreach (Node child in GetChildren()) {
+			RemoveChild(child);
+			child.QueueFree();
+		}
+
+		NewGame = null;
+		QuickStart = null;
+		Tutorial = null;
+		LoadGame = null;
+		LoadScenario = null;
+		HallOfFame = null;
+		ToggleGraphics = null;
+		Preferences = null;
+		AudioPreferences = null;
+		Credits = null;
+		Exit = null;
+
 		NewGame = new Civ3MenuButton() { Text = "New Game" };
 		AddChild(NewGame);
 

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -130,7 +130,7 @@ public partial class Util {
 
 		// Next, before trying the base Civ paths, see if we have it packaged
 		// with C7 and are in standalone mode.
-		string c7BasePath = System.IO.Path.Combine(getProjectDirectoryPath(), "Assets");
+		string c7BasePath = GetC7AssetsPath();
 		string c7Path = FileExistsIgnoringCase(c7BasePath, mediaPath);
 
 		if (C7Settings.UseStandaloneMode()) {
@@ -186,11 +186,12 @@ public partial class Util {
 		return result;
 	}
 
-	static private string getProjectDirectoryPath() {
-		// see issue https://github.com/godotengine/godot/issues/24222#issuecomment-709092664
-		// - use local resource folder while running from the editor binary
-		// - use executable folder in the exported builds
-		return OS.HasFeature("editor") ? "res://" : OS.GetExecutablePath().GetBaseDir();
+	static private string GetC7AssetsPath() {
+		if (OS.HasFeature("editor")) {
+			return "res://Assets";
+		}
+
+		return System.IO.Path.Combine(GamePaths.BaseDir, "Assets");
 	}
 
 	// Replaces image colors based on a given dictionary

--- a/doc/build.md
+++ b/doc/build.md
@@ -1,0 +1,15 @@
+## macOS Build
+
+Run these commands from the repository root:
+
+```bash
+mkdir -p build
+cd C7
+dotnet build C7.sln
+godot-mono --headless --path . --export-release "macOS" ../build/OpenCiv3-mac.zip
+zip -r ../build/OpenCiv3-mac.zip Assets Text Lua
+```
+
+The output archive is:
+
+`build/OpenCiv3-mac.zip`


### PR DESCRIPTION

![basis](https://github.com/user-attachments/assets/16b3c95c-fa35-43e3-9b93-a863f6918953)

Fixes a standalone startup issue on macOS exports where the app could skip the mode-selection flow or fail to resolve C7-packaged assets correctly. This updates main menu initialization to avoid creating classic-only buttons before Civ3 assets are available, resolves C7 asset lookups relative to the export base directory, and adds a concise macOS build guide in doc/build.md.