### PR TITLE
On city destroy, remove ownership from "fringe" tiles outside natural city border

### DIFF
--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -189,7 +189,7 @@ namespace C7GameData {
 				foreach (var fringeTile in tile.GetEdgeNeighbors().Where(x => !borderTileIds.Contains(x.Id))) {
 					if (fringeTile.HasCity) // skip encountered cities, just in case 
 						continue;
-					
+
 					fringeTile.owningCity = null;
 				}
 			}

--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -176,9 +176,19 @@ namespace C7GameData {
 
 		public void UpdateTileOwnersOnCityDestruction(City city) {
 			city.location.owningCity = null;
-
-			foreach (Tile tile in city.GetTilesWithinBorders()) {
+			
+			var borderTiles = city.GetTilesWithinBorders();
+			var borderTileIds = borderTiles.Select(x => x.Id).ToHashSet();
+			
+			foreach (Tile tile in borderTiles) {
 				tile.owningCity = null;
+
+				// Aggressively remove ownership from edge neighbors around the city outside the natural border.
+				// This clears out tile ownership due to Law VII or Law VIII.
+				// Regular tile ownership update will re-assign ownership where needed.
+				foreach (var fringeTile in tile.GetEdgeNeighbors().Where(x => !borderTileIds.Contains(x.Id))) {
+					fringeTile.owningCity = null;	
+				}
 			}
 
 			UpdateTileOwners();

--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -176,10 +176,10 @@ namespace C7GameData {
 
 		public void UpdateTileOwnersOnCityDestruction(City city) {
 			city.location.owningCity = null;
-			
+
 			var borderTiles = city.GetTilesWithinBorders();
 			var borderTileIds = borderTiles.Select(x => x.Id).ToHashSet();
-			
+
 			foreach (Tile tile in borderTiles) {
 				tile.owningCity = null;
 
@@ -187,7 +187,10 @@ namespace C7GameData {
 				// This clears out tile ownership due to Law VII or Law VIII.
 				// Regular tile ownership update will re-assign ownership where needed.
 				foreach (var fringeTile in tile.GetEdgeNeighbors().Where(x => !borderTileIds.Contains(x.Id))) {
-					fringeTile.owningCity = null;	
+					if (fringeTile.HasCity) // skip encountered cities, just in case 
+						continue;
+					
+					fringeTile.owningCity = null;
 				}
 			}
 


### PR DESCRIPTION
Fix for #854.

When a city is destroyed (the default capture mechanism for the time being) a special routine clears out the `owningCity` property from tiles controlled by the city. The current implementation is limited to removing city ownership from tiles within the "natural" culture/rank based city boundary.

If my reading of the laws is correct, it should be enough to simply remove *all* ownership from the tiles around the "natural" city border, as 1) the laws relate to "edge neighbours" of "naturally" owned tiles, and 2) the update mechanism will restore any valid ownership that got removed.

The point is that we *want* to recompute "from scratch" the tile ownership around the destroyed city. Instead of trying to be clever about removing ownership precisely and dealing with corner cases, just take out all tile ownership that *could* be affected, and let the update heal the state. If there's a corner case missed by this scheme, the fix should be done in the update mechanism.

Relevant lore on CFC: *[The Eight Laws of Border Dynamics](https://forums.civfanatics.com/threads/the-eight-laws-of-border-dynamics.106882/)*

-- 

Test save file:
[854_border_recompute.json](https://github.com/user-attachments/files/25329878/854_border_recompute.json)

Screens:
<img width="1149" height="550" alt="borderline_1_before" src="https://github.com/user-attachments/assets/6d8cd2ce-be6c-4563-b1c7-7f162f82b5a7" />
<img width="1147" height="488" alt="borderline_2_current" src="https://github.com/user-attachments/assets/97002a4b-486a-4e8b-baac-c9a80238653e" />
<img width="1150" height="503" alt="borderline_3_new" src="https://github.com/user-attachments/assets/2ed5d9a2-7054-462a-908a-4a82f3cdd85e" />
