### PR TITLE
Add TileInfo

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -51,6 +51,37 @@ public partial class Game : Node {
 	};
 	public GotoInfo gotoInfo = null;
 
+	public class TileInfo {
+		public Tile targetTile;
+		public HashSet<Tile> coveredTiles = [];
+		public HashSet<Tile> cityLabelsToHide = [];
+
+		public TileInfo(Tile tile) {
+			targetTile = tile;
+
+			List<TileDirection> coverage = [TileDirection.SOUTHWEST, TileDirection.SOUTH, TileDirection.SOUTHEAST];
+			foreach (var dir in coverage)
+				if (TryNeighbor(tile, dir, out var neighbor))
+					coveredTiles.Add(neighbor);
+
+			List<TileDirection> labelCoverage = [TileDirection.NORTHWEST, TileDirection.NORTH, TileDirection.NORTHEAST];
+			foreach (var dir in labelCoverage)
+				if (TryNeighbor(tile, dir, out var neighbor))
+					cityLabelsToHide.Add(neighbor);
+		}
+
+		private bool TryNeighbor(Tile tile, TileDirection dir, out Tile neighbor) {
+			neighbor = tile.neighbors[dir];
+			return neighbor != Tile.NONE;
+		}
+
+		public bool IsCovered(Tile tile) => tile == targetTile || coveredTiles.Contains(tile);
+
+		public bool HasCityLabelToCover(Tile tile) => cityLabelsToHide.Contains(tile);
+	};
+
+	public TileInfo tileInfo = null;
+
 	// When in observer mode, the number of turns to play before prompting the
 	// user to advance the turn manually. This allows for more rapid debugging
 	// without pressing the spacebar repeatedly.
