### PR TITLE
Integrate time

### DIFF
--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -7191,6 +7191,39 @@
     "shieldCostPerGold": 4,
     "shieldRateForDisbanding": 0.25
   },
+  "timeOptions": {
+    "baseUnit": "years",
+    "negativeLabel": "BC",
+    "positiveLabel": "AD",
+    "startYear": -4000,
+    "startMonth": 1,
+    "startWeek": 1,
+    "startDay": 1,
+    "startHour": 12,
+    "timeScale": [
+      [
+        25,
+        25,
+        40,
+        50,
+        100,
+        100,
+        100,
+        10000
+      ],
+      [
+        50,
+        40,
+        25,
+        20,
+        10,
+        5,
+        2,
+        1
+      ]
+    ],
+    "turnLimit": 540
+  },
   "techs": [
     {
       "name": "Bronze Working",

--- a/C7/Lua/rules/civ3/gameplay.lua
+++ b/C7/Lua/rules/civ3/gameplay.lua
@@ -14,8 +14,7 @@ end
 
 local gameplay = {}
 
-local void
-function disband_reward(context)
+local function disband_reward(context)
   local unit = context
   local unit_shield_cost = unit.unitType.shieldCost;
 
@@ -41,11 +40,10 @@ function disband_reward(context)
   end
 end
 
-local string
-function get_display_time_text(raw_time)
+local function get_display_time_text(raw_time)
   local bc = game_data().timeOptions.negativeLabel
   local ad = game_data().timeOptions.positiveLabel
-  
+
   -- Years
   if (game_data().timeOptions.baseUnit == time_unit.Years) then
     game_data().timeOptions.SetTimeUnitCurrent(time_unit.Years, raw_time)

--- a/C7/Lua/rules/civ3/gameplay.lua
+++ b/C7/Lua/rules/civ3/gameplay.lua
@@ -2,41 +2,124 @@
 -- The idea for this is to host script paths that are not serialized in the json,
 -- but rather "hardcoded" in the code
 
+local time_unit = ENUMS.TimeUnit
+
 local function game_data()
   return GAME_DATA()
 end
-  
+
 local function rules()
   return GAME_DATA().rules
 end
-  
+
 local gameplay = {}
 
-local function disband_reward(context)
+local void
+function disband_reward(context)
   local unit = context
   local unit_shield_cost = unit.unitType.shieldCost;
-  
+
   local has_city = unit.location.HasCity
   local is_unit_on_own_city = unit.location.OwningPlayer() == unit.owner
-  
+
   if has_city and is_unit_on_own_city then
     local city = unit.location.owningCity;
     local item_produced = city.itemBeingProduced
-    
-      if (item_produced:GetType().Name == "Building" and item_produced.IsGreatWonder() == true) then
-        return
-      end
-        
-      if (item_produced:GetType().Name == "Inflow") then
-        return
-      end
 
-    local reward = math. floor(unit_shield_cost * rules().ShieldRateForDisbanding)
-    game_data().SendMessageToUiFromLua("Our "..unit.name.." has been converted to "..reward.." shields.", unit.location)
+    if (item_produced:GetType().Name == "Building" and item_produced.IsGreatWonder() == true) then
+      return
+    end
+
+    if (item_produced:GetType().Name == "Inflow") then
+      return
+    end
+
+    local reward = math.floor(unit_shield_cost * rules().ShieldRateForDisbanding)
+    game_data().SendMessageToUiFromLua("Our " .. unit.name .. " has been converted to " .. reward .. " shields.",
+      unit.location)
     city.SetStoredShields(reward, true)
   end
 end
+
+local string
+function get_display_time_text(raw_time)
+  local bc = game_data().timeOptions.negativeLabel
+  local ad = game_data().timeOptions.positiveLabel
   
+  -- Years
+  if (game_data().timeOptions.baseUnit == time_unit.Years) then
+    game_data().timeOptions.SetTimeUnitCurrent(time_unit.Years, raw_time)
+    return math.abs(raw_time) .. " " ..
+        (game_data().timeOptions.currentYear < 0 and bc or ad)
+  end
+
+  -- Months
+  if (game_data().timeOptions.baseUnit == time_unit.Months) then
+    local month = game_data().timeOptions.startMonth
+    local start_year = game_data().timeOptions.startYear
+    game_data().timeOptions.SetTimeUnitCurrent(time_unit.Years, start_year)
+    if (raw_time > 12) then
+      month = raw_time % 12
+      game_data().timeOptions.SetTimeUnitCurrent(time_unit.Years, start_year + (raw_time / 12))
+    else
+      month = raw_time
+      game_data().timeOptions.SetTimeUnitCurrent(time_unit.Months, month)
+    end
+    local month_name = game_data().timeOptions.GetAbbrMonthNameByIndex(month) -- can be overriden with a local function if needed
+    return month_name .. ", " .. game_data().timeOptions.currentYear .. " " ..
+        (game_data().timeOptions.currentYear < 0 and bc or ad)
+  end
+
+  -- Weeks
+  if (game_data().timeOptions.baseUnit == time_unit.Weeks) then
+    local week = game_data().timeOptions.startWeek
+    local start_year = game_data().timeOptions.startYear
+    game_data().timeOptions.SetTimeUnitCurrent(time_unit.Years, start_year)
+    if (raw_time > 52) then
+      week = raw_time % 52
+      game_data().timeOptions.SetTimeUnitCurrent(time_unit.Years, start_year + (raw_time / 52))
+    else
+      week = raw_time
+      game_data().timeOptions.SetTimeUnitCurrent(time_unit.Weeks, week)
+    end
+    return "Week " .. week .. ", " .. game_data().timeOptions.currentYear .. " " ..
+        (game_data().timeOptions.currentYear < 0 and bc or ad)
+  end
+
+  -- Days
+  if (game_data().timeOptions.baseUnit == time_unit.Days) then
+    local day = game_data().timeOptions.startDay
+    local start_year = game_data().timeOptions.startYear
+    game_data().timeOptions.SetTimeUnitCurrent(time_unit.Years, start_year)
+    if (raw_time > 365) then
+      day = raw_time % 365
+      game_data().timeOptions.SetTimeUnitCurrent(time_unit.Years, start_year + (raw_time / 365))
+    else
+      day = raw_time
+      game_data().timeOptions.SetTimeUnitCurrent(time_unit.Days, day)
+    end
+    return "Day " .. day .. ", " .. game_data().timeOptions.currentYear .. " " ..
+        (game_data().timeOptions.currentYear < 0 and bc or ad)
+  end
+
+  -- Hours
+  if (game_data().timeOptions.baseUnit == time_unit.Hours) then
+    local hour = game_data().timeOptions.startHour
+    local start_day = game_data().timeOptions.startDay
+    game_data().timeOptions.SetTimeUnitCurrent(time_unit.Days, start_day)
+    if (raw_time > 24) then
+      hour = raw_time % 24
+      game_data().timeOptions.SetTimeUnitCurrent(time_unit.Days, start_day + (raw_time / 24))
+    else
+      hour = raw_time
+      game_data().timeOptions.SetTimeUnitCurrent(time_unit.Hours, hour)
+    end
+    return "Hour " .. hour .. ", Day " .. game_data().timeOptions.currentDay
+  end
+
+  return "-12345 AD"
+end
+
 gameplay = {
   units = {
     -- Context = MapUnit mapUnit
@@ -44,6 +127,12 @@ gameplay = {
       disband_reward(context)
     end,
   },
+  time = {
+    -- Context = int time
+    display_text = function(context)
+      return get_display_time_text(context)
+    end,
+  }
 }
 
 return gameplay

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -38,6 +38,8 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 	private Timer blinkingTimer = new Timer();
 	private bool timerStarted = false;  //This "isStopped" returns false if it's never been started.  So we need this to know if we've ever started it.
 
+	private float extraXOffset = 7;
+
 	[Signal] public delegate void BlinkyEndTurnButtonPressedEventHandler();
 	[Signal] public delegate void CenterCameraOnActiveUnitEventHandler();
 
@@ -113,11 +115,11 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 		// Player info
 		civAndGovt.SetPosition(new Vector2(0, 80));
 		boxRightRectangle.AddChild(civAndGovt);
-		civAndGovt.SetTextAndCenterLabel("Carthage - Despotism (5.5.0)");
+		civAndGovt.SetTextAndCenterLabel("Netherlands - Despotism (5.5.0)", extraXOffset);
 
 		yearAndGold.SetPosition(new Vector2(0, 94));
 		boxRightRectangle.AddChild(yearAndGold);
-		yearAndGold.SetTextAndCenterLabel("Turn 0  10 Gold (+0 per turn)");
+		yearAndGold.SetTextAndCenterLabel("Turn 0  10 Gold (+0 per turn)", extraXOffset);
 
 		scienceProgress.SetPosition(new Vector2(0, 108));
 		boxRightRectangle.AddChild(scienceProgress);
@@ -244,18 +246,16 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 				int gold = player.gold;
 				int goldPerTurn = player.CalculateGoldPerTurn();
 
-				if (goldPerTurn >= 0) {
-					yearAndGold.Text = $"Turn {turnNumber}  {gold} Gold (+{goldPerTurn} per turn)";
-				} else {
-					yearAndGold.Text = $"Turn {turnNumber}  {gold} Gold ({goldPerTurn} per turn)";
-				}
+				var turnText = gD.timeOptions.GetDisplayTime(turnNumber);
+				var gptText = $"{(goldPerTurn >= 0 ? "+" : "")}{goldPerTurn}";
+				yearAndGold.SetTextAndCenterLabel($"{turnText}  {gold} Gold ({gptText} per turn)", extraXOffset);
 			}
 
 			// Tech progress.
-			scienceProgress.SetTextAndCenterLabel(player.SummarizeScience(gD));
+			scienceProgress.SetTextAndCenterLabel(player.SummarizeScience(gD), extraXOffset);
 
 			// Civ and government.
-			civAndGovt.SetTextAndCenterLabel($"{player.civilization.name} - {player.government.name} (5.5.0)");
+			civAndGovt.SetTextAndCenterLabel($"{player.civilization.name} - {player.government.name} (5.5.0)", extraXOffset);
 		});
 
 		base._Process(delta);

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -113,17 +113,14 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 		boxRightRectangle.AddChild(terrainType);
 
 		// Player info
