### PR TITLE
Load jungleVolcanoTexture

### DIFF
--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -115,6 +115,7 @@ public partial class HillsLayer : LooseLayer {
 		jungleHillsTexture = TextureLoader.Load("terrain.hill.jungle");
 		volcanosTexture = TextureLoader.Load("terrain.volcano.base");
 		forestVolcanoTexture = TextureLoader.Load("terrain.volcano.forest");
+		jungleVolcanoTexture = TextureLoader.Load("terrain.volcano.jungle");
 	}
 
 	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {


### PR DESCRIPTION
We weren't loading this texture at all, causing some error flooding which in turn potentially also slowed the game down.

Thanks to @ajhalme for picking up on it