### PR TITLE
Unit disband utilizing the Lua layer

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -810,15 +810,16 @@ public partial class Game : Node {
 
 		if (currentAction == C7Action.UnitDisband) {
 			if (CurrentlySelectedUnit == null || CurrentlySelectedUnit == MapUnit.NONE) {
+				log.Warning("Trying to disband null or NONE unit");
 				return;
 			}
 			popupOverlay.ShowPopup(
 				new ConfirmationPopup(
-					$"Disband {CurrentlySelectedUnit.name}? Pardon me but these are OUR people. Do \nyou really want to disband them?",
+					$"Disband {CurrentlySelectedUnit.name}? Pardon me but these are OUR people.\nDo you really want to disband them?",
 					"Yes, we need to!",
 					"No. Maybe you are right, advisor.",
 					() => {
-						new ActionToEngineMsg(() => CurrentlySelectedUnit?.disband()).send();
+						new ActionToEngineMsg(async () => await CurrentlySelectedUnit.Disband()).send();
 					}),
 				PopupOverlay.PopupCategory.Advisor);
 		}

--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -7188,7 +7188,8 @@
     "defaultDealDuration": 20,
     "treasuryInterestRate": 0.05,
     "maxInterest": 50,
-    "shieldCostPerGold": 4
+    "shieldCostPerGold": 4,
+    "shieldRateForDisbanding": 0.25
   },
   "techs": [
     {

--- a/C7/Lua/rules/civ3.lua
+++ b/C7/Lua/rules/civ3.lua
@@ -7,5 +7,6 @@ return {
   --]]
   terraforms = require "civ3.terraforms",
   terrain_improvements = require "civ3.terrain_improvements",
-  inflows = require "civ3.inflows"
+  inflows = require "civ3.inflows",
+  gameplay = require "civ3.gameplay",
 }

--- a/C7/Lua/rules/civ3/gameplay.lua
+++ b/C7/Lua/rules/civ3/gameplay.lua
@@ -1,0 +1,49 @@
+﻿-- A generic lua script for orchestrating behaviours during gameplay.
+-- The idea for this is to host script paths that are not serialized in the json,
+-- but rather "hardcoded" in the code
+
+local function game_data()
+  return GAME_DATA()
+end
+  
+local function rules()
+  return GAME_DATA().rules
+end
+  
+local gameplay = {}
+
+local function disband_reward(context)
+  local unit = context
+  local unit_shield_cost = unit.unitType.shieldCost;
+  
+  local has_city = unit.location.HasCity
+  local is_unit_on_own_city = unit.location.OwningPlayer() == unit.owner
+  
+  if has_city and is_unit_on_own_city then
+    local city = unit.location.owningCity;
+    local item_produced = city.itemBeingProduced
+    
+      if (item_produced:GetType().Name == "Building" and item_produced.IsGreatWonder() == true) then
+        return
+      end
+        
+      if (item_produced:GetType().Name == "Inflow") then
+        return
+      end
+
+    local reward = math. floor(unit_shield_cost * rules().ShieldRateForDisbanding)
+    game_data().SendMessageToUiFromLua("Our "..unit.name.." has been converted to "..reward.." shields.", unit.location)
+    city.SetStoredShields(reward, true)
+  end
+end
+  
+gameplay = {
+  units = {
+    -- Context = MapUnit mapUnit
+    disband = function(context)
+      disband_reward(context)
+    end,
+  },
+}
+
+return gameplay

--- a/C7/Util.cs
+++ b/C7/Util.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using C7.Textures;
 using C7Engine;
+using C7Engine.Lua;
 using ConvertCiv3Media;
 using Godot;
 using QueryCiv3;
@@ -396,5 +397,6 @@ public partial class Util {
 		TextureLoader.ClearCache();
 		AnimationManager.ClearCache();
 		PlayerTextureUtil.ClearCache();
+		RulesEngine.ClearCache();
 	}
 }

