### PR TITLE
Add dynamic world size selectors in New Game

### DIFF
--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -8890,5 +8890,58 @@
       "corruptionPercentage": 100,
       "militaryLaw": 1
     }
+  ],
+  "worldSizes" : [
+    {
+      "name": "Tiny",
+      "length": 80,
+      "height": 60,
+      "width": 60,
+      "optimalNumberOfCities": 14,
+      "techRate": 160,
+      "distanceBetweenCivs": 11,
+      "numberOfCivs": 4
+    },
+    {
+      "name": "Small",
+      "length": 80,
+      "height": 80,
+      "width": 80,
+      "optimalNumberOfCities": 17,
+      "techRate": 200,
+      "distanceBetweenCivs": 11,
+      "numberOfCivs": 6
+    },
+    {
+      "name": "Standard",
+      "length": 80,
+      "height": 100,
+      "width": 100,
+      "optimalNumberOfCities": 20,
+      "techRate": 240,
+      "distanceBetweenCivs": 12,      
+      "numberOfCivs": 8,
+      "isDefault" : true
+    },
+    {
+      "name": "Large",
+      "length": 80,
+      "height": 130,
+      "width": 130,
+      "optimalNumberOfCities": 28,
+      "techRate": 320,
+      "distanceBetweenCivs": 18,
+      "numberOfCivs": 12
+    },
+    {
+      "name": "Huge",
+      "length": 80,
+      "height": 160,
+      "width": 160,
+      "optimalNumberOfCities": 36,
+      "techRate": 400,
+      "distanceBetweenCivs": 24,
+      "numberOfCivs": 16
+    }
   ]
 }

--- a/C7/Textures/PlayerTextureUtil.cs.uid
+++ b/C7/Textures/PlayerTextureUtil.cs.uid
@@ -1,0 +1,1 @@
+uid://dfc5qvfimbmfk

