### PR TITLE
Civ primary and secondary colors

### DIFF
--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -5530,7 +5530,8 @@
     {
       "name": "A Barbarian Chiefdom",
       "noun": "Barbarians",
-      "colorIndex": 0,
+      "primaryColorIndex": 0,
+      "secondaryColorIndex": 0,
       "leaderGender": "male",
       "cityNames": [
         "Chanca",
@@ -5616,7 +5617,8 @@
       "name": "Rome",
       "noun": "Romans",
       "leader": "Caesar",
-      "colorIndex": 1,
+      "primaryColorIndex": 1,
+      "secondaryColorIndex": 1,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\CE_all.pcx",
       "cityNames": [
@@ -5679,7 +5681,8 @@
       "name": "Egypt",
       "noun": "Egyptians",
       "leader": "Cleopatra",
-      "colorIndex": 3,
+      "primaryColorIndex": 3,
+      "secondaryColorIndex": 3,
       "leaderGender": "female",
       "leaderArtFile": "art\\advisors\\CL_all.pcx",
       "cityNames": [
@@ -5727,7 +5730,8 @@
       "name": "Greece",
       "noun": "Greeks",
       "leader": "Alexander",
-      "colorIndex": 10,
+      "primaryColorIndex": 10,
+      "secondaryColorIndex": 10,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\AL_all.pcx",
       "cityNames": [
@@ -5775,7 +5779,8 @@
       "name": "Babylon",
       "noun": "Babylonians",
       "leader": "Hammurabi",
-      "colorIndex": 1,
+      "primaryColorIndex": 1,
+      "secondaryColorIndex": 13,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\HA_all.pcx",
       "cityNames": [
@@ -5821,7 +5826,8 @@
       "name": "Germany",
       "noun": "Germans",
       "leader": "Bismarck",
-      "colorIndex": 6,
+      "primaryColorIndex": 6,
+      "secondaryColorIndex": 6,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\BS_all.pcx",
       "cityNames": [
@@ -5856,7 +5862,8 @@
       "name": "Russia",
       "noun": "Russians",
       "leader": "Catherine",
-      "colorIndex": 9,
+      "primaryColorIndex": 9,
+      "secondaryColorIndex": 9,
       "leaderGender": "female",
       "leaderArtFile": "art\\advisors\\CA_all.pcx",
       "cityNames": [
@@ -5914,7 +5921,8 @@
       "name": "China",
       "noun": "Chinese",
       "leader": "Mao",
-      "colorIndex": 5,
+      "primaryColorIndex": 5,
+      "secondaryColorIndex": 15,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\MO_all.pcx",
       "cityNames": [
@@ -5951,7 +5959,8 @@
       "name": "America",
       "noun": "Americans",
       "leader": "Lincoln",
-      "colorIndex": 5,
+      "primaryColorIndex": 5,
+      "secondaryColorIndex": 5,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\AB_all.pcx",
       "cityNames": [
@@ -6010,7 +6019,8 @@
       "name": "Japan",
       "noun": "Japanese",
       "leader": "Tokugawa",
-      "colorIndex": 4,
+      "primaryColorIndex": 4,
+      "secondaryColorIndex": 11,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\TO_all.pcx",
       "cityNames": [
@@ -6055,7 +6065,8 @@
       "name": "France",
       "noun": "French",
       "leader": "Joan d\u0027Arc",
-      "colorIndex": 7,
+      "primaryColorIndex": 7,
+      "secondaryColorIndex": 7,
       "leaderGender": "female",
       "leaderArtFile": "art\\advisors\\JO_all.pcx",
       "cityNames": [
@@ -6095,7 +6106,8 @@
       "name": "India",
       "noun": "Indians",
       "leader": "Gandhi",
-      "colorIndex": 8,
+      "primaryColorIndex": 8,
+      "secondaryColorIndex": 12,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\GH_all.pcx",
       "cityNames": [
@@ -6131,7 +6143,8 @@
       "name": "Persia",
       "noun": "Persians",
       "leader": "Xerxes",
-      "colorIndex": 10,
+      "primaryColorIndex": 10,
+      "secondaryColorIndex": 14,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\XE_all.pcx",
       "cityNames": [
@@ -6179,7 +6192,8 @@
       "name": "Aztecs",
       "noun": "Aztecs",
       "leader": "Montezuma",
-      "colorIndex": 4,
+      "primaryColorIndex": 4,
+      "secondaryColorIndex": 4,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\MN_all.pcx",
       "cityNames": [
@@ -6234,7 +6248,8 @@
       "name": "Zululand",
       "noun": "Zulu",
       "leader": "Shaka",
-      "colorIndex": 3,
+      "primaryColorIndex": 3,
+      "secondaryColorIndex": 16,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\ZU_all.pcx",
       "cityNames": [
@@ -6269,7 +6284,8 @@
       "name": "Iroquois",
       "noun": "Iroquois",
       "leader": "Hiawatha",
-      "colorIndex": 8,
+      "primaryColorIndex": 8,
+      "secondaryColorIndex": 8,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\HI_all.pcx",
       "cityNames": [
@@ -6317,7 +6333,8 @@
       "name": "England",
       "noun": "English",
       "leader": "Elizabeth",
-      "colorIndex": 2,
+      "primaryColorIndex": 2,
+      "secondaryColorIndex": 2,
       "leaderGender": "female",
       "leaderArtFile": "art\\advisors\\LZ_all.pcx",
       "cityNames": [
@@ -6365,7 +6382,8 @@
       "name": "Mongols",
       "noun": "Mongols",
       "leader": "Temujin",
-      "colorIndex": 3,
+      "primaryColorIndex": 3,
+      "secondaryColorIndex": 26,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\x_temujin advisor.pcx",
       "cityNames": [
@@ -6414,7 +6432,8 @@
       "name": "Spain",
       "noun": "Spanish",
       "leader": "Isabella",
-      "colorIndex": 5,
+      "primaryColorIndex": 5,
+      "secondaryColorIndex": 20,
       "leaderGender": "female",
       "leaderArtFile": "art\\advisors\\x_isabell advisor.pcx",
       "cityNames": [
@@ -6464,7 +6483,8 @@
       "name": "Scandinavia",
       "noun": "Vikings",
       "leader": "Ragnar Lodbrok",
-      "colorIndex": 8,
+      "primaryColorIndex": 8,
+      "secondaryColorIndex": 31,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\x_ragnar advisor.pcx",
       "cityNames": [
@@ -6516,7 +6536,8 @@
       "name": "Ottomans",
       "noun": "Ottomans",
       "leader": "Osman",
-      "colorIndex": 2,
+      "primaryColorIndex": 2,
+      "secondaryColorIndex": 18,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\x_osman advisor.pcx",
       "cityNames": [
@@ -6564,7 +6585,8 @@
       "name": "Celts",
       "noun": "Celts",
       "leader": "Brennus",
-      "colorIndex": 4,
+      "primaryColorIndex": 4,
+      "secondaryColorIndex": 25,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\x_brennus advisor.pcx",
       "cityNames": [
@@ -6613,7 +6635,8 @@
       "name": "Arabia",
       "noun": "Arabs",
       "leader": "Abu Bakr",
-      "colorIndex": 7,
+      "primaryColorIndex": 7,
+      "secondaryColorIndex": 30,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\x_abu bakr advisor.pcx",
       "cityNames": [
@@ -6660,7 +6683,8 @@
       "name": "Carthage",
       "noun": "Carthaginians",
       "leader": "Hannibal",
-      "colorIndex": 9,
+      "primaryColorIndex": 9,
+      "secondaryColorIndex": 11,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\x_Hannibal advisor.pcx",
       "cityNames": [
@@ -6709,7 +6733,8 @@
       "name": "Korea",
       "noun": "Koreans",
       "leader": "Wang Kon",
-      "colorIndex": 6,
+      "primaryColorIndex": 6,
+      "secondaryColorIndex": 19,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\x_Wang Kon advisor.pcx",
       "cityNames": [
@@ -6758,7 +6783,8 @@
       "name": "Sumeria",
       "noun": "Sumerians",
       "leader": "Gilgamesh",
-      "colorIndex": 5,
+      "primaryColorIndex": 5,
+      "secondaryColorIndex": 20,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\x2_Gilgamesh advisor.pcx",
       "cityNames": [
@@ -6802,7 +6828,8 @@
       "name": "Hittites",
       "noun": "Hittites",
       "leader": "Mursilis",
-      "colorIndex": 14,
+      "primaryColorIndex": 14,
+      "secondaryColorIndex": 27,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\x2_Mursilis advisor.pcx",
       "cityNames": [
@@ -6846,7 +6873,8 @@
       "name": "Netherlands",
       "noun": "Dutch",
       "leader": "William",
-      "colorIndex": 2,
+      "primaryColorIndex": 2,
+      "secondaryColorIndex": 18,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\x2_William advisor.pcx",
       "cityNames": [
@@ -6890,7 +6918,8 @@
       "name": "Portugal",
       "noun": "Portuguese",
       "leader": "Henry",
-      "colorIndex": 8,
+      "primaryColorIndex": 8,
+      "secondaryColorIndex": 17,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\x2_Henry advisor.pcx",
       "cityNames": [
@@ -6945,7 +6974,8 @@
       "name": "Byzantines",
       "noun": "Byzantines",
       "leader": "Theodora",
-      "colorIndex": 11,
+      "primaryColorIndex": 11,
+      "secondaryColorIndex": 1,
       "leaderGender": "female",
       "leaderArtFile": "art\\advisors\\x2_Theodora advisor.pcx",
       "cityNames": [
@@ -6989,7 +7019,8 @@
       "name": "Inca",
       "noun": "Inca",
       "leader": "Pachacuti",
-      "colorIndex": 7,
+      "primaryColorIndex": 7,
+      "secondaryColorIndex": 8,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\x2_Pachacuti advisor.pcx",
       "cityNames": [
@@ -7033,7 +7064,8 @@
       "name": "Maya",
       "noun": "Maya",
       "leader": "Smoke-Jaguar",
-      "colorIndex": 6,
+      "primaryColorIndex": 6,
+      "secondaryColorIndex": 5,
       "leaderGender": "male",
       "leaderArtFile": "art\\advisors\\x2_Smoke-Jaguar_advisor.pcx",
       "cityNames": [

--- a/C7/Map/BorderLayer.cs
+++ b/C7/Map/BorderLayer.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
+using C7.Textures;
 using C7GameData;
 using Godot;
-using ConvertCiv3Media;
-using System;
 
 namespace C7.Map {
 	// The layer responsible for drawing civilization borders.
@@ -57,7 +56,7 @@ namespace C7.Map {
 				return;
 			}
 
-			Color borderColor = TextureLoader.LoadColor(tile.owningCity.owner.colorIndex);
+			Color borderColor = TextureLoader.LoadColor(tile.owningCity.owner.GetPlayerColor());
 			TileDirection[] borderDirections = [TileDirection.NORTHEAST, TileDirection.NORTHWEST, TileDirection.SOUTHEAST, TileDirection.SOUTHWEST];
 
 			foreach (TileDirection dir in borderDirections) {

--- a/C7/Map/CityLabelScene.cs
+++ b/C7/Map/CityLabelScene.cs
@@ -1,5 +1,5 @@
+using C7.Textures;
 using C7GameData;
-using ConvertCiv3Media;
 using Godot;
 
 namespace C7.Map {
@@ -69,7 +69,7 @@ namespace C7.Map {
 		public CityLabelScene(City city) {
 			this.city = city;
 
-			civColor = new Color(TextureLoader.LoadColor(city.owner.colorIndex), TRANSPARENCY);
+			civColor = new Color(TextureLoader.LoadColor(city.owner.GetPlayerColor()), TRANSPARENCY);
 
 			// Set up UI hierarchy
 			AddChild(labelPanel);

--- a/C7/Map/UnitLayer.cs
+++ b/C7/Map/UnitLayer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using C7.Textures;
 using C7GameData;
 using Godot;
 
@@ -123,7 +124,7 @@ public partial class UnitLayer : LooseLayer {
 
 		inst.SetPosition(framePosition);
 
-		Color civColor = TextureLoader.LoadColor(unit.owner.colorIndex);
+		Color civColor = TextureLoader.LoadColor(unit.owner.GetPlayerColor());
 		int nextFrame = inst.GetNextFrameByProgress(animName, appearance.progress);
 		inst.material.SetShaderParameter("tintColor", new Vector3(civColor.R, civColor.G, civColor.B));
 

--- a/C7/Textures/PlayerTextureUtil.cs
+++ b/C7/Textures/PlayerTextureUtil.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using C7Engine;
+using C7GameData;
+using System.Linq;
+using Godot;
+
+namespace C7.Textures;
+
+public static class PlayerTextureUtil {
+	private static Dictionary<int, ShaderMaterial> materialCache = [];
+	private static Dictionary<ID, int> colorsInUseCache = [];
+
+	public static int GetPlayerColor(this Player player) {
+		if (!colorsInUseCache.ContainsKey(player.id)) {
+			InitializeCivColors(EngineStorage.gameData);
+		}
+		return colorsInUseCache[player.id];
+	}
+
+	private static int LoadCivColor(Player player) {
+		if (colorsInUseCache.TryGetValue(player.id, out int colorIndex))
+			return colorIndex;
+
+		if (colorsInUseCache.ContainsValue(player.primaryColorIndex)) {
+			colorsInUseCache.Add(player.id, player.secondaryColorIndex);
+			return player.secondaryColorIndex;
+		}
+
+		colorsInUseCache.Add(player.id, player.primaryColorIndex);
+		return player.primaryColorIndex;
+	}
+
+	// This will only run the first time we ask for any civ's color, for all the civs
+	private static void InitializeCivColors(GameData gameData) {
+		// a first basic run to assign the colors
+		foreach (var player in gameData.players) {
+			LoadCivColor(player);
+		}
+
+		// a second run to avoid duplicate colors if possible
+		foreach (var player in gameData.players) {
+			if (colorsInUseCache.Values.Count(p => p == player.GetPlayerColor()) > 1) {
+				colorsInUseCache.Remove(player.id);
+				LoadCivColor(player);
+			}
+		}
+	}
+
+	public static ShaderMaterial GetShaderMaterialForUnit(int civIndex) {
+		if (materialCache.TryGetValue(civIndex, out ShaderMaterial material)) {
+			return material;
+		}
+		material = new();
+		material.Shader = GD.Load<Shader>("res://UnitTint.gdshader");
+		Color civColor = TextureLoader.LoadColor(civIndex);
+		material.SetShaderParameter("tintColor", new Vector3(civColor.R, civColor.G, civColor.B));
+		materialCache[civIndex] = material;
+		return material;
+	}
+
+	public static void ClearCache() {
+		materialCache.Clear();
+		colorsInUseCache.Clear();
+	}
+}

--- a/C7/Textures/PlayerTextureUtil.cs
+++ b/C7/Textures/PlayerTextureUtil.cs
@@ -7,16 +7,16 @@ using Godot;
 namespace C7.Textures;
 
 public static class PlayerTextureUtil {
-    // <colorIndex, shaderMaterial>
+	// <colorIndex, shaderMaterial>
 	private static Dictionary<int, ShaderMaterial> materialCache = [];
-    // <playerId, colorIndex>
+	// <playerId, colorIndex>
 	private static Dictionary<ID, int> colorsInUseCache = [];
 
-    /// <summary>
-    /// Returns the color index this player will use for the game, for their border, uniform, etc
-    /// </summary>
-    /// <param name="player"></param>
-    /// <returns>the color index number</returns>
+	/// <summary>
+	/// Returns the color index this player will use for the game, for their border, uniform, etc
+	/// </summary>
+	/// <param name="player"></param>
+	/// <returns>the color index number</returns>
 	public static int GetPlayerColor(this Player player) {
 		if (!colorsInUseCache.ContainsKey(player.id)) {
 			InitializeCivColors(EngineStorage.gameData);
@@ -24,22 +24,22 @@ public static class PlayerTextureUtil {
 		return colorsInUseCache[player.id];
 	}
 
-    // If the player's primary color is in use, fall back to their secondary color.
-    // This may already be in use, but that's ok; we don't have a third
-    // color for each civ to fall back to.
-    //
-    // If this runs for a second time from InitializeCivColors()
-    // we want to return if possible a color that is not already in use.
-    // Consider a game where the Netherlands and England are in play.
-    // Netherlands' color indexes are 2, 18
-    // England's color indexes    are 2, 2
-    // If the player is playing as England, we will pick 2 either way.
-    // Then, Netherlands will pick 18, because 2 is in use.
-    // But if the player is playing as the Netherlands, we will pick 2, because the player's civ is first on the list.
-    // Then, when England's turn comes, we try the primary 2, it's in use, so we pick the secondary 2.
-    // After all player are assigned at least one color, we check for duplicates in the colorsInUseCache values.
-    // Netherlands is the first player we check, we find that their color, 2, is a duplicate, 
-    // so we assign the secondary color 18 to the Netherlands, and England keep their 2.
+	// If the player's primary color is in use, fall back to their secondary color.
+	// This may already be in use, but that's ok; we don't have a third
+	// color for each civ to fall back to.
+	//
+	// If this runs for a second time from InitializeCivColors()
+	// we want to return if possible a color that is not already in use.
+	// Consider a game where the Netherlands and England are in play.
+	// Netherlands' color indexes are 2, 18
+	// England's color indexes    are 2, 2
+	// If the player is playing as England, we will pick 2 either way.
+	// Then, Netherlands will pick 18, because 2 is in use.
+	// But if the player is playing as the Netherlands, we will pick 2, because the player's civ is first on the list.
+	// Then, when England's turn comes, we try the primary 2, it's in use, so we pick the secondary 2.
+	// After all player are assigned at least one color, we check for duplicates in the colorsInUseCache values.
+	// Netherlands is the first player we check, we find that their color, 2, is a duplicate, 
+	// so we assign the secondary color 18 to the Netherlands, and England keep their 2.
 	private static int LoadCivColor(Player player) {
 		if (colorsInUseCache.TryGetValue(player.id, out int colorIndex))
 			return colorIndex;

--- a/C7/Textures/PlayerTextureUtil.cs
+++ b/C7/Textures/PlayerTextureUtil.cs
@@ -7,9 +7,16 @@ using Godot;
 namespace C7.Textures;
 
 public static class PlayerTextureUtil {
+    // <colorIndex, shaderMaterial>
 	private static Dictionary<int, ShaderMaterial> materialCache = [];
+    // <playerId, colorIndex>
 	private static Dictionary<ID, int> colorsInUseCache = [];
 
+    /// <summary>
+    /// Returns the color index this player will use for the game, for their border, uniform, etc
+    /// </summary>
+    /// <param name="player"></param>
+    /// <returns>the color index number</returns>
 	public static int GetPlayerColor(this Player player) {
 		if (!colorsInUseCache.ContainsKey(player.id)) {
 			InitializeCivColors(EngineStorage.gameData);
@@ -17,6 +24,22 @@ public static class PlayerTextureUtil {
 		return colorsInUseCache[player.id];
 	}
 
+    // If the player's primary color is in use, fall back to their secondary color.
+    // This may already be in use, but that's ok; we don't have a third
+    // color for each civ to fall back to.
+    //
+    // If this runs for a second time from InitializeCivColors()
+    // we want to return if possible a color that is not already in use.
+    // Consider a game where the Netherlands and England are in play.
+    // Netherlands' color indexes are 2, 18
+    // England's color indexes    are 2, 2
+    // If the player is playing as England, we will pick 2 either way.
+    // Then, Netherlands will pick 18, because 2 is in use.
+    // But if the player is playing as the Netherlands, we will pick 2, because the player's civ is first on the list.
+    // Then, when England's turn comes, we try the primary 2, it's in use, so we pick the secondary 2.
+    // After all player are assigned at least one color, we check for duplicates in the colorsInUseCache values.
+    // Netherlands is the first player we check, we find that their color, 2, is a duplicate, 
+    // so we assign the secondary color 18 to the Netherlands, and England keep their 2.
 	private static int LoadCivColor(Player player) {
 		if (colorsInUseCache.TryGetValue(player.id, out int colorIndex))
 			return colorIndex;

--- a/C7/Textures/TextureLoader.cs
+++ b/C7/Textures/TextureLoader.cs
@@ -75,7 +75,6 @@ public static class TextureLoader {
 	private static Dictionary<string, Pcx> PcxCache = [];
 	private static Dictionary<string, Image> PngCache = [];
 	private static Dictionary<string, Color> colorCache = [];
-	private static Dictionary<int, ShaderMaterial> materialCache = [];
 
 	private static Dictionary<string, ImageTexture> configKeyCache = [];
 	private static Dictionary<(string configKey, object obj), ImageTexture> objectMappingCache = [];
@@ -458,18 +457,6 @@ public static class TextureLoader {
 		return png;
 	}
 
-	public static ShaderMaterial GetShaderMaterialForUnit(int civIndex) {
-		if (materialCache.TryGetValue(civIndex, out ShaderMaterial material)) {
-			return material;
-		}
-		material = new();
-		material.Shader = GD.Load<Shader>("res://UnitTint.gdshader");
-		Color civColor = LoadColor(civIndex);
-		material.SetShaderParameter("tintColor", new Vector3(civColor.R, civColor.G, civColor.B));
-		materialCache[civIndex] = material;
-		return material;
-	}
-
 	public static void ClearCache() {
 		PcxCache.Clear();
 		PngCache.Clear();
@@ -478,6 +465,5 @@ public static class TextureLoader {
 		objectMappingCache.Clear();
 		animationCache.Clear();
 		colorCache.Clear();
-		materialCache.Clear();
 	}
 }

--- a/C7/UIElements/CityScreen/CityScreen.cs
+++ b/C7/UIElements/CityScreen/CityScreen.cs
@@ -4,6 +4,7 @@ using Serilog;
 using System.Collections.Generic;
 using C7GameData;
 using C7.Map;
+using C7.Textures;
 using C7Engine;
 using C7Engine.AI;
 
@@ -597,7 +598,7 @@ public partial class CityScreen : Control {
 
 		if (city.itemBeingProduced is UnitPrototype up) {
 			AnimationManager animationManager = mapView.game.animationController.civ3AnimData.forUnit(up, MapUnit.AnimatedAction.DEFAULT).animationManager;
-			ShaderMaterial material = TextureLoader.GetShaderMaterialForUnit(city.owner.colorIndex);
+			ShaderMaterial material = PlayerTextureUtil.GetShaderMaterialForUnit(city.owner.GetPlayerColor());
 			(ImageTexture baseImage, ImageTexture imageTint) = animationManager.GetAnimationFrameAndTintTextures(up);
 
 			// Add the base sprite.

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -1,3 +1,4 @@
+using C7.Textures;
 using Godot;
 using C7GameData;
 using Serilog;
@@ -282,7 +283,7 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 		ImageTexture baseFrame = AnimationManager.AnimationThumbnails[key];
 		ImageTexture tintFrame = AnimationManager.AnimationTintThumbnails[key];
 
-		ShaderMaterial material = TextureLoader.GetShaderMaterialForUnit(unit.owner.colorIndex);
+		ShaderMaterial material = PlayerTextureUtil.GetShaderMaterialForUnit(unit.owner.GetPlayerColor());
 
 		// Add the base sprite.
 		unitPlaceholder = new Sprite2D();

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using C7.Textures;
 using C7Engine;
 using ConvertCiv3Media;
 using Godot;
@@ -394,5 +395,6 @@ public partial class Util {
 		flicCache.Clear();
 		TextureLoader.ClearCache();
 		AnimationManager.ClearCache();
+		PlayerTextureUtil.ClearCache();
 	}
 }

--- a/C7Engine/C7GameData/Civilization.cs
+++ b/C7Engine/C7GameData/Civilization.cs
@@ -33,7 +33,8 @@ namespace C7GameData {
 		// `noun` is "Americans" for "America", or "Spanish" for "Spain", etc.
 		public string noun;
 		public string leader;
-		public int colorIndex;
+		public int primaryColorIndex;
+		public int secondaryColorIndex;
 		public Gender leaderGender;
 
 		// Like `art\advisors\LZ_all.pcx` for the English.

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -362,7 +362,8 @@ namespace C7GameData {
 					noun = race.Noun,
 					leader = race.LeaderName,
 					leaderGender = race.LeaderGender == 0 ? Gender.Male : Gender.Female,
-					colorIndex = race.DefaultColor,
+					primaryColorIndex = race.DefaultColor,
+					secondaryColorIndex = race.UniqueColor,
 					isBarbarian = i == 0 ? true : false,
 				};
 				foreach (RACE_City city in theBiq.RaceCityName[i]) {
@@ -447,6 +448,9 @@ namespace C7GameData {
 					player.human = true;
 					foundHuman = true;
 				}
+
+				// Team color in scenarios
+				player.primaryColorIndex = lead.Color;
 
 				++leadIndex;
 			}
@@ -773,7 +777,8 @@ namespace C7GameData {
 		private SavePlayer MakeSavePlayerFromCiv(Civilization civ, bool isBarbarian, bool isHuman, string era) {
 			return new SavePlayer {
 				id = ids.CreateID("player"),
-				colorIndex = civ.colorIndex,
+				primaryColorIndex = civ.primaryColorIndex,
+				secondaryColorIndex = civ.secondaryColorIndex,
 				human = isHuman,
 				civilization = civ.name,
 

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -44,7 +44,8 @@ namespace C7GameData {
 		private static ILogger log = Log.ForContext<Player>();
 
 		public ID id { get; internal set; }
-		public int colorIndex;
+		public int primaryColorIndex;
+		public int secondaryColorIndex;
 		public bool isBarbarians { get => civilization.isBarbarian; }
 		//TODO: Refactor front-end so it sends player GUID with requests.
 		//We should allow multiple humans, this is a temporary measure.

--- a/C7Engine/C7GameData/Save/SavePlayer.cs
+++ b/C7Engine/C7GameData/Save/SavePlayer.cs
@@ -5,7 +5,8 @@ namespace C7GameData.Save {
 
 	public class SavePlayer {
 		public ID id;
-		public int colorIndex;
+		public int primaryColorIndex;
+		public int secondaryColorIndex;
 		public bool human = false;
 		public bool hasPlayedCurrentTurn = false;
 		public bool defeated = false;
@@ -65,7 +66,8 @@ namespace C7GameData.Save {
 				isHuman = human,
 				hasPlayedThisTurn = hasPlayedCurrentTurn,
 				defeated = defeated,
-				colorIndex = colorIndex,
+				primaryColorIndex = primaryColorIndex,
+				secondaryColorIndex = secondaryColorIndex,
 				civilization = civilization is not null ? civilizations.Find(civ => civ.name == civilization) : null,
 				knownTechs = knownTechs,
 				eraCivilopediaName = eraCivilopediaName,
@@ -109,7 +111,8 @@ namespace C7GameData.Save {
 
 		public SavePlayer(Player player) {
 			id = player.id;
-			colorIndex = player.colorIndex;
+			primaryColorIndex = player.primaryColorIndex;
+			secondaryColorIndex = player.secondaryColorIndex;
 			human = player.isHuman;
 			hasPlayedCurrentTurn = player.hasPlayedThisTurn;
 			defeated = player.defeated;

--- a/C7Engine/GameSetup.cs
+++ b/C7Engine/GameSetup.cs
@@ -74,7 +74,8 @@ public class GameSetup {
 		SavePlayer player = new() {
 			human = isHuman,
 			id = ids.CreateID("Player"),
-			colorIndex = civ.colorIndex,
+			primaryColorIndex = civ.primaryColorIndex,
+			secondaryColorIndex = civ.secondaryColorIndex,
 			civilization = civ.name,
 			knownTechs = civ.startingTechs,
 			// TODO: stop hardcoding this

--- a/QueryCiv3/BiqSections/Lead.cs
+++ b/QueryCiv3/BiqSections/Lead.cs
@@ -40,7 +40,7 @@ namespace QueryCiv3.Biq {
 		public int StartCash; // $$$$$$$$$$$$$$$$$
 		public int Government;
 		public int Civ; // -3: any, -2: random
-		public int Color;
+		public int Color; // the team color
 		public int SkipFirstTurn;
 		private fixed byte UnknownBuffer2[4];
 		public byte StartEmbassies;


### PR DESCRIPTION
Implemented primary and secondary colors, with some functionality to try and avoid duplicates.

Also moved the shader caching, as well as the new color calculations to a new Util class as they are specific to the gameplay and not the pure loading of files/colors