### PR TITLE
Fixes for custom map issues

### DIFF
--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -47,13 +47,9 @@ public partial class TerrainLayer : LooseLayer {
 		}
 
 		public int CompareTo(TileToDraw other) {
-			// "other" might be null, in which case we should return a positive value. CompareTo(null) will do this.
-			try {
-				return this.tile.ExtraInfo.BaseTerrainFileID.CompareTo(other?.tile.ExtraInfo.BaseTerrainFileID);
-			} catch (Exception) {
-				//It also could be Tile.NONE.  In which case, also return a positive value.
-				return 1;
-			}
+			var a= this?.tile?.ExtraInfo?.BaseTerrainFileID ?? int.MaxValue;
+			var b= other?.tile?.ExtraInfo?.BaseTerrainFileID ?? int.MaxValue;
+			return a.CompareTo(b);
 		}
 	}
 

--- a/C7Engine/MapGenerator.cs
+++ b/C7Engine/MapGenerator.cs
@@ -77,6 +77,9 @@ namespace C7Engine {
 			}
 			log.Information("Seed: " + wc.mapSeed);
 
+			// Step 0: Sanitize world characteristics
+			SanitizeWorldCharacteristics(wc);
+
 			// Step 1: generate the general shape of the terrain.
 			GameMap gameMap = GenerateTerrainShape(wc);
 
@@ -123,13 +126,26 @@ namespace C7Engine {
 
 			// TODO: Goody huts, barbarian camps.
 
-
-
 			// Last step: Assign the terrain file and image ids to each tile so
 			// we know which texture to use when displaying them.
 			TerrainTextureFiles.AssignTextureDetails(new Random(wc.mapSeed + 0xebac), wc.terrainTypes, gameMap);
 
 			return gameMap;
+		}
+
+		private static void SanitizeWorldCharacteristics(WorldCharacteristics wc) {
+			// TODO: Supporting maps of odd dimensions should be doable, but beyond current tiling implementation 
+			// As a mitigation, we simply shrink the map dimensions a bit 
+
+			if (wc.worldSize.width % 2 == 1) {
+				log.Warning("Uneven map width. Shrinking by one.");
+				wc.worldSize.width -= 1;
+			}
+
+			if (wc.worldSize.height % 2 == 1) {
+				log.Warning("Uneven map height. Shrinking by one.");
+				wc.worldSize.height -= 1;
+			}
 		}
 
 		private static GameMap GenerateTerrainShape(WorldCharacteristics wc) {
@@ -1415,7 +1431,7 @@ namespace C7Engine {
 
 			if (wc.worldSize.numberOfCivs > startingLocations.Count)
 				log.Error("More civs than available starting locations.");
-			
+
 			// Before using the starting locations, shuffle them, so that the
 			// human player doesn't always get the best starting spot.
 			rand.Shuffle<Tile>(CollectionsMarshal.AsSpan(startingLocations));
@@ -1460,7 +1476,7 @@ namespace C7Engine {
 			if (attempt > 2) {
 				minDistance /= 2;
 			}
-			
+
 			if (attempt > 3) {
 				minDistance -= attempt;
 				minDistance = Math.Max(minDistance, 3); // hard floor

--- a/C7Engine/MapGenerator.cs
+++ b/C7Engine/MapGenerator.cs
@@ -1413,6 +1413,9 @@ namespace C7Engine {
 				}
 			}
 
+			if (wc.worldSize.numberOfCivs > startingLocations.Count)
+				log.Error("More civs than available starting locations.");
+			
 			// Before using the starting locations, shuffle them, so that the
 			// human player doesn't always get the best starting spot.
 			rand.Shuffle<Tile>(CollectionsMarshal.AsSpan(startingLocations));
@@ -1456,6 +1459,11 @@ namespace C7Engine {
 		private static bool TileIsTooCloseToOtherStarts(Tile t, List<Tile> startingLocations, int minDistance, int attempt) {
 			if (attempt > 2) {
 				minDistance /= 2;
+			}
+			
+			if (attempt > 3) {
+				minDistance -= attempt;
+				minDistance = Math.Max(minDistance, 3); // hard floor
 			}
 
 			foreach (Tile start in startingLocations) {


### PR DESCRIPTION
Fixes/mitigations for #899, custom map pains.

First issue is due to map gen bailing out too early due to extreme custom maps failing to honour civ distancing rules even after initial halving mitigation. This patch allows progressively closer and closer civ placement, down to a hard floor of 3.

Second issue is due to odd-valued map dimensions tripping up some of the tiling / map gen logic. Instead of dealing with stride issues and tile indexing maths, a simple mitigation is to adjust the world characteristics and and shrink world size by one relative to the spec, so dimensions become even-valued. Odd-valued maps should be doable, but support for such probably isn't a high priority.

Final fix is to unrelated to the reported issue. `TileToDraw` in `MapView` seems to be some sort of texture sorting based performance enhancement. The tile comparison logic inside the mechanism generously allows for null comparison tiles on the right hand side, but doesn't handle left hand side null tiles. Worse still, the current error handling means that the right hand side wins every one of these degenerate comparisons, resulting in chaos in things like sorting algorithms. I was hitting some poor performance / freezing due to infinite looping. The fix cleans up the comparison with consistent null handling.