### PR TITLE
Support broadside attack facing

### DIFF
--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -792,6 +792,7 @@
       "defense": 0,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -868,6 +869,7 @@
       "defense": 0,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -945,6 +947,7 @@
       "defense": 0,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Russia",
         "America",
@@ -989,6 +992,7 @@
       "defense": 0,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1055,6 +1059,7 @@
       "defense": 6,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1125,6 +1130,7 @@
       "defense": 11,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1195,6 +1201,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "A Barbarian Chiefdom",
         "Rome",
@@ -1263,6 +1270,7 @@
       "defense": 1,
       "bombard": 1,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1329,6 +1337,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1393,6 +1402,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Egypt",
         "Greece",
@@ -1461,6 +1471,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Greece",
@@ -1530,6 +1541,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "A Barbarian Chiefdom",
         "Rome",
@@ -1601,6 +1613,7 @@
       "defense": 3,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1669,6 +1682,7 @@
       "defense": 1,
       "bombard": 2,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1736,6 +1750,7 @@
       "defense": 4,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1806,6 +1821,7 @@
       "defense": 3,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1873,6 +1889,7 @@
       "defense": 6,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1941,6 +1958,7 @@
       "defense": 3,
       "bombard": 0,
       "movement": 3,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2010,6 +2028,7 @@
       "defense": 10,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2081,6 +2100,7 @@
       "defense": 8,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2152,6 +2172,7 @@
       "defense": 18,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2223,6 +2244,7 @@
       "defense": 16,
       "bombard": 0,
       "movement": 3,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2294,6 +2316,7 @@
       "defense": 0,
       "bombard": 4,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2363,6 +2386,7 @@
       "defense": 0,
       "bombard": 8,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2435,6 +2459,7 @@
       "defense": 0,
       "bombard": 12,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2576,6 +2601,7 @@
       "defense": 0,
       "bombard": 16,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2646,6 +2672,7 @@
       "defense": 0,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2718,6 +2745,7 @@
       "defense": 0,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3066,6 +3094,7 @@
       "defense": 6,
       "bombard": 6,
       "movement": 3,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3139,6 +3168,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 6,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3209,6 +3239,7 @@
       "defense": 8,
       "bombard": 0,
       "movement": 7,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3279,6 +3310,7 @@
       "defense": 4,
       "bombard": 0,
       "movement": 4,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3349,6 +3381,7 @@
       "defense": 8,
       "bombard": 6,
       "movement": 8,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3492,6 +3525,7 @@
       "defense": 10,
       "bombard": 6,
       "movement": 7,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3564,6 +3598,7 @@
       "defense": 4,
       "bombard": 0,
       "movement": 5,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3634,6 +3669,7 @@
       "defense": 2,
       "bombard": 3,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3703,6 +3739,7 @@
       "defense": 2,
       "bombard": 12,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3771,6 +3808,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3840,6 +3878,7 @@
       "defense": 4,
       "bombard": 3,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3908,6 +3947,7 @@
       "defense": 6,
       "bombard": 6,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3977,6 +4017,7 @@
       "defense": 5,
       "bombard": 18,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4058,6 +4099,7 @@
       "defense": 0,
       "bombard": 0,
       "movement": 3,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4135,6 +4177,7 @@
       "defense": 0,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4202,6 +4245,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Aztecs"
       ],
@@ -4240,6 +4284,7 @@
       "defense": 2,
       "bombard": 1,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Babylon"
       ],
@@ -4278,6 +4323,7 @@
       "defense": 3,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Greece"
       ],
@@ -4316,6 +4362,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Zululand"
       ],
@@ -4354,6 +4401,7 @@
       "defense": 3,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome"
       ],
@@ -4395,6 +4443,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Persia"
       ],
@@ -4436,6 +4485,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Egypt"
       ],
@@ -4477,6 +4527,7 @@
       "defense": 3,
       "bombard": 0,
       "movement": 3,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "China"
       ],
@@ -4519,6 +4570,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Iroquois"
       ],
@@ -4560,6 +4612,7 @@
       "defense": 5,
       "bombard": 2,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "France"
       ],
@@ -4601,6 +4654,7 @@
       "defense": 4,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Japan"
       ],
@@ -4642,6 +4696,7 @@
       "defense": 3,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "India"
       ],
@@ -4680,6 +4735,7 @@
       "defense": 3,
       "bombard": 0,
       "movement": 3,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Russia"
       ],
@@ -4721,6 +4777,7 @@
       "defense": 8,
       "bombard": 0,
       "movement": 3,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Germany"
       ],
@@ -4806,6 +4863,7 @@
       "defense": 4,
       "bombard": 6,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "America"
       ],
@@ -4917,6 +4975,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Mongols"
       ],
@@ -4958,6 +5017,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Spain"
       ],
@@ -4998,6 +5058,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Scandinavia"
       ],
@@ -5036,6 +5097,7 @@
       "defense": 3,
       "bombard": 0,
       "movement": 3,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Ottomans"
       ],
@@ -5077,6 +5139,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Celts"
       ],
@@ -5118,6 +5181,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 3,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Arabia"
       ],
@@ -5160,6 +5224,7 @@
       "defense": 3,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Carthage"
       ],
@@ -5198,6 +5263,7 @@
       "defense": 0,
       "bombard": 8,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Korea"
       ],
