### PR TITLE
Improve contributor docs and test hygiene

### DIFF
--- a/EngineTests/EngineTests.csproj
+++ b/EngineTests/EngineTests.csproj
@@ -7,9 +7,9 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.8" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -19,7 +19,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.1.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="18.5.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\C7Engine\C7Engine.csproj" />

--- a/EngineTests/GameData/MultiTurnDealsTest.cs
+++ b/EngineTests/GameData/MultiTurnDealsTest.cs
@@ -12,13 +12,7 @@ public class MultiTurnDealTest : RemoteSaveLoader {
 	private const string SAVES_FOLDER = "saves/multi-turn-deals";
 	[Fact]
 	public async void TestMultiTurnDeal_Save_A() {
-		// When running the tests via github actions, civ3 isn't installed so we
-		// can't load the default bic.
-		//
-		// See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
-		// for a full list of env vars.
-		string is_on_github = System.Environment.GetEnvironmentVariable("CI");
-		if (is_on_github != null) {
+		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
 			return;
 		}
 
@@ -97,13 +91,7 @@ public class MultiTurnDealTest : RemoteSaveLoader {
 
 	[Fact]
 	public async void TestMultiTurnDeal_Save_B() {
-		// When running the tests via github actions, civ3 isn't installed so we
-		// can't load the default bic.
-		//
-		// See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
-		// for a full list of env vars.
-		string is_on_github = System.Environment.GetEnvironmentVariable("CI");
-		if (is_on_github != null) {
+		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
 			return;
 		}
 
@@ -207,13 +195,7 @@ public class MultiTurnDealTest : RemoteSaveLoader {
 
 	[Fact]
 	public async void TestMultiTurnDeal_Save_C() {
-		// When running the tests via github actions, civ3 isn't installed so we
-		// can't load the default bic.
-		//
-		// See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
-		// for a full list of env vars.
-		string is_on_github = System.Environment.GetEnvironmentVariable("CI");
-		if (is_on_github != null) {
+		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
 			return;
 		}
 
@@ -363,13 +345,7 @@ public class MultiTurnDealTest : RemoteSaveLoader {
 
 	[Fact]
 	public async void TestMultiTurnDeal_Save_D() {
-		// When running the tests via github actions, civ3 isn't installed so we
-		// can't load the default bic.
-		//
-		// See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
-		// for a full list of env vars.
-		string is_on_github = System.Environment.GetEnvironmentVariable("CI");
-		if (is_on_github != null) {
+		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
 			return;
 		}
 
@@ -474,13 +450,10 @@ public class MultiTurnDealTest : RemoteSaveLoader {
 
 	[Fact]
 	public async void TestMultiTurnDeal_Save_E() {
-		// When running the tests via github actions, civ3 isn't installed so we
-		// can't load the default bic.
-		//
-		// See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
-		// for a full list of env vars.
-		string is_on_github = System.Environment.GetEnvironmentVariable("CI");
-		if (is_on_github != null) {
+		if (Civ3TestData.ShouldSkipCiv3DependentTests(
+			"Conquests/Scenarios/8 MP Napoleonic Europe.biq",
+			"Conquests/Conquests/Napoleonic Europe/Text/PediaIcons.txt"
+		)) {
 			return;
 		}
 
@@ -634,13 +607,10 @@ public class MultiTurnDealTest : RemoteSaveLoader {
 
 	[Fact]
 	public async void TestMultiTurnDeal_Save_F() {
-		// When running the tests via github actions, civ3 isn't installed so we
-		// can't load the default bic.
-		//
-		// See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
-		// for a full list of env vars.
-		string is_on_github = System.Environment.GetEnvironmentVariable("CI");
-		if (is_on_github != null) {
+		if (Civ3TestData.ShouldSkipCiv3DependentTests(
+			"Conquests/Scenarios/8 MP Napoleonic Europe.biq",
+			"Conquests/Conquests/Napoleonic Europe/Text/PediaIcons.txt"
+		)) {
 			return;
 		}
 

--- a/EngineTests/GameData/MultiTurnDealsTest.cs
+++ b/EngineTests/GameData/MultiTurnDealsTest.cs
@@ -450,10 +450,7 @@ public class MultiTurnDealTest : RemoteSaveLoader {
 
 	[Fact]
 	public async void TestMultiTurnDeal_Save_E() {
-		if (Civ3TestData.ShouldSkipCiv3DependentTests(
-			"Conquests/Scenarios/8 MP Napoleonic Europe.biq",
-			"Conquests/Conquests/Napoleonic Europe/Text/PediaIcons.txt"
-		)) {
+		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
 			return;
 		}
 
@@ -607,10 +604,7 @@ public class MultiTurnDealTest : RemoteSaveLoader {
 
 	[Fact]
 	public async void TestMultiTurnDeal_Save_F() {
-		if (Civ3TestData.ShouldSkipCiv3DependentTests(
-			"Conquests/Scenarios/8 MP Napoleonic Europe.biq",
-			"Conquests/Conquests/Napoleonic Europe/Text/PediaIcons.txt"
-		)) {
+		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
 			return;
 		}
 

--- a/EngineTests/GameData/SaveTest.cs
+++ b/EngineTests/GameData/SaveTest.cs
@@ -9,6 +9,7 @@ using C7Engine;
 using C7Engine.Lua;
 using C7GameData;
 using C7GameData.Save;
+using EngineTests.Utils;
 using Newtonsoft.Json.Linq;
 using QueryCiv3;
 using Xunit;
@@ -452,13 +453,7 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 
 	[Fact]
 	public async void LoadSampleSaves() {
-		// When running the tests via github actions, civ3 isn't installed so we
-		// can't load the default bic.
-		//
-		// See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
-		// for a full list of env vars.
-		string is_on_github = System.Environment.GetEnvironmentVariable("CI");
-		if (is_on_github != null) { return; }
+		if (Civ3TestData.ShouldSkipCiv3DependentTests()) { return; }
 
 		string savesPath = PathUtils.getDataPath("saves");
 		Directory.CreateDirectory(savesPath);
@@ -496,13 +491,7 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 
 	[Fact]
 	public void LoadAllConquestScenarios() {
-		// When running the tests via github actions, civ3 isn't installed so we can't
-		// check the conquests directories.
-		//
-		// See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
-		// for a full list of env vars.
-		string is_on_github = System.Environment.GetEnvironmentVariable("CI");
-		if (is_on_github != null) { return; }
+		if (Civ3TestData.ShouldSkipCiv3DependentTests()) { return; }
 
 		string[] singleplayerScenarios = {
 			"1 Mesopotamia.biq",

--- a/EngineTests/GameData/UnitPrototypeTest.cs
+++ b/EngineTests/GameData/UnitPrototypeTest.cs
@@ -439,10 +439,9 @@ public class UnitPrototypeScenarioTest : RemoteSaveLoader {
 		// This tests a Conquests scenario with custom rules 
 
 		#region setup
-		if (Civ3TestData.ShouldSkipCiv3DependentTests(
-			"Conquests/Conquests/4 Middle Ages.biq",
-			"Conquests/Conquests/Middle Ages/Text/PediaIcons.txt"
-		)) {
+		// Civ3 isn't installed in CI, so we can't load the default BIC. Local
+		// contributors without Civ3 assets configured should skip this too.
+		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
 			return;
 		}
 		string scenarioBiqPath = Path.Combine(Civ3Location.GetCiv3Path(), "Conquests", "Conquests", "4 Middle Ages.biq");

--- a/EngineTests/GameData/UnitPrototypeTest.cs
+++ b/EngineTests/GameData/UnitPrototypeTest.cs
@@ -18,13 +18,7 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 		// This tests a Conquests game with Conquests rules from a .SAV file
 
 		#region setup
-		// When running the tests via github actions, civ3 isn't installed so we
-		// can't load the default bic.
-		//
-		// See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
-		// for a full list of env vars.
-		string is_on_github = System.Environment.GetEnvironmentVariable("CI");
-		if (is_on_github != null) {
+		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
 			return;
 		}
 
@@ -263,13 +257,7 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 	public async void UnitAvailability_JSON() {
 		// This tests a Conquests game with Conquests rules from a .json file
 		#region setup
-		// When running the tests via github actions, civ3 isn't installed so we
-		// can't load the default bic.
-		//
-		// See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
-		// for a full list of env vars.
-		string is_on_github = System.Environment.GetEnvironmentVariable("CI");
-		if (is_on_github != null) {
+		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
 			return;
 		}
 
@@ -451,13 +439,10 @@ public class UnitPrototypeScenarioTest : RemoteSaveLoader {
 		// This tests a Conquests scenario with custom rules 
 
 		#region setup
-		// When running the tests via github actions, civ3 isn't installed so we
-		// can't load the default bic.
-		//
-		// See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
-		// for a full list of env vars.
-		string is_on_github = System.Environment.GetEnvironmentVariable("CI");
-		if (is_on_github != null) {
+		if (Civ3TestData.ShouldSkipCiv3DependentTests(
+			"Conquests/Conquests/4 Middle Ages.biq",
+			"Conquests/Conquests/Middle Ages/Text/PediaIcons.txt"
+		)) {
 			return;
 		}
 		string scenarioBiqPath = Path.Combine(Civ3Location.GetCiv3Path(), "Conquests", "Conquests", "4 Middle Ages.biq");

--- a/EngineTests/Utils/Civ3TestData.cs
+++ b/EngineTests/Utils/Civ3TestData.cs
@@ -11,13 +11,14 @@ public static class Civ3TestData {
 		"Conquests/Text/PediaIcons.txt",
 	};
 
-	public static bool ShouldSkipCiv3DependentTests(params string[] requiredRelativePaths) {
+	public static bool ShouldSkipCiv3DependentTests() {
+		// GitHub Actions sets CI, and Civ3 is not installed there. Local
+		// contributors can also run without Civ3 assets or CIV3_HOME configured.
 		if (Environment.GetEnvironmentVariable("CI") != null) {
 			return true;
 		}
 
-		string[] requiredFiles = DefaultRequiredFiles.Concat(requiredRelativePaths).ToArray();
-		return requiredFiles.Any(relativePath => !File.Exists(GetCiv3Path(relativePath)));
+		return DefaultRequiredFiles.Any(relativePath => !File.Exists(GetCiv3Path(relativePath)));
 	}
 
 	private static string GetCiv3Path(string relativePath) {

--- a/EngineTests/Utils/Civ3TestData.cs
+++ b/EngineTests/Utils/Civ3TestData.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using System.Linq;
+using QueryCiv3;
+
+namespace EngineTests.Utils;
+
+public static class Civ3TestData {
+	private static readonly string[] DefaultRequiredFiles = {
+		"Conquests/conquests.biq",
+		"Conquests/Text/PediaIcons.txt",
+	};
+
+	public static bool ShouldSkipCiv3DependentTests(params string[] requiredRelativePaths) {
+		if (Environment.GetEnvironmentVariable("CI") != null) {
+			return true;
+		}
+
+		string[] requiredFiles = DefaultRequiredFiles.Concat(requiredRelativePaths).ToArray();
+		return requiredFiles.Any(relativePath => !File.Exists(GetCiv3Path(relativePath)));
+	}
+
+	private static string GetCiv3Path(string relativePath) {
+		string normalizedPath = relativePath
+			.Replace('\\', Path.DirectorySeparatorChar)
+			.Replace('/', Path.DirectorySeparatorChar);
+
+		return Path.Combine(Civ3Location.GetCiv3Path(), normalizedPath);
+	}
+}

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@
 
 ## Status
 
-The latest stable version can be downloaded from the [Releases page](https://github.com/C7-Game/Prototype/releases). Current information on installation and features can always be found on the [project homepage.](https://www.openciv3.org/)
+The latest stable version can be downloaded from the [Releases page](https://github.com/C7-Game/OpenCiv3/releases). Current information on installation and features can always be found on the [project homepage.](https://www.openciv3.org/)
 
 OpenCiv3 is in a pre-alpha state. It is a rudimentary playable game but lacking many mechanics and late-game content, and errors are likely. Keep up with our development for the latest updates and opportunities to contribute!
 
 ## Contributing
 
-Find the project interesting and want to contribute?  See [Contributing](https://github.com/C7-Game/Prototype/wiki/Contributing) on our Wiki for more information! At the moment, additional developer support is the most-needed asset, but all sorts of help (art, writing, project management, playtesting) could be useful.
+Find the project interesting and want to contribute?  See [Contributing](https://github.com/C7-Game/OpenCiv3/wiki/Contributing) on our Wiki for more information! At the moment, additional developer support is the most-needed asset, but all sorts of help (art, writing, project management, playtesting) could be useful.
 
-To set up a working development environment, see [Developing and Setting Up IDEs](https://github.com/C7-Game/Prototype/wiki/Developing-and-Setting-Up-IDEs).
+To set up a working development environment, see [Developing and Setting Up IDEs](https://github.com/C7-Game/OpenCiv3/wiki/Developing-and-Setting-Up-IDEs).
 
 ## What are those subfolders?
 

--- a/doc/dev_environment.md
+++ b/doc/dev_environment.md
@@ -1,56 +1,50 @@
 # Development Environment
 
-This document provides steps to set up a working C7 development environment.
+This document provides steps to set up a working OpenCiv3 development environment. Some source paths still use the older `C7` name; the Godot project and C# solution are in the `C7` directory.
 
 # Requirements
 ## .NET SDK
-Download [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet).
+Download the [.NET SDK](https://dotnet.microsoft.com/en-us/download), version 8.0 or higher. The projects currently target `net8.0`.
 
 ## Godot
-Install the Mono version of [Godot](https://godotengine.org/download). This includes the Godot IDE which is useful for building C7 and in some cases developing UI, but it is not recommended for C# code editing.
+Install the [.NET version of Godot 4.4](https://godotengine.org/download). The Godot editor is useful for importing the project, running the game, wiring scene events, and creating UI, but a full C# IDE is still recommended for code editing.
+
+The first time you check out OpenCiv3, import `C7/project.godot` from the Godot Project Manager. Godot will build the C# project before running it.
 
 # IDEs
-There are two free IDEs recommended for C# development. Follow the steps below for setting up a working development environment in these editors and troubleshooting for common issues. Another alternative is to use [JetBrains Rider](https://www.jetbrains.com/rider/download/), a commercial IDE for C# development. There is a
-[CFC thread](https://forums.civfanatics.com/threads/dev-jetbrains-rider-impressions.675190/) on Rider that may provide additional information on setting it up.
+Most OpenCiv3 development is C#, so use Visual Studio Code or JetBrains Rider alongside the Godot editor. Visual Studio 2019 is no longer a supported setup for current Godot 4/.NET development.
 
 ## Visual Studio Code
 Follow the [official guide](https://code.visualstudio.com/docs/setup/setup-overview#_cross-platform) to install Visual Studio Code for your platform.
 
-Next, install the following plugins from the marketplace:
-1. [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) - this provides syntax highlighting, IntelliSense, find references, and other nice IDE-like features for C#.
-2. [C# Tools for Godot](https://marketplace.visualstudio.com/items?itemName=neikeq.godot-csharp-vscode) - this enables launching C7 from VS Code and debugging
+Next, install the following extensions from the marketplace:
+1. [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) - this provides syntax highlighting, IntelliSense, find references, and other IDE-like features for C#.
+2. [C# Tools for Godot](https://marketplace.visualstudio.com/items?itemName=neikeq.godot-csharp-vscode) - this helps with launching and debugging Godot C# projects from VS Code.
 
-Finally, set up code formatting. For Visual Studio Code, formatting is done with OmniSharp and configured by the `.editorconfig` file. In order to configure OmniSharp, do the following:
-1. In your home directory, create `~/.omnisharp/omnisharp.json` with the following contents
-```
-{
-  "RoslynExtensionsOptions": {
-    "enableAnalyzersSupport": true,
-  },
-  "FormattingOptions": {
-    "enableEditorConfigSupport": true,
-  }
-}
-```
-2. Add the following options to your VS Code `settings.json` (either workspace settings or your user level settings)
-```
+Finally, set up code formatting. The repository uses `.editorconfig`; VS Code can honor it through the C# extension settings. Add the following options to your VS Code `settings.json` if they are not already enabled:
+
+```json
 "omnisharp.enableMsBuildLoadProjectsOnDemand": true,
 "omnisharp.enableEditorConfigSupport": true,
 "omnisharp.enableRoslynAnalyzers": true,
-```
-3. Optionally but recommended, add this option to your VS Code `settings.json` to enable formatting on save
-```
 "[csharp]": {
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": true
 }
 ```
 
 ### Troubleshooting
-- Linting or IntelliSense are completely broken
-  - try adding `"omnisharp.useGlobalMono": "always"` to `settings.json`
-  - you may need to rebuild the entire project through the Godot IDE
+- If linting or IntelliSense are completely broken, rebuild the project through the Godot editor and restart VS Code.
+- If command-line builds fail before Godot has imported the project, open `C7/project.godot` in the Godot editor once, let it finish the initial build, and try again.
 
-## Visual Studio 2019 Community Edition
-It's important to use Visual Studio 2019, as you cannot run/debug Godot from Visual Studio 2022 yet, and 2019 was the first version to be supported.
+## JetBrains Rider
+Rider has strong C# support and good Godot integration. Install Rider, add the Godot Support plugin, and open `C7/C7.sln`. Use a Godot 4 `.NET Executable` run configuration that points at your local Godot executable and the `C7` project directory.
 
-The Visual Studio solution file is already aware of the `.editorconfig` file, so no further setup is required.
+# Build and Test
+From the repository root:
+
+```bash
+dotnet build C7/C7.sln
+dotnet test C7/C7.sln --logger "console;verbosity=detailed"
+```
+
+Some tests load Civilization III assets. Set `CIV3_HOME` to the top-level Civilization III install folder if you want to run those locally.

--- a/doc/dev_environment.md
+++ b/doc/dev_environment.md
@@ -12,7 +12,7 @@ Install the [.NET version of Godot 4.4](https://godotengine.org/download). The G
 The first time you check out OpenCiv3, import `C7/project.godot` from the Godot Project Manager. Godot will build the C# project before running it.
 
 # IDEs
-Most OpenCiv3 development is C#, so use Visual Studio Code or JetBrains Rider alongside the Godot editor. Visual Studio 2019 is no longer a supported setup for current Godot 4/.NET development.
+Most OpenCiv3 development is C#, so use Visual Studio Code or [JetBrains Rider](https://www.jetbrains.com/rider/download/) alongside the Godot editor. Visual Studio 2019 is no longer a supported setup for current Godot 4/.NET development. There is a [CFC thread](https://forums.civfanatics.com/threads/dev-jetbrains-rider-impressions.675190/) on Rider that may provide additional information on setting it up.
 
 ## Visual Studio Code
 Follow the [official guide](https://code.visualstudio.com/docs/setup/setup-overview#_cross-platform) to install Visual Studio Code for your platform.


### PR DESCRIPTION
## Summary

- update contributor documentation links and local setup guidance for the current OpenCiv3 repo, .NET 8+, and Godot 4.4 .NET
- update vulnerable/outdated EngineTests package references, including the ImageSharp patched version
- add a shared test helper so Civ3 asset-dependent tests return early when local Civ3 data is unavailable

## Why

The previous docs still referenced the old Prototype repository and older tooling. Local contributors without Civ3 installed could also hit asset-dependent test failures unless running under CI. This keeps the first-time contributor path cleaner without changing production behavior.

## Validation

- `dotnet restore C7/C7.sln --verbosity:minimal`
- `dotnet list C7/C7.sln package --vulnerable --include-transitive`
- `dotnet build C7/C7.sln --configuration Debug --verbosity:minimal`
- `dotnet format C7/C7.sln whitespace --verify-no-changes --verbosity minimal`
- `dotnet test C7/C7.sln --logger:'console;verbosity=minimal'`
- `git diff --check`

Note: the rebased upstream branch currently emits existing compiler/analyzer warnings during build, but the build exits successfully and tests pass.