### PR TITLE
Fix QuickStart

### DIFF
--- a/C7/UIElements/MainMenu/MainMenu.cs
+++ b/C7/UIElements/MainMenu/MainMenu.cs
@@ -54,8 +54,8 @@ public partial class MainMenu : Node {
 
 		// TODO: enable buttons are features are implemented
 		ButtonContainer.NewGame.Pressed += GoToWorldSetup;
-		ButtonContainer.QuickStart.Pressed += StartGame;
-		ButtonContainer.Tutorial.Pressed += StartGame;
+		ButtonContainer.QuickStart.Pressed += QuickStartGame;
+		ButtonContainer.Tutorial.Pressed += QuickStartGame;
 		ButtonContainer.Tutorial.Visible = false;
 		ButtonContainer.LoadGame.Pressed += LoadGame;
 		ButtonContainer.LoadScenario.Pressed += LoadScenario;
@@ -112,9 +112,10 @@ public partial class MainMenu : Node {
 		GetTree().ChangeSceneToFile("res://UIElements/NewGame/world_setup.tscn");
 	}
 
-	public void StartGame() {
+	public void QuickStartGame() {
 		log.Information("start game button pressed");
 		PlayButtonPressedSound();
+		QuickStartSetup.Init(Global);
 		GetTree().ChangeSceneToFile("res://C7Game.tscn");
 	}
 

--- a/C7/UIElements/NewGame/QuickStartSetup.cs
+++ b/C7/UIElements/NewGame/QuickStartSetup.cs
@@ -1,0 +1,49 @@
+using Godot;
+using System;
+using System.Linq;
+using C7GameData;
+using C7Engine;
+using C7Engine.Lua;
+using Serilog;
+
+public partial class QuickStartSetup : Node {
+	private static ILogger log = LogManager.ForContext<ScenarioSetup>();
+
+	public static void Init(GlobalSingleton globalState) {
+		log.Information("Setting up a QuickStart game");
+
+		globalState.ResetLoadGameFields();
+
+		var save = GameModeLoader.Load(GamePaths.GameModesDir, GamePaths.GameMode);
+
+		globalState.WorldCharacteristics = new WorldCharacteristics(save) {
+			landform = WorldCharacteristics.Landform.Pangaea,
+			oceanCoverage = WorldCharacteristics.OceanCoverage.Percent_70,
+			age = WorldCharacteristics.Age.Billion_4,
+			climate = WorldCharacteristics.Climate.Normal,
+			temperature = WorldCharacteristics.Temperature.Temperate,
+			worldSize = WorldSize.Generic(),
+			mapSeed = new Random().Next(),
+		};
+
+		globalState.SaveGame = save;
+
+		Civilization player =  save.Civilizations.FirstOrDefault(x => x.name == "Netherlands") ?? save.Civilizations[1];
+
+		Difficulty difficulty = save.Difficulties.FirstOrDefault(x => x.Name == "Regent") ?? save.Difficulties[0];
+
+		var opponents = save.Civilizations
+			.Select(x => new SelectedOpponent { isRandom = true })
+			.Take(globalState.WorldCharacteristics.worldSize.numberOfCivs - 1)
+			.ToList();
+
+		GameSetup gameSetup = new() {
+			playerCivilization = player,
+			difficulty = difficulty,
+			worldCharacteristics = globalState.WorldCharacteristics,
+			opponents = opponents
+		};
+
+		gameSetup.Populate(save);
+	}
+}


### PR DESCRIPTION
Looks like Quick Start broke during the base game / save file consolidation effort.

Git bisect suggests it was one of these commits:
19aada80da27a36d8e81dbea90ebc89da175ba5f
42c369674f31968c36c5ff2dd81949157e2076cc

This patch adds a dedicated class that does some default inits, enough to launch a Quick Start game.