### PR TITLE
Tile improvement fix

### DIFF
--- a/C7Engine/C7GameData/Terraform.cs
+++ b/C7Engine/C7GameData/Terraform.cs
@@ -89,6 +89,8 @@ public class Terraform {
 		Effect?.Invoke(new(player, tile, this));
 
 		if (Improvement != null) {
+			if (!tile.overlays.CanAdd(Improvement))
+				throw new InvalidOperationException($"Cannot add {Improvement.key} to the tile {tile}");
 			tile.overlays.Add(Improvement);
 		}
 	}

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -827,9 +827,6 @@ namespace C7GameData {
 		}
 
 		public void Add(TerrainImprovement improvement) {
-			if (!CanAdd(improvement))
-				throw new InvalidOperationException($"Cannot add {improvement.key} to the tile");
-
 			terrainImprovementByLayer.TryGetValue(improvement.layer, out TerrainImprovement replacedImprovement);
 
 			terrainImprovementByLayer[improvement.layer] = improvement;


### PR DESCRIPTION
I had some issues when trying to load a json save where some tiles had railroads. As far as I can tell, this happens, because when we save the overlays, if there is a railroad, we don't save the road that invisibly exists underneath it.

So then, when loading, we try to add railroad to a tile that doesn't seem to have a road.

This does not happen with .biq and .sav files because when debugging I saw that we import both a road and a railroad overlay when laoding the tile info

So now, the only place where we check if we can add an improvement, is during gameplay and not when loading a save. I think it also makes  sense from a cleaner code standpoint, to have a dedicated method to add an improvement, rather than also checking if we can add it in the same method.

I don't think that we need to imitate what the .biq and .sav files do and save both improvements, as we can upgrade and downgrade on the fly.