### PR TITLE
Add river delta textures

### DIFF
--- a/C7/Lua/texture_configs/civ3/terrain.lua
+++ b/C7/Lua/texture_configs/civ3/terrain.lua
@@ -86,6 +86,8 @@ terrain.marsh = {
 
 terrain.river = TERRAIN .. "mtnRivers.pcx"
 
+terrain.river_delta = TERRAIN .. "deltaRivers.pcx"
+
 terrain.tnt = TERRAIN .. "tnt.pcx"
 
 terrain.jungle = {

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -362,43 +362,80 @@ public partial class RiverLayer : LooseLayer {
 	public static readonly Vector2 riverSize = new Vector2(128, 64);
 	public static readonly Vector2 riverCenterOffset = new Vector2(riverSize.X / 2, 0);
 	private ImageTexture riverTexture;
+	private ImageTexture riverDeltaTexture;
 
 	public RiverLayer() {
+		// Both textures are 4x4 grids of equal dimensions
+		// The delta texture has four proper deltas textures and 12 other river segments
 		riverTexture = TextureLoader.Load("terrain.river");
+		riverDeltaTexture = TextureLoader.Load("terrain.river_delta");
 	}
 
 	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
-		//The "point" is the easternmost point of the tile for which we are drawing rivers.
-		//Which river graphics to used is calculated by evaluating the tiles that neighbor
-		//that point.
+		// The point where four terrain tiles meet and where we want to center our river texture.
+		// It is the easternmost point of the current tile.
+		Vector2 thePoint = tileCenter + riverCenterOffset;
+
+		// We draw the texture centered on the point by starting the draw from half of its width away  
+		Vector2 drawOffset = -0.5f * riverSize;
+
+		// The right river texture is calculated by evaluating the tiles around the point
 		Tile northOfPoint = tile.neighbors[TileDirection.NORTHEAST];
 		Tile eastOfPoint = tile.neighbors[TileDirection.EAST];
-		Tile westOfPoint = tile;
 		Tile southOfPoint = tile.neighbors[TileDirection.SOUTHEAST];
+		Tile westOfPoint = tile;
 
-		int riverGraphicsIndex = 0;
-
-		if (northOfPoint.riverSouthwest) {
-			riverGraphicsIndex++;
-		}
-		if (eastOfPoint.riverNorthwest) {
-			riverGraphicsIndex += 2;
-		}
-		if (westOfPoint.riverSoutheast) {
-			riverGraphicsIndex += 4;
-		}
-		if (southOfPoint.riverNortheast) {
-			riverGraphicsIndex += 8;
-		}
-		if (riverGraphicsIndex == 0) {
+		var (row, col, idx) = DeriveTextureIndex(northOfPoint, eastOfPoint, southOfPoint, westOfPoint);
+		if (row < 0 || col < 0)
 			return;
-		}
-		int riverRow = riverGraphicsIndex / 4;
-		int riverColumn = riverGraphicsIndex % 4;
 
-		Rect2 riverRectangle = new Rect2(riverColumn * riverSize.X, riverRow * riverSize.Y, riverSize);
-		Rect2 screenTarget = new Rect2(tileCenter - (float)0.5 * riverSize + riverCenterOffset, riverSize);
-		looseView.DrawTextureRectRegion(riverTexture, screenTarget, riverRectangle);
+		Rect2 riverRectangle = new Rect2(col * riverSize.X, row * riverSize.Y, riverSize);
+		Rect2 screenTarget = new Rect2(thePoint + drawOffset, riverSize);
+
+		// Draw a special river delta texture in certain situations, otherwise draw from the regular river texture.
+		// Note that delta detection can be a forgiving heuristic, as the delta texture also features river elements.
+		if (IsDelta(idx, northOfPoint, eastOfPoint, southOfPoint, westOfPoint))
+			looseView.DrawTextureRectRegion(riverDeltaTexture, screenTarget, riverRectangle);
+		else
+			looseView.DrawTextureRectRegion(riverTexture, screenTarget, riverRectangle);
+	}
+
+	private static (int, int, int) DeriveTextureIndex(Tile north, Tile east, Tile south, Tile west) {
+		var textureIndex = 0;
+
+		if (north.riverSouthwest) {
+			textureIndex++;
+		}
+		if (east.riverNorthwest) {
+			textureIndex += 2;
+		}
+		if (west.riverSoutheast) {
+			textureIndex += 4;
+		}
+		if (south.riverNortheast) {
+			textureIndex += 8;
+		}
+
+		if (textureIndex == 0)
+			return (-1, -1, -1);
+
+		// We will index into a 4x4 texture matrix
+		return (textureIndex / 4, textureIndex % 4, textureIndex);
+	}
+
+	private bool IsDelta(int textureIndex, Tile north, Tile east, Tile south, Tile west) {
+		// The placement calculation is the same for both river tiles and delta tiles.
+		// We simply draw from a different texture if we are on the coast.
+
+		// The delta texture is set up such that the deltas only appear specific indexes.
+		if (textureIndex is not (1 or 2 or 4 or 8))
+			return false;
+
+		// We could get fancy with our delta heuristic, but this simple thing works quite well.
+		if (north.IsWater() || east.IsWater() || south.IsWater() || west.IsWater())
+			return true;
+
+		return false;
 	}
 }
 

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -396,20 +396,17 @@ public partial class RiverLayer : LooseLayer {
 		// Draw a river texture from one of the textures, depending on terrain.
 		// The placement calculation is the same for both river textures.
 
-		if (idx is 1 or 2 or 4 or 8)
-		{
+		if (idx is 1 or 2 or 4 or 8) {
 			// Narrow set has deltas at these indexes
 			if (HasWater(northOfPoint, eastOfPoint, southOfPoint, westOfPoint))
 				looseView.DrawTextureRectRegion(narrowTexture, screenTarget, riverRectangle);
 			else
 				looseView.DrawTextureRectRegion(broadTexture, screenTarget, riverRectangle);
-		}
-		else
-		{
+		} else {
 			// TODO: When to draw from the broad texture? Is it semi-random? Is it based on elevation?
 
 			// Default: narrow rivers, less meandering
-			looseView.DrawTextureRectRegion(narrowTexture, screenTarget, riverRectangle);	
+			looseView.DrawTextureRectRegion(narrowTexture, screenTarget, riverRectangle);
 		}
 	}
 

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -361,14 +361,15 @@ public partial class MarshLayer : LooseLayer {
 public partial class RiverLayer : LooseLayer {
 	public static readonly Vector2 riverSize = new Vector2(128, 64);
 	public static readonly Vector2 riverCenterOffset = new Vector2(riverSize.X / 2, 0);
-	private ImageTexture riverTexture;
-	private ImageTexture riverDeltaTexture;
+	private ImageTexture narrowTexture;
+	private ImageTexture broadTexture;
 
 	public RiverLayer() {
 		// Both textures are 4x4 grids of equal dimensions
-		// The delta texture has four proper deltas textures and 12 other river segments
-		riverTexture = TextureLoader.Load("terrain.river");
-		riverDeltaTexture = TextureLoader.Load("terrain.river_delta");
+		// The narrow texture has four river deltas and 12 narrow river segments
+		// The broad texture has 16 broad river segments with more meandering
+		narrowTexture = TextureLoader.Load("terrain.river_delta");
+		broadTexture = TextureLoader.Load("terrain.river");
 	}
 
 	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
@@ -386,35 +387,51 @@ public partial class RiverLayer : LooseLayer {
 		Tile westOfPoint = tile;
 
 		var (row, col, idx) = DeriveTextureIndex(northOfPoint, eastOfPoint, southOfPoint, westOfPoint);
-		if (row < 0 || col < 0)
+		if (row < 0 || col < 0 || idx < 0)
 			return;
 
 		Rect2 riverRectangle = new Rect2(col * riverSize.X, row * riverSize.Y, riverSize);
 		Rect2 screenTarget = new Rect2(thePoint + drawOffset, riverSize);
 
-		// Draw a special river delta texture in certain situations, otherwise draw from the regular river texture.
-		// Note that delta detection can be a forgiving heuristic, as the delta texture also features river elements.
-		if (IsDelta(idx, northOfPoint, eastOfPoint, southOfPoint, westOfPoint))
-			looseView.DrawTextureRectRegion(riverDeltaTexture, screenTarget, riverRectangle);
+		// Draw a river texture from one of the textures, depending on terrain.
+		// The placement calculation is the same for both river textures.
+
+		if (idx is 1 or 2 or 4 or 8)
+		{
+			// Narrow set has deltas at these indexes
+			if (HasWater(northOfPoint, eastOfPoint, southOfPoint, westOfPoint))
+				looseView.DrawTextureRectRegion(narrowTexture, screenTarget, riverRectangle);
+			else
+				looseView.DrawTextureRectRegion(broadTexture, screenTarget, riverRectangle);
+		}
 		else
-			looseView.DrawTextureRectRegion(riverTexture, screenTarget, riverRectangle);
+		{
+			// TODO: When to draw from the broad texture? Is it semi-random? Is it based on elevation?
+
+			// Default: narrow rivers, less meandering
+			looseView.DrawTextureRectRegion(narrowTexture, screenTarget, riverRectangle);	
+		}
 	}
 
 	private static (int, int, int) DeriveTextureIndex(Tile north, Tile east, Tile south, Tile west) {
 		var textureIndex = 0;
 
-		if (north.riverSouthwest) {
-			textureIndex++;
+		if (north.riverSouthwest || west.riverNortheast) {
+			textureIndex += 1;
 		}
-		if (east.riverNorthwest) {
+		if (east.riverNorthwest || north.riverSoutheast) {
 			textureIndex += 2;
 		}
-		if (west.riverSoutheast) {
+		if (west.riverSoutheast || south.riverNorthwest) {
 			textureIndex += 4;
 		}
-		if (south.riverNortheast) {
+		if (south.riverNortheast || east.riverSouthwest) {
 			textureIndex += 8;
 		}
+
+		// Passes "The Point" only: an oasis
+		if (textureIndex == 0 && (north.riverSouth || east.riverWest || west.riverEast || south.riverNorth))
+			return (0, 0, 0);
 
 		if (textureIndex == 0)
 			return (-1, -1, -1);
@@ -423,19 +440,8 @@ public partial class RiverLayer : LooseLayer {
 		return (textureIndex / 4, textureIndex % 4, textureIndex);
 	}
 
-	private bool IsDelta(int textureIndex, Tile north, Tile east, Tile south, Tile west) {
-		// The placement calculation is the same for both river tiles and delta tiles.
-		// We simply draw from a different texture if we are on the coast.
-
-		// The delta texture is set up such that the deltas only appear specific indexes.
-		if (textureIndex is not (1 or 2 or 4 or 8))
-			return false;
-
-		// We could get fancy with our delta heuristic, but this simple thing works quite well.
-		if (north.IsWater() || east.IsWater() || south.IsWater() || west.IsWater())
-			return true;
-
-		return false;
+	private bool HasWater(Tile north, Tile east, Tile south, Tile west) {
+		return north.IsWater() || east.IsWater() || south.IsWater() || west.IsWater();
 	}
 }
 


### PR DESCRIPTION
Fixes #107, missing river delta textures. See also Draft PR #433 about a tile map variant, linked to #407.

There are two river textures in the Civ3 Art assets, a regular set and one for river deltas, to be drawn when the river meets the sea. The delta textures are not currently being loaded in.

This patch adds the textures, and applies according to a simple heuristic. Given the close relationship between the two tile sets and how they are deployed, the implementation reduces to a simple check to see whether the tile drawing is happening next to water tiles or not.

[Sample save file](https://github.com/user-attachments/files/25402664/107_river_deltas.json)

Given how closely related to the regular river tiles the delta tiles are, regardless of how the tile map effort proceeds, #433 can probably be closed off.

--

<img width="1804" height="629" alt="river_delta_trio" src="https://github.com/user-attachments/assets/76713881-fbce-4737-983c-74b82459c431" />
<img width="1155" height="776" alt="riverdelta_old" src="https://github.com/user-attachments/assets/512fd08a-3780-41c6-8cb6-7e3e0eb7b5a0" />
<img width="1152" height="768" alt="riverdelta_new" src="https://github.com/user-attachments/assets/308d1bbe-7271-40dc-b4d8-78a27b6ef0fb" />
<img width="1918" height="998" alt="riverdelta_original" src="https://github.com/user-attachments/assets/fed02df1-32e9-4626-80fd-8404dd55d777" />

Note the non-delta river segments in the delta texture:
<img width="500" height="522" alt="tilemap_riverdelta" src="https://github.com/user-attachments/assets/ca17487c-f10b-4761-b182-63172cc7f070" />