@@ -5240,6 +5306,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -5310,6 +5377,7 @@
       "defense": 6,
       "bombard": 3,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -5377,6 +5445,7 @@
       "defense": 0,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5408,6 +5477,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5441,6 +5511,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5474,6 +5545,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5507,6 +5579,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5540,6 +5613,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5573,6 +5647,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5606,6 +5681,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5639,6 +5715,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5672,6 +5749,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5705,6 +5783,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5738,6 +5817,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5771,6 +5851,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5804,6 +5885,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5837,6 +5919,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5870,6 +5953,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5903,6 +5987,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5936,6 +6021,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5969,6 +6055,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6002,6 +6089,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6035,6 +6123,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6068,6 +6157,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6101,6 +6191,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6134,6 +6225,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6167,6 +6259,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6200,6 +6293,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Sumeria"
       ],
@@ -6238,6 +6332,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Hittites"
       ],
@@ -6278,6 +6373,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6311,6 +6407,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6344,6 +6441,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6417,6 +6515,7 @@
       "defense": 4,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Netherlands"
       ],
@@ -6457,6 +6556,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6491,6 +6591,7 @@
       "defense": 0,
       "bombard": 6,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -6559,6 +6660,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6592,6 +6694,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6625,6 +6728,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6658,6 +6762,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Inca"
       ],
@@ -6696,6 +6801,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Maya"
       ],
@@ -6734,6 +6840,7 @@
       "defense": 1,
       "bombard": 2,
       "movement": 3,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Byzantines"
       ],
@@ -6773,6 +6880,7 @@
       "defense": 10,
       "bombard": 7,
       "movement": 6,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -6844,6 +6952,7 @@
       "defense": 3,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6881,6 +6990,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6985,6 +7095,7 @@
       "defense": 9,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7057,6 +7168,7 @@
       "defense": 14,
       "bombard": 6,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7124,6 +7236,7 @@
       "defense": 6,
       "bombard": 0,
       "movement": 1,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7192,6 +7305,7 @@
       "defense": 6,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",

--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -792,7 +792,6 @@
       "defense": 0,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -869,7 +868,6 @@
       "defense": 0,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -947,7 +945,6 @@
       "defense": 0,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Russia",
         "America",
@@ -992,7 +989,6 @@
       "defense": 0,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1059,7 +1055,6 @@
       "defense": 6,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1130,7 +1125,6 @@
       "defense": 11,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1201,7 +1195,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "A Barbarian Chiefdom",
         "Rome",
@@ -1270,7 +1263,6 @@
       "defense": 1,
       "bombard": 1,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1337,7 +1329,6 @@
       "defense": 2,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1402,7 +1393,6 @@
       "defense": 2,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Egypt",
         "Greece",
@@ -1471,7 +1461,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Greece",
@@ -1541,7 +1530,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "A Barbarian Chiefdom",
         "Rome",
@@ -1613,7 +1601,6 @@
       "defense": 3,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1682,7 +1669,6 @@
       "defense": 1,
       "bombard": 2,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1750,7 +1736,6 @@
       "defense": 4,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1821,7 +1806,6 @@
       "defense": 3,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1889,7 +1873,6 @@
       "defense": 6,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1958,7 +1941,6 @@
       "defense": 3,
       "bombard": 0,
       "movement": 3,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2028,7 +2010,6 @@
       "defense": 10,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2100,7 +2081,6 @@
       "defense": 8,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2172,7 +2152,6 @@
       "defense": 18,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2244,7 +2223,6 @@
       "defense": 16,
       "bombard": 0,
       "movement": 3,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2316,7 +2294,6 @@
       "defense": 0,
       "bombard": 4,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2386,7 +2363,6 @@
       "defense": 0,
       "bombard": 8,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2459,7 +2435,6 @@
       "defense": 0,
       "bombard": 12,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2529,7 +2504,9 @@
       "defense": 0,
       "bombard": 16,
       "movement": 2,
-      "rotateBeforeAttack": true,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2601,7 +2578,6 @@
       "defense": 0,
       "bombard": 16,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2672,7 +2648,6 @@
       "defense": 0,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2745,7 +2720,6 @@
       "defense": 0,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2817,7 +2791,9 @@
       "defense": 1,
       "bombard": 0,
       "movement": 3,
-      "rotateBeforeAttack": true,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2885,7 +2861,9 @@
       "defense": 2,
       "bombard": 0,
       "movement": 4,
-      "rotateBeforeAttack": true,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2953,7 +2931,9 @@
       "defense": 2,
       "bombard": 3,
       "movement": 5,
-      "rotateBeforeAttack": true,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3025,7 +3005,9 @@
       "defense": 2,
       "bombard": 0,
       "movement": 4,
-      "rotateBeforeAttack": true,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3094,7 +3076,6 @@
       "defense": 6,
       "bombard": 6,
       "movement": 3,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3168,7 +3149,6 @@
       "defense": 2,
       "bombard": 0,
       "movement": 6,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3239,7 +3219,6 @@
       "defense": 8,
       "bombard": 0,
       "movement": 7,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3310,7 +3289,6 @@
       "defense": 4,
       "bombard": 0,
       "movement": 4,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3381,7 +3359,6 @@
       "defense": 8,
       "bombard": 6,
       "movement": 8,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3453,7 +3430,9 @@
       "defense": 12,
       "bombard": 8,
       "movement": 5,
