### PR TITLE
Implement culture groups for civilizations

### DIFF
--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -5534,6 +5534,7 @@
       "primaryColorIndex": 0,
       "secondaryColorIndex": 0,
       "leaderGender": "male",
+      "cultureGroupKey": "None",
       "cityNames": [
         "Chanca",
         "Lupaca",
@@ -5622,6 +5623,7 @@
       "primaryColorIndex": 1,
       "secondaryColorIndex": 1,
       "leaderGender": "male",
+      "cultureGroupKey": "Mediterranean",
       "leaderArtFile": "art\\advisors\\CE_all.pcx",
       "cityNames": [
         "Rome",
@@ -5687,6 +5689,7 @@
       "primaryColorIndex": 3,
       "secondaryColorIndex": 3,
       "leaderGender": "female",
+      "cultureGroupKey": "Mediterranean",
       "leaderArtFile": "art\\advisors\\CL_all.pcx",
       "cityNames": [
         "Thebes",
@@ -5737,6 +5740,7 @@
       "primaryColorIndex": 10,
       "secondaryColorIndex": 10,
       "leaderGender": "male",
+      "cultureGroupKey": "Mediterranean",
       "leaderArtFile": "art\\advisors\\AL_all.pcx",
       "cityNames": [
         "Athens",
@@ -5787,6 +5791,7 @@
       "primaryColorIndex": 1,
       "secondaryColorIndex": 13,
       "leaderGender": "male",
+      "cultureGroupKey": "Mid East",
       "leaderArtFile": "art\\advisors\\HA_all.pcx",
       "cityNames": [
         "Babylon",
@@ -5835,6 +5840,7 @@
       "primaryColorIndex": 6,
       "secondaryColorIndex": 6,
       "leaderGender": "male",
+      "cultureGroupKey": "European",
       "leaderArtFile": "art\\advisors\\BS_all.pcx",
       "cityNames": [
         "Berlin",
@@ -5872,6 +5878,7 @@
       "primaryColorIndex": 9,
       "secondaryColorIndex": 9,
       "leaderGender": "female",
+      "cultureGroupKey": "European",
       "leaderArtFile": "art\\advisors\\CA_all.pcx",
       "cityNames": [
         "Moscow",
@@ -5932,6 +5939,7 @@
       "primaryColorIndex": 5,
       "secondaryColorIndex": 15,
       "leaderGender": "male",
+      "cultureGroupKey": "Asian",
       "leaderArtFile": "art\\advisors\\MO_all.pcx",
       "cityNames": [
         "Beijing",
@@ -5971,6 +5979,7 @@
       "primaryColorIndex": 5,
       "secondaryColorIndex": 5,
       "leaderGender": "male",
+      "cultureGroupKey": "American",
       "leaderArtFile": "art\\advisors\\AB_all.pcx",
       "cityNames": [
         "Washington",
@@ -6032,6 +6041,7 @@
       "primaryColorIndex": 4,
       "secondaryColorIndex": 11,
       "leaderGender": "male",
+      "cultureGroupKey": "Asian",
       "leaderArtFile": "art\\advisors\\TO_all.pcx",
       "cityNames": [
         "Kyoto",
@@ -6079,6 +6089,7 @@
       "primaryColorIndex": 7,
       "secondaryColorIndex": 7,
       "leaderGender": "female",
+      "cultureGroupKey": "European",
       "leaderArtFile": "art\\advisors\\JO_all.pcx",
       "cityNames": [
         "Paris",
@@ -6121,6 +6132,7 @@
       "primaryColorIndex": 8,
       "secondaryColorIndex": 12,
       "leaderGender": "male",
+      "cultureGroupKey": "Asian",
       "leaderArtFile": "art\\advisors\\GH_all.pcx",
       "cityNames": [
         "Delhi",
@@ -6159,6 +6171,7 @@
       "primaryColorIndex": 10,
       "secondaryColorIndex": 14,
       "leaderGender": "male",
+      "cultureGroupKey": "Mid East",
       "leaderArtFile": "art\\advisors\\XE_all.pcx",
       "cityNames": [
         "Persepolis",
@@ -6209,6 +6222,7 @@
       "primaryColorIndex": 4,
       "secondaryColorIndex": 4,
       "leaderGender": "male",
+      "cultureGroupKey": "American",
       "leaderArtFile": "art\\advisors\\MN_all.pcx",
       "cityNames": [
         "Tenochtitlan",
@@ -6266,6 +6280,7 @@
       "primaryColorIndex": 3,
       "secondaryColorIndex": 16,
       "leaderGender": "male",
+      "cultureGroupKey": "Mid East",
       "leaderArtFile": "art\\advisors\\ZU_all.pcx",
       "cityNames": [
         "Zimbabwe",
@@ -6303,6 +6318,7 @@
       "primaryColorIndex": 8,
       "secondaryColorIndex": 8,
       "leaderGender": "male",
+      "cultureGroupKey": "American",
       "leaderArtFile": "art\\advisors\\HI_all.pcx",
       "cityNames": [
         "Salamanca",
@@ -6353,6 +6369,7 @@
       "primaryColorIndex": 2,
       "secondaryColorIndex": 2,
       "leaderGender": "female",
+      "cultureGroupKey": "European",
       "leaderArtFile": "art\\advisors\\LZ_all.pcx",
       "cityNames": [
         "London",
@@ -6403,6 +6420,7 @@
       "primaryColorIndex": 3,
       "secondaryColorIndex": 26,
       "leaderGender": "male",
+      "cultureGroupKey": "Asian",
       "leaderArtFile": "art\\advisors\\x_temujin advisor.pcx",
       "cityNames": [
         "Karakorum",
@@ -6454,6 +6472,7 @@
       "primaryColorIndex": 5,
       "secondaryColorIndex": 20,
       "leaderGender": "female",
+      "cultureGroupKey": "European",
       "leaderArtFile": "art\\advisors\\x_isabell advisor.pcx",
       "cityNames": [
         "Madrid",
@@ -6506,6 +6525,7 @@
       "primaryColorIndex": 8,
       "secondaryColorIndex": 31,
       "leaderGender": "male",
+      "cultureGroupKey": "European",
       "leaderArtFile": "art\\advisors\\x_ragnar advisor.pcx",
       "cityNames": [
         "Trondheim",
@@ -6560,6 +6580,7 @@
       "primaryColorIndex": 2,
       "secondaryColorIndex": 18,
       "leaderGender": "male",
+      "cultureGroupKey": "Mid East",
       "leaderArtFile": "art\\advisors\\x_osman advisor.pcx",
       "cityNames": [
         "Istanbul",
@@ -6610,6 +6631,7 @@
       "primaryColorIndex": 4,
       "secondaryColorIndex": 25,
       "leaderGender": "male",
+      "cultureGroupKey": "European",
       "leaderArtFile": "art\\advisors\\x_brennus advisor.pcx",
       "cityNames": [
         "Entremont",
@@ -6661,6 +6683,7 @@
       "primaryColorIndex": 7,
       "secondaryColorIndex": 30,
       "leaderGender": "male",
+      "cultureGroupKey": "Mid East",
       "leaderArtFile": "art\\advisors\\x_abu bakr advisor.pcx",
       "cityNames": [
         "Mecca",
@@ -6710,6 +6733,7 @@
       "primaryColorIndex": 9,
       "secondaryColorIndex": 11,
       "leaderGender": "male",
+      "cultureGroupKey": "Mediterranean",
       "leaderArtFile": "art\\advisors\\x_Hannibal advisor.pcx",
       "cityNames": [
         "Carthage",
@@ -6761,6 +6785,7 @@
       "primaryColorIndex": 6,
       "secondaryColorIndex": 19,
       "leaderGender": "male",
+      "cultureGroupKey": "Asian",
       "leaderArtFile": "art\\advisors\\x_Wang Kon advisor.pcx",
       "cityNames": [
         "Seoul",
@@ -6812,6 +6837,7 @@
       "primaryColorIndex": 5,
       "secondaryColorIndex": 20,
       "leaderGender": "male",
+      "cultureGroupKey": "Mid East",
       "leaderArtFile": "art\\advisors\\x2_Gilgamesh advisor.pcx",
       "cityNames": [
         "Ur",
@@ -6858,6 +6884,7 @@
       "primaryColorIndex": 14,
       "secondaryColorIndex": 27,
       "leaderGender": "male",
+      "cultureGroupKey": "Mid East",
       "leaderArtFile": "art\\advisors\\x2_Mursilis advisor.pcx",
       "cityNames": [
         "Hattusas",
@@ -6904,6 +6931,7 @@
       "primaryColorIndex": 2,
       "secondaryColorIndex": 18,
       "leaderGender": "male",
+      "cultureGroupKey": "European",
       "leaderArtFile": "art\\advisors\\x2_William advisor.pcx",
       "cityNames": [
         "Amsterdam",
@@ -6950,6 +6978,7 @@
       "primaryColorIndex": 8,
       "secondaryColorIndex": 17,
       "leaderGender": "male",
+      "cultureGroupKey": "European",
       "leaderArtFile": "art\\advisors\\x2_Henry advisor.pcx",
       "cityNames": [
         "Lisbon",
@@ -7007,6 +7036,7 @@
       "primaryColorIndex": 11,
       "secondaryColorIndex": 1,
       "leaderGender": "female",
+      "cultureGroupKey": "Mediterranean",
       "leaderArtFile": "art\\advisors\\x2_Theodora advisor.pcx",
       "cityNames": [
         "Constantinople",
@@ -7053,6 +7083,7 @@
       "primaryColorIndex": 7,
       "secondaryColorIndex": 8,
       "leaderGender": "male",
+      "cultureGroupKey": "American",
       "leaderArtFile": "art\\advisors\\x2_Pachacuti advisor.pcx",
       "cityNames": [
         "Cuzco",
@@ -7099,6 +7130,7 @@
       "primaryColorIndex": 6,
       "secondaryColorIndex": 5,
       "leaderGender": "male",
+      "cultureGroupKey": "American",
       "leaderArtFile": "art\\advisors\\x2_Smoke-Jaguar_advisor.pcx",
       "cityNames": [
         "Chich\u00E9n Itza",
@@ -7137,6 +7169,32 @@
         "agricultural"
       ],
       "isBarbarian": false
+    }
+  ],
+  "cultureGroups": [
+    {
+      "index": -1,
+      "name": "None"
+    },
+    {
+      "index": 0,
+      "name": "American"
+    },
+    {
+      "index": 1,
+      "name": "European"
+    },
+    {
+      "index": 2,
+      "name": "Mediterranean"
+    },
+    {
+      "index": 3,
+      "name": "Mid East"
+    },
+    {
+      "index": 4,
+      "name": "Asian"
     }
   ],
   "strengthBonuses": [

--- a/C7Engine/C7GameData/Civilization.cs
+++ b/C7Engine/C7GameData/Civilization.cs
@@ -11,6 +11,11 @@ namespace C7GameData {
 		Female,
 	}
 
+	public class CultureGroup() {
+		public int index { get; init; }
+		public string name { get; init; }
+	}
+
 	public class Civilization {
 		public enum Trait {
 			Militaristic,
@@ -38,6 +43,22 @@ namespace C7GameData {
 		public int primaryColorIndex;
 		public int secondaryColorIndex;
 		public Gender leaderGender;
+
+		[JsonIgnore]
+		public CultureGroup cultureGroup { get; private set; }
+
+		// This is null during gameplay to discourage usage, and instead use the cultureGroup
+		// It's only used for saving/loading 
+		public string cultureGroupKey;
+
+		public void SetCultureGroup(int index, string cultureGroupName) {
+			cultureGroupKey = null;
+			var cg = new CultureGroup {
+				index = index,
+				name = cultureGroupName
+			};
+			cultureGroup = cg;
+		}
 
 		// Like `art\advisors\LZ_all.pcx` for the English.
 		public string leaderArtFile;

--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -31,6 +31,7 @@ namespace C7GameData {
 		public List<City> cities = new List<City>();
 
 		internal List<Civilization> civilizations = new List<Civilization>();
+		internal HashSet<CultureGroup> cultureGroups = new HashSet<CultureGroup>();
 
 		public List<ExperienceLevel> experienceLevels = new List<ExperienceLevel>();
 		public List<Tech> techs = new();

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -60,6 +60,7 @@ namespace C7GameData {
 			save.TerrainImprovements = SaveTerrainImprovement.Civ3Improvements().ToList();
 
 			ImportRaces();
+			ImportCultureGroups();
 			ImportTechs();
 			ImportCiv3Resources();
 			ImportTerraforms();
@@ -355,6 +356,23 @@ namespace C7GameData {
 			}
 		}
 
+		private void ImportCultureGroups() {
+			BiqData theBiq = biq.Race is null ? defaultBiq : biq;
+			HashSet<CultureGroup> cultureGroups = new HashSet<CultureGroup>();
+			HashSet<int> cultureGroupsIndexes = new HashSet<int>();
+			int i = 0;
+			foreach (RACE race in theBiq.Race) {
+				if (cultureGroupsIndexes.Add(race.CultureGroup)) {
+					var cg = new CultureGroup() {
+						index = race.CultureGroup,
+						name = GetCultureGroupIdentifier(race.CultureGroup),
+					};
+					cultureGroups.Add(cg);
+				}
+			}
+			save.CultureGroups = cultureGroups.OrderBy(c => c.index).ToHashSet();
+		}
+
 		private void ImportRaces() {
 			BiqData theBiq = biq.Race is null ? defaultBiq : biq;
 			int i = 0;
@@ -373,6 +391,7 @@ namespace C7GameData {
 					civ.cityNames.Add(city.Name);
 				}
 				civ.traits = LoadCivTraits(race).ToHashSet();
+				civ.cultureGroupKey = GetCultureGroupIdentifier(race.CultureGroup);
 
 				// Look up the image for non-barbarian civs.
 				string artName = pediaIcons.GetLeaderArtName(race.CivilopediaEntry);
@@ -383,6 +402,17 @@ namespace C7GameData {
 				save.Civilizations.Add(civ);
 				i++;
 			}
+		}
+
+		private static string GetCultureGroupIdentifier(int cultureGroupIndex) {
+			if (cultureGroupIndex == -1) return "None"; // Barbarians
+			if (cultureGroupIndex == 0) return "American";
+			if (cultureGroupIndex == 1) return "European";
+			if (cultureGroupIndex == 2) return "Mediterranean";
+			if (cultureGroupIndex == 3) return "Mid East";
+			if (cultureGroupIndex == 4) return "Asian";
+			log.Error($"The culture group index {cultureGroupIndex} is invalid. Defaulting to `American`.");
+			return "American";
 		}
 
 		private static IEnumerable<Civilization.Trait> LoadCivTraits(RACE race) {

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -440,7 +440,7 @@ namespace C7GameData {
 		}
 
 		public bool WouldAcceptDealFrom(GameData gameData, Player other, TradeOffer theirOffer, TradeOffer ourOffer) {
-			// TODO: consider any factors like trade reputations here
+			// TODO: consider any factors like trade reputations here and culture groups
 			// TODO: figure out when peace is acceptable
 			int theirGoldValue = theirOffer.GoldEquivalentFor(gameData, this);
 			int ourGoldValue = ourOffer.GoldEquivalentFor(gameData, this);

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -7,7 +7,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using C7Engine;
-using Serilog;
 
 namespace C7GameData.Save {
 
@@ -54,6 +53,7 @@ namespace C7GameData.Save {
 				Seed = data.seed,
 				TurnNumber = data.turn,
 				Civilizations = data.civilizations,
+				CultureGroups = data.cultureGroups,
 				Map = new SaveMap(data.map),
 				TerrainTypes = data.terrainTypes,
 				Resources = data.Resources,
@@ -78,6 +78,9 @@ namespace C7GameData.Save {
 				Rules = data.rules,
 				TerrainImprovements = data.terrainImprovements.ConvertAll(ti => ti.ToSaveTerrainImprovement())
 			};
+			foreach (var saveCivilization in save.Civilizations) {
+				saveCivilization.cultureGroupKey = save.CultureGroups.First(c => c.name == saveCivilization.cultureGroup.name).name;
+			}
 			save.StrengthBonuses.Add(data.fortificationBonus);
 			save.StrengthBonuses.Add(data.riverCrossingBonus);
 			save.StrengthBonuses.Add(data.cityLevel1DefenseBonus);
@@ -119,6 +122,7 @@ namespace C7GameData.Save {
 			ConvertBarbarianInfo(data);
 			ConvertStrengthBonuses(data);
 			ConvertHealRates(data);
+			ConvertCultureGroups(data);
 
 			data.defaultExperienceLevelKey = DefaultExperienceLevel;
 			data.defaultExperienceLevel = data.experienceLevels.Find(el => el.key == DefaultExperienceLevel);
@@ -165,6 +169,7 @@ namespace C7GameData.Save {
 				Resources = Resources,
 				scenarioSearchPath = ScenarioSearchPath,
 				civilizations = Civilizations,
+				cultureGroups = CultureGroups,
 				citizenTypes = CitizenTypes,
 				governments = Governments,
 				worldSizes = WorldSizes,
@@ -383,6 +388,16 @@ namespace C7GameData.Save {
 			data.healRateInCity = HealRates["city"];
 		}
 
+		private void ConvertCultureGroups(GameData data) {
+			foreach (var civilization in data.civilizations) {
+				var cg = data.cultureGroups.FirstOrDefault(c => c.name == civilization.cultureGroupKey);
+				if (cg == null) {
+					throw new Exception(string.Format($"Culture group name `{civilization.cultureGroupKey}` for civilization {civilization.name} was not found in game data."));
+				}
+				civilization.SetCultureGroup(cg.index, cg.name);
+			}
+		}
+
 		public string Version = "0.0.0";
 		public int Seed = -1;
 		public int TurnNumber = 0;
@@ -401,6 +416,7 @@ namespace C7GameData.Save {
 		public List<ExperienceLevel> ExperienceLevels = new List<ExperienceLevel>();
 		public string DefaultExperienceLevel; // key
 		public List<Civilization> Civilizations = new List<Civilization>();
+		public HashSet<CultureGroup> CultureGroups = new HashSet<CultureGroup>();
 		public List<StrengthBonus> StrengthBonuses = new List<StrengthBonus>();
 		public Dictionary<string, int> HealRates = new Dictionary<string, int>();
 		public Rules Rules = new();

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -390,6 +390,8 @@ namespace C7GameData.Save {
 
 		private void ConvertCultureGroups(GameData data) {
 			foreach (var civilization in data.civilizations) {
+				// because this might be initialized from the tests
+				if (civilization.cultureGroup != null) continue;
 				var cg = data.cultureGroups.FirstOrDefault(c => c.name == civilization.cultureGroupKey);
 				if (cg == null) {
 					throw new Exception(string.Format($"Culture group name `{civilization.cultureGroupKey}` for civilization {civilization.name} was not found in game data."));

--- a/C7Engine/GameSetup.cs
+++ b/C7Engine/GameSetup.cs
@@ -44,6 +44,9 @@ public class GameSetup {
 		AddPlayer(save, save.Civilizations.Find(c => c.isBarbarian), isHuman: false);
 		save.BarbarianInfo.barbarianActivity = worldCharacteristics.barbarianActivity;
 
+		// TODO: There is an option called "Culturally Linked Start Loc."
+		// which (if on) puts players with the same culture group near each other
+
 		// Add the human player.
 		AddPlayer(save, this.playerCivilization, isHuman: true);
 


### PR DESCRIPTION
As the title says.

All .biq and .sav files seem to have hardcoded the 6 culture group values, but on our end should be fairly easily expandable.

Right now these don't really have any effect in the game, but when we start loading culture specific building textures for example, we will start seeing some meaningfull changes.