### PR TITLE
Put a 5 minute timeout on CI test runs and improve some debugging aspects

### DIFF
--- a/.github/workflows/export-c7.yml
+++ b/.github/workflows/export-c7.yml
@@ -52,7 +52,15 @@ jobs:
         godot -v --headless --export${BUILD_SUFFIX} "Windows Desktop" ../build/${FOLDER_NAME}/${EXPORT_NAME}.exe
     - name: Run tests
       run: |
-        dotnet test C7
+        dotnet test C7 --blame-hang-dump-type full --blame-hang-timeout 5m --logger:"console;verbosity=detailed"
+    - name: Upload Hang Dump
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: hang-dump-${{ github.job }}-${{ github.run_id }}
+        path: |
+          EngineTests/TestResults/**/*.dmp
+          EngineTests/TestResults/**/*.xml
     - name: Verify formatting (`run dotnet format C7/C7.sln whitespace` to fix)
       run: |
         dotnet format C7/C7.sln whitespace --verify-no-changes
@@ -91,7 +99,15 @@ jobs:
         godot -v --headless --export${BUILD_SUFFIX} "Linux/X11" ../build/${FOLDER_NAME}/${EXPORT_NAME}.x86_64
     - name: Run tests
       run: |
-        dotnet test C7
+        dotnet test C7 --blame-hang-dump-type full --blame-hang-timeout 5m --logger:"console;verbosity=detailed"
+    - name: Upload Hang Dump
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: hang-dump-${{ github.job }}-${{ github.run_id }}
+        path: |
+          EngineTests/TestResults/**/*.dmp
+          EngineTests/TestResults/**/*.xml
     - name: Verify formatting (`run dotnet format C7/C7.sln whitespace` to fix)
       run: |
         dotnet format C7/C7.sln whitespace --verify-no-changes
@@ -133,7 +149,15 @@ jobs:
         godot -v --headless --export${BUILD_SUFFIX} "macOS" ../build/${FOLDER_NAME}.zip
     - name: Run tests
       run: |
-        dotnet test C7
+        dotnet test C7 --blame-hang-dump-type full --blame-hang-timeout 5m --logger:"console;verbosity=detailed"
+    - name: Upload Hang Dump
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: hang-dump-${{ github.job }}-${{ github.run_id }}
+        path: |
+          EngineTests/TestResults/**/*.dmp
+          EngineTests/TestResults/**/*.xml
     - name: Verify formatting (`run dotnet format C7/C7.sln whitespace` to fix)
       run: |
         dotnet format C7/C7.sln whitespace --verify-no-changes

--- a/EngineTests/EngineTests.csproj
+++ b/EngineTests/EngineTests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.8" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/EngineTests/GameData/SaveTest.cs
+++ b/EngineTests/GameData/SaveTest.cs
@@ -12,6 +12,7 @@ using C7GameData.Save;
 using Newtonsoft.Json.Linq;
 using QueryCiv3;
 using Xunit;
+using Serilog;
 
 namespace EngineTests.GameData;
 
@@ -169,7 +170,12 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 				switch (msg) {
 					case MsgStartTurn mST:
 						return;
+					case MsgWarDeclaration mWD:
+						continue;
+					case MsgShowTemporaryPopup mSTP:
+						continue;
 					default:
+						throw new Exception($"{msg}");
 						continue;
 				}
 			}
@@ -229,6 +235,11 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 	[InlineData(SaveType.basic, "basic")]
 	[InlineData(SaveType.standalone, "standalone")]
 	public void SimpleGame(SaveType saveType, string outputFilePostfix) {
+		Log.Logger = new LoggerConfiguration()
+			.WriteTo.Console(outputTemplate: "[{Level:u3}] {Timestamp:HH:mm:ss} {SourceContext}: {Message:lj} {NewLine}{Exception}")
+			.MinimumLevel.Information()
+			.CreateLogger();
+
 		SaveGame developerSave = GetSave(saveType);
 
 		new MsgSetAnimationsEnabled(false).send();


### PR DESCRIPTION
Getting the hang dumps and info logging would have been very helpful with the recent stuck tests.