### PR TITLE
Civ destruction | UI button behaviour and focus fix

### DIFF
--- a/C7/UIElements/GameStatus/ConsoleButton.cs
+++ b/C7/UIElements/GameStatus/ConsoleButton.cs
@@ -1,5 +1,4 @@
 using Godot;
-using System;
 
 /// <summary>
 /// ConsoleButton is a custom control node that displays a textured button with a
@@ -28,7 +27,13 @@ public partial class ConsoleButton : Control {
 			TexturePressed = TextureLoader.Load("ui.console.pressed"),
 			TooltipText = tooltipText
 		};
-		button.Pressed += () => { EmitSignal(SignalName.Pressed); };
+		button.Pressed += () => {
+			EmitSignal(SignalName.Pressed);
+			// When first clicked the button has focus
+			// If we press the spacebar or enter after, it still has focus
+			// so it gets triggered again, and we don't want that
+			button.FocusMode = FocusModeEnum.None;
+		};
 
 		Label label = new() {
 			Text = text,
@@ -50,5 +55,9 @@ public partial class ConsoleButton : Control {
 
 	public void ShowButton() {
 		button.Show();
+	}
+
+	public void HideButton() {
+		button.Hide();
 	}
 }

--- a/C7/UIElements/GameStatus/StatusMenu.cs
+++ b/C7/UIElements/GameStatus/StatusMenu.cs
@@ -1,5 +1,4 @@
 using Godot;
-using System;
 using C7GameData;
 using C7Engine;
 
@@ -27,6 +26,12 @@ public partial class StatusMenu : Control {
 			// Only show the diplomacy button if we have civs to talk to.
 			if (player.playerRelationships.Count > 0) {
 				openDiplomacy.ShowButton();
+			} else {
+				// After meeting a civ and revealed the button,
+				// if that civ gets destroyed and we don't have any more relationships
+				// with other civs (haven't met them yet) we should hide the button again.
+				// It will be shown again when we meet another civ.
+				openDiplomacy.HideButton();
 			}
 
 			// TODO: Don't show the palace button if the player can't start building the palace

--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -207,10 +207,14 @@ namespace C7GameData {
 
 			// This was the last city of the civilization, so destroy remaining
 			// units.
-			player.defeated = true;
-			for (int i = 0; i < player.units.Count; ++i) {
+			// Start from the end and start deleting backwards
+			// because the other way doesn't actually go through all units
+			// probably because we keep modifying the list and its count gets all messed up
+			for (int i = player.units.Count - 1; i >= 0; --i) {
 				DisbandUnit(player.units[i]);
 			}
+
+			player.defeated = true;
 
 			// Remove this civ from all other player's relationships.
 			foreach (Player p in players) {


### PR DESCRIPTION
Properly get rid of all the destroyed civ units.
Show and hide the diplomacy button depending on if we know any other civ. 
Fix TextureButton to not have focus after been clicked, so it doesn't get triggered by space/enter keystrokes afterwards.