-		civAndGovt.SetPosition(new Vector2(0, 80));
 		boxRightRectangle.AddChild(civAndGovt);
-		civAndGovt.SetTextAndCenterLabel("Netherlands - Despotism (5.5.0)", extraXOffset);
+		civAndGovt.SetTextAndCenterLabel("Netherlands - Despotism (5.5.0)").AddXOffset(extraXOffset).AddYOffset(80);
 
-		yearAndGold.SetPosition(new Vector2(0, 94));
 		boxRightRectangle.AddChild(yearAndGold);
-		yearAndGold.SetTextAndCenterLabel("Turn 0  10 Gold (+0 per turn)", extraXOffset);
+		yearAndGold.SetTextAndCenterLabel("Turn 0  10 Gold (+0 per turn)").AddXOffset(extraXOffset).AddYOffset(94);
 
-		scienceProgress.SetPosition(new Vector2(0, 108));
 		boxRightRectangle.AddChild(scienceProgress);
-		scienceProgress.SetTextAndCenterLabel("");
+		scienceProgress.SetTextAndCenterLabel("").AddXOffset(extraXOffset).AddYOffset(108);
 
 		// End of turn suggestions
 		suggestion.HorizontalAlignment = HorizontalAlignment.Right;
@@ -248,14 +245,14 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 
 				var turnText = gD.timeOptions.GetDisplayTime(turnNumber);
 				var gptText = $"{(goldPerTurn >= 0 ? "+" : "")}{goldPerTurn}";