--- a/C7Engine/AI/UnitAI/SettlerAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerAI.cs
@@ -59,7 +59,7 @@ namespace C7Engine {
 						log.Information("Building city with " + unit);
 						//TODO: This should use a message, and the message handler should cause the disbanding to happen.
 						CityInteractions.BuildCity(unit.location, player, unit.owner.GetNextCityName());
-						unit.disband();
+						unit.RemoveFromPlay();
 					} else if (data.escort == null) {
 						log.Information($"Settler {unit.id} is waiting for an escort");
 						unit.movementPoints.onConsumeAll();
@@ -72,11 +72,11 @@ namespace C7Engine {
 					if (unit.location.cityAtTile != null) {
 						//TODO: Actually join the city.  Haven't added that action.
 						//For now, just get rid of the unit.  Sorry, bro.
-						unit.disband();
+						unit.RemoveFromPlay();
 					} else {
 						//TODO: Eventually, go to the city we're supposed to join
 						//For now, just disband
-						unit.disband();
+						unit.RemoveFromPlay();
 					}
 					break;
 			}

--- a/C7Engine/C7GameData/Building.cs
+++ b/C7Engine/C7GameData/Building.cs
@@ -104,6 +104,11 @@ namespace C7GameData {
 			LoadLuaFunctions(gameData);
 		}
 
+		[LuaMethod]
+		public bool IsGreatWonder() {
+			return this.greatWonderProperties != null;
+		}
+
 		public bool CanProduce(City city, HashSet<Resource> accessibleResources) {
 			if (!city.owner.HasRequiredTechnology(this)) {
 				return false;

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -49,7 +49,7 @@ namespace C7GameData {
 
 		//Temporary production code because production is fun.
 		public IProducible itemBeingProduced;
-		public int shieldsStored = 0;
+		public int shieldsStored { get; private set; } = 0;
 
 		public int foodStored = 0;
 
@@ -101,6 +101,20 @@ namespace C7GameData {
 
 		public bool IsCapital() {
 			return capital;
+		}
+
+		/// <summary>
+		/// Sets the current shield amount in the production box. If the add parameter is true, the shields get appended.<br/>
+		/// </summary>
+		/// <param name="shields">The number of shields to be added</param>
+		/// <param name="add">If true, the shields get appended, otherwise they overwrite the current value</param>
+		[LuaMethod]
+		public void SetStoredShields(int shields, bool add = false) {
+			// TODO: account for overflow if needed
+			if (add)
+				this.shieldsStored += shields;
+			else
+				this.shieldsStored = shields;
 		}
 
 		public List<CityBuilding> GetBuildings() {

--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using Serilog;
 using C7Engine.Lua;
 using C7Engine.Pathing;
+using System.Threading.Tasks;
+using C7Engine;
 
 namespace C7GameData {
 	public class GameData {
@@ -209,7 +211,7 @@ namespace C7GameData {
 			// units.
 			player.defeated = true;
 			for (int i = 0; i < player.units.Count; ++i) {
-				DisbandUnit(player.units[i]);
+				RemoveUnit(player.units[i]);
 			}
 
 			// Remove this civ from all other player's relationships.
@@ -220,7 +222,25 @@ namespace C7GameData {
 			return true;
 		}
 
-		public void DisbandUnit(MapUnit unit) {
+		[LuaMethod]
+		public void SendMessageToUiFromLua(string message, Tile location) {
+			log.Information($"[LUA API] - {message}");
+			new MsgShowTemporaryPopup(message, location).send();
+
+		}
+
+		public async Task DisbandUnit(MapUnit unit) {
+			log.Information($"Player {unit.owner} disbands unit: {unit}");
+
+			var disbandFunction = this.luaRulesEngine.ImportFunc<Action<MapUnit>>("gameplay.units.disband", true);
+			disbandFunction.Invoke(unit);
+
+			await unit.animateAsync(MapUnit.AnimatedAction.DEATH, AnimationEnding.Pause);
+
+			RemoveUnit(unit);
+		}
+
+		internal void RemoveUnit(MapUnit unit) {
 			// Set unit's hit points to zero to indicate that it's no longer alive. Ultimately we may not want to do this. I'm only doing it right
 			// now since this way all the UI needs to do to check if the selected unit has been destroyed is to check its hit points.
 			unit.hitPointsRemaining = 0;
@@ -235,12 +255,10 @@ namespace C7GameData {
 			unit.location.unitsOnTile.Remove(unit);
 			mapUnits.Remove(unit);
 
-			// TODO: why not just do Player p = unit.owner; p.units.Remove(unit);?
-			foreach (Player player in players) {
-				if (player.units.Contains(unit)) {
-					player.units.Remove(unit);
-				}
-			}
+			Player owner = unit.owner;
+			owner.units.Remove(unit);
+
+			log.Information($"Player {owner} removed unit: {unit}");
 		}
 
 		public int TechCostFor(Tech tech, Player player) {

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -1730,6 +1730,7 @@ namespace C7GameData {
 			save.Rules.MaxRankOfBarbarianCampTiles = 2;
 			save.Rules.DefaultDealDuration = 20;
 			save.Rules.ShieldCostPerGold = rule.ShieldsCostPerGold;
+			save.Rules.ShieldRateForDisbanding = 0.25f;
 		}
 
 		private static void SetWorldWrap(SavData civ3Save, SaveGame save) {

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -392,7 +392,7 @@ namespace C7GameData {
 				var (dead, alive) = (result == CombatResult.AttackerKilled) ? (attacker, defender) : (defender, attacker);
 				alive.RollToPromote(dead);
 				await dead.animateAsync(MapUnit.AnimatedAction.DEATH);
-				dead.disband();
+				dead.RemoveFromPlay();
 			}
 
 			if (result.DefenderWon())
@@ -427,7 +427,7 @@ namespace C7GameData {
 			if (target.hitPointsRemaining <= 0) {
 				RollToPromote(target);
 				await target.animateAsync(MapUnit.AnimatedAction.DEATH);
-				target.disband();
+				target.RemoveFromPlay();
 			}
 
 			facingDirection = unitOriginalOrientation;
@@ -482,7 +482,7 @@ namespace C7GameData {
 					// TODO: Add rules for how much gold is taken.
 					int goldTaken = tile.cityAtTile.owner.gold / 4;
 					tile.cityAtTile.owner.gold -= goldTaken;
-					disband();
+					this.RemoveFromPlay();
 					if (tile.cityAtTile.owner.isHuman) {
 						new MsgShowMilitaryAdvisorPopup($"Barbarians have stolen {goldTaken} gold from our cities!\nWe need a stronger military.", happy: false).send();
 					}
@@ -734,8 +734,12 @@ namespace C7GameData {
 			movementPoints.skipTurn();
 		}
 
-		public void disband() {
-			EngineStorage.gameData.DisbandUnit(this);
+		public async Task Disband() {
+			await EngineStorage.gameData.DisbandUnit(this);
+		}
+
+		public void RemoveFromPlay() {
+			EngineStorage.gameData.RemoveUnit(this);
 		}
 
 		public bool canBuildCity() {
@@ -759,10 +763,7 @@ namespace C7GameData {
 			// TODO: Need to check somewhere that this unit is allowed to build a city on its current tile. Either do that here or in every caller
 			// (probably best to just do it here).
 			City city = CityInteractions.BuildCity(location, owner, cityName);
-
-			// TODO: Should directly delete the unit instead of disbanding it. Disbanding in a city will eventually award shields, which we
-			// obviously don't want to do here.
-			disband();
+			this.RemoveFromPlay();
 
 			return city;
 		}

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -102,10 +102,25 @@ namespace C7GameData {
 			get => _gold;
 			set {
 				if (value < 0) {
+					// TODO: the exception is ok for development, but perhaps a warning log
+					// and a Math Max function (0, value) is more appropriate at some point
 					throw new Exception($"bad gold value of {value} for {this}");
 				}
 				_gold = value;
 			}
+		}
+
+		/// <summary>
+		/// Sets the current gold amount of the player. If the add parameter is true, the gold gets appended.<br/>
+		/// </summary>
+		/// <param name="amount">The number of gold to be added</param>
+		/// <param name="add">If true, the gold gets appended, otherwise it overwrites the current value</param>
+		[LuaMethod]
+		public void SetGold(int amount, bool add = false) {
+			if (add)
+				this.gold += amount;
+			else
+				this.gold = amount;
 		}
 
 		// The number of "beakers" (gold) spent on the currently researched
@@ -710,9 +725,9 @@ namespace C7GameData {
 				var (_, _, unitSupportCost) = TotalUnitsAllowedUnitsAndSupportCost();
 				if (unitSupportCost > 0) {
 					for (int i = 0; i < unitSupportCost / government.unitCost; ++i) {
-						MapUnit unitToDisband = units[GameData.rng.Next(units.Count)];
-						log.Information($"{this} is out of gold, disbanding {unitToDisband} at {unitToDisband.location} to being unit support costs under control");
-						gameData.DisbandUnit(unitToDisband);
+						MapUnit unitToRemove = units[GameData.rng.Next(units.Count)];
+						log.Information($"{this} is out of gold, disbanding {unitToRemove} at {unitToRemove.location} to being unit support costs under control");
+						gameData.RemoveUnit(unitToRemove);
 					}
 					continue;
 				}

--- a/C7Engine/C7GameData/Rules.cs
+++ b/C7Engine/C7GameData/Rules.cs
@@ -21,5 +21,6 @@ namespace C7GameData {
 		public float TreasuryInterestRate = .05f;
 		public int MaxInterest = 50;
 		public int ShieldCostPerGold;
+		public float ShieldRateForDisbanding; // per cent
 	}
 }

--- a/C7Engine/C7GameData/Save/SaveCity.cs
+++ b/C7Engine/C7GameData/Save/SaveCity.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace C7GameData.Save {
@@ -102,12 +101,13 @@ namespace C7GameData.Save {
 					ProducibleType.UNIT => unitPrototypes.Find(proto => proto.name == producible),
 					ProducibleType.BUILDING => buildings.Find(building => building.name == producible),
 				},
-				shieldsStored = shieldsStored,
 				foodStored = foodStored,
 				turnsOfUnhappinessDueToPopRushing = turnsOfUnhappinessDueToPopRushing,
 				capital = capital,
 				constructed_buildings = this.buildings.ConvertAll(building => building.ToCityBuilding(buildings, players)),
 			};
+
+			city.SetStoredShields(shieldsStored);
 
 			foreach (KeyValuePair<string, int> keyValuePair in perPlayerCulture) {
 				city.perPlayerCulture.Add(players.Find(x => x.id.ToString() == keyValuePair.Key), keyValuePair.Value);

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -508,8 +508,8 @@ namespace C7GameData {
 
 				City c = other.cityAtTile;
 				int shieldsAwarded = EngineStorage.gameData.rules.ForestValueInShields;
-				c.shieldsStored += shieldsAwarded;
-				c.shieldsStored = Math.Min(c.shieldsStored, c.owner.ShieldCost(c.itemBeingProduced));
+				c.SetStoredShields(shieldsAwarded, true);
+				c.SetStoredShields(Math.Min(c.shieldsStored, c.owner.ShieldCost(c.itemBeingProduced)));
 
 				if (c.owner.isHuman) {
 					new MsgShowTemporaryPopup($"{shieldsAwarded} shields awarded for clearing forests", other).send();
@@ -731,7 +731,7 @@ namespace C7GameData {
 					// Ensure we only destroy units of the losing side of the
 					// combat, not the unit entering the city.
 					if (destroyedUnit.owner == owner) {
-						destroyedUnit.disband();
+						destroyedUnit.RemoveFromPlay();
 					}
 				}
 			}

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+using System.Threading.Tasks;
 using Serilog;
 
 namespace C7Engine {
@@ -84,9 +84,15 @@ namespace C7Engine {
 	// Actions that require more than a 1 or 2 line lambda should probably use
 	// a custom subclass.
 	public class ActionToEngineMsg : MessageToEngine {
-		private Action action;
-		public ActionToEngineMsg(Action action) {
+		private Func<Task> action;
+		public ActionToEngineMsg(Func<Task> action) {
 			this.action = action;
+		}
+		public ActionToEngineMsg(Action action) {
+			this.action = () => {
+				action();
+				return Task.CompletedTask;
+			};
 		}
 
 		public override void process() {

--- a/C7Engine/Lua/RulesEngine.cs
+++ b/C7Engine/Lua/RulesEngine.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
 using MoonSharp.Interpreter;
@@ -29,6 +30,8 @@ public class RulesEngine {
 	static ILogger log = Log.ForContext<RulesEngine>();
 	Script script = new();
 	Table rules;
+
+	private static Dictionary<string, Delegate> funcCache = new Dictionary<string, Delegate>();
 
 	static RulesEngine() {
 		RegisterTypes();
@@ -65,7 +68,14 @@ public class RulesEngine {
 	/// The path to the function should be a dot-separated string
 	/// representing the path through the rules table
 	/// (e.g. "building.production_rules.must_be_coastal")
-	public T ImportFunc<T>(string functionPath) where T : Delegate {
+	/// 
+	///  If specified, the method will return the cached Delegate
+	/// associated with the functionPath string.
+	public T ImportFunc<T>(string functionPath, bool cache = false) where T : Delegate {
+		if (cache && funcCache.TryGetValue(functionPath, out Delegate func)) {
+			return (T)(object)func;
+		}
+
 		if (script == null || rules == null)
 			throw new InvalidOperationException("Engine is not initialized");
 		if (functionPath == null)
@@ -73,6 +83,10 @@ public class RulesEngine {
 
 		Closure closure = ResolveFunctionPath(functionPath);
 		Delegate del = DelegateConverter.CreateDelegate(script, closure, typeof(T));
+
+		if (cache)
+			funcCache[functionPath] = del;
+
 		return (T)(object)del;
 	}
 
@@ -136,5 +150,9 @@ public class RulesEngine {
 
 	void RegisterGlobals() {
 		script.Globals["GAME_DATA"] = () => DynValue.FromObject(script, EngineStorage.gameData);
+	}
+
+	public static void ClearCache() {
+		funcCache.Clear();
 	}
 }

--- a/C7Engine/LuaMethodAttribute.cs
+++ b/C7Engine/LuaMethodAttribute.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace C7Engine;
+
+/// <summary>
+/// An attribute to mark methods that are exposed and used (or are intended to be used) in the Lua layer.<br/>
+/// This is intended to be primarily a visual aid, especially for methods that seem unused by the native c# code.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public class LuaMethodAttribute : Attribute { }

--- a/EngineTests/GameData/CityTest.cs
+++ b/EngineTests/GameData/CityTest.cs
@@ -19,7 +19,7 @@ public class CityTest {
 
 		City city = new City(Tile.NONE, player, "Fighter Town, USA", ID.None("city"));
 		city.itemBeingProduced = warrior;
-		city.shieldsStored = 9;
+		city.SetStoredShields(9);
 
 		TerrainType oneShield = new TerrainType();
 		oneShield.baseShieldProduction = 1;


### PR DESCRIPTION
In short these are the highlights for this PR

1. Implemented the disband mechanic, and separated from unit removal without reward.
2. LuaMethod annotation
3. Wrote c# methods to specifically be utilized by the Lua layer
4. Added option to cache delegates instead of having to parse them each time we call a lua function

This PR introduces more than the disband mechanic itself. Its implementation is straight forward, but its rewards calculations are done completely on the Lua layer.
I chose not to add the function call for the reward to the json because it's gameplay specific and used only in one specific place, and instead added a hook for a custom implementation. Let me know your thoughts on that.

After some thinking and experimentation, especially after implementing the Inflow calculation, I added a few methods that would make the Lua behaviour more customizable in general. Now, it's left to the modder to decide if they want to give back shields, or for example gold, or both, in any scenario. I think this is the way to move forward, expose more of these methods like, AddTech, or AddBuilding, etc, so we hardcode as little as possible to the c#.
You will see above these methods that I have added a new Attribute `LuaMethod`, which as I explain is there (for now) purely as visual aid. I didn't go and add this in the other methods I know are used by lua already, as I would like your thoughts on this first.

Another thing is the `ActionToEngineMsg`, I wanted to have the disband action as an async method, because it contains an animation. 
I had some problems with the current structure of  `ActionToEngineMsg` and Rider suggested to add another cunstructor, and it snowballed from there. This is the only thing I am not sure what it does 100% and if it has any side effects, but I playtested a bunch, and didn't see anything weird.

The other thing is, I added an option to cache the delgate connected to the lua function path, so that we don't have to parse the lua script everytime. I googled a bunch for this as well, aside from playtesting, if it had any unwanted effects, and the conclusion seems to be that's it's fine.

The whole implementation was triggered because I saw a TODO a few lines below `TechCostFor` in the `GameData` class which says

> TODO: See this this whole equation can be configurable

I was about to add a bunch of rules to make the disband reward mechanic friendlier than it would have been if it a straight up c# implementation, but I think I came up with a better plan.

Last side note, I think we need to clean up some classes, have some java like setters/getters, private variables, and reusable constructors, both for clarity and safety but also so that Lua can safely call them.

Again, let me know your thoughts, or if you have any questions.

PS I am working my way through what I actually started off to do initially, which is the capture mechanism of units, but I don't want to end up submitting a 50 file PR with all the surrounding changes I have come across along the way.