@@ -550,8 +581,23 @@ public partial class Game : Node {
 		else if (!shiftDown && tile.cityAtTile?.owner == controller)
 			// There are no units, but this is the player's city.
 			new RightClickCityMenu(this, tile).Open(eventMouseButton.Position);
+		else
+			ShowTileInfo(tile);
 
 		LogTileDetails(tile);
+	}
+
+	public void ShowTileInfo(Tile tile) {
+		tileInfo = new TileInfo(tile);
+		var zoom = mapView.cameraZoom;
+		var tileCenter = mapView.screenLocationOfTile(tile, true);
+		var tileInfoPopup = new TileInfoPopup(this, tile, tileCenter, zoom);
+		popupOverlay.ShowPopup(tileInfoPopup, PopupOverlay.PopupCategory.TileInfo);
+	}
+
+	public void HideTileInfo() {
+		tileInfo = null;
+		popupOverlay.OnHidePopup();
 	}
 
 	private void LogTileDetails(Tile tile) {
@@ -717,6 +763,11 @@ public partial class Game : Node {
 	}
 
 	private void ProcessAction(string currentAction) {
+		if (currentAction == C7Action.Escape && tileInfo != null) {
+			HideTileInfo();
+			return;
+		}
+
 		if (currentAction == C7Action.Escape && popupOverlay.ShowingPopup) {
 			popupOverlay.OnHidePopup();
 			return;

--- a/C7/Lua/texture_configs/c7.lua
+++ b/C7/Lua/texture_configs/c7.lua
@@ -8,6 +8,7 @@ local utils = require "utils"
 
 local c7_texture_list = {
   "Art/buttonsFINAL.png",
+  "Art/TileInfo.png",
   "Art/X-o_ALLstates-sprite.png",
   "Art/SmallHeads/popHeads.png",
   "Art/Terrain/Mountains-snow.png",

--- a/C7/Lua/texture_configs/civ3.lua
+++ b/C7/Lua/texture_configs/civ3.lua
@@ -6,6 +6,7 @@ local EXIT_BOX = "Art/exitBox-backgroundStates.pcx"
 local INTERFACE = "Art/interface/"
 local X_O = "Art/X-o_ALLstates-sprite.pcx"
 local SCIENCE_NAV = "Art/Tech Chooser/scienceNAV.pcx"
+local TILEINFO = "Art/TileInfo.pcx"
 
 local CITY_SCREEN = "Art/city screen/"
 local CITY_BUTTONS = "Art/city screen/cityMgmtButtons.pcx"
@@ -405,6 +406,12 @@ textures.lower_left_infobox = {
       path = INTERFACE .. "box left color.pcx",
       alpha = INTERFACE .. "box left alpha.pcx",
     },
+}
+
+textures.tileinfo = {
+      box = {
+        path = TILEINFO
+      },
 }
 
 textures.popup_background = {

--- a/C7/Map/CityLayer.cs
+++ b/C7/Map/CityLayer.cs
@@ -11,6 +11,10 @@ namespace C7.Map {
 		}
 
 		public void UpdateAfterCityDestruction(City city) {
+			EraseCity(city);
+		}
+
+		private void EraseCity(City city) {
 			citySceneLookup.Remove(city, out CityScene cityScene);
 			if (cityScene != null) {
 				cityScene.Hide();
@@ -19,6 +23,11 @@ namespace C7.Map {
 
 		public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
 			if (tile.cityAtTile is null) {
+				return;
+			}
+
+			if (looseView.IsTileCoveredByTileInfo(tile)) {
+				EraseCity(tile.cityAtTile);
 				return;
 			}
 
@@ -34,6 +43,11 @@ namespace C7.Map {
 				CityScene scene = citySceneLookup[city];
 				scene.SetTileCenter(tileCenter2I);
 				scene._Draw();
+
+				if (looseView.HasCityLabelToHideFromTileInfo(tile))
+					scene.HideLabel();
+				else
+					scene.ShowLabel();
 			}
 		}
 	}

--- a/C7/Map/CityScene.cs
+++ b/C7/Map/CityScene.cs
@@ -98,5 +98,8 @@ namespace C7.Map {
 			cityGraphics.MouseFilter = Control.MouseFilterEnum.Ignore;
 			cityGraphics.Texture = cityTexture;
 		}
+
+		public void HideLabel() => cityLabelScene?.Hide();
+		public void ShowLabel() => cityLabelScene?.Show();
 	}
 }

--- a/C7/Map/FogOfWarLayer.cs
+++ b/C7/Map/FogOfWarLayer.cs
@@ -22,33 +22,28 @@ namespace C7.Map {
 			Tile east = tile.neighbors[TileDirection.NORTHEAST];
 			Tile west = tile.neighbors[TileDirection.NORTHWEST];
 
-			TileKnowledge tileKnowledge = gameData.GetFirstHumanPlayer().tileKnowledge;
+			var tk = gameData.GetFirstHumanPlayer().tileKnowledge;
+			var ti = looseView.mapView.game.tileInfo;
+
+			(bool, bool, bool) Status(Tile tile) {
+				return (tk.isTileKnown(tile), tk.isActiveTile(tile), ti?.targetTile == tile);
+			}
+
 			int column = 0;
 			int row = 0;
+			bool known, active, target;
 
-			if (tileKnowledge.isActiveTile(north)) {
-				column += 2;
-			} else if (tileKnowledge.isTileKnown(north)) {
-				column += 1;
-			}
+			(known, active, target) = Status(north);
+			column += known ? (active || target) ? 2 : 1 : 0;
 
-			if (tileKnowledge.isActiveTile(west)) {
-				column += 6;
-			} else if (tileKnowledge.isTileKnown(west)) {
-				column += 3;
-			}
+			(known, active, target) = Status(west);
+			column += known ? (active || target) ? 6 : 3 : 0;
 
-			if (tileKnowledge.isActiveTile(east)) {
-				row += 2;
-			} else if (tileKnowledge.isTileKnown(east)) {
-				row += 1;
-			}
+			(known, active, target) = Status(east);
+			row += known ? (active || target) ? 2 : 1 : 0;
 
-			if (tileKnowledge.isActiveTile(south)) {
-				row += 6;
-			} else if (tileKnowledge.isTileKnown(south)) {
-				row += 3;
-			}
+			(known, active, target) = Status(south);
+			row += known ? (active || target) ? 6 : 3 : 0;
 
 			// save a few draw calls when the tile is completely visible
 			if (column == 8 && row == 8) {

--- a/C7/Map/UnitLayer.cs
+++ b/C7/Map/UnitLayer.cs
@@ -226,6 +226,10 @@ public partial class UnitLayer : LooseLayer {
 			return;
 		}
 
+		if (looseView.IsTileCoveredByTileInfo(tile)) {
+			return;
+		}
+
 		// First draw animated effects. These will always appear over top of units regardless of draw order due to z-index.
 		C7Animation tileEffect = looseView.mapView.game.animationController.animTracker.getTileEffect(tile);
 		if (tileEffect != null) {

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -515,7 +515,7 @@ public partial class LooseView : Node2D {
 				layer.onEndDraw(this, gD);
 			}
 
-			foreach (GridLayer layer in layers.Where(layer => layer.visible && layer is GridLayer).Cast<GridLayer>()) {
+			foreach (var layer in layers.Where(layer => layer.visible && layer is GridLayer)) {
 				layer.onBeginDraw(this, gD);
 				foreach (VisibleTile vT in visibleKnownTiles.Concat(visibleUnKnownTiles)) {
 					layer.drawObject(this, gD, vT.tile, vT.tileCenter);
@@ -578,6 +578,22 @@ public partial class LooseView : Node2D {
 		}
 		TileKnowledge knowledge = gameData.GetFirstHumanPlayer().tileKnowledge;
 		return tile != Tile.NONE && knowledge.isTileKnown(tile);
+	}
+
+	public bool IsTileCoveredByTileInfo(Tile tile) {
+		var target = mapView.game.tileInfo;
+		if (target == null) return false;
+
+		return target.IsCovered(tile);
+	}
+
+	public bool HasCityLabelToHideFromTileInfo(Tile tile) {
+		if (!tile.HasCity) return false;
+
+		var target = mapView.game.tileInfo;
+		if (target == null) return false;
+
+		return target.HasCityLabelToCover(tile);
 	}
 }
 

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -13,6 +13,7 @@ public partial class PopupOverlay : HBoxContainer {
 	[Signal] public delegate void BuildCityEventHandler(string name);
 	[Signal] public delegate void DiplomacySelectionEventHandler(ParameterWrapper<ID> opponentPlayer);
 	[Signal] public delegate void HidePopupEventHandler();
+	[Signal] public delegate void ClickEventHandler();
 
 	Control currentChild = null;
 
@@ -22,21 +23,17 @@ public partial class PopupOverlay : HBoxContainer {
 	public enum PopupCategory {
 		Advisor,
 		Console,
-		Info    //Sounds similar to the above, but lower-pitched in the second half
+		Info,    //Sounds similar to the above, but lower-pitched in the second half
+		TileInfo
 	}
 
 	public void OnHidePopup() {
-		// 1. enable mouse interaction with non-UI nodes
-		MouseFilter = MouseFilterEnum.Pass;
-		RemoveChild(currentChild);
-		currentChild = null;
+		Reconnect();
+		if (currentChild != null) {
+			RemoveChild(currentChild);
+			currentChild = null;
+		}
 		Hide();
-
-		// 2. enable mouse interactions with other UI elements
-		setMouseFilter(control, MouseFilterEnum.Pass);
-
-		// 3. enable clicking other UI elements
-		control.ProcessMode = ProcessModeEnum.Inherit;
 	}
 
 	public bool ShowingPopup => currentChild is not null;
@@ -45,15 +42,6 @@ public partial class PopupOverlay : HBoxContainer {
 		AudioStreamPlayer player = GetNode<AudioStreamPlayer>("PopupSound");
 		player.Stream = wav;
 		player.Play();
-	}
-
-	private void setMouseFilter(Node n, MouseFilterEnum filter) {
-		foreach (Node child in n?.GetChildren()) {
-			setMouseFilter(child, filter);
-		}
-		if (n is Control control) {
-			control.MouseFilter = filter;
-		}
 	}
 
 	public void ShowPopup(Popup child, PopupCategory category) {
@@ -72,29 +60,69 @@ public partial class PopupOverlay : HBoxContainer {
 		AddChild(child);
 		currentChild = child;
 
-		string soundFile = category switch {
+		var soundFile = category switch {
 			PopupCategory.Advisor => "Sounds/PopupAdvisor.wav",
 			PopupCategory.Console => "Sounds/PopupConsole.wav",
 			PopupCategory.Info => "Sounds/PopupInfo.wav",
-			_ => "",
+			_ => null
 		};
-		if (soundFile == "") {
-			log.Error("Invalid popup category");
-		}
-		AudioStreamWav wav = Util.LoadCiv3WAVFromDisk(soundFile);
 
-		// 1. prevent mouse interaction with non-UI elements (ie. the map)
-		MouseFilter = MouseFilterEnum.Stop;
+		var wav = soundFile == null ? null : Util.LoadCiv3WAVFromDisk(soundFile);
 
-		// 2. prevent clicking other UI elements
-		control.ProcessMode = ProcessModeEnum.Disabled;
-
-		// 3. ignore all mouse input on other UI elements (ie. button color changes on hover)
-		setMouseFilter(control, MouseFilterEnum.Ignore);
+		Isolate();
 
 		Show();
+
 		if (wav != null) {
 			PlaySound(wav);
+		}
+	}
+
+	/// <summary>
+	/// Creates a modal context by preventing UI events outside the popup context.
+	/// Inverse of `Reconnect(..)`.
+	/// </summary>
+	private void Isolate() {
+		// 1. Overlay catches mouse events, prevents event propagation
+		MouseFilter = MouseFilterEnum.Stop;
+
+		// 2. Stop the world: switch off UI elements
+		control.ProcessMode = ProcessModeEnum.Disabled;
+
+		// 3. Ignore all mouse input on UI elements
+		SetMouseFilter(control, MouseFilterEnum.Ignore);
+	}
+
+	/// <summary>
+	/// Unwind a modal context by allowing UI events outside the popup context.
+	/// Inverse of `Isolate(..)`.
+	/// </summary>
+	private void Reconnect() {
+		// 1. Let events propagate past the overlay
+		control.MouseFilter = MouseFilterEnum.Pass;
+
+		// 2. Let UI elements catch mouse inputs again
+		SetMouseFilter(control, MouseFilterEnum.Pass);
+
+		// 3. Restart the world: let UI elements run normal
+		control.ProcessMode = ProcessModeEnum.Inherit;
+	}
+
+	/// Recursively set MouseFilter on node children and their children, etc.
+	private static void SetMouseFilter(Node n, MouseFilterEnum filter) {
+		foreach (var child in n?.GetChildren() ?? []) {
+			SetMouseFilter(child, filter);
+		}
+		if (n is Control control) {
+			control.MouseFilter = filter;
+		}
+	}
+
+	public override void _GuiInput(InputEvent @event) {
+		// Raise an event when popup overlay catches a click that the popup itself misses.
+		// This usually means a click outside the popup modal.
+		if (Visible && @event is InputEventMouseButton ev && ev.Pressed) {
+			EmitSignal(SignalName.Click);
 		}
 	}
 

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -140,5 +140,20 @@ public partial class PopupOverlay : HBoxContainer {
 			// as most of the global ones should *not* go through here.
 			GetViewport().SetInputAsHandled();
 		}
+
+		if (@event is InputEventMouseButton ev) {
+			// Catch right clicks over UI elements to stop awkward TileInfo renders 
+			if (ev.ButtonIndex == MouseButton.Right) {
+				if (IsOverUI()) {
+					AcceptEvent();
+					GetViewport().SetInputAsHandled();
+				}
+			}
+		}
+	}
+
+	private bool IsOverUI() {
+		Control ctrl = GetViewport().GuiGetHoveredControl();
+		return ctrl is TextureButton or TextureRect;
 	}
 }

--- a/C7/UIElements/Popups/TileInfoPopup.cs
+++ b/C7/UIElements/Popups/TileInfoPopup.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using C7Engine;
+using C7GameData;
+using Godot;
+using Serilog;
+
+public partial class TileInfoPopup : Popup {
+	private readonly Game _game;
+	private readonly Tile _tile;
+	private readonly Vector2 _position;
+	private readonly float _zoom;
+
+	private TextureRect boxTextureRect = new();
+	private TextureButton closeButton = new();
+
+	private Label terrainLabel = new();
+	private Label overlayLabel = new();
+	private Label resourceLabel = new();
+
+	private Label foodLabel = new();
+	private Label shieldLabel = new();
+	private Label goldLabel = new();
+
+	private List<Label> _labels = new();
+
+	public TileInfoPopup(Game game, Tile tile, Vector2 position, float zoom) {
+		_game = game;
+		_tile = tile;
+		_position = position;
+		_zoom = zoom;
+
+		margins = new Margins();
+		alignment = BoxContainer.AlignmentMode.Begin;
+
+		_labels.AddRange([terrainLabel, overlayLabel, resourceLabel, foodLabel, shieldLabel, goldLabel]);
+
+		InitBoxTexture();
+		InitCloseButton();
+	}
+
+	private void InitBoxTexture() {
+		ImageTexture boxTexture = TextureLoader.Load("tileinfo.box");
+		boxTextureRect = new TextureRect();
+		boxTextureRect.Texture = boxTexture;
+	}
+
+	private void InitCloseButton() {
+		ImageTexture xTexture = TextureLoader.Load("ui.cancel.normal");
+		ImageTexture xHover = TextureLoader.Load("ui.cancel.hover");
+		ImageTexture xPressed = TextureLoader.Load("ui.cancel.pressed");
+
+		closeButton.TextureNormal = xTexture;
+		closeButton.TextureHover = xHover;
+		closeButton.TexturePressed = xPressed;
+
+		closeButton.ActionMode = BaseButton.ActionModeEnum.Release;
+		closeButton.Pressed += Close;
+	}
+
+	private void DrawTileInfoBox(Vector2 tileCenter) {
+		var scale = new Vector2(_zoom, _zoom);
+
+		// Re-position box
+		var boxWidth = boxTextureRect.Texture.GetWidth() * _zoom;
+		var boxHeight = boxTextureRect.Texture.GetHeight() * _zoom;
+		var offset = new Vector2(0, 32 * _zoom); // tileHeight / 2
+		var center = new Vector2(boxWidth / 2f, boxHeight / 2f);
+		boxTextureRect.SetPosition(tileCenter - center + offset);
+		boxTextureRect.SetScale(scale);
+
+		// Re-position close button
+		var buttonWidth = closeButton.TextureNormal.GetWidth() * _zoom;
+		var buttonOffset = new Vector2(boxWidth - buttonWidth, 0);
+		var buttonMargin = 10 * _zoom;
+		closeButton.SetPosition(boxTextureRect.Position + buttonOffset + new Vector2(-buttonMargin, buttonMargin));
+		closeButton.SetScale(scale);
+
+		// Re-position labels
+		var xStep = 100 * _zoom;
+		var yStep = 15 * _zoom;
+		var contentOffset = new Vector2(25, 105) * _zoom;
+		var contentAnchor = boxTextureRect.Position + contentOffset;
+		terrainLabel.SetPosition(contentAnchor + new Vector2(0, 0));
+		overlayLabel.SetPosition(contentAnchor + new Vector2(0, yStep));
+		resourceLabel.SetPosition(contentAnchor + new Vector2(0, 2 * yStep));
+		foodLabel.SetPosition(contentAnchor + new Vector2(xStep, 0));
+		shieldLabel.SetPosition(contentAnchor + new Vector2(xStep, yStep));
+		goldLabel.SetPosition(contentAnchor + new Vector2(xStep, 2 * yStep));
+
+		var fontSize = (int) Math.Ceiling(12 * _zoom);
+		foreach (var label in _labels) {
+			label.AddThemeFontSizeOverride("font_size", fontSize);
+		}
+
+		// Assemble
+		AddChild(boxTextureRect);
+		AddChild(closeButton);
+		foreach (var label in _labels)
+			AddChild(label);
+
+		// Show elements
+		boxTextureRect.Show();
+		closeButton.Show();
+		foreach (var label in _labels)
+			label.Show();
+	}
+
+	private void SetTileInfoContent(Tile tile, GameData gameData) {
+		var player = gameData.GetFirstHumanPlayer();
+		var isObserverMode = gameData.observerMode;
+
+		if (player.tileKnowledge.isTileKnown(tile) || isObserverMode) {
+			terrainLabel.Text = tile.baseTerrainType?.DisplayName ?? "";
+			overlayLabel.Text = tile.overlayTerrainType?.DisplayName ?? "";
+			resourceLabel.Text = tile.Resource?.Name ?? "";
+			foodLabel.Text = $"Food: {tile.foodYield(player).baseYield}";
+			shieldLabel.Text = $"Shields: {tile.productionYield(player).baseYield}";
+			goldLabel.Text = $"Gold: {tile.commerceYield(player).baseYield}";
+
+			if (tile.baseTerrainType == tile.overlayTerrainType)
+				overlayLabel.Text = "";
+
+			if (tile.Resource != null && !player.KnowsAboutResource(tile.Resource) && !isObserverMode)
+				resourceLabel.Text = "";
+
+		} else {
+			terrainLabel.Text = "";
+			overlayLabel.Text = "No information available";
+			resourceLabel.Text = "";
+			foodLabel.Text = "";
+			shieldLabel.Text = "";
+			goldLabel.Text = "";
+		}
+	}
+
+	private void Close() {
+		_game.HideTileInfo();
+	}
+
+	public override void _Ready() {
+		base._Ready();
+
+		DrawTileInfoBox(_position);
+
+		EngineStorage.ReadGameData((GameData gameData) => {
+			SetTileInfoContent(_tile, gameData);
+		});
+
+		var overlay = GetParent<PopupOverlay>();
+		overlay.Click += Close; // a click outside the box means close
+	}
+
+	public override void _GuiInput(InputEvent @event) {
+		// ignore clicks inside box
+		if (Visible && @event is InputEventMouseButton ev && ev.Pressed) {
+			GetViewport().SetInputAsHandled();
+		}
+	}
+}

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -132,6 +132,11 @@ public partial class RightClickTileMenu : RightClickMenu {
 	public void ResetItems(Tile tile, Dictionary<ID, bool> uiUpdatedUnitStates = null) {
 		RemoveAll();
 
+		AddItem($"Show Tile Information", () => {
+			game.ShowTileInfo(tile);
+			CloseAndDelete();
+		});
+
 		bool observerMode = false;
 		EngineStorage.ReadGameData((GameData gameData) => {
 			observerMode = gameData.observerMode;


### PR DESCRIPTION
Adds basic TileInfo popup.

The implementation is based on a new terrain layer that exposes the targeted terrain tile by selectively removing some of the overlays around the target tile. The terrain layer implementation allows for the Tile Info popup to stay in place even if the map is moved, but it does complicated some things, as we want to ultimately draw in the UI layer.

Implementation follows GotoLayer implementation in that we set the target tile object when we right click somewhere in the open map, or select the target from the context menu. In the TileInfo layer this selection is then ignored by all tiles expect the selected one. Presentation and content logic is mostly confined to the new layer, but the "stripping back the layers" implementation means that some of the overlay layers also need to know about the TileInfo context, so they *don't* draw parts that would be exposed inside the TileInfo window.

Trickiest part here is hiding the *city labels* from tiles to the North, NE, or NW of the target tile, as these overlap the target tile. We resort to some gnarly hackery to hide the labels. We want to keep the city (as it shows outside the frame), but hide the label (as it shows up inside).

I'm fairly confident that this approach is aligned with original's, as the size of the TileInfo frame perfectly covers the tiles South, SW, and SE of the target, each of which needs to set to temporarily not draw any units, as these would show up in the Tile Info window.

As a bonus, I added the tile coordinates up top, as I often wanted to know these while debugging. 

**Note**: standalone mode needs the corresponding frame asset.

--
### From the Civ Guide
<img width="449" height="398" alt="tile_information_in_guide" src="https://github.com/user-attachments/assets/e0307c02-329e-4ac1-939a-cc8397723bb5" />

### Original game samples (justification issues probably due to my dodgy Steam install)
<img width="862" height="500" alt="tile_information_samples" src="https://github.com/user-attachments/assets/446cae6e-1d48-4bfe-98c7-75253bf8ac2b" />

### OpenCiv3
<img width="1152" height="465" alt="fileinfo_openciv3" src="https://github.com/user-attachments/assets/d7da04ad-6774-4b84-b225-0376c7840e7d" />