--- a/C7/UIElements/NewGame/PlayerSetup.cs
+++ b/C7/UIElements/NewGame/PlayerSetup.cs
@@ -36,9 +36,6 @@ public partial class PlayerSetup : Control {
 	Civilization selectedCivilization;
 	Difficulty selectedDifficulty;
 
-	// TODO: read this from the rules based on the world size
-	const int NUM_OPPONENTS = 7;
-
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
 		GlobalSingleton global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
@@ -75,7 +72,7 @@ public partial class PlayerSetup : Control {
 		DisplaySelectedLeader();
 
 		// Set up the options for opponents.
-		AddOpponentSelectors();
+		AddOpponentSelectors(global.WorldCharacteristics.worldSize.numberOfCivs);
 
 		// Set up the difficulty buttons
 		difficultyContainer.Columns = save.Difficulties.Count;
@@ -106,9 +103,10 @@ public partial class PlayerSetup : Control {
 		GetTree().ChangeSceneToFile("res://UIElements/MainMenu/main_menu.tscn");
 	}
 
-	private void AddOpponentSelectors() {
-		// TODO: The number of opponents should come from the rule set.
-		for (int i = 0; i < NUM_OPPONENTS; ++i) {
+	private void AddOpponentSelectors(int numberOfCivs) {
+		int numOpponents = numberOfCivs - 1;
+
+		for (int i = 0; i < numOpponents; ++i) {
 			OptionButton optionButton = new();
 			StyleBoxFlat styleBox = new() {
 				BorderColor = Color.Color8(150, 150, 150, 220),
@@ -136,7 +134,7 @@ public partial class PlayerSetup : Control {
 			opponentListContainer.AddChild(container);
 			container.AddChild(optionButton);
 
-			container.CustomMinimumSize = new Vector2(312.0f / opponentListContainer.Columns, 315.0f / NUM_OPPONENTS);
+			container.CustomMinimumSize = new Vector2(312.0f / opponentListContainer.Columns, 315.0f / numOpponents);
 			optionButton.CustomMinimumSize = new Vector2(290.0f / opponentListContainer.Columns, optionButton.CustomMinimumSize.Y);
 
 			foreach (Civilization civ in save.Civilizations) {

--- a/C7/UIElements/NewGame/WorldSetup.cs
+++ b/C7/UIElements/NewGame/WorldSetup.cs
@@ -2,12 +2,13 @@ using Godot;
 using System;
 using C7Engine;
 using C7Engine.Lua;
+using C7GameData;
 using C7GameData.Save;
 using Serilog;
 
 [Tool]
 public partial class WorldSetup : Control {
-	private static ILogger log = LogManager.ForContext<WorldSetup>();
+	private ILogger log = LogManager.ForContext<WorldSetup>();
 
 	[Export] TextureRect background;
 
@@ -57,13 +58,6 @@ public partial class WorldSetup : Control {
 	[Export] TextureRect billion4Large;
 	[Export] TextureRect billion5Large;
 
-	[Export] CheckButton tinySize;
-	[Export] CheckButton smallSize;
-	[Export] CheckButton standardSize;
-	[Export] CheckButton largeSize;
-	[Export] CheckButton hugeSize;
-	[Export] CheckButton randomSize;
-
 	[Export] TextureButton confirm;
 	[Export] TextureButton cancel;
 
@@ -74,6 +68,12 @@ public partial class WorldSetup : Control {
 	WorldCharacteristics.Age age = WorldCharacteristics.Age.Billion_4;
 	WorldCharacteristics.Temperature temp = WorldCharacteristics.Temperature.Temperate;
 	WorldCharacteristics.Climate clim = WorldCharacteristics.Climate.Normal;
+
+	private WorldSize _worldSize = WorldSize.Generic();
+
+	private int GameSeed => int.Parse(seedInput.Text);
+
+	private SaveGame _saveGame;
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
@@ -266,14 +266,51 @@ public partial class WorldSetup : Control {
 		billion4Large.Visible = true;
 		billion4.ButtonPressed = true;
 
-		// TODO: handle different map sizes properly (including loading the
-		// optimal city number, etc)
-		tinySize.Visible = false;
-		smallSize.Visible = false;
-		standardSize.Visible = false;
-		largeSize.Visible = false;
-		hugeSize.Visible = false;
-		randomSize.Visible = false;
+		_saveGame = GameModeLoader.Load(GamePaths.GameModesDir, GamePaths.GameMode);
+
+		InitMapSizes();
+	}
+
+	private void InitMapSizes() {
+		var worldSizeButtons = GetNode("%WorldSizeButtons");
+		var worldSizeButtonsContainer = worldSizeButtons.GetNode<VBoxContainer>("%WorldSizeButtonsContainer");
+
+		var defaultSizeButton = worldSizeButtons.GetNode<Civ3MenuButton>("%DefaultSizeButton");
+		var randomSizeButton = worldSizeButtons.GetNode<Civ3MenuButton>("%RandomSizeButton");
+		var worldSizeButtonGroup = defaultSizeButton.ButtonGroup;
+
+		var sizeRandom = GameSeed == -1 ? new Random() : new Random(GameSeed);
+
+		defaultSizeButton.Pressed += () => {
+			_worldSize = WorldSize.Generic();
+		};
+		randomSizeButton.Pressed += () => {
+			var wss = _saveGame?.WorldSizes ?? [];
+			_worldSize = wss.Count > 0 ? wss[sizeRandom.Next(wss.Count)] : WorldSize.Generic();
+		};
+
+		try {
+			// Dynamically create a new button for each world size in the game 
+			foreach (var ws in _saveGame.WorldSizes) {
+				var worldSizeButton = new Civ3MenuButton
+				{
+					Text = ws.name,
+					textPosition = Civ3MenuButton.TextPosition.TextRightOfIcon,
+					FontSize = 0,
+					ButtonGroup = worldSizeButtonGroup,
+					ToggleMode = true,
+					ButtonPressed = ws.isDefault
+				};
+				worldSizeButton.Pressed += () => _worldSize = ws;
+				worldSizeButtonsContainer.AddChild(worldSizeButton);
+			}
+
+			// Move random as last in the list and drop default map option and 
+			worldSizeButtonsContainer.MoveChild(randomSizeButton, -1);
+			defaultSizeButton.QueueFree();
+		} catch (Exception ex) {
+			log.Warning(ex, "Failed to load map sizes from game mode.");
+		}
 	}
 
 	private void ResetLandformGraphics() {
@@ -313,26 +350,18 @@ public partial class WorldSetup : Control {
 	private void CreateGame() {
 		GlobalSingleton Global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
 		Global.ResetLoadGameFields();
-		SaveGame save = GameModeLoader.Load(GamePaths.GameModesDir, GamePaths.GameMode);
 
-		Global.WorldCharacteristics = new WorldCharacteristics(save) {
+		Global.WorldCharacteristics = new WorldCharacteristics(_saveGame) {
 			landform = landform,
 			oceanCoverage = ocean,
 			age = age,
 			climate = clim,
 			temperature = temp,
-			worldSize = new WorldSize() {
-				width = 100,
-				height = 100,
-				numberOfCivs = 8,
-				distanceBetweenCivs = 12,
-				techRate = 240,
-				optimalNumberOfCities = 20,
-			},
-			mapSeed = Int32.Parse(seedInput.Text),
+			worldSize = _worldSize,
+			mapSeed = GameSeed,
 		};
 
-		Global.SaveGame = save;
+		Global.SaveGame = _saveGame;
 
 		GetTree().ChangeSceneToFile("res://UIElements/NewGame/player_setup.tscn");
 	}

--- a/C7/UIElements/NewGame/WorldSetup.cs
+++ b/C7/UIElements/NewGame/WorldSetup.cs
@@ -305,6 +305,10 @@ public partial class WorldSetup : Control {
 				};
 				worldSizeButton.Pressed += () => _worldSize = ws;
 				worldSizeButtonsContainer.AddChild(worldSizeButton);
+
+				// apply the default immediately (last isDefault=true wins)
+				if (ws.isDefault)
+					_worldSize = ws;
 			}
 
 			// Move random as last in the list and drop default map option and 

--- a/C7/UIElements/NewGame/WorldSetup.cs
+++ b/C7/UIElements/NewGame/WorldSetup.cs
@@ -63,6 +63,8 @@ public partial class WorldSetup : Control {
 
 	[Export] LineEdit seedInput;
 
+	[Export] VBoxContainer worldSizeButtonsContainer;
+
 	WorldCharacteristics.Landform landform = WorldCharacteristics.Landform.Pangaea;
 	WorldCharacteristics.OceanCoverage ocean = WorldCharacteristics.OceanCoverage.Percent_70;
 	WorldCharacteristics.Age age = WorldCharacteristics.Age.Billion_4;
@@ -273,8 +275,6 @@ public partial class WorldSetup : Control {
 
 	private void InitMapSizes() {
 		var sizeRandom = new Random();
-
-		var worldSizeButtonsContainer = GetNode<VBoxContainer>("Background/WorldSizeButtonsScroller/WorldSizeButtonsContainer");
 
 		var worldSizeButtonGroup = new ButtonGroup() { ResourceName = "WorldSizeButtonGroup" };
 		var randomSizeButton = new Civ3MenuButton

--- a/C7/UIElements/NewGame/WorldSetup.cs
+++ b/C7/UIElements/NewGame/WorldSetup.cs
@@ -272,18 +272,20 @@ public partial class WorldSetup : Control {
 	}
 
 	private void InitMapSizes() {
-		var worldSizeButtons = GetNode("%WorldSizeButtons");
-		var worldSizeButtonsContainer = worldSizeButtons.GetNode<VBoxContainer>("%WorldSizeButtonsContainer");
+		var sizeRandom = new Random();
 
-		var defaultSizeButton = worldSizeButtons.GetNode<Civ3MenuButton>("%DefaultSizeButton");
-		var randomSizeButton = worldSizeButtons.GetNode<Civ3MenuButton>("%RandomSizeButton");
-		var worldSizeButtonGroup = defaultSizeButton.ButtonGroup;
+		var worldSizeButtonsContainer = GetNode<VBoxContainer>("Background/WorldSizeButtonsScroller/WorldSizeButtonsContainer");
 
-		var sizeRandom = GameSeed == -1 ? new Random() : new Random(GameSeed);
-
-		defaultSizeButton.Pressed += () => {
-			_worldSize = WorldSize.Generic();
+		var worldSizeButtonGroup = new ButtonGroup() { ResourceName = "WorldSizeButtonGroup" };
+		var randomSizeButton = new Civ3MenuButton
+		{
+			Text = "Random",
+			textPosition = Civ3MenuButton.TextPosition.TextRightOfIcon,
+			FontSize = 0,
+			ButtonGroup = worldSizeButtonGroup,
+			ToggleMode = true
 		};
+
 		randomSizeButton.Pressed += () => {
 			var wss = _saveGame?.WorldSizes ?? [];
 			_worldSize = wss.Count > 0 ? wss[sizeRandom.Next(wss.Count)] : WorldSize.Generic();
@@ -306,8 +308,7 @@ public partial class WorldSetup : Control {
 			}
 
 			// Move random as last in the list and drop default map option and 
-			worldSizeButtonsContainer.MoveChild(randomSizeButton, -1);
-			defaultSizeButton.QueueFree();
+			worldSizeButtonsContainer.AddChild(randomSizeButton);
 		} catch (Exception ex) {
 			log.Warning(ex, "Failed to load map sizes from game mode.");
 		}

--- a/C7/UIElements/NewGame/player_setup.tscn
+++ b/C7/UIElements/NewGame/player_setup.tscn
@@ -30,7 +30,7 @@ script = ExtResource("1")
 background = NodePath("Background")
 playerListContainer = NodePath("Background/CenterContainer/PlayerListContainer")
 civLabel = NodePath("Background/CivLabel")
-opponentListContainer = NodePath("Background/OpponentListContainer")
+opponentListContainer = NodePath("Background/OpponentListScroller/OpponentListContainer")
 difficultyContainer = NodePath("Background/DifficultyContainer")
 confirm = NodePath("Background/Confirm")
 cancel = NodePath("Background/Cancel")
@@ -83,12 +83,15 @@ theme_override_font_sizes/font_size = 15
 text = "DIFFICULTY"
 vertical_alignment = 1
 
-[node name="OpponentListContainer" type="GridContainer" parent="Background"]
+[node name="OpponentListScroller" type="ScrollContainer" parent="Background"]
 layout_mode = 0
-offset_left = 636.0
-offset_top = 123.0
-offset_right = 948.0
+offset_left = 630.0
+offset_top = 120.0
+offset_right = 951.0
 offset_bottom = 458.0
+
+[node name="OpponentListContainer" type="GridContainer" parent="Background/OpponentListScroller"]
+layout_mode = 2
 
 [node name="CenterContainer" type="CenterContainer" parent="Background"]
 layout_mode = 0

--- a/C7/UIElements/NewGame/world_setup.tscn
+++ b/C7/UIElements/NewGame/world_setup.tscn
@@ -1,14 +1,9 @@
-[gd_scene load_steps=16 format=3 uid="uid://b3qpc8q2w7rru"]
+[gd_scene format=3 uid="uid://b3qpc8q2w7rru"]
 
 [ext_resource type="Script" uid="uid://bvgtd1omfo4du" path="res://UIElements/NewGame/WorldSetup.cs" id="1_tyjud"]
 [ext_resource type="Script" uid="uid://doqipc4rnaotx" path="res://UIElements/Civ3TextureRect.cs" id="2"]
 [ext_resource type="Script" uid="uid://dcrdcjop64t6t" path="res://UIElements/Civ3TextureButton.cs" id="3"]
-
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_rlsqa"]
-
-[sub_resource type="ButtonGroup" id="ButtonGroup_v0f8b"]
-
-[sub_resource type="StyleBoxLine" id="StyleBoxLine_joj1k"]
+[ext_resource type="Script" uid="uid://34cq5uvdrhkp" path="res://UIElements/MainMenu/Civ3MenuButton.cs" id="4_p6qd0"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_13ceg"]
 bg_color = Color(0.6, 0.6, 0.6, 0)
@@ -17,6 +12,8 @@ border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
 border_color = Color(0, 0, 0, 1)
+
+[sub_resource type="StyleBoxLine" id="StyleBoxLine_joj1k"]
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_2b8n4"]
 
@@ -40,7 +37,10 @@ keycode = 4194305
 [sub_resource type="Shortcut" id="Shortcut_7oyjg"]
 events = [SubResource("InputEventKey_klcu1")]
 
-[node name="Control" type="CenterContainer" node_paths=PackedStringArray("background", "pangaeaLabel", "continentsLabel", "archipelagoLabel", "pangaea60", "pangaea70", "pangaea80", "continents60", "continents70", "continents80", "archipelago60", "archipelago70", "archipelago80", "pangaea60Large", "pangaea70Large", "pangaea80Large", "continents60Large", "continents70Large", "continents80Large", "archipelago60Large", "archipelago70Large", "archipelago80Large", "arid", "normal", "wet", "cool", "temperate", "warm", "billion3", "billion4", "billion5", "aridLarge", "normalLarge", "wetLarge", "coolLarge", "temperateLarge", "warmLarge", "billion3Large", "billion4Large", "billion5Large", "tinySize", "smallSize", "standardSize", "largeSize", "hugeSize", "randomSize", "confirm", "cancel", "seedInput")]
+[sub_resource type="ButtonGroup" id="ButtonGroup_p6qd0"]
+resource_name = "WorldSizeButtonGroup"
+
+[node name="Control" type="CenterContainer" node_paths=PackedStringArray("background", "pangaeaLabel", "continentsLabel", "archipelagoLabel", "pangaea60", "pangaea70", "pangaea80", "continents60", "continents70", "continents80", "archipelago60", "archipelago70", "archipelago80", "pangaea60Large", "pangaea70Large", "pangaea80Large", "continents60Large", "continents70Large", "continents80Large", "archipelago60Large", "archipelago70Large", "archipelago80Large", "arid", "normal", "wet", "cool", "temperate", "warm", "billion3", "billion4", "billion5", "aridLarge", "normalLarge", "wetLarge", "coolLarge", "temperateLarge", "warmLarge", "billion3Large", "billion4Large", "billion5Large", "confirm", "cancel", "seedInput")]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -87,12 +87,6 @@ warmLarge = NodePath("Background/WarmLarge")
 billion3Large = NodePath("Background/Billion3Large")
 billion4Large = NodePath("Background/Billion4Large")
 billion5Large = NodePath("Background/Billion5Large")
-tinySize = NodePath("Background/TinySize")
-smallSize = NodePath("Background/SmallSize")
-standardSize = NodePath("Background/StandardSize")
-largeSize = NodePath("Background/LargeSize")
-hugeSize = NodePath("Background/HugeSize")
-randomSize = NodePath("Background/RandomSize")
 confirm = NodePath("Background/Confirm")
 cancel = NodePath("Background/Cancel")
 seedInput = NodePath("Background/SeedInput")
@@ -100,125 +94,6 @@ seedInput = NodePath("Background/SeedInput")
 [node name="Background" type="TextureRect" parent="."]
 layout_mode = 2
 script = ExtResource("2")
-
-[node name="Label" type="Label" parent="Background"]
-layout_mode = 0
-offset_left = 118.0
-offset_top = 96.0
-offset_right = 270.0
-offset_bottom = 119.0
-theme_override_font_sizes/font_size = 16
-text = "WORLD SIZE"
-horizontal_alignment = 1
-
-[node name="TinySize" type="CheckButton" parent="Background"]
-visible = false
-layout_mode = 0
-offset_left = 167.0
-offset_top = 115.0
-offset_right = 242.0
-offset_bottom = 141.0
-theme_override_colors/font_hover_pressed_color = Color(0.0305083, 0.489873, 0.588479, 1)
-theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_pressed_color = Color(0.0305083, 0.489873, 0.588479, 1)
-theme_override_font_sizes/font_size = 16
-theme_override_styles/pressed = SubResource("StyleBoxEmpty_rlsqa")
-theme_override_styles/normal = SubResource("StyleBoxEmpty_rlsqa")
-button_group = SubResource("ButtonGroup_v0f8b")
-text = "Tiny"
-alignment = 2
-
-[node name="SmallSize" type="CheckButton" parent="Background"]
-visible = false
-layout_mode = 0
-offset_left = 160.0
-offset_top = 137.0
-offset_right = 242.0
-offset_bottom = 163.0
-theme_override_colors/font_hover_pressed_color = Color(0.0305083, 0.489873, 0.588479, 1)
-theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_pressed_color = Color(0.0305083, 0.489873, 0.588479, 1)
-theme_override_font_sizes/font_size = 16
-theme_override_styles/pressed = SubResource("StyleBoxEmpty_rlsqa")
-theme_override_styles/normal = SubResource("StyleBoxEmpty_rlsqa")
-button_group = SubResource("ButtonGroup_v0f8b")
-text = "Small"
-alignment = 2
-
-[node name="StandardSize" type="CheckButton" parent="Background"]
-visible = false
-layout_mode = 0
-offset_left = 136.0
-offset_top = 159.0
-offset_right = 241.0
-offset_bottom = 185.0
-theme_override_colors/font_hover_pressed_color = Color(0.0305083, 0.489873, 0.588479, 1)
-theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_pressed_color = Color(0.0305083, 0.489873, 0.588479, 1)
-theme_override_font_sizes/font_size = 16
-theme_override_styles/pressed = SubResource("StyleBoxEmpty_rlsqa")
-theme_override_styles/normal = SubResource("StyleBoxEmpty_rlsqa")
-button_pressed = true
-button_group = SubResource("ButtonGroup_v0f8b")
-text = "Standard"
-alignment = 2
-
-[node name="LargeSize" type="CheckButton" parent="Background"]
-visible = false
-layout_mode = 0
-offset_left = 162.0
-offset_top = 183.0
-offset_right = 241.0
-offset_bottom = 209.0
-theme_override_colors/font_hover_pressed_color = Color(0.0305083, 0.489873, 0.588479, 1)
-theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_pressed_color = Color(0.0305083, 0.489873, 0.588479, 1)
-theme_override_font_sizes/font_size = 16
-theme_override_styles/pressed = SubResource("StyleBoxEmpty_rlsqa")
-theme_override_styles/normal = SubResource("StyleBoxEmpty_rlsqa")
-button_group = SubResource("ButtonGroup_v0f8b")
-text = "Large"
-alignment = 2
-
-[node name="HugeSize" type="CheckButton" parent="Background"]
-visible = false
-layout_mode = 0
-offset_left = 163.0
-offset_top = 208.0
-offset_right = 240.0
-offset_bottom = 234.0
-theme_override_colors/font_hover_pressed_color = Color(0.0305083, 0.489873, 0.588479, 1)
-theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_pressed_color = Color(0.0305083, 0.489873, 0.588479, 1)
-theme_override_font_sizes/font_size = 16
-theme_override_styles/pressed = SubResource("StyleBoxEmpty_rlsqa")
-theme_override_styles/normal = SubResource("StyleBoxEmpty_rlsqa")
-button_group = SubResource("ButtonGroup_v0f8b")
-text = "Huge"
-alignment = 2
-
-[node name="RandomSize" type="CheckButton" parent="Background"]
-visible = false
-layout_mode = 0
-offset_left = 140.0
-offset_top = 231.0
-offset_right = 240.0
-offset_bottom = 257.0
-theme_override_colors/font_hover_pressed_color = Color(0.0305083, 0.489873, 0.588479, 1)
-theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_pressed_color = Color(0.0305083, 0.489873, 0.588479, 1)
-theme_override_font_sizes/font_size = 16
-theme_override_styles/pressed = SubResource("StyleBoxEmpty_rlsqa")
-theme_override_styles/normal = SubResource("StyleBoxEmpty_rlsqa")
-button_group = SubResource("ButtonGroup_v0f8b")
-text = "Random"
-alignment = 2
 
 [node name="Label2" type="Label" parent="Background"]
 layout_mode = 0
@@ -238,8 +113,8 @@ offset_top = 20.0
 offset_right = 824.0
 offset_bottom = 48.0
 theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_styles/focus = SubResource("StyleBoxLine_joj1k")
 theme_override_styles/normal = SubResource("StyleBoxFlat_13ceg")
+theme_override_styles/focus = SubResource("StyleBoxLine_joj1k")
 text = "-1"
 virtual_keyboard_type = 2
 
@@ -756,3 +631,166 @@ offset_right = 1007.0
 offset_bottom = 748.0
 shortcut = SubResource("Shortcut_7oyjg")
 script = ExtResource("3")
+
+[node name="WorldSizeButtons" type="Node2D" parent="."]
+unique_name_in_owner = true
+position = Vector2(177, 93)
+
+[node name="WorldSizeLabel" type="Label" parent="WorldSizeButtons"]
+offset_top = 7.0
+offset_right = 165.0
+offset_bottom = 30.0
+theme_override_font_sizes/font_size = 16
+text = "WORLD SIZE"
+horizontal_alignment = 1
+
+[node name="WorldSizeButtonsScroller" type="ScrollContainer" parent="WorldSizeButtons"]
+offset_left = 11.0
+offset_top = 30.0
+offset_right = 154.0
+offset_bottom = 166.0
+
+[node name="WorldSizeButtonsContainer" type="VBoxContainer" parent="WorldSizeButtons/WorldSizeButtonsScroller"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_constants/separation = 1
+
+[node name="DefaultSizeButton" type="BaseButton" parent="WorldSizeButtons/WorldSizeButtonsScroller/WorldSizeButtonsContainer"]
+unique_name_in_owner = true
+process_mode = 0
+process_priority = 0
+process_physics_priority = 0
+process_thread_group = 0
+physics_interpolation_mode = 2
+auto_translate_mode = 0
+editor_description = ""
+visible = true
+modulate = Color(1, 1, 1, 1)
+self_modulate = Color(1, 1, 1, 1)
+show_behind_parent = false
+top_level = false
+clip_children = 0
+light_mask = 1
+visibility_layer = 1
+z_index = 0
+z_as_relative = true
+y_sort_enabled = false
+texture_filter = 0
+texture_repeat = 0
+material = null
+use_parent_material = false
+clip_contents = false
+custom_minimum_size = Vector2(0, 0)
+layout_direction = 0
+layout_mode = 2
+size_flags_horizontal = 1
+size_flags_vertical = 1
+size_flags_stretch_ratio = 1.0
+localize_numeral_system = true
+tooltip_text = ""
+tooltip_auto_translate_mode = 0
+focus_neighbor_left = NodePath("")
+focus_neighbor_top = NodePath("")
+focus_neighbor_right = NodePath("")
+focus_neighbor_bottom = NodePath("")
+focus_next = NodePath("")
+focus_previous = NodePath("")
+focus_mode = 2
+focus_behavior_recursive = 0
+mouse_filter = 0
+mouse_behavior_recursive = 0
+mouse_force_pass_scroll_events = true
+mouse_default_cursor_shape = 0
+accessibility_name = ""
+accessibility_description = ""
+accessibility_live = 0
+accessibility_controls_nodes = Array[NodePath]([])
+accessibility_described_by_nodes = Array[NodePath]([])
+accessibility_labeled_by_nodes = Array[NodePath]([])
+accessibility_flow_to_nodes = Array[NodePath]([])
+theme = null
+theme_type_variation = &""
+disabled = false
+toggle_mode = true
+button_pressed = true
+action_mode = 1
+button_mask = 1
+keep_pressed_outside = false
+button_group = SubResource("ButtonGroup_p6qd0")
+shortcut = null
+shortcut_feedback = true
+shortcut_in_tooltip = true
+script = ExtResource("4_p6qd0")
+Text = "Default"
+textPosition = 1
+metadata/_custom_type_script = "uid://34cq5uvdrhkp"
+
+[node name="RandomSizeButton" type="BaseButton" parent="WorldSizeButtons/WorldSizeButtonsScroller/WorldSizeButtonsContainer"]
+unique_name_in_owner = true
+process_mode = 0
+process_priority = 0
+process_physics_priority = 0
+process_thread_group = 0
+physics_interpolation_mode = 2
+auto_translate_mode = 0
+editor_description = ""
+visible = true
+modulate = Color(1, 1, 1, 1)
+self_modulate = Color(1, 1, 1, 1)
+show_behind_parent = false
+top_level = false
+clip_children = 0
+light_mask = 1
+visibility_layer = 1
+z_index = 0
+z_as_relative = true
+y_sort_enabled = false
+texture_filter = 0
+texture_repeat = 0
+material = null
+use_parent_material = false
+clip_contents = false
+custom_minimum_size = Vector2(0, 0)
+layout_direction = 0
+layout_mode = 2
+size_flags_horizontal = 1
+size_flags_vertical = 1
+size_flags_stretch_ratio = 1.0
+localize_numeral_system = true
+tooltip_text = ""
+tooltip_auto_translate_mode = 0
+focus_neighbor_left = NodePath("")
+focus_neighbor_top = NodePath("")
+focus_neighbor_right = NodePath("")
+focus_neighbor_bottom = NodePath("")
+focus_next = NodePath("")
+focus_previous = NodePath("")
+focus_mode = 2
+focus_behavior_recursive = 0
+mouse_filter = 0
+mouse_behavior_recursive = 0
+mouse_force_pass_scroll_events = true
+mouse_default_cursor_shape = 0
+accessibility_name = ""
+accessibility_description = ""
+accessibility_live = 0
+accessibility_controls_nodes = Array[NodePath]([])
+accessibility_described_by_nodes = Array[NodePath]([])
+accessibility_labeled_by_nodes = Array[NodePath]([])
+accessibility_flow_to_nodes = Array[NodePath]([])
+theme = null
+theme_type_variation = &""
+disabled = false
+toggle_mode = true
+button_pressed = false
+action_mode = 1
+button_mask = 1
+keep_pressed_outside = false
+button_group = SubResource("ButtonGroup_p6qd0")
+shortcut = null
+shortcut_feedback = true
+shortcut_in_tooltip = true
+script = ExtResource("4_p6qd0")
+Text = "Random"
+textPosition = 1
+metadata/_custom_type_script = "uid://34cq5uvdrhkp"

--- a/C7/UIElements/NewGame/world_setup.tscn
+++ b/C7/UIElements/NewGame/world_setup.tscn
@@ -36,7 +36,7 @@ keycode = 4194305
 [sub_resource type="Shortcut" id="Shortcut_7oyjg"]
 events = [SubResource("InputEventKey_klcu1")]
 
-[node name="Control" type="CenterContainer" node_paths=PackedStringArray("background", "pangaeaLabel", "continentsLabel", "archipelagoLabel", "pangaea60", "pangaea70", "pangaea80", "continents60", "continents70", "continents80", "archipelago60", "archipelago70", "archipelago80", "pangaea60Large", "pangaea70Large", "pangaea80Large", "continents60Large", "continents70Large", "continents80Large", "archipelago60Large", "archipelago70Large", "archipelago80Large", "arid", "normal", "wet", "cool", "temperate", "warm", "billion3", "billion4", "billion5", "aridLarge", "normalLarge", "wetLarge", "coolLarge", "temperateLarge", "warmLarge", "billion3Large", "billion4Large", "billion5Large", "confirm", "cancel", "seedInput")]
+[node name="Control" type="CenterContainer" node_paths=PackedStringArray("background", "pangaeaLabel", "continentsLabel", "archipelagoLabel", "pangaea60", "pangaea70", "pangaea80", "continents60", "continents70", "continents80", "archipelago60", "archipelago70", "archipelago80", "pangaea60Large", "pangaea70Large", "pangaea80Large", "continents60Large", "continents70Large", "continents80Large", "archipelago60Large", "archipelago70Large", "archipelago80Large", "arid", "normal", "wet", "cool", "temperate", "warm", "billion3", "billion4", "billion5", "aridLarge", "normalLarge", "wetLarge", "coolLarge", "temperateLarge", "warmLarge", "billion3Large", "billion4Large", "billion5Large", "confirm", "cancel", "seedInput", "worldSizeButtonsContainer")]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -86,6 +86,7 @@ billion5Large = NodePath("Background/Billion5Large")
 confirm = NodePath("Background/Confirm")
 cancel = NodePath("Background/Cancel")
 seedInput = NodePath("Background/SeedInput")
+worldSizeButtonsContainer = NodePath("Background/WorldSizeButtonsScroller/WorldSizeButtonsContainer")
 
 [node name="Background" type="TextureRect" parent="."]
 layout_mode = 2

--- a/C7/UIElements/NewGame/world_setup.tscn
+++ b/C7/UIElements/NewGame/world_setup.tscn
@@ -1,9 +1,10 @@
-[gd_scene format=3 uid="uid://b3qpc8q2w7rru"]
+[gd_scene load_steps=14 format=3 uid="uid://b3qpc8q2w7rru"]
 
 [ext_resource type="Script" uid="uid://bvgtd1omfo4du" path="res://UIElements/NewGame/WorldSetup.cs" id="1_tyjud"]
 [ext_resource type="Script" uid="uid://doqipc4rnaotx" path="res://UIElements/Civ3TextureRect.cs" id="2"]
 [ext_resource type="Script" uid="uid://dcrdcjop64t6t" path="res://UIElements/Civ3TextureButton.cs" id="3"]
-[ext_resource type="Script" uid="uid://34cq5uvdrhkp" path="res://UIElements/MainMenu/Civ3MenuButton.cs" id="4_p6qd0"]
+
+[sub_resource type="StyleBoxLine" id="StyleBoxLine_joj1k"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_13ceg"]
 bg_color = Color(0.6, 0.6, 0.6, 0)
@@ -12,8 +13,6 @@ border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
 border_color = Color(0, 0, 0, 1)
-
-[sub_resource type="StyleBoxLine" id="StyleBoxLine_joj1k"]
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_2b8n4"]
 
@@ -36,9 +35,6 @@ keycode = 4194305
 
 [sub_resource type="Shortcut" id="Shortcut_7oyjg"]
 events = [SubResource("InputEventKey_klcu1")]
-
-[sub_resource type="ButtonGroup" id="ButtonGroup_p6qd0"]
-resource_name = "WorldSizeButtonGroup"
 
 [node name="Control" type="CenterContainer" node_paths=PackedStringArray("background", "pangaeaLabel", "continentsLabel", "archipelagoLabel", "pangaea60", "pangaea70", "pangaea80", "continents60", "continents70", "continents80", "archipelago60", "archipelago70", "archipelago80", "pangaea60Large", "pangaea70Large", "pangaea80Large", "continents60Large", "continents70Large", "continents80Large", "archipelago60Large", "archipelago70Large", "archipelago80Large", "arid", "normal", "wet", "cool", "temperate", "warm", "billion3", "billion4", "billion5", "aridLarge", "normalLarge", "wetLarge", "coolLarge", "temperateLarge", "warmLarge", "billion3Large", "billion4Large", "billion5Large", "confirm", "cancel", "seedInput")]
 anchors_preset = 15
@@ -95,6 +91,16 @@ seedInput = NodePath("Background/SeedInput")
 layout_mode = 2
 script = ExtResource("2")
 
+[node name="Label" type="Label" parent="Background"]
+layout_mode = 0
+offset_left = 118.0
+offset_top = 96.0
+offset_right = 270.0
+offset_bottom = 119.0
+theme_override_font_sizes/font_size = 16
+text = "WORLD SIZE"
+horizontal_alignment = 1
+
 [node name="Label2" type="Label" parent="Background"]
 layout_mode = 0
 offset_left = 114.0
@@ -113,8 +119,8 @@ offset_top = 20.0
 offset_right = 824.0
 offset_bottom = 48.0
 theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_styles/normal = SubResource("StyleBoxFlat_13ceg")
 theme_override_styles/focus = SubResource("StyleBoxLine_joj1k")
+theme_override_styles/normal = SubResource("StyleBoxFlat_13ceg")
 text = "-1"
 virtual_keyboard_type = 2
 
@@ -632,165 +638,12 @@ offset_bottom = 748.0
 shortcut = SubResource("Shortcut_7oyjg")
 script = ExtResource("3")
 
-[node name="WorldSizeButtons" type="Node2D" parent="."]
-unique_name_in_owner = true
-position = Vector2(177, 93)
+[node name="WorldSizeButtonsScroller" type="ScrollContainer" parent="Background"]
+layout_mode = 0
+offset_left = 116.0
+offset_top = 114.0
+offset_right = 272.0
+offset_bottom = 256.0
 
-[node name="WorldSizeLabel" type="Label" parent="WorldSizeButtons"]
-offset_top = 7.0
-offset_right = 165.0
-offset_bottom = 30.0
-theme_override_font_sizes/font_size = 16
-text = "WORLD SIZE"
-horizontal_alignment = 1
-
-[node name="WorldSizeButtonsScroller" type="ScrollContainer" parent="WorldSizeButtons"]
-offset_left = 11.0
-offset_top = 30.0
-offset_right = 154.0
-offset_bottom = 166.0
-
-[node name="WorldSizeButtonsContainer" type="VBoxContainer" parent="WorldSizeButtons/WorldSizeButtonsScroller"]
-unique_name_in_owner = true
+[node name="WorldSizeButtonsContainer" type="VBoxContainer" parent="Background/WorldSizeButtonsScroller"]
 layout_mode = 2
-theme_override_constants/separation = 1
-
-[node name="DefaultSizeButton" type="BaseButton" parent="WorldSizeButtons/WorldSizeButtonsScroller/WorldSizeButtonsContainer"]
-unique_name_in_owner = true
-process_mode = 0
-process_priority = 0
-process_physics_priority = 0
-process_thread_group = 0
-physics_interpolation_mode = 2
-auto_translate_mode = 0
-editor_description = ""
-visible = true
-modulate = Color(1, 1, 1, 1)
-self_modulate = Color(1, 1, 1, 1)
-show_behind_parent = false
-top_level = false
-clip_children = 0
-light_mask = 1
-visibility_layer = 1
-z_index = 0
-z_as_relative = true
-y_sort_enabled = false
-texture_filter = 0
-texture_repeat = 0
-material = null
-use_parent_material = false
-clip_contents = false
-custom_minimum_size = Vector2(0, 0)
-layout_direction = 0
-layout_mode = 2
-size_flags_horizontal = 1
-size_flags_vertical = 1
-size_flags_stretch_ratio = 1.0
-localize_numeral_system = true
-tooltip_text = ""
-tooltip_auto_translate_mode = 0
-focus_neighbor_left = NodePath("")
-focus_neighbor_top = NodePath("")
-focus_neighbor_right = NodePath("")
-focus_neighbor_bottom = NodePath("")
-focus_next = NodePath("")
-focus_previous = NodePath("")
-focus_mode = 2
-focus_behavior_recursive = 0
-mouse_filter = 0
-mouse_behavior_recursive = 0
-mouse_force_pass_scroll_events = true
-mouse_default_cursor_shape = 0
-accessibility_name = ""
-accessibility_description = ""
-accessibility_live = 0
-accessibility_controls_nodes = Array[NodePath]([])
-accessibility_described_by_nodes = Array[NodePath]([])
-accessibility_labeled_by_nodes = Array[NodePath]([])
-accessibility_flow_to_nodes = Array[NodePath]([])
-theme = null
-theme_type_variation = &""
-disabled = false
-toggle_mode = true
-button_pressed = true
-action_mode = 1
-button_mask = 1
-keep_pressed_outside = false
-button_group = SubResource("ButtonGroup_p6qd0")
-shortcut = null
-shortcut_feedback = true
-shortcut_in_tooltip = true
-script = ExtResource("4_p6qd0")
-Text = "Default"
-textPosition = 1
-metadata/_custom_type_script = "uid://34cq5uvdrhkp"
-
-[node name="RandomSizeButton" type="BaseButton" parent="WorldSizeButtons/WorldSizeButtonsScroller/WorldSizeButtonsContainer"]
-unique_name_in_owner = true
-process_mode = 0
-process_priority = 0
-process_physics_priority = 0
-process_thread_group = 0
-physics_interpolation_mode = 2
-auto_translate_mode = 0
-editor_description = ""
-visible = true
-modulate = Color(1, 1, 1, 1)
-self_modulate = Color(1, 1, 1, 1)
-show_behind_parent = false
-top_level = false
-clip_children = 0
-light_mask = 1
-visibility_layer = 1
-z_index = 0
-z_as_relative = true
-y_sort_enabled = false
-texture_filter = 0
-texture_repeat = 0
-material = null
-use_parent_material = false
-clip_contents = false
-custom_minimum_size = Vector2(0, 0)
-layout_direction = 0
-layout_mode = 2
-size_flags_horizontal = 1
-size_flags_vertical = 1
-size_flags_stretch_ratio = 1.0
-localize_numeral_system = true
-tooltip_text = ""
-tooltip_auto_translate_mode = 0
-focus_neighbor_left = NodePath("")
-focus_neighbor_top = NodePath("")
-focus_neighbor_right = NodePath("")
-focus_neighbor_bottom = NodePath("")
-focus_next = NodePath("")
-focus_previous = NodePath("")
-focus_mode = 2
-focus_behavior_recursive = 0
-mouse_filter = 0
-mouse_behavior_recursive = 0
-mouse_force_pass_scroll_events = true
-mouse_default_cursor_shape = 0
-accessibility_name = ""
-accessibility_description = ""
-accessibility_live = 0
-accessibility_controls_nodes = Array[NodePath]([])
-accessibility_described_by_nodes = Array[NodePath]([])
-accessibility_labeled_by_nodes = Array[NodePath]([])
-accessibility_flow_to_nodes = Array[NodePath]([])
-theme = null
-theme_type_variation = &""
-disabled = false
-toggle_mode = true
-button_pressed = false
-action_mode = 1
-button_mask = 1
-keep_pressed_outside = false
-button_group = SubResource("ButtonGroup_p6qd0")
-shortcut = null
-shortcut_feedback = true
-shortcut_in_tooltip = true
-script = ExtResource("4_p6qd0")
-Text = "Random"
-textPosition = 1
-metadata/_custom_type_script = "uid://34cq5uvdrhkp"

--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -37,6 +37,7 @@ namespace C7GameData {
 		public List<CitizenType> citizenTypes = new();
 		public List<Terraform> Terraforms = new();
 		public List<Government> governments = new();
+		public List<WorldSize> worldSizes = new();
 		public List<Difficulty> difficulties = new();
 		public Difficulty gameDifficulty = new();
 		public string defaultExperienceLevelKey;

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -72,6 +72,7 @@ namespace C7GameData.Save {
 				CitizenTypes = data.citizenTypes,
 				TerraForms = data.Terraforms.ConvertAll(t => t.ToSaveTerraform()),
 				Governments = data.governments,
+				WorldSizes = data.worldSizes,
 				Difficulties = data.difficulties,
 				GameDifficulty = data.gameDifficulty,
 				Rules = data.rules,
@@ -166,6 +167,7 @@ namespace C7GameData.Save {
 				civilizations = Civilizations,
 				citizenTypes = CitizenTypes,
 				governments = Governments,
+				worldSizes = WorldSizes,
 				difficulties = Difficulties,
 				gameDifficulty = GameDifficulty,
 				ids = new ID.Factory(this),
@@ -406,6 +408,7 @@ namespace C7GameData.Save {
 		public List<CitizenType> CitizenTypes = new();
 		public List<SaveTerraform> TerraForms = new();
 		public List<Government> Governments = new();
+		public List<WorldSize> WorldSizes = new();
 
 		// The relative directory that can be used to find scenario-specific
 		// assets.

--- a/C7Engine/C7GameData/WorldSize.cs
+++ b/C7Engine/C7GameData/WorldSize.cs
@@ -1,0 +1,29 @@
+namespace C7GameData {
+	public class WorldSize {
+		public string name;
+
+		public int width;
+		public int height;
+
+		public int optimalNumberOfCities;
+		public int techRate;
+
+		public int distanceBetweenCivs;
+		public int numberOfCivs;
+
+		public bool isDefault;
+
+		public static WorldSize Generic() {
+			return new WorldSize() {
+				name = "Default",
+				width = 100,
+				height = 100,
+				numberOfCivs = 8,
+				distanceBetweenCivs = 12,
+				techRate = 240,
+				optimalNumberOfCities = 20,
+				isDefault = true
+			};
+		}
+	}
+}

--- a/C7Engine/MapGenerator.cs
+++ b/C7Engine/MapGenerator.cs
@@ -8,17 +8,6 @@ namespace C7Engine {
 	using C7GameData;
 	using C7GameData.Save;
 
-	public class WorldSize {
-		public int width;
-		public int height;
-
-		public int optimalNumberOfCities;
-		public int techRate;
-
-		public int distanceBetweenCivs;
-		public int numberOfCivs;
-	}
-
 	public class WorldCharacteristics {
 		public enum Climate {
 			Arid,


### PR DESCRIPTION
Fixes #800, creating games with different world sizes. A continuation of #850 (and #847) , incorporating the suggested improvements around data-driven UI elements.

This patch extends the base ruleset with standard world sizes extracted from a C3C save file with DumpObject. I added `isDefault` as a way to indicate which one is the default world size.

On the UI side, I've replaced the previously disabled set of world size buttons with a dynamically generated set of `Civ3MenuButtons` for a nice uniform look. The default set is based on the base ruleset as loaded into the New Game context as a save file.

As a bit of polish, both the world size controller and the Opponent selection controller now have ScrollContainers.

![world_size_selector](https://github.com/user-attachments/assets/83d2754d-4200-4686-b26c-3b4b2f003d34)
