### PR TITLE
Ensure that animations never run in observer mode

### DIFF
--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -166,7 +166,7 @@ namespace C7GameData {
 		}
 
 		public async Task animateAsync(MapUnit.AnimatedAction action, AnimationEnding ending = AnimationEnding.Stop) {
-			if (EngineStorage.animationsEnabled) {
+			if (EngineStorage.animationsEnabled && !EngineStorage.gameData.observerMode) {
 				var msg = new MsgStartUnitAnimation(this, action, ending);
 				msg.send();
 


### PR DESCRIPTION
This avoids any issues with the "shift" key toggling animations colliding with the "ctrl+alt+shift+o" shortcut for observer mode.