### PR TITLE
 Disable test parallelization; fix setup for PlayerRelationshipTest

### DIFF
--- a/EngineTests/GameData/PlayerRelationshipTest.cs
+++ b/EngineTests/GameData/PlayerRelationshipTest.cs
@@ -1,43 +1,23 @@
 using System;
 using C7Engine;
 using C7GameData;
-using C7GameData.Save;
 using Xunit;
 using static C7GameData.PlayerRelationship;
 
 namespace EngineTests.GameData;
 
-public class GameDataFixture : IDisposable {
-	public SaveGame SaveGame { get; }
-	public C7GameData.GameData GameData { get; }
+public class PlayerRelationshipTest : IClassFixture<SaveGameFixture> {
+	C7GameData.GameData gameData;
 
-	public GameDataFixture(SaveGameFixture saveGameFixture) {
-		SaveGame = saveGameFixture.saveGame;
+	public PlayerRelationshipTest(SaveGameFixture fixture) {
+		gameData = fixture.saveGame.ToGameData(PathUtils.luaRulesDir);
 
-		GameData = SaveGame.ToGameData(PathUtils.luaRulesDir);
-
-		EngineStorage.InitializeGameDataForTests(GameData);
-	}
-
-	public void Dispose() {
-		return;
-	}
-}
-
-[CollectionDefinition("GameDataCollection")]
-public class GameDataCollection : ICollectionFixture<SaveGameFixture> { }
-
-[Collection("GameDataCollection")]
-public class PlayerRelationshipTest : IClassFixture<GameDataFixture> {
-	GameDataFixture fixture;
-
-	public PlayerRelationshipTest(GameDataFixture fixture) {
-		this.fixture = fixture;
+		EngineStorage.InitializeGameDataForTests(gameData);
 	}
 
 	[Fact]
 	public void TestHumanToBarbarianRelationship() {
-		C7GameData.GameData gd = fixture.GameData;
+		C7GameData.GameData gd = gameData;
 
 		Player playerA = gd.players[0];
 		Player playerB = gd.players[2];
@@ -56,7 +36,7 @@ public class PlayerRelationshipTest : IClassFixture<GameDataFixture> {
 
 	[Fact]
 	public void TestRelationshipAtVariousPoints() {
-		C7GameData.GameData gd = fixture.GameData;
+		C7GameData.GameData gd = gameData;
 
 		Player playerA = gd.players[1];
 		Player playerB = gd.players[2];
@@ -108,7 +88,7 @@ public class PlayerRelationshipTest : IClassFixture<GameDataFixture> {
 
 	[Fact]
 	public void TestMultiTurnDealRegistration() {
-		C7GameData.GameData gd = fixture.GameData;
+		C7GameData.GameData gd = gameData;
 
 		Player playerA = gd.players[2];
 		Player playerB = gd.players[3];

--- a/EngineTests/XunitSettings.cs
+++ b/EngineTests/XunitSettings.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
First, this PR disables running tests in parallel. By default, XUnit executes tests from different classes in parallel (however, tests from the same class are not executed in parallel against each other). Docs: https://xunit.net/docs/running-tests-in-parallel

For our project, this can be problematic, since some tests access and overwrite the `EngineStorage.gameData` global. Parallel execution is a likely cause of tests hanging. `SaveTest` contains a while loop that waits for engine messages while simulating the game. If `PlayerRelationshipTest` overwrites the engine’s `gameData`, the expected message will never arrive and the test will wait indefinitely.

Second, this PR fixes `PlayerRelationshipTest` initialization. When I was merging #848, I mistakenly put test setup logic inside a fixture. This was a blunder, since fixtures are created once per test class. What I need is to set up the test data per test method. To fix this, I moved the initialization logic into the test constructor, which is executed before each test: https://xunit.net/docs/shared-context.html