### PR TITLE
player relationships: Remove the message to the engine

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -320,7 +320,10 @@ public partial class Game : Node {
 		EngineStorage.ReadGameData((GameData gameData) => {
 			log.Information("Starting player turn");
 
-			new MsgCheckObsoleteDeals(controller).send();
+			// TODO: Before we call this method to automatically end obsolete deals, we could make this more versatile.
+			// For example unless we have a good reason, as a human, receiving luxuries, gpt,
+			// or having an active RoP, doesn't hurt us.
+			PlayerRelationship.CheckForObsoleteDeals(controller, gameData.players, gameData.turn);
 
 			// If the player can now pick a new government, force them to do so.
 			// When the popup is closed we call OnPlayerStartTurn again. This isn't

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -28,7 +28,10 @@ namespace C7Engine {
 			stopwatch.Start();
 			log.Information("-> Begin " + player.civilization.cityNames[0] + " turn");
 
-			new MsgCheckObsoleteDeals(player).send();
+			// TODO: Before we call this method to automatically end obsolete deals, we could make this more versatile.
+			// For example unless we have a good reason, as a human, receiving luxuries, gpt,
+			// or having an active RoP, doesn't hurt us.
+			PlayerRelationship.CheckForObsoleteDeals(player, EngineStorage.gameData.players, EngineStorage.gameData.turn);
 
 			MaybeDoPriorityReevaluation(player);
 			MaybePickTechToResearch(player, techs);

--- a/C7Engine/C7GameData/PlayerRelationship.cs
+++ b/C7Engine/C7GameData/PlayerRelationship.cs
@@ -197,6 +197,8 @@ public class PlayerRelationship {
 	/// <param name="players"></param>
 	/// <param name="currentTurn"></param>
 	public static void CheckForObsoleteDeals(Player player, List<Player> players, int currentTurn) {
+		log.Information($"Checking to terminate any deals past their due duration for player {player}");
+
 		var playerIds = players.Select(x => x.id).ToList();
 
 		// check player's relationship with the other players

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -360,22 +360,4 @@ namespace C7Engine {
 	public class MsgDiplomacyCompleted : MessageToEngine {
 		public override void process() { }
 	}
-
-	public class MsgCheckObsoleteDeals : MessageToEngine {
-		private ILogger log = Log.ForContext<MsgCheckObsoleteDeals>();
-		private Player player;
-
-		public MsgCheckObsoleteDeals(Player player) {
-			this.player = player;
-		}
-
-		public override void process() {
-			log.Information($"Checking to terminate any deals past their due duration for player {player}");
-
-			// TODO: Before we call this method to automatically end obsolete deals, we could make this more versatile.
-			// For example unless we have a good reason, as a human, receiving luxuries, gpt,
-			// or having an active RoP, doesn't hurt us.
-			PlayerRelationship.CheckForObsoleteDeals(player, EngineStorage.gameData.players, EngineStorage.gameData.turn);
-		}
-	}
 }


### PR DESCRIPTION
Both places where we created the message already could access the gamedata directly, and this seems to be one of the two things that was slowing down observer mode on my chromebook (the other being animations not being disabled, somehow).

I suspect there was some weirdness with repeatedly trying to reacquire the mutex we were already holding or something.