-				yearAndGold.SetTextAndCenterLabel($"{turnText}  {gold} Gold ({gptText} per turn)", extraXOffset);
+				yearAndGold.SetTextAndCenterLabel($"{turnText}  {gold} Gold ({gptText} per turn)").AddXOffset(extraXOffset);
 			}
 
 			// Tech progress.
-			scienceProgress.SetTextAndCenterLabel(player.SummarizeScience(gD), extraXOffset);
+			scienceProgress.SetTextAndCenterLabel(player.SummarizeScience(gD)).AddXOffset(extraXOffset);
 
 			// Civ and government.
-			civAndGovt.SetTextAndCenterLabel($"{player.civilization.name} - {player.government.name} (5.5.0)", extraXOffset);
+			civAndGovt.SetTextAndCenterLabel($"{player.civilization.name} - {player.government.name} (5.5.0)").AddXOffset(extraXOffset);
 		});
 
 		base._Process(delta);

--- a/C7/UIElements/LabelExtensions.cs
+++ b/C7/UIElements/LabelExtensions.cs
@@ -1,7 +1,7 @@
 using Godot;
 
 public static class LabelExtensions {
-	public static void SetTextAndCenterLabel(this Label label, string text, float additionalXOffset = 0) {
+	public static Label SetTextAndCenterLabel(this Label label, string text) {
 		//For the centered labels, we anchor them center, with equal weight on each side.
 		//Then, when they are visible, we add a left margin that's negative and equal to half
 		//their width.
@@ -10,6 +10,16 @@ public static class LabelExtensions {
 		label.HorizontalAlignment = HorizontalAlignment.Center;
 		label.AnchorLeft = 0.5f;
 		label.AnchorRight = 0.5f;
-		label.OffsetLeft = -1 * (label.Size.X / 2.0f) + additionalXOffset;
+		label.OffsetLeft = -1 * (label.Size.X / 2.0f);
+		return label;
+	}
+
+	public static Label AddXOffset(this Label label, float xOffset) {
+		label.OffsetLeft += xOffset;
+		return label;
+	}
+	public static Label AddYOffset(this Label label, float yOffset) {
+		label.OffsetTop += yOffset;
+		return label;
 	}
 }

--- a/C7/UIElements/LabelExtensions.cs
+++ b/C7/UIElements/LabelExtensions.cs
@@ -1,7 +1,7 @@
 using Godot;
 
 public static class LabelExtensions {
-	public static void SetTextAndCenterLabel(this Label label, string text) {
+	public static void SetTextAndCenterLabel(this Label label, string text, float additionalXOffset = 0) {
 		//For the centered labels, we anchor them center, with equal weight on each side.
 		//Then, when they are visible, we add a left margin that's negative and equal to half
 		//their width.
@@ -10,6 +10,6 @@ public static class LabelExtensions {
 		label.HorizontalAlignment = HorizontalAlignment.Center;
 		label.AnchorLeft = 0.5f;
 		label.AnchorRight = 0.5f;
-		label.OffsetLeft = -1 * (label.Size.X / 2.0f);
+		label.OffsetLeft = -1 * (label.Size.X / 2.0f) + additionalXOffset;
 	}
 }

--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -43,6 +43,7 @@ namespace C7GameData {
 		public string defaultExperienceLevelKey;
 		public ExperienceLevel defaultExperienceLevel;
 		public Rules rules;
+		public TimeOptions timeOptions;
 
 		public BarbarianInfo barbarianInfo = new BarbarianInfo();
 

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -59,6 +59,7 @@ namespace C7GameData {
 		private void ImportSharedBiqData() {
 			save.TerrainImprovements = SaveTerrainImprovement.Civ3Improvements().ToList();
 
+			ImportTimeScale();
 			ImportRaces();
 			ImportTechs();
 			ImportCiv3Resources();
@@ -322,6 +323,34 @@ namespace C7GameData {
 			int Y = tileIndex / (mapWidth / 2);
 			int X = tileIndex % (mapWidth / 2) * 2 + (Y % 2);
 			return (X, Y);
+		}
+
+		private void ImportTimeScale() {
+			save.TimeOptions = new TimeOptions() {
+				baseUnit = (TimeUnit)biq.Game[0].BaseTimeUnit,
+				startYear = biq.Game[0].StartYear,
+				startMonth = biq.Game[0].StartMonth,
+				startWeek = biq.Game[0].StartWeek,
+				turnLimit = biq.Game[0].TurnTimeLimit,
+				negativeLabel = "BC",
+				positiveLabel = "AD",
+			};
+
+			save.TimeOptions.timeScale = new int[2, 8];
+
+			for (int i = 0; i < 7; ++i) {
+				var turns = biq.Game[0].TimescaleNumberOfTurns[i];
+				var units = biq.Game[0].TurnNumberOfTimeUnits[i];
+				save.TimeOptions.timeScale[0, i] = turns;
+				save.TimeOptions.timeScale[1, i] = units;
+			}
+
+			// Add some extra padding at the end to allow continuing playing 1 turn at a time.
+			// CivIII allows dates from -10000 to 10000, so 50000 is enough to cover for that,
+			// and for our custom scenarios from now on, this value is easily editable in the json
+			save.TimeOptions.timeScale[0, 7] = 50000;
+			save.TimeOptions.timeScale[1, 7] = 1;
+
 		}
 
 		private void ImportCiv3Resources() {

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -76,6 +76,7 @@ namespace C7GameData.Save {
 				Difficulties = data.difficulties,
 				GameDifficulty = data.gameDifficulty,
 				Rules = data.rules,
+				TimeOptions = data.timeOptions,
 				TerrainImprovements = data.terrainImprovements.ConvertAll(ti => ti.ToSaveTerrainImprovement())
 			};
 			save.StrengthBonuses.Add(data.fortificationBonus);
@@ -173,6 +174,7 @@ namespace C7GameData.Save {
 				ids = new ID.Factory(this),
 				experienceLevels = ExperienceLevels,
 				rules = Rules,
+				timeOptions = TimeOptions,
 				GreatWondersBuilt = GreatWondersBuilt,
 			};
 		}
@@ -404,6 +406,7 @@ namespace C7GameData.Save {
 		public List<StrengthBonus> StrengthBonuses = new List<StrengthBonus>();
 		public Dictionary<string, int> HealRates = new Dictionary<string, int>();
 		public Rules Rules = new();
+		public TimeOptions TimeOptions = new();
 		public List<SaveTech> Techs = new();
 		public List<CitizenType> CitizenTypes = new();
 		public List<SaveTerraform> TerraForms = new();

--- a/C7Engine/C7GameData/TimeOptions.cs
+++ b/C7Engine/C7GameData/TimeOptions.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text.Json.Serialization;
+using C7Engine;
+using Serilog;
+
+namespace C7GameData;
+
+public enum TimeUnit {
+	Years,
+	Months,
+	Weeks,
+	Days,
+	Hours,
+}
+
+public sealed class TimeOptions {
+	public TimeUnit baseUnit { get; init; } = TimeUnit.Years;
+	public string negativeLabel { get; init; } = "BC";
+	public string positiveLabel { get; init; } = "AD";
+	public int startYear { get; init; } = -4000;
+	public int startMonth { get; init; } = 1;
+
+	public int startWeek { get; init; } = 1;
+	// custom
+	public int startDay { get; init; } = 1;
+	// custom
+	public int startHour { get; init; } = 12;
+	public int[,] timeScale { get; set; } = new int[,] { { 25, 25, 40, 50, 100, 100, 100, 50000 }, { 50, 40, 25, 20, 10, 5, 2, 1 } };
+
+	public int turnLimit { get; init; } = 540;
+
+	// the sum of all the turns included in the timeScale array
+	// e.x. in a standard game of 540 turns, the totalTurns amounts to 440 turns
+	// after that we default to 1 timeUnit/per turn
+	private int totalTurns = -1;
+
+	[JsonIgnore]
+	public int currentYear { get; private set; } = -1;
+	[JsonIgnore]
+	public int currentMonth { get; private set; } = -1;
+	[JsonIgnore]
+	public int currentWeek { get; private set; } = -1;
+	[JsonIgnore]
+	// custom
+	public int currentDay { get; private set; } = -1;
+	[JsonIgnore]
+	// custom
+	public int currentHour { get; private set; } = -1;
+
+	// used to cache the turn number to display text value
+	private Dictionary<int, string> DisplayTime = [];
+
+
+	/// <summary>
+	/// Get the corresponding NON-normalized time unit number based on the turn number,
+	/// taking into account the various time intervals from the timeSpan array.<br/><br/>
+	/// In a standard game, for years as a base time unit, turn 0 will return -4000, turn 1 will return -3950, etc<br/><br/>
+	/// For months as a base time unit (and 1 unit intervals) turn 2 will be month 3, turn 14 will be month 15, etc<br/><br/>
+	/// For weeks as a base time unit (and 1 unit intervals) turn 2 will be week 3, turn 54 will be week 55, etc<br/>
+	/// </summary>
+	/// <param name="current"></param>
+	/// <returns></returns>
+	/// <exception cref="Exception"></exception>
+	public int GetRawNumber(int current) {
+		int i = 0;
+		int acc = timeScale[0, i];
+		var currentNormalized = current;
+		while (acc <= GetTotalTurns()) {
+			int extra = 0;
+			if (current <= acc) {
+				for (int j = 0; j < i; j++) {
+					// sum all the previous turns in years/months/weeks
+					extra += timeScale[0, j] * timeScale[1, j];
+					// forces the currentNormalized to have a value that we can use
+					// e.x. if the current turn is 26, we are on the "second" iteration of the timeScale array
+					// so we remove 25 that is the previous iteration, and now currentNormalized is 1,
+					// and we can calculate the timeUnit for this iteration (1*40 in a std game)
+					// think of it as a modulo operation, but for uneven divisor numbers
+					currentNormalized -= timeScale[0, j];
+				}
+
+				var value = GetStartingPoint() + (currentNormalized * timeScale[1, i]) + extra;
+				SetTimeUnitCurrent(value);
+				return value;
+			}
+
+			++i;
+			acc += timeScale[0, i];
+		}
+
+		throw new Exception($"The current turn {current} is beyond our powers");
+	}
+
+	/// <summary>
+	/// Get the turn number from the current unit time.<br/>
+	/// So, assuming a std game<br/>
+	/// -3950 will return 1, etc<br/>
+	/// month 5, Year 1, will return 4, month 3 year 2 will return 14, etc<br/>
+	/// week 3 will return 3, and week 53 will  return 1, etc<br/>
+	/// </summary>
+	/// <param name="time"></param>
+	/// <returns></returns>
+	/// <exception cref="Exception"></exception>
+	public int GetTurnFromRaw(int time) {
+		int current = GetStartingPoint();
+		int turn = 0;
+		var extra = 0;
+		for (int i = 0; i < timeScale.GetLength(1); i++) {
+			var j = 1;
+			if (time == current) return turn;
+			while (current + extra < time && j <= timeScale[0, i]) {
+				extra += timeScale[1, i];
+				++turn;
+				if (current + extra == time)
+					return turn;
+				++j;
+			}
+		}
+
+		throw new Exception($"The current time {time} is unknown to us");
+	}
+
+	/// <summary>
+	/// The total number of accumulated turns included in the game data
+	/// </summary>
+	/// <returns></returns>
+	private int GetTotalTurns() {
+		if (totalTurns != -1) return totalTurns;
+		totalTurns = 0;
+		var len = timeScale.GetLength(1);
+		for (int i = 0; i < len; i++) {
+			totalTurns += timeScale[0, i];
+		}
+		return totalTurns;
+	}
+
+	public string GetDisplayTime(int current) {
+		if (DisplayTime.TryGetValue(current, out var value)) return value;
+		var time = GetRawNumber(current);
+		var displayText = GetDisplayTimeFromRaw(time);
+		DisplayTime[current] = displayText;
+		return displayText;
+	}
+
+	public string GetDisplayTimeFromRaw(int time) {
+		string label = "PLACEHOLDER_TIME";
+		var displayTimeLabelFunction = EngineStorage.gameData.luaRulesEngine.ImportFunc<Func<int, string>>("gameplay.time.display_text", true);
+		label = displayTimeLabelFunction.Invoke(time);
+		return label;
+	}
+
+	private int GetStartingPoint() {
+		return baseUnit switch {
+			TimeUnit.Years => currentYear = startYear,
+			TimeUnit.Months => currentMonth = startMonth,
+			TimeUnit.Weeks => currentWeek = startWeek,
+			TimeUnit.Days => currentDay = startDay,
+			TimeUnit.Hours => currentHour = startHour,
+			_ => throw new InvalidEnumArgumentException($"{baseUnit} is not a valid TimeUnit")
+		};
+	}
+
+	private void SetTimeUnitCurrent(int value) {
+		switch (baseUnit) {
+			case TimeUnit.Years:
+				currentYear = value;
+				break;
+			case TimeUnit.Months:
+				currentMonth = value;
+				break;
+			case TimeUnit.Weeks:
+				currentWeek = value;
+				break;
+			case TimeUnit.Days:
+				currentDay = value;
+				break;
+			case TimeUnit.Hours:
+				currentHour = value;
+				break;
+			default:
+				throw new InvalidEnumArgumentException($"{baseUnit} is not a valid TimeUnit");
+		}
+	}
+
+	[LuaMethod]
+	public void SetTimeUnitCurrent(TimeUnit timeUnit, int value) {
+		Log.Information($"Setting unit {timeUnit} to {value}");
+		switch (timeUnit) {
+			case TimeUnit.Years:
+				currentYear = value;
+				break;
+			case TimeUnit.Months:
+				currentMonth = value;
+				break;
+			case TimeUnit.Weeks:
+				currentWeek = value;
+				break;
+			case TimeUnit.Days:
+				currentDay = value;
+				break;
+			case TimeUnit.Hours:
+				currentHour = value;
+				break;
+			default:
+				throw new InvalidEnumArgumentException($"{baseUnit} is not a valid TimeUnit");
+		}
+	}
+
+	[LuaMethod]
+	public string GetAbbrMonthNameByIndex(int index) {
+		return CultureInfo.CurrentCulture.DateTimeFormat.GetAbbreviatedMonthName(index);
+	}
+	[LuaMethod]
+	public string GetMonthNameByIndex(int index) {
+		return CultureInfo.CurrentCulture.DateTimeFormat.GetMonthName(index);
+	}
+}

--- a/EngineTests/GameData/SaveTest.cs
+++ b/EngineTests/GameData/SaveTest.cs
@@ -310,6 +310,142 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 
 
 	[Fact]
+	public void TurnTimeCalculations() {
+		Player human = CreateHeadlessGame(fixture.saveGame);
+		WaitForStartTurnMessage();
+
+		C7GameData.GameData gd = null;
+		EngineStorage.ReadGameData((C7GameData.GameData gameData) => { gd = gameData; });
+
+		// YEARS
+
+		// --------------- 50 turn interval for 25 turns ---------------
+		Assert.Equal(-4000, gd.timeOptions.GetRawNumber(0));
+		Assert.Equal(0, gd.timeOptions.GetTurnFromRaw(-4000));
+		Assert.Equal(-3950, gd.timeOptions.GetRawNumber(1));
+		Assert.Equal(1, gd.timeOptions.GetTurnFromRaw(-3950));
+		Assert.Equal(2, gd.timeOptions.GetTurnFromRaw(-3900));
+		Assert.Equal(-2800, gd.timeOptions.GetRawNumber(24));
+		Assert.Equal(-2750, gd.timeOptions.GetRawNumber(25));
+
+		// --------------- 40 turn interval for 25 turns ---------------
+		Assert.Equal(-2710, gd.timeOptions.GetRawNumber(26));
+		Assert.Equal(26, gd.timeOptions.GetTurnFromRaw(-2710));
+		Assert.Equal(-2670, gd.timeOptions.GetRawNumber(27));
+		Assert.Equal(-1790, gd.timeOptions.GetRawNumber(49));
+		Assert.Equal(-1750, gd.timeOptions.GetRawNumber(50));
+
+		// --------------- 25 turn interval for 40 turns ---------------
+		Assert.Equal(-1725, gd.timeOptions.GetRawNumber(51));
+		Assert.Equal(52, gd.timeOptions.GetTurnFromRaw(-1700));
+		Assert.Equal(-1700, gd.timeOptions.GetRawNumber(52));
+		Assert.Equal(-1675, gd.timeOptions.GetRawNumber(53));
+		Assert.Equal(-1525, gd.timeOptions.GetRawNumber(59));
+		Assert.Equal(-775, gd.timeOptions.GetRawNumber(89));
+		Assert.Equal(-750, gd.timeOptions.GetRawNumber(90));
+		Assert.Equal(90, gd.timeOptions.GetTurnFromRaw(-750));
+
+		// --------------- 20 turn interval for 50 turns ---------------
+		Assert.Equal(-730, gd.timeOptions.GetRawNumber(91));
+		Assert.Equal(91, gd.timeOptions.GetTurnFromRaw(-730));
+		Assert.Equal(-710, gd.timeOptions.GetRawNumber(92));
+		Assert.Equal(-570, gd.timeOptions.GetRawNumber(99));
+		Assert.Equal(-470, gd.timeOptions.GetRawNumber(104));
+		Assert.Equal(230, gd.timeOptions.GetRawNumber(139));
+		Assert.Equal(250, gd.timeOptions.GetRawNumber(140));
+		Assert.Equal(140, gd.timeOptions.GetTurnFromRaw(250));
+
+		// --------------- 10 turn interval for 100 turns ---------------
+		Assert.Equal(260, gd.timeOptions.GetRawNumber(141));
+		Assert.Equal(141, gd.timeOptions.GetTurnFromRaw(260));
+		Assert.Equal(270, gd.timeOptions.GetRawNumber(142));
+		Assert.Equal(280, gd.timeOptions.GetRawNumber(143));
+		Assert.Equal(600, gd.timeOptions.GetRawNumber(175));
+		//...
+		Assert.Equal(1230, gd.timeOptions.GetRawNumber(238));
+		Assert.Equal(1240, gd.timeOptions.GetRawNumber(239));
+		Assert.Equal(1250, gd.timeOptions.GetRawNumber(240));
+
+		// --------------- 5  turn interval for 100 turns ---------------
+		Assert.Equal(1255, gd.timeOptions.GetRawNumber(241));
+		Assert.Equal(241, gd.timeOptions.GetTurnFromRaw(1255));
+		Assert.Equal(1260, gd.timeOptions.GetRawNumber(242));
+		Assert.Equal(1560, gd.timeOptions.GetRawNumber(302));
+		Assert.Equal(1745, gd.timeOptions.GetRawNumber(339));
+		Assert.Equal(1750, gd.timeOptions.GetRawNumber(340));
+
+		// --------------- 2  turn interval for 100 turns ---------------
+		Assert.Equal(1752, gd.timeOptions.GetRawNumber(341));
+		Assert.Equal(1754, gd.timeOptions.GetRawNumber(342));
+		Assert.Equal(342, gd.timeOptions.GetTurnFromRaw(1754));
+		// ...
+		Assert.Equal(1948, gd.timeOptions.GetRawNumber(439));
+		Assert.Equal(1950, gd.timeOptions.GetRawNumber(440));
+
+		// ---------------   1  turn interval forEVER     ---------------
+		Assert.Equal(1951, gd.timeOptions.GetRawNumber(441));
+		Assert.Equal(1955, gd.timeOptions.GetRawNumber(445));
+		Assert.Equal(445, gd.timeOptions.GetTurnFromRaw(1955));
+		Assert.Equal(2000, gd.timeOptions.GetRawNumber(490));
+		Assert.Equal(2500, gd.timeOptions.GetRawNumber(990));
+
+
+
+		// MONTHS
+
+		gd.timeOptions = new TimeOptions() {
+			baseUnit = TimeUnit.Months,
+			startMonth = 0, // to simplify the math
+			timeScale = new int[,] { { 25, 35, 40, 50, 100, 100, 100, 1000 }, { 12, 6, 4, 3, 2, 2, 1, 1 } }
+		};
+
+		// 12 moths every turn for 25 turns
+		Assert.Equal(0, gd.timeOptions.GetRawNumber(0));
+
+		Assert.Equal(12, gd.timeOptions.GetRawNumber(1));
+		Assert.Equal(1, gd.timeOptions.GetTurnFromRaw(12));
+
+		Assert.Equal(24, gd.timeOptions.GetRawNumber(2));
+		Assert.Equal(2, gd.timeOptions.GetTurnFromRaw(24));
+		Assert.Equal(0, gd.timeOptions.GetTurnFromRaw(0));
+
+		// 6 moths every turn for 35 turns
+		Assert.Equal(306, gd.timeOptions.GetRawNumber(26));
+		Assert.Equal(26, gd.timeOptions.GetTurnFromRaw(306));
+
+		// 4 moths every turn for 40 turns
+		Assert.Equal(514, gd.timeOptions.GetRawNumber(61));
+		Assert.Equal(61, gd.timeOptions.GetTurnFromRaw(514));
+
+		// WEEKS
+
+		gd.timeOptions = new TimeOptions() {
+			baseUnit = TimeUnit.Weeks,
+			startWeek = 0, // to simplify the math
+			timeScale = new int[,] { { 25, 35, 40, 50, 100, 100, 100, 1000 }, { 8, 4, 2, 2, 2, 2, 1, 1 } }
+		};
+
+		// 8 weeks every turn for 25 turns
+		Assert.Equal(0, gd.timeOptions.GetRawNumber(0));
+		Assert.Equal(0, gd.timeOptions.GetTurnFromRaw(0));
+
+		Assert.Equal(8, gd.timeOptions.GetRawNumber(1));
+		Assert.Equal(1, gd.timeOptions.GetTurnFromRaw(8));
+
+		Assert.Equal(16, gd.timeOptions.GetRawNumber(2));
+		Assert.Equal(2, gd.timeOptions.GetTurnFromRaw(16));
+
+		// 4 weeks every turn for 35 turns
+		Assert.Equal(220, gd.timeOptions.GetRawNumber(30));
+		Assert.Equal(30, gd.timeOptions.GetTurnFromRaw(220));
+
+		// 2 weeks every turn for 40 turns
+		Assert.Equal(342, gd.timeOptions.GetRawNumber(61));
+		Assert.Equal(61, gd.timeOptions.GetTurnFromRaw(342));
+	}
+
+
+	[Fact]
 	public async void LoadSampleSaves() {
 		// When running the tests via github actions, civ3 isn't installed so we
 		// can't load the default bic.


### PR DESCRIPTION
This PR introduces the following

Read time data from the .biq/.sav files
Implement a mod friednly way to display the time to the player. In the main c# code we only calculate the "raw" turn number (e.x. -4000, when we display 4000 BC)
Besides the standard time units (years, months, weeks), days and hours are added. How the are displayed is as modable as the rest of the tim units.
Some tests to make sure the raw conversions are working properly.