### PR TITLE
Fix/unit movement

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -949,7 +949,7 @@ public partial class Game : Node {
 
 					// If we couldn't enter this tile without a war declaration,
 					// record which civ we need to declare war on.
-					if (!unit.CanEnterTile(tile, TileProbe.CombatProbe())) {
+					if (!unit.CanEnterTile(tile, TileProbe.MoveAggroProbe())) {
 						if (tile.cityAtTile != null) {
 							result.requiresWarDeclarationOnPlayer = tile.cityAtTile.owner;
 						} else {

--- a/C7/Map/GotoLayer.cs
+++ b/C7/Map/GotoLayer.cs
@@ -85,7 +85,7 @@ public partial class GotoLayer : LooseLayer {
 			DrawStaticGoToCursor(looseView, tileCenter, 0, true);
 		}
 
-		if (gotoInfo.path != null && unit.CanEnterTile(gotoInfo.destinationTile, TileProbe.GotoProbe())) {
+		if (gotoInfo.path != null && unit.CanEnterTile(gotoInfo.destinationTile, TileProbe.DeclareWarProbe())) {
 			List<Tile> tiles = new List<Tile>();
 			tiles.Add(unitOriginTile);
 			tiles.AddRange(gotoInfo.path.path);

--- a/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
+++ b/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
@@ -30,7 +30,7 @@ namespace C7Engine.Pathing {
 					// to allow pathing to attack. We don't want to try and path
 					// through opponents on the way to our destination though,
 					// as we can get stuck.
-					var probe = neighbor == destination ? TileProbe.PathCombatProbe() : TileProbe.PathProbe();
+					var probe = neighbor == destination ? TileProbe.MoveAggroProbe() : TileProbe.MoveNonAggroProbe();
 					return unit.CanEnterTile(neighbor, probe);
 				}
 			);

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -239,7 +239,7 @@ namespace C7Engine {
 			}
 
 			List<Tile> reachableBarbCampsTiles = player.tileKnowledge.AllKnownTiles()
-				.Where(t => unit.CanEnterTile(t, TileProbe.AiCombatProbe()) && t.hasBarbarianCamp).ToList();
+				.Where(t => unit.CanEnterTile(t, TileProbe.MoveAggroProbe()) && t.hasBarbarianCamp).ToList();
 
 			Tile closestBarbCamp = Tile.NONE;
 			int closestBarbDistance = int.MaxValue;

--- a/C7Engine/AI/UnitAI/CombatAI.cs
+++ b/C7Engine/AI/UnitAI/CombatAI.cs
@@ -81,7 +81,7 @@ namespace C7Engine.AI.UnitAI {
 			}
 
 			// Move along the path, initiating combat if we reach our target.
-			return this.TryToMoveAlongPath(unit, ref data.path, TileProbe.AiCombatProbe());
+			return this.TryToMoveAlongPath(unit, ref data.path, TileProbe.MoveAggroProbe());
 		}
 
 		public string SummarizePlan() {

--- a/C7Engine/AI/UnitAI/DefenderAI.cs
+++ b/C7Engine/AI/UnitAI/DefenderAI.cs
@@ -53,7 +53,7 @@ namespace C7Engine.AI.UnitAI {
 				return C7GameData.UnitAI.Result.Done;
 			} else {
 				log.Debug("Moving defender towards " + data.destination);
-				return this.TryToMoveAlongPath(unit, ref data.pathToDestination, TileProbe.AiMoveProbe());
+				return this.TryToMoveAlongPath(unit, ref data.pathToDestination, TileProbe.MoveNonAggroProbe());
 			}
 		}
 

--- a/C7Engine/AI/UnitAI/EscortAI.cs
+++ b/C7Engine/AI/UnitAI/EscortAI.cs
@@ -80,7 +80,7 @@ namespace C7Engine {
 
 			// Move to the unit we're escorting.
 			TilePath path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, data.unitToEscort.location, unit);
-			result = this.TryToMoveAlongPath(unit, ref path, TileProbe.AiMoveProbe());
+			result = this.TryToMoveAlongPath(unit, ref path, TileProbe.MoveNonAggroProbe());
 			if (result != UnitAI.Result.InProgress) {
 				return result;
 			}

--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -51,7 +51,7 @@ namespace C7Engine {
 				return UnitAI.Result.Done;
 			}
 
-			return this.TryToMoveAlongPath(unit, ref data.pathToDestination, TileProbe.AiMoveProbe());
+			return this.TryToMoveAlongPath(unit, ref data.pathToDestination, TileProbe.MoveNonAggroProbe());
 		}
 
 		public string SummarizePlan() {

--- a/C7Engine/AI/UnitAI/SettlerAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerAI.cs
@@ -65,7 +65,7 @@ namespace C7Engine {
 						unit.movementPoints.onConsumeAll();
 						return C7GameData.UnitAI.Result.InProgress;
 					} else {
-						return this.TryToMoveAlongPath(unit, ref data.pathToDestination, TileProbe.AiMoveProbe());
+						return this.TryToMoveAlongPath(unit, ref data.pathToDestination, TileProbe.MoveNonAggroProbe());
 					}
 					break;
 				case SettlerAIData.SettlerGoal.JOIN_CITY:

--- a/C7Engine/AI/UnitAI/WorkerAI.cs
+++ b/C7Engine/AI/UnitAI/WorkerAI.cs
@@ -79,7 +79,7 @@ namespace C7Engine {
 				return PerformWorkerMove(unit, improvement);
 			}
 
-			return this.TryToMoveAlongPath(unit, ref data.pathToDestination, TileProbe.AiMoveProbe());
+			return this.TryToMoveAlongPath(unit, ref data.pathToDestination, TileProbe.MoveNonAggroProbe());
 		}
 
 		private static Terraform? GetTileImprovement(Tile t, MapUnit unit) {

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -363,7 +363,7 @@ namespace C7GameData {
 						// TODO: Defender retreat behavior requires some more work. There's an issue for it here:
 						// https://github.com/C7-Game/Prototype/issues/274
 						Tile retreatDestination = defender.location.neighbors[attacker.facingDirection];
-						if ((retreatDestination != Tile.NONE) && defender.CanEnterTile(retreatDestination, TileProbe.PathProbe())) {
+						if ((retreatDestination != Tile.NONE) && defender.CanEnterTile(retreatDestination, TileProbe.MoveNonAggroProbe())) {
 							await defender.move(attacker.facingDirection, true);
 							result = CombatResult.DefenderRetreated;
 							break;
@@ -603,7 +603,7 @@ namespace C7GameData {
 		public async Task<bool> move(TileDirection dir, bool wait = false) {
 			(int dx, int dy) = dir.toCoordDiff();
 			Tile newLoc = EngineStorage.gameData.map.tileAt(dx + location.XCoordinate, dy + location.YCoordinate);
-			if ((newLoc != Tile.NONE) && CanEnterTile(newLoc, TileProbe.MoveProbe()) && (movementPoints.canMove)) {
+			if ((newLoc != Tile.NONE) && CanEnterTile(newLoc, TileProbe.MoveAggroWithNoticeProbe()) && (movementPoints.canMove)) {
 				facingDirection = dir;
 				wake();
 
@@ -898,36 +898,20 @@ namespace C7GameData {
 		public bool AllowWarDeclaration { get; init; }
 		public bool RaiseNotice { get; init; }
 
-		public static TileProbe AiMoveProbe() {
-			return new TileProbe() { AllowCombat = false, AllowWarDeclaration = false, RaiseNotice = false };
+		public static TileProbe MoveNonAggroProbe() {
+			return new TileProbe();
 		}
 
-		public static TileProbe AiCombatProbe() {
-			return new TileProbe() { AllowCombat = true, AllowWarDeclaration = false, RaiseNotice = false };
+		public static TileProbe MoveAggroProbe() {
+			return new TileProbe() { AllowCombat = true };
 		}
 
-		public static TileProbe PathProbe() {
-			return new TileProbe() { AllowCombat = false, RaiseNotice = false };
-		}
-
-		public static TileProbe PathCombatProbe() {
-			return new TileProbe() { AllowCombat = true, RaiseNotice = false };
-		}
-
-		public static TileProbe MoveProbe() {
+		public static TileProbe MoveAggroWithNoticeProbe() {
 			return new TileProbe() { AllowCombat = true, RaiseNotice = true };
 		}
 
-		public static TileProbe CombatProbe() {
-			return new TileProbe() { AllowCombat = true, AllowWarDeclaration = false, RaiseNotice = false };
-		}
-
-		public static TileProbe GotoProbe() {
-			return new TileProbe() { AllowCombat = true, AllowWarDeclaration = true, RaiseNotice = false };
-		}
-
 		public static TileProbe DeclareWarProbe() {
-			return new TileProbe() { AllowCombat = true, AllowWarDeclaration = true, RaiseNotice = false };
+			return new TileProbe() { AllowCombat = true, AllowWarDeclaration = true };
 		}
 	}
 }

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -542,7 +542,7 @@ namespace C7GameData {
 					}
 					return false;
 				}
-            }
+			}
 
 			// If we allow declaring war on this move, then it doesn't matter if
 			// there are units belonging to another player on the tile.

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -529,22 +529,20 @@ namespace C7GameData {
 			if (this.IsLandUnit() && !tile.IsLand())
 				return false;
 
-			if (!HasRank()) {
+			if (!this.HasRank()) {
 				if (HasHostileCity(tile, owner)) {
 					if (probe.RaiseNotice) {
 						new MsgShowTemporaryPopup($"Only combat units can capture cities and improvements.", location).send();
-						return false;
 					}
-					return true;
+					return false;
 				}
-				if (HasHostileUnits(tile, owner)) {
+				if (HasHostileUnits(tile, owner) || (tile.hasBarbarianCamp && !this.owner.isBarbarians)) {
 					if (probe.RaiseNotice) {
 						new MsgShowTemporaryPopup($"Non-combat units may not attack.", location).send();
-						return false;
 					}
-					return true;
+					return false;
 				}
-			}
+            }
 
 			// If we allow declaring war on this move, then it doesn't matter if
 			// there are units belonging to another player on the tile.


### PR DESCRIPTION
I think the bug was two-fold.

First all the issues after many many replays, seems to be that non combat units (Worker, Scout, Settler) tried to enter a tile where there was either a Barbarian or a Barbarian camp. The camps weren't accounted for.

Secondly, there were 2 early returns, but they weren't dependant on HasHostileCity() or HasHostileUnits() but rather, whether we raised a notice to the player. 

If you have any ideas on how we could unit test this effectively, let me know.

Right now I have tested this just by playing 10-15 games in a row in observer mode for 100 turns each, and I didn't crash. Previously every 3-4 games max, I had this issue.