### PR TITLE
Biq and SAV enhancements

### DIFF
--- a/QueryCiv3/Biq.cs
+++ b/QueryCiv3/Biq.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using QueryCiv3.Biq;
 
 namespace QueryCiv3 {
@@ -240,7 +239,7 @@ namespace QueryCiv3 {
 								for (int i = 0; i < count; i++) {
 									Buffer.MemoryCopy(dataPtr, gamePtr, GAME_LEN_1, GAME_LEN_1);
 									gamePtr += GAME_LEN_1;
-									playableCivs = Game[i].NumberOfPlayableCivs == 0 ? 31 : Game[i].NumberOfPlayableCivs;
+									playableCivs = Game[i].NumberOfPlayableCivs;
 									GameCiv[i] = new int[playableCivs];
 									rowLength = playableCivs * sizeof(int);
 									fixed (void* ptr2 = GameCiv[i]) Buffer.MemoryCopy(dataPtr + GAME_LEN_1, ptr2, rowLength, rowLength);

--- a/QueryCiv3/BiqSections/Game.cs
+++ b/QueryCiv3/BiqSections/Game.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.InteropServices;
 
 namespace QueryCiv3.Biq {
@@ -25,11 +24,16 @@ namespace QueryCiv3.Biq {
 		public int Length;
 		public int DefaultGameRules; // 0: don't use, 1: use
 		public int DefaultVictoryConditions; // 0: don't use, 1: use
-		public int NumberOfPlayableCivs; // 0: all playable
+											 // By playable here, it means these civs' data are included in the game data,
+											 // not necessarily that the human player can pick them,
+											 // or that they are even a part of the game
+		public int NumberOfPlayableCivs; // 0: all (31) playable
 
 		/*
             Dynamic length gap
-            In BIQ files, for each playable civ, there is a 1 int long ID for that civ
+            In BIQ files, if the NumberOfPlayableCivs is > 0,
+            for each playable civ, there is a 1 int long ID for that civ.
+            If the NumberOfPlayableCivs is 0 this section has been observed to have 0 length. 
             Data is instead stored in 2d array GameCiv
         */
 
@@ -39,18 +43,22 @@ namespace QueryCiv3.Biq {
 		public bool DiplomaticVictory { get => Util.GetFlag(Flags[0], 2); }
 		public bool ConquestVictory { get => Util.GetFlag(Flags[0], 3); }
 		public bool CulturalVictory { get => Util.GetFlag(Flags[0], 4); }
-		public bool CivSpecificAbilities { get => Util.GetFlag(Flags[0], 5); }
+		public bool CivSpecificAbilities { get => Util.GetFlag(Flags[0], 5); } // PTW, or at least not present in Conquests biq >= 12.8
 		public bool CulturallyLinkedStart { get => Util.GetFlag(Flags[0], 6); }
-		public bool RestartPlayers { get => Util.GetFlag(Flags[0], 7); }
+		public bool RespawnAiPlayers { get => Util.GetFlag(Flags[0], 7); }
 
 		public bool PreserveRandomSeed { get => Util.GetFlag(Flags[1], 0); }
 		public bool AcceleratedProduction { get => Util.GetFlag(Flags[1], 1); }
-		public bool Elimination { get => Util.GetFlag(Flags[1], 2); }
+		public bool CityElimination { get => Util.GetFlag(Flags[1], 2); }
 		public bool Regicide { get => Util.GetFlag(Flags[1], 3); }
 		public bool MassRegicide { get => Util.GetFlag(Flags[1], 4); }
-		public bool VictoryLocations { get => Util.GetFlag(Flags[1], 5); }
-		public bool CaptureTheFlag { get => Util.GetFlag(Flags[1], 6); }
+		public bool VictoryLocations { get => Util.GetFlag(Flags[1], 5); } // 'Victory Point Scoring' flag in Editor
+		public bool CaptureTheFlag { get => Util.GetFlag(Flags[1], 6); } // 'Capture the Unit' flag in Editor
 		public bool AllowCulturalConversions { get => Util.GetFlag(Flags[1], 7); }
+
+		public bool WonderVictory { get => Util.GetFlag(Flags[2], 0); }
+		public bool ReverseCaptureTheFlag { get => Util.GetFlag(Flags[2], 1); }
+		public bool AllowScientificLeaders { get => Util.GetFlag(Flags[2], 2); }
 
 		public int PlaceCaptureUnits;
 		public int AutoPlaceKings;
@@ -71,9 +79,13 @@ namespace QueryCiv3.Biq {
 
 		/*
             Dynamic length gap
-            In BIQ files, for each playable civ, there is a single int for alliance status
+            In BIQ files, if the NumberOfPlayableCivs is > 0,
+            for each playable civ, there is a single int for alliance status.
+            If the NumberOfPlayableCivs is 0 this section has been observed to have 0 length. 
             Data is instead stored in 2d array GameAlliance
         */
+
+		// (4 bytes - long		map visible, BIX >= 11.19 ONLY, not BIQ (major=12))
 
 		public int VictoryPointLimit;
 		public int CityEliminationCount;
@@ -102,7 +114,7 @@ namespace QueryCiv3.Biq {
 		public int PlagueStrength;
 		public int PlagueGracePeriod;
 		public int PlagueMaxOccurance;
-		private fixed byte UnknownBuffer2[264];
+		private fixed byte UnknownBuffer2[264]; // one 4-byte int + 260 bytes of string?
 		public int RespawnFlagUnits;
 		public byte CaptureAnyFlag;
 		public int GoldForCapture;

--- a/QueryCiv3/BiqSections/Rule.cs
+++ b/QueryCiv3/BiqSections/Rule.cs
@@ -79,6 +79,8 @@ namespace QueryCiv3.Biq {
 		public int MaximumResearchTime;
 		public int MinimumResearchTime;
 		public int FlagUnitType;
+
+		// Only in conquests
 		public int UpgradeCost;
 	}
 }

--- a/QueryCiv3/QueryCiv3.cs
+++ b/QueryCiv3/QueryCiv3.cs
@@ -2,6 +2,20 @@ using System;
 using System.Collections.Generic;
 
 namespace QueryCiv3 {
+	public enum FileVersion {
+		Vanilla,
+		PlayTheWorld,
+		Conquests,
+	}
+
+	public class Civ3Version {
+		public FileVersion FileVersion;
+		public string FileTypeName;
+		public short MagicNumber; // not sure what it is, or even if it is in anything except .sav files
+		public int MajorVersion;
+		public int MinorVersion;
+	}
+
 	public class Civ3Section {
 		public string Name;
 		public int Offset;
@@ -11,12 +25,13 @@ namespace QueryCiv3 {
 		public Civ3Section[] Sections { get; protected set; }
 		public bool IsGameFile { get; protected set; }
 		public bool IsBicFile { get; protected set; }
+		public Civ3Version Civ3Version { get; protected set; }
 		public int Length => FileData.Length;
 		public Civ3File(byte[] fileBytes) {
 			this.FileData = fileBytes;
 			Sections = PopulateSections(FileData);
-			byte[] Civ3Bytes = new byte[]{0x43, 0x49, 0x56, 0x33};
-			byte[] BicBytes = new byte[]{0x42, 0x49, 0x43};
+			byte[] Civ3Bytes = new byte[]{0x43, 0x49, 0x56, 0x33}; // CIV3
+			byte[] BicBytes = new byte[]{0x42, 0x49, 0x43}; // BIC
 			IsGameFile = true;
 			IsBicFile = true;
 			for (int i = 0; i < 4; i++) {
@@ -27,6 +42,42 @@ namespace QueryCiv3 {
 					IsBicFile = false;
 				}
 			}
+
+			this.Civ3Version = PopulateCiv3Version();
+		}
+
+		private Civ3Version PopulateCiv3Version() {
+			string header = "";
+			short mag = -1;
+			int maj = -1;
+			int min = -1;
+
+			if (IsGameFile) {
+				header = GetString(0, 4);
+				mag = ReadInt16(4);
+				maj = ReadInt32(6);
+				min = ReadInt32(10);
+			} else if (IsBicFile) {
+				header = GetString(0, 4);
+				mag = -1;
+				maj = ReadInt32(24);
+				min = ReadInt32(28);
+			}
+
+			return new Civ3Version() {
+				FileTypeName = header,
+				FileVersion = GetGameVersion(header, maj),
+				MagicNumber = mag,
+				MajorVersion = maj,
+				MinorVersion = min,
+			};
+		}
+
+		private FileVersion GetGameVersion(string input, int majorVersion) {
+			if ((input == "BICX" && majorVersion == 12) || (input == "BICQ" && majorVersion == 12)) return FileVersion.Conquests;
+			if (input == "BICX") return FileVersion.PlayTheWorld;
+			if (input == "BIC") return FileVersion.Vanilla;
+			return FileVersion.Conquests;
 		}
 		public Boolean SectionExists(string sectionName) {
 			bool result = false;

--- a/QueryCiv3/SavSections/Game.cs
+++ b/QueryCiv3/SavSections/Game.cs
@@ -17,16 +17,20 @@ namespace QueryCiv3.Sav {
 		public bool CulturalVictory { get => Util.GetFlag(Flags[4], 4); }
 		public bool CivSpecificAbilities { get => Util.GetFlag(Flags[4], 5); }
 		public bool CulturallyLinkedStart { get => Util.GetFlag(Flags[4], 6); }
-		public bool RestartPlayers { get => Util.GetFlag(Flags[4], 7); }
+		public bool RespawnAiPlayers { get => Util.GetFlag(Flags[4], 7); }
 
 		public bool PreserveRandomSeed { get => Util.GetFlag(Flags[5], 0); }
 		public bool AcceleratedProduction { get => Util.GetFlag(Flags[5], 1); }
-		public bool Elimination { get => Util.GetFlag(Flags[5], 2); }
+		public bool CityElimination { get => Util.GetFlag(Flags[5], 2); }
 		public bool Regicide { get => Util.GetFlag(Flags[5], 3); }
 		public bool MassRegicide { get => Util.GetFlag(Flags[5], 4); }
 		public bool VictoryLocations { get => Util.GetFlag(Flags[5], 5); }
 		public bool CaptureTheFlag { get => Util.GetFlag(Flags[5], 6); }
 		public bool AllowCulturalConversions { get => Util.GetFlag(Flags[5], 7); }
+
+		public bool WonderVictory { get => Util.GetFlag(Flags[6], 0); }
+		public bool ReverseCaptureTheFlag { get => Util.GetFlag(Flags[6], 1); }
+		public bool AllowScientificLeaders { get => Util.GetFlag(Flags[6], 2); }
 
 
 		public int DifficultyID;


### PR DESCRIPTION
This PR in short:
Add version info for .biq and .sav files.
Add a few more flags in the GAME structs (both .biq and .sav) 
Some comments and observations on the data structures 
Fix bug(?) where if the player number is 0 in the biq file, certain dynamic parts have also 0 length

I came across this .sav file, where it was clear that some data had either uninitialized values (usually in the form of -842150451 which is 0xCDCDCDCD in hex), or had plain wrong values, but the save progressed normally in the original civ3 game.

What I tracked it down to was that, even with an unmodified conquests.biq file, if you start a game choosing Quick Start certain values in the binary where "missing", notably the dynamic parts in the .biq GAME struct, which contain a) the ids of the civs in game and b) their alliance statuses.

That caused the whole reading of the binary to be offset by some amount, which I think is constant regardless of settings (4 bytes * 31 players (ids) + 4 bytes * 31 players (alliances)), resulting in junk data after that point in the corresponding GAME struct.

It also seems that the game at this point also assigns some default values, regardless of what it's loading from, so for example, the plague name might be "Plague" in the conquests.biq, or even absent if it's a PTW file, but upon inspection after loading, the plague name has the value "Black Death", which seems to be hadcoded in the game exe itself (found using Ghidra).

Tha flags/comments and the version are bonuses that I came across/added during the investigation.

Ah, almost forgot, [Quintillus' editor source code](https://sr.ht/~adj/Civ_III_Scenario_Editor/) was a big help to be able to identify biq and sav versions, as well as the [decompression tool ](https://forums.civfanatics.com/resources/cross-platform-sav-biq-decompressor-command-line.22852/)