### PR TITLE
Spawn barbarian sea units on sea tiles

### DIFF
--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -265,6 +265,26 @@ namespace C7GameData {
 			log.Information($"Player {owner} removed unit: {unit}");
 		}
 
+		internal void SpawnUnit(Player player, UnitPrototype unitType, Tile tile) {
+			// TODO: consolidate unit spawning routines (here) 
+
+			MapUnit newUnit = unitType.GetInstance(this);
+			newUnit.location = tile;
+			newUnit.owner = player;
+			newUnit.nationality = player.civilization;
+			// TODO: make this a conscript.
+			newUnit.experienceLevelKey = defaultExperienceLevelKey;
+			newUnit.experienceLevel = defaultExperienceLevel;
+			newUnit.hitPointsRemaining = 3;
+
+			tile.unitsOnTile.Add(newUnit);
+			mapUnits.Add(newUnit);
+			player.units.Add(newUnit);
+
+			log.Debug("New unit of type {type} added at {tile} for player {player}",
+				unitType.name, tile, player);
+		}
+
 		public int TechCostFor(Tech tech, Player player) {
 			// Cost formula from https://forums.civfanatics.com/threads/research-cost-formula-v1-29f.29485/.
 			// Research Cost = [MM * [10*COST * (1 - N/[CL*1.75])]/(CF * 10)] - progress

--- a/C7Engine/C7GameData/TerrainType.cs
+++ b/C7Engine/C7GameData/TerrainType.cs
@@ -49,6 +49,10 @@ namespace C7GameData {
 			return Key.Equals("coast") || Key.Equals("sea") || Key.Equals("ocean");
 		}
 
+		public bool isCoast() {
+			return Key.Equals("coast");
+		}
+
 		public override string ToString() {
 			return DisplayName + "(" + baseFoodProduction + ", " + baseShieldProduction + ", " + baseCommerceProduction + ")";
 		}

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -234,6 +234,10 @@ namespace C7GameData {
 			return baseTerrainType.isWater();
 		}
 
+		public bool IsCoast() {
+			return baseTerrainType.isCoast();
+		}
+
 		public bool IsAllowCities() {
 			return overlayTerrainType.allowCities && !hasBarbarianCamp;
 		}

--- a/C7Engine/EntryPoints/BarbarianInteractions.cs
+++ b/C7Engine/EntryPoints/BarbarianInteractions.cs
@@ -48,9 +48,9 @@ public class BarbarianInteractions {
 		if (unitType.IsLandUnit())
 			return camp;
 
-		// Spawn sea units on a sea tile, but not in a lake or on a tile occupied by another player
+		// Spawn sea units on a coast tile, but not in a lake or on a tile occupied by another player
 		bool CanSpawnSeaUnits(Tile t) =>
-			t.IsWater() && !t.isFreshWater && t.unitsOnTile.TrueForAll(u => u.owner == player);
+			t.IsCoast() && !t.isFreshWater && t.unitsOnTile.TrueForAll(u => u.owner == player);
 
 		if (unitType.IsSeaUnit()) {
 			// Check first two ranks around camp for a suitable tile, or bail with a null 

--- a/C7Engine/EntryPoints/BarbarianInteractions.cs
+++ b/C7Engine/EntryPoints/BarbarianInteractions.cs
@@ -25,7 +25,9 @@ public class BarbarianInteractions {
 		foreach (Tile camp in spawningCamps) {
 			UnitPrototype unitType = SelectBarbarianUnitType(gameData.barbarianInfo, camp);
 			Tile tile = SelectSpawnTile(barbPlayer, camp, unitType);
-			gameData.SpawnUnit(barbPlayer, unitType, tile);
+			if (tile != null) {
+				gameData.SpawnUnit(barbPlayer, unitType, tile);
+			}
 		}
 
 		return barbariansToSpawn;
@@ -47,9 +49,13 @@ public class BarbarianInteractions {
 			return camp;
 
 		// Spawn sea units on a sea tile, but not in a lake or on a tile occupied by another player
+		bool CanSpawnSeaUnits(Tile t) =>
+			t.IsWater() && !t.isFreshWater && t.unitsOnTile.TrueForAll(u => u.owner == player);
+
 		if (unitType.IsSeaUnit()) {
-			return camp.FindInRing(1,
-				t => t.IsWater() && !t.isFreshWater && t.unitsOnTile.TrueForAll(u => u.owner == player));
+			// Check first two ranks around camp for a suitable tile, or bail with a null 
+			return camp.FindInRing(1, CanSpawnSeaUnits)
+				?? camp.FindInRing(2, CanSpawnSeaUnits);
 		}
 
 		// Default to camp 

--- a/C7Engine/EntryPoints/BarbarianInteractions.cs
+++ b/C7Engine/EntryPoints/BarbarianInteractions.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using C7GameData;
+
+namespace C7Engine;
+
+public class BarbarianInteractions {
+	public static int SpawnBarbarians(GameData gameData) {
+		Player barbPlayer = gameData.players.Find(player => player.isBarbarians);
+
+		// A random 5% of camps will spawn a unit each turn. Shuffle the
+		// camps to make this random.
+		int barbariansToSpawn = (int)Math.Ceiling(GameData.rng.Next(gameData.map.barbarianCamps.Count) / 20.0);
+		List<int> tileIndicies = Enumerable.Range(0, gameData.map.barbarianCamps.Count).ToList();
+		GameData.rng.Shuffle<int>(CollectionsMarshal.AsSpan(tileIndicies));
+
+		// Sample barbarian camps
+		var spawningCamps = tileIndicies
+			.Select(i => gameData.map.barbarianCamps[i])
+			.Take(barbariansToSpawn);
+
+		// Spawn a unit
+		foreach (Tile camp in spawningCamps) {
+			UnitPrototype unitType = SelectBarbarianUnitType(gameData.barbarianInfo, camp);
+			Tile tile = SelectSpawnTile(barbPlayer, camp, unitType);
+			gameData.SpawnUnit(barbPlayer, unitType, tile);
+		}
+
+		return barbariansToSpawn;
+	}
+
+	public static UnitPrototype SelectBarbarianUnitType(BarbarianInfo barbInfo, Tile tile) {
+		// Coastal camps have a 20% chance of spawning a sea unit
+		if (tile.NeighborsWater() && GameData.rng.Next(100) < 20) {
+			return barbInfo.barbarianSeaUnitProto;
+		}
+
+		// Land units are generated in a 3:1 ratio, three advanced units for every basic barbarian
+		return GameData.rng.Next(100) < 25 ? barbInfo.advancedBarbarian : barbInfo.basicBarbarian;
+	}
+
+	public static Tile SelectSpawnTile(Player player, Tile camp, UnitPrototype unitType) {
+		// Spawn land units at the camp
+		if (unitType.IsLandUnit())
+			return camp;
+
+		// Spawn sea units on a sea tile, but not in a lake or on a tile occupied by another player
+		if (unitType.IsSeaUnit()) {
+			return camp.FindInRing(1,
+				t => t.IsWater() && !t.isFreshWater && t.unitsOnTile.TrueForAll(u => u.owner == player));
+		}
+
+		// Default to camp 
+		return camp;
+	}
+}

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -1,11 +1,8 @@
 using System.Diagnostics;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Linq;
+using System.Net.NetworkInformation;
 using Serilog;
 
 namespace C7Engine {
-	using System;
 	using System.Threading.Tasks;
 	using C7GameData;
 
@@ -39,7 +36,7 @@ namespace C7Engine {
 				//at the same place in the order.  Confirmed this is what Civ3 does.
 				UnitInteractions.ClearWaitQueue();
 
-				SpawnBarbarians(gameData);
+				BarbarianInteractions.SpawnBarbarians(gameData);
 
 				gameData.turn++;
 				foreach (Player player in gameData.players) {
@@ -107,42 +104,6 @@ namespace C7Engine {
 				}
 			}
 			return false;
-		}
-
-		private static void SpawnBarbarians(GameData gameData) {
-			Player barbPlayer = gameData.players.Find(player => player.isBarbarians);
-
-			// A random 5% of camps will spawn a unit each turn. Shuffle the
-			// camps to make this random.
-			int barbariansToSpawn = (int)Math.Ceiling(GameData.rng.Next(gameData.map.barbarianCamps.Count) / 20.0);
-			List<int> tileIndicies = Enumerable.Range(0, gameData.map.barbarianCamps.Count).ToList();
-			GameData.rng.Shuffle<int>(CollectionsMarshal.AsSpan(tileIndicies));
-
-			for (int i = 0; i < barbariansToSpawn; ++i) {
-				Tile tile = gameData.map.barbarianCamps[tileIndicies[i]];
-
-				// Its a 3:1 ratio of advanced to basic barbarians.
-				UnitPrototype unitType = GameData.rng.Next(100) < 25 ? gameData.barbarianInfo.advancedBarbarian : gameData.barbarianInfo.basicBarbarian;
-				// Give costal camps a chance to spawn a boat.
-				if (tile.NeighborsWater() && GameData.rng.Next(100) < 20) {
-					unitType = gameData.barbarianInfo.barbarianSeaUnitProto;
-				}
-
-				MapUnit newUnit = unitType.GetInstance(gameData);
-				newUnit.location = tile;
-				newUnit.owner = barbPlayer;
-				newUnit.nationality = barbPlayer.civilization;
-				// TODO: make this a conscript.
-				newUnit.experienceLevelKey = gameData.defaultExperienceLevelKey;
-				newUnit.experienceLevel = gameData.defaultExperienceLevel;
-				newUnit.hitPointsRemaining = 3;
-
-				tile.unitsOnTile.Add(newUnit);
-				gameData.mapUnits.Add(newUnit);
-				barbPlayer.units.Add(newUnit);
-
-				log.Debug("New barbarian of type {type} added at {tile}", unitType.name, tile);
-			}
 		}
 
 		///Eventually we'll have a game year or month or whatever, but for now this provides feedback on our progression


### PR DESCRIPTION
Fixes #860, Barbarian galley spawning.

I refactored the barbarian spawning logic and pushed it into its own `BarbarianInteractions` class, to line up with some of the prior art in `/Entrypoints`.

Spawning new units in the game should probably be centralised somewhere. I pushed the spawning into GameData, as the City class routine for adding units can probably be made to reuse it there.

<img width="1130" height="459" alt="barb_galleys" src="https://github.com/user-attachments/assets/4abd45db-9c3e-4f35-a07c-d3d4223abc7f" />

