### PR TITLE
Implement Quick Start parameters persistence

### DIFF
--- a/C7/UIElements/NewGame/PlayerSetup.cs
+++ b/C7/UIElements/NewGame/PlayerSetup.cs
@@ -235,8 +235,7 @@ public partial class PlayerSetup : Control {
 		thread.Start();
 	}
 
-	private void PersistGameSettings(GlobalSingleton global)
-	{
+	private void PersistGameSettings(GlobalSingleton global) {
 		try {
 			WorldCharacteristics world = global.WorldCharacteristics;
 			C7Settings.SetValue("lastGame", "worldSize", world.worldSize.name);

--- a/C7/UIElements/NewGame/PlayerSetup.cs
+++ b/C7/UIElements/NewGame/PlayerSetup.cs
@@ -224,6 +224,8 @@ public partial class PlayerSetup : Control {
 			opponents = CollectSelectedOpponents()
 		};
 
+		PersistGameSettings(gameSetup);
+
 		// World generation can take a bit of time if multiple attempts are
 		// needed, so we don't want to tie up the UI thread.
 		Thread thread = new(() => {
@@ -235,22 +237,21 @@ public partial class PlayerSetup : Control {
 		thread.Start();
 	}
 
-	private void PersistGameSettings(GlobalSingleton global) {
+	private void PersistGameSettings(GameSetup gameSetup) {
 		try {
-			WorldCharacteristics world = global.WorldCharacteristics;
-			C7Settings.SetValue("lastGame", "worldSize", world.worldSize.name);
-			C7Settings.SetValue("lastGame", "barbarianActivity", world.barbarianActivity.ToString());
-			C7Settings.SetValue("lastGame", "landform", world.landform.ToString());
-			C7Settings.SetValue("lastGame", "oceanCoverage", world.oceanCoverage.ToString());
-			C7Settings.SetValue("lastGame", "climate", world.climate.ToString());
-			C7Settings.SetValue("lastGame", "temperature", world.temperature.ToString());
-			C7Settings.SetValue("lastGame", "age", world.age.ToString());
-			C7Settings.SetValue("lastGame", "civilization", selectedCivilization.name);
-			C7Settings.SetValue("lastGame", "difficulty", selectedDifficulty.Name);
+			C7Settings.SetValue(C7Settings.LastGame.SectionName, C7Settings.LastGame.WorldSize, gameSetup.worldCharacteristics.worldSize.name);
+			C7Settings.SetValue(C7Settings.LastGame.SectionName, C7Settings.LastGame.BarbarianActivity, gameSetup.worldCharacteristics.barbarianActivity.ToString());
+			C7Settings.SetValue(C7Settings.LastGame.SectionName, C7Settings.LastGame.Landform, gameSetup.worldCharacteristics.landform.ToString());
+			C7Settings.SetValue(C7Settings.LastGame.SectionName, C7Settings.LastGame.OceanCoverage, gameSetup.worldCharacteristics.oceanCoverage.ToString());
+			C7Settings.SetValue(C7Settings.LastGame.SectionName, C7Settings.LastGame.Climate, gameSetup.worldCharacteristics.climate.ToString());
+			C7Settings.SetValue(C7Settings.LastGame.SectionName, C7Settings.LastGame.Temperature, gameSetup.worldCharacteristics.temperature.ToString());
+			C7Settings.SetValue(C7Settings.LastGame.SectionName, C7Settings.LastGame.Age, gameSetup.worldCharacteristics.age.ToString());
+			C7Settings.SetValue(C7Settings.LastGame.SectionName, C7Settings.LastGame.Civilization, gameSetup.playerCivilization.name);
+			C7Settings.SetValue(C7Settings.LastGame.SectionName, C7Settings.LastGame.Difficulty, gameSetup.difficulty.Name);
 
-			List<SelectedOpponent> ops = CollectSelectedOpponents();
-			string opponentsValue = string.Join(",", ops.Select(o => o.isRandom ? "Random" : o.Name));
-			C7Settings.SetValue("lastGame", "opponents", opponentsValue);
+			List<SelectedOpponent> ops = gameSetup.opponents;
+			string opponentsValue = string.Join("|", ops.Select(o => o.isRandom ? "Random" : o.Name));
+			C7Settings.SetValue(C7Settings.LastGame.SectionName, C7Settings.LastGame.Opponents, opponentsValue);
 
 			C7Settings.SaveSettings();
 		} catch (Exception e) {
@@ -259,8 +260,6 @@ public partial class PlayerSetup : Control {
 	}
 
 	private void StartGame() {
-		GlobalSingleton global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
-		PersistGameSettings(global);
 		GetTree().ChangeSceneToFile("res://C7Game.tscn");
 	}
 }

--- a/C7/UIElements/NewGame/PlayerSetup.cs
+++ b/C7/UIElements/NewGame/PlayerSetup.cs
@@ -235,7 +235,33 @@ public partial class PlayerSetup : Control {
 		thread.Start();
 	}
 
+	private void PersistGameSettings(GlobalSingleton global)
+	{
+		try {
+			WorldCharacteristics world = global.WorldCharacteristics;
+			C7Settings.SetValue("lastGame", "worldSize", world.worldSize.name);
+			C7Settings.SetValue("lastGame", "barbarianActivity", world.barbarianActivity.ToString());
+			C7Settings.SetValue("lastGame", "landform", world.landform.ToString());
+			C7Settings.SetValue("lastGame", "oceanCoverage", world.oceanCoverage.ToString());
+			C7Settings.SetValue("lastGame", "climate", world.climate.ToString());
+			C7Settings.SetValue("lastGame", "temperature", world.temperature.ToString());
+			C7Settings.SetValue("lastGame", "age", world.age.ToString());
+			C7Settings.SetValue("lastGame", "civilization", selectedCivilization.name);
+			C7Settings.SetValue("lastGame", "difficulty", selectedDifficulty.Name);
+
+			List<SelectedOpponent> ops = CollectSelectedOpponents();
+			string opponentsValue = string.Join(",", ops.Select(o => o.isRandom ? "Random" : o.Name));
+			C7Settings.SetValue("lastGame", "opponents", opponentsValue);
+
+			C7Settings.SaveSettings();
+		} catch (Exception e) {
+			log.Error(e, "Failed to persist game settings to C7.ini");
+		}
+	}
+
 	private void StartGame() {
+		GlobalSingleton global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
+		PersistGameSettings(global);
 		GetTree().ChangeSceneToFile("res://C7Game.tscn");
 	}
 }

--- a/C7/UIElements/NewGame/QuickStartSetup.cs
+++ b/C7/UIElements/NewGame/QuickStartSetup.cs
@@ -57,9 +57,9 @@ public partial class QuickStartSetup : Node {
 	private static WorldSize GetWorldSize(List<WorldSize> availableSizes) {
 		string lastWorldSize = C7Settings.GetSettingValue("lastGame", "worldSize");
 		return availableSizes.FirstOrDefault(ws =>
-			       string.Equals(ws.name, lastWorldSize, StringComparison.OrdinalIgnoreCase))
-		       ?? availableSizes.FirstOrDefault(ws => ws.isDefault)
-		       ?? WorldSize.Generic();
+				   string.Equals(ws.name, lastWorldSize, StringComparison.OrdinalIgnoreCase))
+			   ?? availableSizes.FirstOrDefault(ws => ws.isDefault)
+			   ?? WorldSize.Generic();
 	}
 
 	private static List<SelectedOpponent> GetOpponents(int expectedCount) {
@@ -68,9 +68,9 @@ public partial class QuickStartSetup : Node {
 
 		if (!string.IsNullOrEmpty(opsRaw)) {
 			foreach (string name in opsRaw
-				         .Split(',').Select(n => n.Trim())
-				         .Where(n => !string.IsNullOrEmpty(n))
-			        ) {
+						 .Split(',').Select(n => n.Trim())
+						 .Where(n => !string.IsNullOrEmpty(n))
+					) {
 				opponents.Add(name == "Random"
 					? new SelectedOpponent { isRandom = true }
 					: new SelectedOpponent { isRandom = false, Name = name });

--- a/C7/UIElements/NewGame/QuickStartSetup.cs
+++ b/C7/UIElements/NewGame/QuickStartSetup.cs
@@ -16,28 +16,25 @@ public partial class QuickStartSetup : Node {
 		globalState.ResetLoadGameFields();
 
 		var save = GameModeLoader.Load(GamePaths.GameModesDir, GamePaths.GameMode);
+		WorldSize worldSize = GetWorldSize(save.WorldSizes);
 
 		globalState.WorldCharacteristics = new WorldCharacteristics(save) {
-			barbarianActivity = GetSetting("barbarianActivity", BarbarianActivity.Roaming),
-			landform = GetSetting("landform", WorldCharacteristics.Landform.Pangaea),
-			oceanCoverage = GetSetting("oceanCoverage", WorldCharacteristics.OceanCoverage.Percent_70),
-			age = GetSetting("age", WorldCharacteristics.Age.Billion_4),
-			climate = GetSetting("climate", WorldCharacteristics.Climate.Normal),
-			temperature = GetSetting("temperature", WorldCharacteristics.Temperature.Temperate),
-			worldSize = GetWorldSize(save.WorldSizes),
+			barbarianActivity = GetBarbarianActivity(),
+			landform = GetLandform(),
+			oceanCoverage = GetOceanCoverage(),
+			age = GetAge(),
+			climate = GetClimate(),
+			temperature = GetTemperature(),
+			worldSize = worldSize,
 			mapSeed = new Random().Next(),
 		};
 
 		globalState.SaveGame = save;
 
-		string lastCivilization = C7Settings.GetSettingsValueOrDefault("lastGame", "civilization", "Netherlands");
-		Civilization player = save.Civilizations.FirstOrDefault(civ => civ.name == lastCivilization) ?? save.Civilizations[1];
+		Civilization player = GetPlayerCivilization(save.Civilizations);
+		Difficulty difficulty = GetDifficulty(save.Difficulties);
 
-		string lastDifficulty = C7Settings.GetSettingsValueOrDefault("lastGame", "difficulty", "Regent");
-		Difficulty difficulty = save.Difficulties.FirstOrDefault(diff => diff.Name == lastDifficulty) ?? save.Difficulties[0];
-
-		int numOpponents = globalState.WorldCharacteristics.worldSize.numberOfCivs - 1;
-		List<SelectedOpponent> opponents = GetOpponents(numOpponents);
+		List<SelectedOpponent> opponents = GetOpponents(save.Civilizations, worldSize.numberOfCivs - 1);
 
 		GameSetup gameSetup = new() {
 			playerCivilization = player,
@@ -49,40 +46,73 @@ public partial class QuickStartSetup : Node {
 		gameSetup.Populate(save);
 	}
 
-	private static T GetSetting<T>(string key, T defaultValue) where T : struct, Enum {
-		string value = C7Settings.GetSettingValue("lastGame", key);
-		return Enum.TryParse(value, true, out T result) ? result : defaultValue;
+	private static BarbarianActivity GetBarbarianActivity() {
+		return C7Settings.GetTypedSettingOrDefault(C7Settings.LastGame.SectionName, C7Settings.LastGame.BarbarianActivity, BarbarianActivity.Roaming);
+	}
+
+	private static WorldCharacteristics.Landform GetLandform() {
+		return C7Settings.GetTypedSettingOrDefault(C7Settings.LastGame.SectionName, C7Settings.LastGame.Landform, WorldCharacteristics.Landform.Pangaea);
+	}
+
+	private static WorldCharacteristics.OceanCoverage GetOceanCoverage() {
+		return C7Settings.GetTypedSettingOrDefault(C7Settings.LastGame.SectionName, C7Settings.LastGame.OceanCoverage, WorldCharacteristics.OceanCoverage.Percent_70);
+	}
+
+	private static WorldCharacteristics.Age GetAge() {
+		return C7Settings.GetTypedSettingOrDefault(C7Settings.LastGame.SectionName, C7Settings.LastGame.Age, WorldCharacteristics.Age.Billion_4);
+	}
+
+	private static WorldCharacteristics.Climate GetClimate() {
+		return C7Settings.GetTypedSettingOrDefault(C7Settings.LastGame.SectionName, C7Settings.LastGame.Climate, WorldCharacteristics.Climate.Normal);
+	}
+
+	private static WorldCharacteristics.Temperature GetTemperature() {
+		return C7Settings.GetTypedSettingOrDefault(C7Settings.LastGame.SectionName, C7Settings.LastGame.Temperature, WorldCharacteristics.Temperature.Temperate);
 	}
 
 	private static WorldSize GetWorldSize(List<WorldSize> availableSizes) {
-		string lastWorldSize = C7Settings.GetSettingValue("lastGame", "worldSize");
+		string lastWorldSize = C7Settings.GetSettingValue(C7Settings.LastGame.SectionName, C7Settings.LastGame.WorldSize);
 		return availableSizes.FirstOrDefault(ws =>
 				   string.Equals(ws.name, lastWorldSize, StringComparison.OrdinalIgnoreCase))
 			   ?? availableSizes.FirstOrDefault(ws => ws.isDefault)
 			   ?? WorldSize.Generic();
 	}
 
-	private static List<SelectedOpponent> GetOpponents(int expectedCount) {
-		string opsRaw = C7Settings.GetSettingsValueOrDefault("lastGame", "opponents", "");
+	private static Civilization GetPlayerCivilization(List<Civilization> civilizations) {
+		string lastCiv = C7Settings.GetSettingsValueOrDefault(C7Settings.LastGame.SectionName, C7Settings.LastGame.Civilization, "Netherlands");
+		return civilizations.FirstOrDefault(civ => civ.name == lastCiv) ?? civilizations.First();
+	}
+
+	private static Difficulty GetDifficulty(List<Difficulty> difficulties) {
+		string lastDiff = C7Settings.GetSettingsValueOrDefault(C7Settings.LastGame.SectionName, C7Settings.LastGame.Difficulty, "Regent");
+		return difficulties.FirstOrDefault(diff => diff.Name == lastDiff) ?? difficulties.First();
+	}
+
+	private static List<SelectedOpponent> GetOpponents(List<Civilization> availableCivilizations, int expectedCount) {
+		string opsRaw = C7Settings.GetSettingsValueOrDefault(C7Settings.LastGame.SectionName, C7Settings.LastGame.Opponents, "");
 		List<SelectedOpponent> opponents = [];
 
 		if (!string.IsNullOrEmpty(opsRaw)) {
-			foreach (string name in opsRaw
-						 .Split(',').Select(n => n.Trim())
-						 .Where(n => !string.IsNullOrEmpty(n))
-					) {
-				opponents.Add(name == "Random"
-					? new SelectedOpponent { isRandom = true }
-					: new SelectedOpponent { isRandom = false, Name = name });
-			}
+			var cleanNames = opsRaw.Split('|')
+				.Select(n => n.Trim())
+				.Where(n => !string.IsNullOrEmpty(n));
+
+			opponents.AddRange(cleanNames.Select(name => ToSelectedOpponent(name, availableCivilizations)));
 		}
 
-		if (opponents.Count == 0) {
-			for (int i = 0; i < expectedCount; i++) {
-				opponents.Add(new SelectedOpponent { isRandom = true });
-			}
+		while (opponents.Count < expectedCount) {
+			opponents.Add(new SelectedOpponent { isRandom = true });
 		}
 
 		return opponents.Take(expectedCount).ToList();
 	}
+
+	private static SelectedOpponent ToSelectedOpponent(string name, List<Civilization> availableCivs) {
+		if (name == "Random" || availableCivs.All(c => c.name != name)) {
+			return new SelectedOpponent { isRandom = true };
+		}
+
+		return new SelectedOpponent { isRandom = false, Name = name };
+	}
+
 }

--- a/C7/UIElements/NewGame/QuickStartSetup.cs
+++ b/C7/UIElements/NewGame/QuickStartSetup.cs
@@ -1,5 +1,6 @@
 using Godot;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using C7GameData;
 using C7Engine;
@@ -17,25 +18,26 @@ public partial class QuickStartSetup : Node {
 		var save = GameModeLoader.Load(GamePaths.GameModesDir, GamePaths.GameMode);
 
 		globalState.WorldCharacteristics = new WorldCharacteristics(save) {
-			landform = WorldCharacteristics.Landform.Pangaea,
-			oceanCoverage = WorldCharacteristics.OceanCoverage.Percent_70,
-			age = WorldCharacteristics.Age.Billion_4,
-			climate = WorldCharacteristics.Climate.Normal,
-			temperature = WorldCharacteristics.Temperature.Temperate,
-			worldSize = WorldSize.Generic(),
+			barbarianActivity = GetSetting("barbarianActivity", BarbarianActivity.Roaming),
+			landform = GetSetting("landform", WorldCharacteristics.Landform.Pangaea),
+			oceanCoverage = GetSetting("oceanCoverage", WorldCharacteristics.OceanCoverage.Percent_70),
+			age = GetSetting("age", WorldCharacteristics.Age.Billion_4),
+			climate = GetSetting("climate", WorldCharacteristics.Climate.Normal),
+			temperature = GetSetting("temperature", WorldCharacteristics.Temperature.Temperate),
+			worldSize = GetWorldSize(save.WorldSizes),
 			mapSeed = new Random().Next(),
 		};
 
 		globalState.SaveGame = save;
 
-		Civilization player =  save.Civilizations.FirstOrDefault(x => x.name == "Netherlands") ?? save.Civilizations[1];
+		string lastCivilization = C7Settings.GetSettingsValueOrDefault("lastGame", "civilization", "Netherlands");
+		Civilization player = save.Civilizations.FirstOrDefault(civ => civ.name == lastCivilization) ?? save.Civilizations[1];
 
-		Difficulty difficulty = save.Difficulties.FirstOrDefault(x => x.Name == "Regent") ?? save.Difficulties[0];
+		string lastDifficulty = C7Settings.GetSettingsValueOrDefault("lastGame", "difficulty", "Regent");
+		Difficulty difficulty = save.Difficulties.FirstOrDefault(diff => diff.Name == lastDifficulty) ?? save.Difficulties[0];
 
-		var opponents = save.Civilizations
-			.Select(x => new SelectedOpponent { isRandom = true })
-			.Take(globalState.WorldCharacteristics.worldSize.numberOfCivs - 1)
-			.ToList();
+		int numOpponents = globalState.WorldCharacteristics.worldSize.numberOfCivs - 1;
+		List<SelectedOpponent> opponents = GetOpponents(numOpponents);
 
 		GameSetup gameSetup = new() {
 			playerCivilization = player,
@@ -45,5 +47,42 @@ public partial class QuickStartSetup : Node {
 		};
 
 		gameSetup.Populate(save);
+	}
+
+	private static T GetSetting<T>(string key, T defaultValue) where T : struct, Enum {
+		string value = C7Settings.GetSettingValue("lastGame", key);
+		return Enum.TryParse(value, true, out T result) ? result : defaultValue;
+	}
+
+	private static WorldSize GetWorldSize(List<WorldSize> availableSizes) {
+		string lastWorldSize = C7Settings.GetSettingValue("lastGame", "worldSize");
+		return availableSizes.FirstOrDefault(ws =>
+			       string.Equals(ws.name, lastWorldSize, StringComparison.OrdinalIgnoreCase))
+		       ?? availableSizes.FirstOrDefault(ws => ws.isDefault)
+		       ?? WorldSize.Generic();
+	}
+
+	private static List<SelectedOpponent> GetOpponents(int expectedCount) {
+		string opsRaw = C7Settings.GetSettingsValueOrDefault("lastGame", "opponents", "");
+		List<SelectedOpponent> opponents = [];
+
+		if (!string.IsNullOrEmpty(opsRaw)) {
+			foreach (string name in opsRaw
+				         .Split(',').Select(n => n.Trim())
+				         .Where(n => !string.IsNullOrEmpty(n))
+			        ) {
+				opponents.Add(name == "Random"
+					? new SelectedOpponent { isRandom = true }
+					: new SelectedOpponent { isRandom = false, Name = name });
+			}
+		}
+
+		if (opponents.Count == 0) {
+			for (int i = 0; i < expectedCount; i++) {
+				opponents.Add(new SelectedOpponent { isRandom = true });
+			}
+		}
+
+		return opponents.Take(expectedCount).ToList();
 	}
 }

--- a/C7Engine/C7Settings.cs
+++ b/C7Engine/C7Settings.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using IniParser.Model;
 using IniParser.Exceptions;
 
@@ -5,6 +8,20 @@ namespace C7Engine {
 	public class C7Settings {
 		private const string SETTINGS_FILE_NAME = "C7.ini";
 		public static IniData settings;
+
+		public static class LastGame {
+			public const string SectionName = nameof(LastGame);
+			public const string WorldSize = nameof(WorldSize);
+			public const string BarbarianActivity = nameof(BarbarianActivity);
+			public const string Landform = nameof(Landform);
+			public const string OceanCoverage = nameof(OceanCoverage);
+			public const string Climate = nameof(Climate);
+			public const string Temperature = nameof(Temperature);
+			public const string Age = nameof(Age);
+			public const string Civilization = nameof(Civilization);
+			public const string Difficulty = nameof(Difficulty);
+			public const string Opponents = nameof(Opponents);
+		}
 
 		public static void LoadSettings() {
 			try {
@@ -45,6 +62,11 @@ namespace C7Engine {
 				return defaultValue;
 			}
 			return settings[section][key];
+		}
+
+		public static T GetTypedSettingOrDefault<T>(string section, string key, T defaultValue) where T : struct, Enum {
+			string value = GetSettingValue(section, key);
+			return Enum.TryParse(value, true, out T result) ? result : defaultValue;
 		}
 
 		public static bool UseStandaloneMode() {


### PR DESCRIPTION
This PR addresses #910

Implements Quick Start with the last settings.

This PR implements the persistence of game parameters as described in the Civ3 manual for the **Quick Start** functionality. The game now remembers and replicates the settings (civilization, difficulty, world traits, and opponents) from the last manually created game.

When PlayerSetup calls StartGame, the settings are saved to C7.ini

The settings are loaded on QuickStartSetup to reproduce last game preferences. 