### PR TITLE
Standardise TemporaryPopup usage, add invalid navigation popups

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -279,8 +279,7 @@ public partial class Game : Node {
 				break;
 			case MsgShowTemporaryPopup mSTP:
 				Vector2 pos = mapView.screenLocationOfTile(mSTP.location, true);
-				Vector2 offset = new(0, -32);
-				TemporaryPopup.Show(this, mSTP.message, pos + offset);
+				TemporaryPopup.Show(this, mSTP.message, pos);
 				break;
 			case MsgUnitMoved mUUAAB:
 				EmitSignal(SignalName.UnitMoved, new ParameterWrapper<MapUnit>(mUUAAB.Unit));
@@ -519,10 +518,7 @@ public partial class Game : Node {
 
 		bool canMove = unitSelector.SetSelectedUnit(to_select);
 		if (!canMove) {
-			TemporaryPopup popup = new("This unit has already moved.", 1);
-			popup.SetPosition(eventMouseButton.Position + new Vector2(0, -64));
-			AddChild(popup);
-			popup.ShowPopup();
+			TemporaryPopup.Show(this, "This unit has already moved.", eventMouseButton.Position);
 		}
 	}
 

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -932,7 +932,7 @@ public partial class Game : Node {
 				// declare war with the move) mark the path.
 				if (result.moveCost == -1
 					&& unit.location.distanceTo(tile) == 1
-					&& unit.CanEnterTile(tile, allowCombat: true, allowWarDeclaration: true)) {
+					&& unit.CanEnterTile(tile, TileProbe.DeclareWarProbe())) {
 					Queue<Tile> pathQueue = new();
 					pathQueue.Enqueue(tile);
 
@@ -944,7 +944,7 @@ public partial class Game : Node {
 
 					// If we couldn't enter this tile without a war declaration,
 					// record which civ we need to declare war on.
-					if (!unit.CanEnterTile(tile, allowCombat: true, allowWarDeclaration: false)) {
+					if (!unit.CanEnterTile(tile, TileProbe.CombatProbe())) {
 						if (tile.cityAtTile != null) {
 							result.requiresWarDeclarationOnPlayer = tile.cityAtTile.owner;
 						} else {

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -278,10 +278,9 @@ public partial class Game : Node {
 				turnsLeftToFastForward = 0;
 				break;
 			case MsgShowTemporaryPopup mSTP:
-				TemporaryPopup popup = new(mSTP.message, 1);
-				popup.SetPosition(mapView.screenLocationOfTile(mSTP.location, true) + new Vector2(0, -64));
-				AddChild(popup);
-				popup.ShowPopup();
+				Vector2 pos = mapView.screenLocationOfTile(mSTP.location, true);
+				Vector2 offset = new(0, -32);
+				TemporaryPopup.Show(this, mSTP.message, pos + offset);
 				break;
 			case MsgUnitMoved mUUAAB:
 				EmitSignal(SignalName.UnitMoved, new ParameterWrapper<MapUnit>(mUUAAB.Unit));

--- a/C7/Map/GotoLayer.cs
+++ b/C7/Map/GotoLayer.cs
@@ -85,7 +85,7 @@ public partial class GotoLayer : LooseLayer {
 			DrawStaticGoToCursor(looseView, tileCenter, 0, true);
 		}
 
-		if (gotoInfo.path != null && unit.CanEnterTile(gotoInfo.destinationTile, true, true)) {
+		if (gotoInfo.path != null && unit.CanEnterTile(gotoInfo.destinationTile, TileProbe.GotoProbe())) {
 			List<Tile> tiles = new List<Tile>();
 			tiles.Add(unitOriginTile);
 			tiles.AddRange(gotoInfo.path.path);

--- a/C7/UIElements/Advisors/TechBox.cs
+++ b/C7/UIElements/Advisors/TechBox.cs
@@ -156,7 +156,7 @@ public partial class TechBox : TextureButton {
 		smallFontTheme.SetColor("font_color", "Label", new Color(0.71f, 0.35f, 0.13f));
 
 		var customTheme = new Theme();
-		customTheme.SetStylebox("panel", "TooltipPanel", TemporaryPopup.PopupTechStyleBox());
+		customTheme.SetStylebox("panel", "TooltipPanel", TemporaryPopup.TooltipStyleBox());
 		customTheme.SetColor("font_color", "TooltipLabel", Colors.Black);
 		customTheme.SetFontSize("font_size", "TooltipLabel", 12);
 		this.Theme = customTheme;

--- a/C7/UIElements/Popups/TemporaryPopup.cs
+++ b/C7/UIElements/Popups/TemporaryPopup.cs
@@ -14,13 +14,23 @@ public partial class TemporaryPopup : Label {
 	}
 
 	// A stylebox that works well for temporary popups or tooltips in game.
-	public static StyleBoxFlat PopupStyleBox() {
+	public static StyleBoxFlat TooltipStyleBox() {
 		StyleBoxFlat styleBox = new();
 		styleBox.ContentMarginLeft = 5;
 		styleBox.ContentMarginRight = 5;
 		styleBox.ContentMarginTop = 2;
 		styleBox.ContentMarginBottom = 2;
 		styleBox.BgColor = Color.FromHtml("1C1C1C");
+		return styleBox;
+	}
+
+	public static StyleBoxFlat PopupStyleBox() {
+		StyleBoxFlat styleBox = new();
+		styleBox.ContentMarginLeft = 5;
+		styleBox.ContentMarginRight = 5;
+		styleBox.ContentMarginTop = 2;
+		styleBox.ContentMarginBottom = 2;
+		styleBox.BgColor = Color.FromHtml("1C1C1C99");
 		return styleBox;
 	}
 
@@ -40,10 +50,15 @@ public partial class TemporaryPopup : Label {
 	}
 
 	public static void Show(Node parent, string msg, Vector2 rootPosition) {
-		TemporaryPopup popup = new(msg, 1);
-		Vector2 offset = new(0, -64);
-		popup.SetPosition(rootPosition + offset);
+		TemporaryPopup popup = new(msg, 2);
+		popup.SetPosition(rootPosition);
 		parent.AddChild(popup);
+
+		// Center the text, adjust it slightly above the target (tile) position.
+		// Note: Label size isn't defined until node has been added to the tree.
+		Vector2 offset = new(-(popup.Size.X / 2), -64);
+		popup.SetPosition(rootPosition + offset);
+
 		popup.ShowPopup();
 	}
 

--- a/C7/UIElements/Popups/TemporaryPopup.cs
+++ b/C7/UIElements/Popups/TemporaryPopup.cs
@@ -39,6 +39,14 @@ public partial class TemporaryPopup : Label {
 		return styleBox;
 	}
 
+	public static void Show(Node parent, string msg, Vector2 rootPosition) {
+		TemporaryPopup popup = new(msg, 1);
+		Vector2 offset = new(0, -64);
+		popup.SetPosition(rootPosition + offset);
+		parent.AddChild(popup);
+		popup.ShowPopup();
+	}
+
 	public async void ShowPopup() {
 		// Wait until we hit our duration then destroy ourself.
 		await Task.Delay(durationInMillis);

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -102,10 +102,7 @@ public partial class RightClickMenu : VBoxContainer {
 	}
 
 	public void ShowCannotMovePopup() {
-		TemporaryPopup popup = new("This unit has already moved.", 1);
-		popup.SetPosition(position + new Vector2(0, -64));
-		GetParent().AddChild(popup);
-		popup.ShowPopup();
+		TemporaryPopup.Show(GetParent(), "This unit has already moved.", position);
 	}
 }
 

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -101,7 +101,7 @@ public partial class UnitButtons : VBoxContainer {
 			button.TooltipText = tooltipText;
 
 			var customTheme = new Theme();
-			customTheme.SetStylebox("panel", "TooltipPanel", TemporaryPopup.PopupStyleBox());
+			customTheme.SetStylebox("panel", "TooltipPanel", TemporaryPopup.TooltipStyleBox());
 			customTheme.SetColor("font_color", "TooltipLabel", Colors.White);
 			button.Theme = customTheme;
 		}

--- a/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
+++ b/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
@@ -30,8 +30,8 @@ namespace C7Engine.Pathing {
 					// to allow pathing to attack. We don't want to try and path
 					// through opponents on the way to our destination though,
 					// as we can get stuck.
-					bool allowCombat = neighbor == destination;
-					return unit.CanEnterTile(neighbor, allowCombat);
+					var probe = neighbor == destination ? TileProbe.PathCombatProbe() : TileProbe.PathProbe();
+					return unit.CanEnterTile(neighbor, probe);
 				}
 			);
 		}

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -247,7 +247,7 @@ namespace C7Engine {
 			}
 
 			List<Tile> reachableBarbCampsTiles = player.tileKnowledge.AllKnownTiles()
-				.Where(t => unit.CanEnterTile(t, true) && t.hasBarbarianCamp).ToList();
+				.Where(t => unit.CanEnterTile(t, TileProbe.AiCombatProbe()) && t.hasBarbarianCamp).ToList();
 
 			Tile closestBarbCamp = Tile.NONE;
 			int closestBarbDistance = int.MaxValue;

--- a/C7Engine/AI/UnitAI/CombatAI.cs
+++ b/C7Engine/AI/UnitAI/CombatAI.cs
@@ -81,7 +81,7 @@ namespace C7Engine.AI.UnitAI {
 			}
 
 			// Move along the path, initiating combat if we reach our target.
-			return this.TryToMoveAlongPath(unit, ref data.path, allowCombat: true);
+			return this.TryToMoveAlongPath(unit, ref data.path, TileProbe.AiCombatProbe());
 		}
 
 		public string SummarizePlan() {

--- a/C7Engine/AI/UnitAI/DefenderAI.cs
+++ b/C7Engine/AI/UnitAI/DefenderAI.cs
@@ -53,7 +53,7 @@ namespace C7Engine.AI.UnitAI {
 				return C7GameData.UnitAI.Result.Done;
 			} else {
 				log.Debug("Moving defender towards " + data.destination);
-				return this.TryToMoveAlongPath(unit, ref data.pathToDestination, allowCombat: false);
+				return this.TryToMoveAlongPath(unit, ref data.pathToDestination, TileProbe.AiMoveProbe());
 			}
 		}
 

--- a/C7Engine/AI/UnitAI/EscortAI.cs
+++ b/C7Engine/AI/UnitAI/EscortAI.cs
@@ -80,7 +80,7 @@ namespace C7Engine {
 
 			// Move to the unit we're escorting.
 			TilePath path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, data.unitToEscort.location, unit);
-			result = this.TryToMoveAlongPath(unit, ref path, allowCombat: false);
+			result = this.TryToMoveAlongPath(unit, ref path, TileProbe.AiMoveProbe());
 			if (result != UnitAI.Result.InProgress) {
 				return result;
 			}

--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -51,7 +51,7 @@ namespace C7Engine {
 				return UnitAI.Result.Done;
 			}
 
-			return this.TryToMoveAlongPath(unit, ref data.pathToDestination, allowCombat: false);
+			return this.TryToMoveAlongPath(unit, ref data.pathToDestination, TileProbe.AiMoveProbe());
 		}
 
 		public string SummarizePlan() {

--- a/C7Engine/AI/UnitAI/SettlerAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerAI.cs
@@ -66,7 +66,7 @@ namespace C7Engine {
 						unit.movementPoints.onConsumeAll();
 						return C7GameData.UnitAI.Result.InProgress;
 					} else {
-						return this.TryToMoveAlongPath(unit, ref data.pathToDestination, allowCombat: false);
+						return this.TryToMoveAlongPath(unit, ref data.pathToDestination, TileProbe.AiMoveProbe());
 					}
 					break;
 				case SettlerAIData.SettlerGoal.JOIN_CITY:

--- a/C7Engine/AI/UnitAI/WorkerAI.cs
+++ b/C7Engine/AI/UnitAI/WorkerAI.cs
@@ -79,7 +79,7 @@ namespace C7Engine {
 				return PerformWorkerMove(unit, improvement);
 			}
 
-			return this.TryToMoveAlongPath(unit, ref data.pathToDestination, allowCombat: false);
+			return this.TryToMoveAlongPath(unit, ref data.pathToDestination, TileProbe.AiMoveProbe());
 		}
 
 		private static Terraform? GetTileImprovement(Tile t, MapUnit unit) {

--- a/C7Engine/AI/UnitAiExtension.cs
+++ b/C7Engine/AI/UnitAiExtension.cs
@@ -13,17 +13,17 @@ namespace C7Engine {
 		// Attempts to move the supplied unit along the given path.
 		//
 		// `path` is a ref so that the path can be recalculated if necessary.
-		public static MoveResult TryToMoveAlongPath(this UnitAI unitAi, MapUnit unit, ref TilePath path, bool allowCombat) {
+		public static MoveResult TryToMoveAlongPath(this UnitAI unitAi, MapUnit unit, ref TilePath path, TileProbe probe) {
 			if (!unit.movementPoints.canMove) {
 				return UnitAI.Result.InProgress;
 			}
 			Tile nextTile = path.Next();
-			if (nextTile == Tile.NONE || !unit.CanEnterTile(nextTile, allowCombat)) {
+			if (nextTile == Tile.NONE || !unit.CanEnterTile(nextTile, probe)) {
 				log.Information($"Attempting to repath {unit} from {unit.location} to {path.destination}");
 				// Attempt to repath. If we succeed, return inprogress so we get
 				// called again.
 				path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, path.destination, unit);
-				if ((path?.PathLength() ?? -1) == -1 || path.PeekNext() == Tile.NONE || !unit.CanEnterTile(path.PeekNext(), allowCombat)) {
+				if ((path?.PathLength() ?? -1) == -1 || path.PeekNext() == Tile.NONE || !unit.CanEnterTile(path.PeekNext(), probe)) {
 					return UnitAI.Result.Error;
 				}
 

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -74,6 +74,10 @@ namespace C7GameData {
 			return IsLandUnit() && unitType.defense > 0;
 		}
 
+		public bool IsNonCombatUnit() {
+			return unitType.attack == 0;
+		}
+
 		public bool HasRank() {
 			return this.unitType.attack > 0 || this.unitType.defense > 0;
 		}
@@ -500,6 +504,14 @@ namespace C7GameData {
 		// Like above, but allows specifying that we want to handle the case
 		// where a war declaration could be made before the move.
 		public bool CanEnterTile(Tile tile, bool allowCombat, bool allowWarDeclaration) {
+			return CanEnterTile(tile, new TileProbe() {
+				AllowCombat = allowCombat,
+				AllowWarDeclaration = allowWarDeclaration
+			});
+		}
+
+		// Generalized check to see whether a given tile is accessible to the unit in a given context.
+		public bool CanEnterTile(Tile tile, TileProbe probe) {
 			if (this.owner.isHuman && !this.owner.HasExploredTile(tile))
 				return true;
 
@@ -521,10 +533,25 @@ namespace C7GameData {
 			if (this.IsLandUnit() && !tile.IsLand())
 				return false;
 
+			if (IsNonCombatUnit()) {
+				if (HasHostileCity(tile, owner)) {
+					if (probe.RaiseNotice) {
+						new MsgShowTemporaryPopup($"Only combat units can capture cities and improvements.", tile).send();
+					}
+					return false;
+				}
+				if (HasHostileUnits(tile, owner)) {
+					if (probe.RaiseNotice) {
+						new MsgShowTemporaryPopup($"Non-combat units may not attack.", tile).send();
+					}
+					return false;
+				}
+			}
+
 			// If we allow declaring war on this move, then it doesn't matter if
 			// there are units belonging to another player on the tile.
 			// TODO: unbreakable alliances
-			if (allowWarDeclaration) {
+			if (probe.AllowWarDeclaration) {
 				return true;
 			}
 
@@ -541,7 +568,7 @@ namespace C7GameData {
 				foreach (MapUnit other in tile.unitsOnTile) {
 					if (other.owner != owner) {
 						if (!other.owner.IsAtPeaceWith(owner))
-							return allowCombat && unitType.attack > 0;
+							return probe.AllowCombat && unitType.attack > 0;
 						return false;
 					}
 				}
@@ -550,11 +577,23 @@ namespace C7GameData {
 			// Check for cities belonging to other civs.
 			if (tile.cityAtTile != null && tile.cityAtTile.owner != owner) {
 				if (!this.owner.isHuman || this.owner.tileKnowledge.isActiveTile(tile))
-					return allowCombat;
+					return probe.AllowCombat;
 				return false;
 			}
 
 			return true;
+		}
+
+		private static bool HasHostileUnits(Tile tile, Player player) {
+			foreach (MapUnit other in tile.unitsOnTile) {
+				if (player != other.owner && !player.IsAtPeaceWith(other.owner))
+					return true;
+			}
+			return false;
+		}
+
+		private static bool HasHostileCity(Tile tile, Player player) {
+			return tile.HasCity && !player.IsAtPeaceWith(tile.cityAtTile.owner);
 		}
 
 		/// <summary>
@@ -568,7 +607,7 @@ namespace C7GameData {
 		public async Task<bool> move(TileDirection dir, bool wait = false) {
 			(int dx, int dy) = dir.toCoordDiff();
 			Tile newLoc = EngineStorage.gameData.map.tileAt(dx + location.XCoordinate, dy + location.YCoordinate);
-			if ((newLoc != Tile.NONE) && CanEnterTile(newLoc, true) && (movementPoints.canMove)) {
+			if ((newLoc != Tile.NONE) && CanEnterTile(newLoc, TileProbe.MoveProbe()) && (movementPoints.canMove)) {
 				facingDirection = dir;
 				wake();
 
@@ -855,6 +894,16 @@ namespace C7GameData {
 			// unit.availableActions.Add("rename");
 
 			return result;
+		}
+	}
+
+	public class TileProbe {
+		public bool AllowCombat { get; set; }
+		public bool AllowWarDeclaration { get; set; }
+		public bool RaiseNotice { get; set; }
+
+		public static TileProbe MoveProbe() {
+			return new TileProbe() { AllowCombat = true, RaiseNotice = true };
 		}
 	}
 }

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -74,10 +74,6 @@ namespace C7GameData {
 			return IsLandUnit() && unitType.defense > 0;
 		}
 
-		public bool IsNonCombatUnit() {
-			return unitType.attack == 0;
-		}
-
 		public bool HasRank() {
 			return this.unitType.attack > 0 || this.unitType.defense > 0;
 		}
@@ -354,7 +350,7 @@ namespace C7GameData {
 						// TODO: Defender retreat behavior requires some more work. There's an issue for it here:
 						// https://github.com/C7-Game/Prototype/issues/274
 						Tile retreatDestination = defender.location.neighbors[attacker.facingDirection];
-						if ((retreatDestination != Tile.NONE) && defender.CanEnterTile(retreatDestination, false)) {
+						if ((retreatDestination != Tile.NONE) && defender.CanEnterTile(retreatDestination, TileProbe.PathProbe())) {
 							await defender.move(attacker.facingDirection, true);
 							result = CombatResult.DefenderRetreated;
 							break;
@@ -497,19 +493,6 @@ namespace C7GameData {
 			}
 		}
 
-		public bool CanEnterTile(Tile tile, bool allowCombat) {
-			return CanEnterTile(tile, allowCombat, allowWarDeclaration: false);
-		}
-
-		// Like above, but allows specifying that we want to handle the case
-		// where a war declaration could be made before the move.
-		public bool CanEnterTile(Tile tile, bool allowCombat, bool allowWarDeclaration) {
-			return CanEnterTile(tile, new TileProbe() {
-				AllowCombat = allowCombat,
-				AllowWarDeclaration = allowWarDeclaration
-			});
-		}
-
 		// Generalized check to see whether a given tile is accessible to the unit in a given context.
 		public bool CanEnterTile(Tile tile, TileProbe probe) {
 			if (this.owner.isHuman && !this.owner.HasExploredTile(tile))
@@ -533,18 +516,20 @@ namespace C7GameData {
 			if (this.IsLandUnit() && !tile.IsLand())
 				return false;
 
-			if (IsNonCombatUnit()) {
+			if (!HasRank()) {
 				if (HasHostileCity(tile, owner)) {
 					if (probe.RaiseNotice) {
 						new MsgShowTemporaryPopup($"Only combat units can capture cities and improvements.", location).send();
+						return false;
 					}
-					return false;
+					return true;
 				}
 				if (HasHostileUnits(tile, owner)) {
 					if (probe.RaiseNotice) {
 						new MsgShowTemporaryPopup($"Non-combat units may not attack.", location).send();
+						return false;
 					}
-					return false;
+					return true;
 				}
 			}
 
@@ -897,13 +882,41 @@ namespace C7GameData {
 		}
 	}
 
-	public class TileProbe {
-		public bool AllowCombat { get; set; }
-		public bool AllowWarDeclaration { get; set; }
-		public bool RaiseNotice { get; set; }
+	public struct TileProbe {
+		public bool AllowCombat { get; init; }
+		public bool AllowWarDeclaration { get; init; }
+		public bool RaiseNotice { get; init; }
+
+		public static TileProbe AiMoveProbe() {
+			return new TileProbe() { AllowCombat = false, AllowWarDeclaration = false, RaiseNotice = false };
+		}
+
+		public static TileProbe AiCombatProbe() {
+			return new TileProbe() { AllowCombat = true, AllowWarDeclaration = false, RaiseNotice = false };
+		}
+
+		public static TileProbe PathProbe() {
+			return new TileProbe() { AllowCombat = false, RaiseNotice = false };
+		}
+
+		public static TileProbe PathCombatProbe() {
+			return new TileProbe() { AllowCombat = true, RaiseNotice = false };
+		}
 
 		public static TileProbe MoveProbe() {
 			return new TileProbe() { AllowCombat = true, RaiseNotice = true };
+		}
+
+		public static TileProbe CombatProbe() {
+			return new TileProbe() { AllowCombat = true, AllowWarDeclaration = false, RaiseNotice = false };
+		}
+
+		public static TileProbe GotoProbe() {
+			return new TileProbe() { AllowCombat = true, AllowWarDeclaration = true, RaiseNotice = false };
+		}
+
+		public static TileProbe DeclareWarProbe() {
+			return new TileProbe() { AllowCombat = true, AllowWarDeclaration = true, RaiseNotice = false };
 		}
 	}
 }

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -536,13 +536,13 @@ namespace C7GameData {
 			if (IsNonCombatUnit()) {
 				if (HasHostileCity(tile, owner)) {
 					if (probe.RaiseNotice) {
-						new MsgShowTemporaryPopup($"Only combat units can capture cities and improvements.", tile).send();
+						new MsgShowTemporaryPopup($"Only combat units can capture cities and improvements.", location).send();
 					}
 					return false;
 				}
 				if (HasHostileUnits(tile, owner)) {
 					if (probe.RaiseNotice) {
-						new MsgShowTemporaryPopup($"Non-combat units may not attack.", tile).send();
+						new MsgShowTemporaryPopup($"Non-combat units may not attack.", location).send();
 					}
 					return false;
 				}

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -510,7 +510,11 @@ namespace C7GameData {
 				int shieldsAwarded = EngineStorage.gameData.rules.ForestValueInShields;
 				c.shieldsStored += shieldsAwarded;
 				c.shieldsStored = Math.Min(c.shieldsStored, c.owner.ShieldCost(c.itemBeingProduced));
-				new MsgShowTemporaryPopup($"{shieldsAwarded} shields awarded for clearing forests", other).send();
+
+				if (c.owner.isHuman) {
+					new MsgShowTemporaryPopup($"{shieldsAwarded} shields awarded for clearing forests", other).send();
+				}
+
 				return;
 			}
 		}


### PR DESCRIPTION
Following up on discussion in #871, I've had a go at adding popup notifications to invalid navigation by "non-combat units" as the siege units are referred to in the original game.

I cleaned up the popup label render so that the text offset calculation is done in one location instead at every call site. I added text centering and some transparency to the label, to make the popup a bit nicer and more like the original. (I made a clone of the StyleBox for tooltips, which work better without transparency.)

Implementing the actual invalid navigation detection proved a bit more challenging than I expected. The method `CanEnterTile(..)` is used in different contexts to check for slightly different things, which made adding side effects a bit tricky. A naive implementation would make it so that the pathing and AI calculations would also raise popups. I ended up generalizing `CanEnterTile(..)` with an additional parameter to enable raising warnings when navigating from the `move(..)` context. The whole `CanEnterTile(..)` pattern probably needs a bit more thought - passing in boolean flags to change the behaviour of the function is a bit of a code smell.

Finally, while adjusting TemporaryPopup usages, I noticed that the existing MsgShowTemporaryPopup call at `MaybeAwardForestClearingShields(..)` was being called even during non-human turns, resulting in seemingly pointless  popup renders somewhere out of camera, deep in other player's territory. I've changed this so shield value popups are rendered only for human players. I want to say that this change had an observable impact on next turn load performance, but I didn't measure.

## Screenshots

### Original game
<img width="304" height="213" alt="non-combat_cannot_attack" src="https://github.com/user-attachments/assets/0f24cd7a-a0e3-4a76-bd10-f6b40d620e8d" />
<img width="420" height="258" alt="only_combat_units_capture" src="https://github.com/user-attachments/assets/fccb7cc6-d89a-46ca-96d3-ce2bd8634425" />

### Existing popup mechanism
<img width="320" height="164" alt="non-combat_cannot_attack_openciv3" src="https://github.com/user-attachments/assets/16d3031f-e356-422d-8c51-684a8a2c2107" />
<img width="611" height="295" alt="only_combat_units_capture_openciv3" src="https://github.com/user-attachments/assets/66e3f3bf-ebfb-46ba-91f2-514aedc1fb38" />

### Revised popup mechanism
<img width="360" height="183" alt="non-combat_cannot_attack_openciv3_new" src="https://github.com/user-attachments/assets/62ad128d-a8ec-4bfc-a23a-e685a383381b" />
<img width="473" height="293" alt="only_combat_units_capture_openciv3_new" src="https://github.com/user-attachments/assets/cf9ed0e3-47ff-4ab2-8f02-3f0df3e9510b" />


