### PR TITLE
Added a property "Name" in MapUnit

### DIFF
--- a/C7/Text/c7-static-map-save-standalone.json
+++ b/C7/Text/c7-static-map-save-standalone.json
@@ -68871,6 +68871,7 @@
   "units": [
     {
       "id": "Settler-1",
+      "name": "Settler",
       "prototype": "Settler",
       "owner": "player-2",
       "previousLocation": {
@@ -68890,6 +68891,7 @@
     },
     {
       "id": "Worker-1",
+      "name": "Worker",
       "prototype": "Worker",
       "owner": "player-2",
       "previousLocation": {
@@ -68909,6 +68911,7 @@
     },
     {
       "id": "Settler-2",
+      "name": "Settler",
       "prototype": "Settler",
       "owner": "player-3",
       "previousLocation": {
@@ -68928,6 +68931,7 @@
     },
     {
       "id": "Worker-2",
+      "name": "Worker",
       "prototype": "Worker",
       "owner": "player-3",
       "previousLocation": {
@@ -68947,6 +68951,7 @@
     },
     {
       "id": "Scout-1",
+      "name": "Scout",
       "prototype": "Scout",
       "owner": "player-3",
       "previousLocation": {
@@ -68966,6 +68971,7 @@
     },
     {
       "id": "Settler-3",
+      "name": "Settler",
       "prototype": "Settler",
       "owner": "player-4",
       "previousLocation": {
@@ -68985,6 +68991,7 @@
     },
     {
       "id": "Worker-3",
+      "name": "Worker",
       "prototype": "Worker",
       "owner": "player-4",
       "previousLocation": {
@@ -69004,6 +69011,7 @@
     },
     {
       "id": "Settler-4",
+      "name": "Settler",
       "prototype": "Settler",
       "owner": "player-5",
       "previousLocation": {
@@ -69023,6 +69031,7 @@
     },
     {
       "id": "Worker-4",
+      "name": "Worker",
       "prototype": "Worker",
       "owner": "player-5",
       "previousLocation": {
@@ -69042,6 +69051,7 @@
     },
     {
       "id": "Scout-2",
+      "name": "Scout",
       "prototype": "Scout",
       "owner": "player-5",
       "previousLocation": {
@@ -69061,6 +69071,7 @@
     },
     {
       "id": "Settler-5",
+      "name": "Settler",
       "prototype": "Settler",
       "owner": "player-6",
       "previousLocation": {
@@ -69080,6 +69091,7 @@
     },
     {
       "id": "Worker-5",
+      "name": "Worker",
       "prototype": "Worker",
       "owner": "player-6",
       "previousLocation": {
@@ -69099,6 +69111,7 @@
     },
     {
       "id": "Settler-6",
+      "name": "Settler",
       "prototype": "Settler",
       "owner": "player-7",
       "previousLocation": {
@@ -69118,6 +69131,7 @@
     },
     {
       "id": "Worker-6",
+      "name": "Worker",
       "prototype": "Worker",
       "owner": "player-7",
       "previousLocation": {
@@ -69137,6 +69151,7 @@
     },
     {
       "id": "Settler-7",
+      "name": "Settler",
       "prototype": "Settler",
       "owner": "player-8",
       "previousLocation": {
@@ -69156,6 +69171,7 @@
     },
     {
       "id": "Worker-7",
+      "name": "Worker",
       "prototype": "Worker",
       "owner": "player-8",
       "previousLocation": {

--- a/C7/Text/c7-static-map-save.json
+++ b/C7/Text/c7-static-map-save.json
@@ -68871,6 +68871,7 @@
   "units": [
     {
       "id": "Settler-1",
+      "name": "Settler",
       "prototype": "Settler",
       "owner": "player-2",
       "previousLocation": {
@@ -68890,6 +68891,7 @@
     },
     {
       "id": "Worker-1",
+      "name": "Worker",
       "prototype": "Worker",
       "owner": "player-2",
       "previousLocation": {
@@ -68909,6 +68911,7 @@
     },
     {
       "id": "Settler-2",
+      "name": "Settler",
       "prototype": "Settler",
       "owner": "player-3",
       "previousLocation": {
@@ -68928,6 +68931,7 @@
     },
     {
       "id": "Worker-2",
+      "name": "Worker",
       "prototype": "Worker",
       "owner": "player-3",
       "previousLocation": {
@@ -68947,6 +68951,7 @@
     },
     {
       "id": "Scout-1",
+      "name": "Scout",
       "prototype": "Scout",
       "owner": "player-3",
       "previousLocation": {
@@ -68966,6 +68971,7 @@
     },
     {
       "id": "Settler-3",
+      "name": "Settler",
       "prototype": "Settler",
       "owner": "player-4",
       "previousLocation": {
@@ -68985,6 +68991,7 @@
     },
     {
       "id": "Worker-3",
+      "name": "Worker",
       "prototype": "Worker",
       "owner": "player-4",
       "previousLocation": {
@@ -69004,6 +69011,7 @@
     },
     {
       "id": "Settler-4",
+      "name": "Settler",
       "prototype": "Settler",
       "owner": "player-5",
       "previousLocation": {
@@ -69023,6 +69031,7 @@
     },
     {
       "id": "Worker-4",
+      "name": "Worker",
       "prototype": "Worker",
       "owner": "player-5",
       "previousLocation": {
@@ -69042,6 +69051,7 @@
     },
     {
       "id": "Scout-2",
+      "name": "Scout",
       "prototype": "Scout",
       "owner": "player-5",
       "previousLocation": {
@@ -69061,6 +69071,7 @@
     },
     {
       "id": "Settler-5",
+      "name": "Settler",
       "prototype": "Settler",
       "owner": "player-6",
       "previousLocation": {
@@ -69080,6 +69091,7 @@
     },
     {
       "id": "Worker-5",
+      "name": "Worker",
       "prototype": "Worker",
       "owner": "player-6",
       "previousLocation": {
@@ -69099,6 +69111,7 @@
     },
     {
       "id": "Settler-6",
+      "name": "Settler",
       "prototype": "Settler",
       "owner": "player-7",
       "previousLocation": {
@@ -69118,6 +69131,7 @@
     },
     {
       "id": "Worker-6",
+      "name": "Worker",
       "prototype": "Worker",
       "owner": "player-7",
       "previousLocation": {
@@ -69137,6 +69151,7 @@
     },
     {
       "id": "Settler-7",
+      "name": "Settler",
       "prototype": "Settler",
       "owner": "player-8",
       "previousLocation": {
@@ -69156,6 +69171,7 @@
     },
     {
       "id": "Worker-7",
+      "name": "Worker",
       "prototype": "Worker",
       "owner": "player-8",
       "previousLocation": {

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -198,7 +198,7 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 			attackDefenseMovement.SetPosition(new Vector2(0, 32));
 			terrainType.SetPosition(new Vector2(0, 46));
 		}
-		unitType.Text = unit.unitType.name;
+		unitType.Text = unit.name;
 		string movementPointsRemaining = unit.movementPoints.canMove ? "" + $"{(unit.movementPoints.getMixedNumber())}" : "0";
 		string bombardText = "";
 		if (unit.unitType.bombard > 0) {

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -794,6 +794,7 @@ namespace C7GameData {
 				ExperienceLevel experience = save.ExperienceLevels[unit.ExperienceLevel];
 				SaveUnit saveUnit = new SaveUnit{
 					id = ids.CreateID(prototype.Name),
+                    name = String.IsNullOrEmpty(unit.Name) ? prototype.Name : unit.Name,
 					owner = player.id,
 					prototype = prototype.Name,
 					currentLocation = new TileLocation(unit.X, unit.Y),
@@ -816,10 +817,11 @@ namespace C7GameData {
 		private void ImportBicUnits() {
 			BiqData theBiq = biq.Unit is null ? defaultBiq : biq;
 
-			var createUnitAtLocation = (SavePlayer player, int unitType, string experienceLevel, int hitPoints, int x, int y) => {
+			var createUnitAtLocation = (SavePlayer player, string unitName, int unitType, string experienceLevel, int hitPoints, int x, int y) => {
 				PRTO prototype = theBiq.Prto[unitType];
 				SaveUnit saveUnit = new SaveUnit{
 					id = ids.CreateID(prototype.Name),
+					name = String.IsNullOrEmpty(unitName) ? prototype.Name : unitName,
 					owner = player.id,
 					prototype = prototype.Name,
 					currentLocation = new TileLocation(x, y),
@@ -840,7 +842,7 @@ namespace C7GameData {
 				// mapping of players and civs.
 				SavePlayer player = save.Players[unit.Owner];
 				ExperienceLevel experience = save.ExperienceLevels[unit.ExperienceLevel];
-				save.Units.Add(createUnitAtLocation(player, unit.UnitType, experience.key, experience.baseHitPoints, unit.X, unit.Y));
+				save.Units.Add(createUnitAtLocation(player, unit.Name, unit.UnitType, experience.key, experience.baseHitPoints, unit.X, unit.Y));
 			}
 
 			RULE rule = theBiq.Rule[0];
@@ -855,10 +857,10 @@ namespace C7GameData {
 				SavePlayer player = save.Players[starting_location.Owner];
 				int baseHitPoints = 3;
 				if (rule.StartUnitType1 >= 0) {
-					save.Units.Add(createUnitAtLocation(player, rule.StartUnitType1, "Regular", baseHitPoints, starting_location.X, starting_location.Y));
+					save.Units.Add(createUnitAtLocation(player, theBiq.Prto[rule.StartUnitType1].Name, rule.StartUnitType1, "Regular", baseHitPoints, starting_location.X, starting_location.Y));
 				}
 				if (rule.StartUnitType2 >= 0) {
-					save.Units.Add(createUnitAtLocation(player, rule.StartUnitType2, "Regular", baseHitPoints, starting_location.X, starting_location.Y));
+					save.Units.Add(createUnitAtLocation(player, theBiq.Prto[rule.StartUnitType2].Name, rule.StartUnitType2, "Regular", baseHitPoints, starting_location.X, starting_location.Y));
 				}
 			}
 		}

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -794,7 +794,7 @@ namespace C7GameData {
 				ExperienceLevel experience = save.ExperienceLevels[unit.ExperienceLevel];
 				SaveUnit saveUnit = new SaveUnit{
 					id = ids.CreateID(prototype.Name),
-                    name = String.IsNullOrEmpty(unit.Name) ? prototype.Name : unit.Name,
+					name = String.IsNullOrEmpty(unit.Name) ? prototype.Name : unit.Name,
 					owner = player.id,
 					prototype = prototype.Name,
 					currentLocation = new TileLocation(unit.X, unit.Y),

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -13,6 +13,7 @@ namespace C7GameData {
 	 **/
 	public class MapUnit {
 		public ID id { get; internal set; }
+		public string name { get; internal set; }
 		public UnitPrototype unitType { get; set; }
 		public Player owner { get; set; }
 		public Tile previousLocation { get; internal set; }
@@ -94,7 +95,7 @@ namespace C7GameData {
 			UnitPrototype type = this.unitType;
 			string hPDesc = ((type.attack > 0) || (type.defense > 0)) ? $" ({hitPointsRemaining}/{maxHitPoints})" : "";
 			string attackDesc = (type.bombard > 0) ? $"{type.attack}({type.bombard})" : type.attack.ToString();
-			return $"{experienceLevel.displayName}{hPDesc} {type.name} ({attackDesc}.{type.defense}.{movementPoints.getMixedNumber()}/{type.movement})";
+			return $"{experienceLevel.displayName}{hPDesc} {this.name} ({attackDesc}.{type.defense}.{movementPoints.getMixedNumber()}/{type.movement})";
 		}
 
 		// TODO: The contents of this enum are copy-pasted from UnitAction in Civ3UnitSprite.cs. We should unify these so we don't have two different

--- a/C7Engine/C7GameData/Save/SaveUnit.cs
+++ b/C7Engine/C7GameData/Save/SaveUnit.cs
@@ -5,6 +5,7 @@ namespace C7GameData.Save {
 
 	public class SaveUnit : IHasID {
 		public ID id { get; set; }
+		public string name;
 		public string prototype;
 		public ID owner;
 		public TileLocation previousLocation = new TileLocation();
@@ -26,6 +27,7 @@ namespace C7GameData.Save {
 
 		public SaveUnit(MapUnit unit, GameMap map) {
 			id = unit.id;
+			name = unit.name;
 			prototype = unit.unitType.name;
 			owner = unit.owner.id;
 			if (unit.previousLocation is not null) {
@@ -65,6 +67,7 @@ namespace C7GameData.Save {
 			};
 			unit.location.unitsOnTile.Add(unit);
 			unit.movementPoints.reset(movePointsRemaining);
+            unit.name = string.IsNullOrEmpty(name) ? unit.unitType.name : name;
 
 			return unit;
 		}

--- a/C7Engine/C7GameData/Save/SaveUnit.cs
+++ b/C7Engine/C7GameData/Save/SaveUnit.cs
@@ -67,7 +67,7 @@ namespace C7GameData.Save {
 			};
 			unit.location.unitsOnTile.Add(unit);
 			unit.movementPoints.reset(movePointsRemaining);
-            unit.name = string.IsNullOrEmpty(name) ? unit.unitType.name : name;
+			unit.name = string.IsNullOrEmpty(name) ? unit.unitType.name : name;
 
 			return unit;
 		}

--- a/C7Engine/C7GameData/UnitPrototype.cs
+++ b/C7Engine/C7GameData/UnitPrototype.cs
@@ -87,6 +87,7 @@ namespace C7GameData {
 		public MapUnit GetInstance(GameData gameData) {
 			MapUnit instance = new MapUnit(gameData.ids.CreateID(this.name));
 			instance.unitType = this;
+			instance.name = this.name;
 			instance.hitPointsRemaining = 3;    //todo: make this configurable
 			instance.movementPoints.reset(movement);
 			return instance;

--- a/C7Engine/GameSetup.cs
+++ b/C7Engine/GameSetup.cs
@@ -100,6 +100,7 @@ public class GameSetup {
 	private void AddUnit(SaveGame save, SavePlayer player, string unitType, TileLocation location) {
 		SaveUnit unit = new() {
 			id = ids.CreateID(unitType),
+            name = unitType,
 			prototype = unitType,
 			owner = player.id,
 			previousLocation = new TileLocation(-1, -1),

--- a/C7Engine/GameSetup.cs
+++ b/C7Engine/GameSetup.cs
@@ -100,7 +100,7 @@ public class GameSetup {
 	private void AddUnit(SaveGame save, SavePlayer player, string unitType, TileLocation location) {
 		SaveUnit unit = new() {
 			id = ids.CreateID(unitType),
-            name = unitType,
+			name = unitType,
 			prototype = unitType,
 			owner = player.id,
 			previousLocation = new TileLocation(-1, -1),


### PR DESCRIPTION
To accomodate for custom names such as in the WWII in the Pacific scenario, and future implementation of renaming units.

The fields in the json files are actually not needed since I am checking for empty or null values for this field and assign the Unit Type name if that's the case, but I left them to be as clear as possible.