-      "rotateBeforeAttack": true,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3525,7 +3504,6 @@
       "defense": 10,
       "bombard": 6,
       "movement": 7,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3598,7 +3576,6 @@
       "defense": 4,
       "bombard": 0,
       "movement": 5,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3669,7 +3646,6 @@
       "defense": 2,
       "bombard": 3,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3739,7 +3715,6 @@
       "defense": 2,
       "bombard": 12,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3808,7 +3783,6 @@
       "defense": 2,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3878,7 +3852,6 @@
       "defense": 4,
       "bombard": 3,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3947,7 +3920,6 @@
       "defense": 6,
       "bombard": 6,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4017,7 +3989,6 @@
       "defense": 5,
       "bombard": 18,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4099,7 +4070,6 @@
       "defense": 0,
       "bombard": 0,
       "movement": 3,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4177,7 +4147,6 @@
       "defense": 0,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4245,7 +4214,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Aztecs"
       ],
@@ -4284,7 +4252,6 @@
       "defense": 2,
       "bombard": 1,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Babylon"
       ],
@@ -4323,7 +4290,6 @@
       "defense": 3,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Greece"
       ],
@@ -4362,7 +4328,6 @@
       "defense": 2,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Zululand"
       ],
@@ -4401,7 +4366,6 @@
       "defense": 3,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome"
       ],
@@ -4443,7 +4407,6 @@
       "defense": 2,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Persia"
       ],
@@ -4485,7 +4448,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Egypt"
       ],
@@ -4527,7 +4489,6 @@
       "defense": 3,
       "bombard": 0,
       "movement": 3,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "China"
       ],
@@ -4570,7 +4531,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Iroquois"
       ],
@@ -4612,7 +4572,6 @@
       "defense": 5,
       "bombard": 2,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "France"
       ],
@@ -4654,7 +4613,6 @@
       "defense": 4,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Japan"
       ],
@@ -4696,7 +4654,6 @@
       "defense": 3,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "India"
       ],
@@ -4735,7 +4692,6 @@
       "defense": 3,
       "bombard": 0,
       "movement": 3,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Russia"
       ],
@@ -4777,7 +4733,6 @@
       "defense": 8,
       "bombard": 0,
       "movement": 3,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Germany"
       ],
@@ -4820,7 +4775,9 @@
       "defense": 2,
       "bombard": 4,
       "movement": 5,
-      "rotateBeforeAttack": true,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "producibleBy": [
         "England"
       ],
@@ -4863,7 +4820,6 @@
       "defense": 4,
       "bombard": 6,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "America"
       ],
@@ -4903,7 +4859,9 @@
       "defense": 1,
       "bombard": 3,
       "movement": 5,
-      "rotateBeforeAttack": true,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4975,7 +4933,6 @@
       "defense": 2,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Mongols"
       ],
@@ -5017,7 +4974,6 @@
       "defense": 2,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Spain"
       ],
@@ -5058,7 +5014,6 @@
       "defense": 2,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Scandinavia"
       ],
@@ -5097,7 +5052,6 @@
       "defense": 3,
       "bombard": 0,
       "movement": 3,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Ottomans"
       ],
@@ -5139,7 +5093,6 @@
       "defense": 2,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Celts"
       ],
@@ -5181,7 +5134,6 @@
       "defense": 2,
       "bombard": 0,
       "movement": 3,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Arabia"
       ],
@@ -5224,7 +5176,6 @@
       "defense": 3,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Carthage"
       ],
@@ -5263,7 +5214,6 @@
       "defense": 0,
       "bombard": 8,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Korea"
       ],
@@ -5306,7 +5256,6 @@
       "defense": 2,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -5377,7 +5326,6 @@
       "defense": 6,
       "bombard": 3,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -5445,7 +5393,6 @@
       "defense": 0,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5477,7 +5424,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5511,7 +5457,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5545,7 +5490,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5579,7 +5523,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5613,7 +5556,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5647,7 +5589,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5681,7 +5622,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5715,7 +5655,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5749,7 +5688,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5783,7 +5721,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5817,7 +5754,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5851,7 +5787,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5885,7 +5820,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5919,7 +5853,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5953,7 +5886,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -5987,7 +5919,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6021,7 +5952,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6055,7 +5985,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6089,7 +6018,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6123,7 +6051,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6157,7 +6084,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6191,7 +6117,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6225,7 +6150,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6259,7 +6183,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6293,7 +6216,6 @@
       "defense": 2,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Sumeria"
       ],
@@ -6332,7 +6254,6 @@
       "defense": 2,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Hittites"
       ],
@@ -6373,7 +6294,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6407,7 +6327,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6441,7 +6360,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6476,7 +6394,9 @@
       "defense": 2,
       "bombard": 0,
       "movement": 4,
-      "rotateBeforeAttack": true,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "producibleBy": [
         "Portugal"
       ],
@@ -6515,7 +6435,6 @@
       "defense": 4,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Netherlands"
       ],
@@ -6556,7 +6475,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6591,7 +6509,6 @@
       "defense": 0,
       "bombard": 6,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -6660,7 +6577,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6694,7 +6610,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6728,7 +6643,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6762,7 +6676,6 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Inca"
       ],
@@ -6801,7 +6714,6 @@
       "defense": 2,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Maya"
       ],
@@ -6840,7 +6752,6 @@
       "defense": 1,
       "bombard": 2,
       "movement": 3,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Byzantines"
       ],
