### PR TITLE
Fix Civ3MenuButton visual multi-select issue

### DIFF
--- a/C7/UIElements/MainMenu/Civ3MenuButton.cs
+++ b/C7/UIElements/MainMenu/Civ3MenuButton.cs
@@ -155,8 +155,7 @@ public partial class Civ3MenuButton : BaseButton {
 		Color currentTextColor = fontColor;
 
 		// ButtonPressed is true if ToggleMode is on and button is selected
-		// DrawMode.Pressed is true if mouse is down on the button
-		bool isEffectivelyPressed = (ToggleMode && ButtonPressed) || GetDrawMode() == DrawMode.Pressed;
+		bool isEffectivelyPressed = (ToggleMode && ButtonPressed);
 
 		if (isEffectivelyPressed) {
 			currentTexture = pressedTexture;


### PR DESCRIPTION
Fix for #898.

Removing the alternative route to "effective press" results in the visual update doing the right thing. We want to only change to the "active" button texture when we have a true click, which in ["active on release"](https://docs.godotengine.org/en/4.4/classes/class_basebutton.html#property-descriptions) `ActionMode` is what we want.

I can't think of a case where the current behaviour is desired, but if we want Civ3MenuButton to change state already on the press down, we probably want to change things up so that the `ActionMode` ("active on press" vs "active on release") is made use of.