@@ -6880,7 +6791,6 @@
       "defense": 10,
       "bombard": 7,
       "movement": 6,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -6952,7 +6862,6 @@
       "defense": 3,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -6990,7 +6899,6 @@
       "defense": 2,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [],
       "unproducible": true,
       "categories": [
@@ -7026,7 +6934,9 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": true,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "upgradeTo": "Galley",
       "producibleBy": [
         "Rome",
@@ -7095,7 +7005,6 @@
       "defense": 9,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7168,7 +7077,6 @@
       "defense": 14,
       "bombard": 6,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7236,7 +7144,6 @@
       "defense": 6,
       "bombard": 0,
       "movement": 1,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7305,7 +7212,6 @@
       "defense": 6,
       "bombard": 0,
       "movement": 2,
-      "rotateBeforeAttack": false,
       "producibleBy": [
         "Rome",
         "Egypt",

--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -2504,6 +2504,7 @@
       "defense": 0,
       "bombard": 16,
       "movement": 2,
+      "rotateBeforeAttack": true,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2788,6 +2789,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 3,
+      "rotateBeforeAttack": true,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2855,6 +2857,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 4,
+      "rotateBeforeAttack": true,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2922,6 +2925,7 @@
       "defense": 2,
       "bombard": 3,
       "movement": 5,
+      "rotateBeforeAttack": true,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2993,6 +2997,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 4,
+      "rotateBeforeAttack": true,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3415,6 +3420,7 @@
       "defense": 12,
       "bombard": 8,
       "movement": 5,
+      "rotateBeforeAttack": true,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4757,6 +4763,7 @@
       "defense": 2,
       "bombard": 4,
       "movement": 5,
+      "rotateBeforeAttack": true,
       "producibleBy": [
         "England"
       ],
@@ -4838,6 +4845,7 @@
       "defense": 1,
       "bombard": 3,
       "movement": 5,
+      "rotateBeforeAttack": true,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -6370,6 +6378,7 @@
       "defense": 2,
       "bombard": 0,
       "movement": 4,
+      "rotateBeforeAttack": true,
       "producibleBy": [
         "Portugal"
       ],
@@ -6907,6 +6916,7 @@
       "defense": 1,
       "bombard": 0,
       "movement": 2,
+      "rotateBeforeAttack": true,
       "upgradeTo": "Galley",
       "producibleBy": [
         "Rome",

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -1189,7 +1189,9 @@ namespace C7GameData {
 				prototype.shieldCost = prto.ShieldCost;
 				prototype.populationCost = prto.PopulationCost;
 				prototype.bombard = prto.BombardStrength;
-				prototype.rotateBeforeAttack = prto.TurnToAttack;
+				if (prto.TurnToAttack) {
+					prototype.flags.Add(SaveUnitPrototype.Flag.RotateBeforeAttack);
+				}
 
 				prototype.actions.UnionWith(GetUnitActions(prto));
 				prototype.terraformActions.UnionWith(GetUnitTerraforms(prto).Select(tfKey => terraformIdByCiv3Key[tfKey]));

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -1189,6 +1189,7 @@ namespace C7GameData {
 				prototype.shieldCost = prto.ShieldCost;
 				prototype.populationCost = prto.PopulationCost;
 				prototype.bombard = prto.BombardStrength;
+				prototype.rotateBeforeAttack = prto.TurnToAttack;
 
 				prototype.actions.UnionWith(GetUnitActions(prto));
 				prototype.terraformActions.UnionWith(GetUnitTerraforms(prto).Select(tfKey => terraformIdByCiv3Key[tfKey]));

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -313,15 +313,25 @@ namespace C7GameData {
 			return ((unitType.movement > 1) && (opponent.unitType.movement <= 1)) ? experienceLevel.retreatChance : 0.0;
 		}
 
+		internal TileDirection GetAttackAnimationDirection(TileDirection attackDirection) {
+			return unitType.rotateBeforeAttack ? attackDirection.rotatedCounterClockwise90Degrees() : attackDirection;
+		}
+
+		internal TileDirection GetDefenseAnimationDirection(TileDirection attackDirection) {
+			return GetAttackAnimationDirection(attackDirection.reversed());
+		}
+
 		public async Task<CombatResult> fight(MapUnit defender) {
 			var attacker = this;
 
-			// Rotate defender to face its attacker. We'll restore the original facing direction at the end of the battle.
+			// Set combat animation facing. We'll restore the defender's original facing direction at the end of the battle.
+			TileDirection attackDirection = attacker.location.directionTo(defender.location);
 			var defenderOriginalDirection = defender.facingDirection;
-			defender.facingDirection = attacker.facingDirection.reversed();
+			attacker.facingDirection = attacker.GetAttackAnimationDirection(attackDirection);
+			defender.facingDirection = defender.GetDefenseAnimationDirection(attackDirection);
 
-			IEnumerable<StrengthBonus> attackBonuses  = attacker.ListStrengthBonusesVersus(defender, CombatRole.Attack , attacker.facingDirection),
-								   defenseBonuses = defender.ListStrengthBonusesVersus(attacker, CombatRole.Defense, attacker.facingDirection);
+			IEnumerable<StrengthBonus> attackBonuses  = attacker.ListStrengthBonusesVersus(defender, CombatRole.Attack , attackDirection),
+								   defenseBonuses = defender.ListStrengthBonusesVersus(attacker, CombatRole.Defense, attackDirection);
 
 			double attackerStrength = attacker.unitType.attack  * StrengthBonus.ListToMultiplier(attackBonuses),
 			   defenderStrength = defender.unitType.defense * StrengthBonus.ListToMultiplier(defenseBonuses);
@@ -344,7 +354,7 @@ namespace C7GameData {
 			MapUnit defensiveBombarder = MapUnit.NONE;
 			double defensiveBombarderStrength = 0.0;
 			foreach (MapUnit candidate in defender.location.unitsOnTile.Where(u => u != defender && !u.owner.IsAtPeaceWith(attacker.owner) && u.defensiveBombardsRemaining > 0)) {
-				double strength = candidate.StrengthVersus(attacker, CombatRole.DefensiveBombard, attacker.facingDirection.reversed());
+				double strength = candidate.StrengthVersus(attacker, CombatRole.DefensiveBombard, attackDirection.reversed());
 				if (strength > defensiveBombarderStrength) {
 					defensiveBombarder = candidate;
 					defensiveBombarderStrength = strength;
@@ -354,12 +364,13 @@ namespace C7GameData {
 			// https://github.com/C7-Game/Prototype/pull/250#discussion_r893051111
 			if (defensiveBombarder != MapUnit.NONE && attacker.hitPointsRemaining > 1) {
 				var dBOriginalDirection = defensiveBombarder.facingDirection;
-				defensiveBombarder.facingDirection = defender.facingDirection;
+				TileDirection defensiveBombardDirection = attackDirection.reversed();
+				defensiveBombarder.facingDirection = defensiveBombarder.GetAttackAnimationDirection(defensiveBombardDirection);
 
 				await defensiveBombarder.animateAsync(MapUnit.AnimatedAction.ATTACK1);
 
 				// dADB = defense Against Defensive Bombard
-				double dADB = attacker.StrengthVersus(defensiveBombarder, CombatRole.DefensiveBombardDefense, defensiveBombarder.facingDirection);
+				double dADB = attacker.StrengthVersus(defensiveBombarder, CombatRole.DefensiveBombardDefense, defensiveBombardDirection);
 				if (GameData.rng.NextDouble() < defensiveBombarderStrength / (defensiveBombarderStrength + dADB))
 					attacker.hitPointsRemaining -= 1;
 
@@ -379,9 +390,9 @@ namespace C7GameData {
 						GameData.rng.NextDouble() < defender.RetreatChance(attacker, false)) {
 						// TODO: Defender retreat behavior requires some more work. There's an issue for it here:
 						// https://github.com/C7-Game/Prototype/issues/274
-						Tile retreatDestination = defender.location.neighbors[attacker.facingDirection];
+						Tile retreatDestination = defender.location.neighbors[attackDirection];
 						if ((retreatDestination != Tile.NONE) && defender.CanEnterTile(retreatDestination, TileProbe.MoveNonAggroProbe())) {
-							await defender.move(attacker.facingDirection, true);
+							await defender.move(attackDirection, true);
 							result = CombatResult.DefenderRetreated;
 							break;
 						}
@@ -659,6 +670,7 @@ namespace C7GameData {
 					}
 				}
 
+				facingDirection = dir;
 				float movementCost = TilePath.GetMovementCost(this.owner, location, dir, newLoc);
 				if (!location.unitsOnTile.Remove(this))
 					throw new System.Exception("Failed to remove unit from tile it's supposed to be on");

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -325,13 +325,14 @@ namespace C7GameData {
 			var attacker = this;
 
 			// Set combat animation facing. We'll restore the defender's original facing direction at the end of the battle.
-			TileDirection attackDirection = attacker.location.directionTo(defender.location);
+			TileDirection attackerAttackDirection = attacker.location.directionTo(defender.location);
+			TileDirection defenderDefenseDirection = attackerAttackDirection.reversed();
 			var defenderOriginalDirection = defender.facingDirection;
-			attacker.facingDirection = attacker.GetAttackAnimationDirection(attackDirection);
-			defender.facingDirection = defender.GetDefenseAnimationDirection(attackDirection);
+			attacker.facingDirection = attacker.GetAttackAnimationDirection(attackerAttackDirection);
+			defender.facingDirection = defender.GetAttackAnimationDirection(defenderDefenseDirection);
 
-			IEnumerable<StrengthBonus> attackBonuses  = attacker.ListStrengthBonusesVersus(defender, CombatRole.Attack , attackDirection),
-								   defenseBonuses = defender.ListStrengthBonusesVersus(attacker, CombatRole.Defense, attackDirection);
+			IEnumerable<StrengthBonus> attackBonuses  = attacker.ListStrengthBonusesVersus(defender, CombatRole.Attack , attackerAttackDirection),
+								   defenseBonuses = defender.ListStrengthBonusesVersus(attacker, CombatRole.Defense, attackerAttackDirection);
 
 			double attackerStrength = attacker.unitType.attack  * StrengthBonus.ListToMultiplier(attackBonuses),
 			   defenderStrength = defender.unitType.defense * StrengthBonus.ListToMultiplier(defenseBonuses);
@@ -354,7 +355,7 @@ namespace C7GameData {
 			MapUnit defensiveBombarder = MapUnit.NONE;
 			double defensiveBombarderStrength = 0.0;
 			foreach (MapUnit candidate in defender.location.unitsOnTile.Where(u => u != defender && !u.owner.IsAtPeaceWith(attacker.owner) && u.defensiveBombardsRemaining > 0)) {
-				double strength = candidate.StrengthVersus(attacker, CombatRole.DefensiveBombard, attackDirection.reversed());
+				double strength = candidate.StrengthVersus(attacker, CombatRole.DefensiveBombard, defenderDefenseDirection);
 				if (strength > defensiveBombarderStrength) {
 					defensiveBombarder = candidate;
 					defensiveBombarderStrength = strength;
@@ -364,7 +365,7 @@ namespace C7GameData {
 			// https://github.com/C7-Game/Prototype/pull/250#discussion_r893051111
 			if (defensiveBombarder != MapUnit.NONE && attacker.hitPointsRemaining > 1) {
 				var dBOriginalDirection = defensiveBombarder.facingDirection;
-				TileDirection defensiveBombardDirection = attackDirection.reversed();
+				TileDirection defensiveBombardDirection = defenderDefenseDirection;
 				defensiveBombarder.facingDirection = defensiveBombarder.GetAttackAnimationDirection(defensiveBombardDirection);
 
 				await defensiveBombarder.animateAsync(MapUnit.AnimatedAction.ATTACK1);
@@ -390,9 +391,9 @@ namespace C7GameData {
 						GameData.rng.NextDouble() < defender.RetreatChance(attacker, false)) {
 						// TODO: Defender retreat behavior requires some more work. There's an issue for it here:
 						// https://github.com/C7-Game/Prototype/issues/274
-						Tile retreatDestination = defender.location.neighbors[attackDirection];
+						Tile retreatDestination = defender.location.neighbors[attackerAttackDirection];
 						if ((retreatDestination != Tile.NONE) && defender.CanEnterTile(retreatDestination, TileProbe.MoveNonAggroProbe())) {
-							await defender.move(attackDirection, true);
+							await defender.move(attackerAttackDirection, true);
 							result = CombatResult.DefenderRetreated;
 							break;
 						}

--- a/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
+++ b/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
@@ -3,6 +3,10 @@ using System.Linq;
 
 namespace C7GameData.Save {
 	public class SaveUnitPrototype {
+		public enum Flag {
+			RotateBeforeAttack,
+		}
+
 		public string name { get; set; }
 		public Art art { get; set; }
 		public int shieldCost { get; set; }
@@ -17,7 +21,10 @@ namespace C7GameData.Save {
 
 		public string upgradeTo;
 		public bool unproducible;
-		public bool rotateBeforeAttack { get; set; }
+
+		// Assorted boolean flags for the unit prototype. They're stored in
+		// this set rather than as booleans to avoid bloating the json file.
+		public HashSet<Flag> flags = [];
 
 		public HashSet<string> categories = new HashSet<string>();
 
@@ -32,9 +39,9 @@ namespace C7GameData.Save {
 		public SaveUnitPrototype() { }
 
 		public SaveUnitPrototype(UnitPrototype proto) {
-			(name, art, shieldCost, populationCost, unproducible, rotateBeforeAttack,
+			(name, art, shieldCost, populationCost, unproducible,
 			attack, defense, bombard, movement) =
-			(proto.name, proto.art, proto.shieldCost, proto.populationCost, proto.unproducible, proto.rotateBeforeAttack,
+			(proto.name, proto.art, proto.shieldCost, proto.populationCost, proto.unproducible,
 			 proto.attack, proto.defense, proto.bombard, proto.movement);
 
 			if (proto.requiredTech != null)
@@ -46,6 +53,7 @@ namespace C7GameData.Save {
 			categories = new HashSet<string>(proto.categories);
 			actions = proto.actions;
 			attributes = new HashSet<string>(proto.attributes);
+			flags = new HashSet<Flag>(proto.flags);
 
 			requiredResources = proto.requiredResources.Select(r => r.Key).ToHashSet();
 			terraformActions = proto.terraformActions.Select(r => r.Id).ToHashSet();

--- a/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
+++ b/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
@@ -17,6 +17,7 @@ namespace C7GameData.Save {
 
 		public string upgradeTo;
 		public bool unproducible;
+		public bool rotateBeforeAttack { get; set; }
 
 		public HashSet<string> categories = new HashSet<string>();
 
@@ -31,9 +32,9 @@ namespace C7GameData.Save {
 		public SaveUnitPrototype() { }
 
 		public SaveUnitPrototype(UnitPrototype proto) {
-			(name, art, shieldCost, populationCost, unproducible,
+			(name, art, shieldCost, populationCost, unproducible, rotateBeforeAttack,
 			attack, defense, bombard, movement) =
-			(proto.name, proto.art, proto.shieldCost, proto.populationCost, proto.unproducible,
+			(proto.name, proto.art, proto.shieldCost, proto.populationCost, proto.unproducible, proto.rotateBeforeAttack,
 			 proto.attack, proto.defense, proto.bombard, proto.movement);
 
 			if (proto.requiredTech != null)

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -803,6 +803,20 @@ namespace C7GameData {
 			}
 		}
 
+		public static TileDirection rotatedCounterClockwise90Degrees(this TileDirection dir) {
+			switch (dir) {
+				case TileDirection.NORTH: return TileDirection.WEST;
+				case TileDirection.NORTHEAST: return TileDirection.NORTHWEST;
+				case TileDirection.EAST: return TileDirection.NORTH;
+				case TileDirection.SOUTHEAST: return TileDirection.NORTHEAST;
+				case TileDirection.SOUTH: return TileDirection.EAST;
+				case TileDirection.SOUTHWEST: return TileDirection.SOUTHEAST;
+				case TileDirection.WEST: return TileDirection.SOUTH;
+				case TileDirection.NORTHWEST: return TileDirection.SOUTHWEST;
+				default: throw new ArgumentOutOfRangeException("Invalid TileDirection");
+			}
+		}
+
 		public static (int, int) toCoordDiff(this TileDirection dir) {
 			switch (dir) {
 				case TileDirection.NORTH: return (0, -2);

--- a/C7Engine/C7GameData/UnitPrototype.cs
+++ b/C7Engine/C7GameData/UnitPrototype.cs
@@ -63,7 +63,17 @@ namespace C7GameData {
 		public HashSet<Civilization> producibleBy { get; set; } = [];
 		public UnitPrototype upgradeTo;
 		public bool unproducible;
-		public bool rotateBeforeAttack { get; set; }
+		public HashSet<SaveUnitPrototype.Flag> flags = [];
+		public bool rotateBeforeAttack {
+			get => flags.Contains(SaveUnitPrototype.Flag.RotateBeforeAttack);
+			set {
+				if (value) {
+					flags.Add(SaveUnitPrototype.Flag.RotateBeforeAttack);
+				} else {
+					flags.Remove(SaveUnitPrototype.Flag.RotateBeforeAttack);
+				}
+			}
+		}
 
 		public HashSet<string> categories = new HashSet<string>();
 
@@ -80,13 +90,14 @@ namespace C7GameData {
 		public UnitPrototype() { }
 
 		public UnitPrototype(SaveUnitPrototype proto, IEnumerable<Terraform> terraforms) {
-			(name, art, shieldCost, populationCost, attack, defense, bombard, movement, unproducible, rotateBeforeAttack) =
+			(name, art, shieldCost, populationCost, attack, defense, bombard, movement, unproducible) =
 			(proto.name, proto.art, proto.shieldCost, proto.populationCost,
-			 proto.attack, proto.defense, proto.bombard, proto.movement, proto.unproducible, proto.rotateBeforeAttack);
+			 proto.attack, proto.defense, proto.bombard, proto.movement, proto.unproducible);
 
 			categories = new HashSet<string>(proto.categories);
 			actions = proto.actions;
 			attributes = new HashSet<string>(proto.attributes);
+			flags = new HashSet<SaveUnitPrototype.Flag>(proto.flags);
 
 			terraformActions = proto.terraformActions.Select(id => terraforms.First(t => t.Id == id)).ToHashSet();
 		}

--- a/C7Engine/C7GameData/UnitPrototype.cs
+++ b/C7Engine/C7GameData/UnitPrototype.cs
@@ -63,6 +63,7 @@ namespace C7GameData {
 		public HashSet<Civilization> producibleBy { get; set; } = [];
 		public UnitPrototype upgradeTo;
 		public bool unproducible;
+		public bool rotateBeforeAttack { get; set; }
 
 		public HashSet<string> categories = new HashSet<string>();
 
@@ -79,9 +80,9 @@ namespace C7GameData {
 		public UnitPrototype() { }
 
 		public UnitPrototype(SaveUnitPrototype proto, IEnumerable<Terraform> terraforms) {
-			(name, art, shieldCost, populationCost, attack, defense, bombard, movement, unproducible) =
+			(name, art, shieldCost, populationCost, attack, defense, bombard, movement, unproducible, rotateBeforeAttack) =
 			(proto.name, proto.art, proto.shieldCost, proto.populationCost,
-			 proto.attack, proto.defense, proto.bombard, proto.movement, proto.unproducible);
+			 proto.attack, proto.defense, proto.bombard, proto.movement, proto.unproducible, proto.rotateBeforeAttack);
 
 			categories = new HashSet<string>(proto.categories);
 			actions = proto.actions;

--- a/EngineTests/GameData/MapUnitCombatFacingTest.cs
+++ b/EngineTests/GameData/MapUnitCombatFacingTest.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Linq;
+using C7Engine.Lua;
+using C7GameData;
+using Xunit;
+
+namespace EngineTests.GameData;
+
+public class MapUnitCombatFacingTest {
+	[Fact]
+	public void UnitsTurnTowardTargetWhenRotateBeforeAttackIsDisabled() {
+		MapUnit unit = MakeUnit(rotateBeforeAttack: false);
+
+		Assert.Equal(TileDirection.EAST, unit.GetAttackAnimationDirection(TileDirection.EAST));
+		Assert.Equal(TileDirection.WEST, unit.GetDefenseAnimationDirection(TileDirection.EAST));
+	}
+
+	[Fact]
+	public void UnitsUseBroadsideFacingWhenRotateBeforeAttackIsEnabled() {
+		MapUnit unit = MakeUnit(rotateBeforeAttack: true);
+
+		Assert.Equal(TileDirection.NORTH, unit.GetAttackAnimationDirection(TileDirection.EAST));
+		Assert.Equal(TileDirection.SOUTH, unit.GetDefenseAnimationDirection(TileDirection.EAST));
+	}
+
+	[Fact]
+	public void UnitPrototypePreservesRotateBeforeAttackFromSavedPrototype() {
+		UnitPrototype unit = new(new() {
+			name = "Galley",
+			rotateBeforeAttack = true,
+		}, []);
+
+		Assert.True(unit.rotateBeforeAttack);
+	}
+
+	[Fact]
+	public void BaseRulesetMarksBroadsideUnitsAsRotateBeforeAttack() {
+		string[] expectedRotatingUnits = [
+			"Radar Artillery",
+			"Galley",
+			"Caravel",
+			"Frigate",
+			"Galleon",
+			"Battleship",
+			"Man-O-War",
+			"Privateer",
+			"Carrack",
+			"Curragh",
+		];
+
+		HashSet<string> rotatingUnits = GameModeLoader.Load(PathUtils.gameModesDir, new GameModeConfig("base-ruleset.json"))
+			.UnitPrototypes
+			.Where(proto => proto.rotateBeforeAttack)
+			.Select(proto => proto.name)
+			.ToHashSet();
+
+		foreach (string unitName in expectedRotatingUnits) {
+			Assert.True(rotatingUnits.Contains(unitName), $"{unitName} should rotate before attack.");
+		}
+	}
+
+	private static MapUnit MakeUnit(bool rotateBeforeAttack) {
+		return new(ID.None("unit")) {
+			unitType = new() {
+				rotateBeforeAttack = rotateBeforeAttack,
+			}
+		};
+	}
+}

--- a/EngineTests/GameData/MapUnitCombatFacingTest.cs
+++ b/EngineTests/GameData/MapUnitCombatFacingTest.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using C7Engine.Lua;
 using C7GameData;
+using C7GameData.Save;
 using Xunit;
 
 namespace EngineTests.GameData;
@@ -29,10 +30,11 @@ public class MapUnitCombatFacingTest {
 	public void UnitPrototypePreservesRotateBeforeAttackFromSavedPrototype() {
 		UnitPrototype unit = new(new() {
 			name = "Galley",
-			rotateBeforeAttack = true,
+			flags = [SaveUnitPrototype.Flag.RotateBeforeAttack],
 		}, []);
 
 		Assert.True(unit.rotateBeforeAttack);
+		Assert.Contains(SaveUnitPrototype.Flag.RotateBeforeAttack, unit.flags);
 	}
 
 	[Fact]
@@ -54,15 +56,25 @@ public class MapUnitCombatFacingTest {
 		JsonElement unitPrototypes = ruleset.RootElement.GetProperty("unitPrototypes");
 		foreach (JsonElement unitPrototype in unitPrototypes.EnumerateArray()) {
 			string unitName = unitPrototype.GetProperty("name").GetString();
-			Assert.True(unitPrototype.TryGetProperty("rotateBeforeAttack", out _), $"{unitName} should declare rotateBeforeAttack.");
+			Assert.False(unitPrototype.TryGetProperty("rotateBeforeAttack", out _), $"{unitName} should use flags for unit abilities.");
 		}
 
 		HashSet<string> rotatingUnits = unitPrototypes.EnumerateArray()
-			.Where(unitPrototype => unitPrototype.GetProperty("rotateBeforeAttack").GetBoolean())
+			.Where(unitPrototype => UnitFlags(unitPrototype).Contains("rotateBeforeAttack"))
 			.Select(unitPrototype => unitPrototype.GetProperty("name").GetString())
 			.ToHashSet();
 
 		Assert.Equal(expectedRotatingUnits.OrderBy(unitName => unitName), rotatingUnits.OrderBy(unitName => unitName));
+	}
+
+	private static HashSet<string> UnitFlags(JsonElement unitPrototype) {
+		if (!unitPrototype.TryGetProperty("flags", out JsonElement flags)) {
+			return [];
+		}
+
+		return flags.EnumerateArray()
+			.Select(flag => flag.GetString())
+			.ToHashSet();
 	}
 
 	private static MapUnit MakeUnit(bool rotateBeforeAttack) {

--- a/EngineTests/GameData/MapUnitCombatFacingTest.cs
+++ b/EngineTests/GameData/MapUnitCombatFacingTest.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text.Json;
 using C7Engine.Lua;
 using C7GameData;
 using Xunit;
@@ -48,15 +50,19 @@ public class MapUnitCombatFacingTest {
 			"Curragh",
 		];
 
-		HashSet<string> rotatingUnits = GameModeLoader.Load(PathUtils.gameModesDir, new GameModeConfig("base-ruleset.json"))
-			.UnitPrototypes
-			.Where(proto => proto.rotateBeforeAttack)
-			.Select(proto => proto.name)
+		using JsonDocument ruleset = JsonDocument.Parse(File.ReadAllText(Path.Combine(PathUtils.gameModesDir, "base-ruleset.json")));
+		JsonElement unitPrototypes = ruleset.RootElement.GetProperty("unitPrototypes");
+		foreach (JsonElement unitPrototype in unitPrototypes.EnumerateArray()) {
+			string unitName = unitPrototype.GetProperty("name").GetString();
+			Assert.True(unitPrototype.TryGetProperty("rotateBeforeAttack", out _), $"{unitName} should declare rotateBeforeAttack.");
+		}
+
+		HashSet<string> rotatingUnits = unitPrototypes.EnumerateArray()
+			.Where(unitPrototype => unitPrototype.GetProperty("rotateBeforeAttack").GetBoolean())
+			.Select(unitPrototype => unitPrototype.GetProperty("name").GetString())
 			.ToHashSet();
 
-		foreach (string unitName in expectedRotatingUnits) {
-			Assert.True(rotatingUnits.Contains(unitName), $"{unitName} should rotate before attack.");
-		}
+		Assert.Equal(expectedRotatingUnits.OrderBy(unitName => unitName), rotatingUnits.OrderBy(unitName => unitName));
 	}
 
 	private static MapUnit MakeUnit(bool rotateBeforeAttack) {


### PR DESCRIPTION
﻿## Summary
- Import the Civ3 `TurnToAttack` flag into unit prototype data.
- Use that flag to rotate attack animations counter-clockwise for broadside units while keeping combat bonuses, retreats, and defensive bombard logic based on the real attack direction.
- Add `rotateBeforeAttack` data to the base ruleset so new games load the same unit prototype behavior.
- Add focused tests for normal facing, broadside facing, save conversion, and base-ruleset entries.

Fixes #902.

## Testing
- Created a loadable save file with two Frigates on adjacent coast tiles, loaded it in OpenCiv3, and fought the ships to check the firing direction.
- `dotnet build C7/C7.sln`
- `dotnet format C7/C7.sln whitespace --verify-no-changes`
- `dotnet test C7/C7.sln` with `CIV3_HOME` set: 62 passed
- `git diff --check`
- `dotnet list C7/C7.sln package --vulnerable --include-transitive`: no vulnerable packages
