### PR TITLE
Some improvement to the game loop

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -9,7 +9,72 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+public class GotoInfo {
+	public Tile destinationTile = null;
+	public int moveCost = -1;
+	public TilePath path = null;
+	public HashSet<System.Numerics.Vector2> pathCoords;
+	public bool attackingMove = false;
+	public Player requiresWarDeclarationOnPlayer = null;
+};
+
+public class TileInfo {
+	public Tile targetTile;
+	public HashSet<Tile> coveredTiles = [];
+	public HashSet<Tile> cityLabelsToHide = [];
+
+	public TileInfo(Tile tile) {
+		targetTile = tile;
+
+		List<TileDirection> coverage = [TileDirection.SOUTHWEST, TileDirection.SOUTH, TileDirection.SOUTHEAST];
+		foreach (var dir in coverage)
+			if (TryNeighbor(tile, dir, out var neighbor))
+				coveredTiles.Add(neighbor);
+
+		List<TileDirection> labelCoverage = [TileDirection.NORTHWEST, TileDirection.NORTH, TileDirection.NORTHEAST];
+		foreach (var dir in labelCoverage)
+			if (TryNeighbor(tile, dir, out var neighbor))
+				cityLabelsToHide.Add(neighbor);
+	}
+
+	private bool TryNeighbor(Tile tile, TileDirection dir, out Tile neighbor) {
+		neighbor = tile.neighbors[dir];
+		return neighbor != Tile.NONE;
+	}
+
+	public bool IsCovered(Tile tile) => tile == targetTile || coveredTiles.Contains(tile);
+
+	public bool HasCityLabelToCover(Tile tile) => cityLabelsToHide.Contains(tile);
+};
+
+public class BombardInfo {
+	public MapUnit bombardingUnit;
+	public Tile mouseTile;
+
+	public BombardInfo(MapUnit bombardingUnit) {
+		this.bombardingUnit = bombardingUnit;
+	}
+
+	public bool requiresWarDeclaration(Tile tile, out Player player) {
+		player = null;
+
+		var bombarder = bombardingUnit.owner;
+		var foreignUnits = tile.unitsOnTile.Where(x => x.owner != bombarder).ToList();
+		if (!foreignUnits.Any())
+			return false;
+
+		var targetPlayers = foreignUnits.Select(x => x.owner).Distinct();
+		var friendly= targetPlayers.Where(p => bombarder.IsAtPeaceWith(p)).ToList();
+		player = friendly.FirstOrDefault();
+		return friendly.Any();
+
+		// TODO: handle complex scenarios arising from multiple civs co-located on tile
+	}
+};
+
 public partial class Game : Node {
+	private ILogger log = LogManager.ForContext<Game>();
+
 	[Signal] public delegate void TurnEndedEventHandler();
 	[Signal] public delegate void ShowSpecificAdvisorEventHandler();
 	[Signal] public delegate void ShowCityScreenEventHandler();
@@ -20,106 +85,10 @@ public partial class Game : Node {
 
 	[Signal] public delegate void UnitMovedEventHandler();
 
-	private ILogger log = LogManager.ForContext<Game>();
-
-	public enum GameState {
-		PreGame,
-		PlayerTurn,
-		ComputerTurn
-	}
-
-	public Player controller; // Player that's controlling the UI.
-
-	private MapView mapView;
-
-	public GameState CurrentState { get; private set; } = GameState.PreGame;
-
-	public MapUnit CurrentlySelectedUnit => unitSelector.CurrentlySelectedUnit;
-	private bool HasCurrentlySelectedUnit() => CurrentlySelectedUnit != MapUnit.NONE;
-
-	// When the game is in "goto" mode, the current destination and the cost of getting
-	// there, in turns.
-	//
-	// Otherwise null.
-	public class GotoInfo {
-		public Tile destinationTile = null;
-		public int moveCost = -1;
-		public TilePath path = null;
-		public HashSet<System.Numerics.Vector2> pathCoords;
-		public bool attackingMove = false;
-		public Player requiresWarDeclarationOnPlayer = null;
-	};
-	public GotoInfo gotoInfo = null;
-
-	public class BombardInfo {
-		public MapUnit bombardingUnit;
-		public Tile mouseTile;
-
-		public BombardInfo(MapUnit bombardingUnit) {
-			this.bombardingUnit = bombardingUnit;
-		}
-
-		public bool requiresWarDeclaration(Tile tile, out Player player) {
-			player = null;
-
-			var bombarder = bombardingUnit.owner;
-			var foreignUnits = tile.unitsOnTile.Where(x => x.owner != bombarder).ToList();
-			if (!foreignUnits.Any())
-				return false;
-
-			var targetPlayers = foreignUnits.Select(x => x.owner).Distinct();
-			var friendly= targetPlayers.Where(p => bombarder.IsAtPeaceWith(p)).ToList();
-			player = friendly.FirstOrDefault();
-			return friendly.Any();
-
-			// TODO: handle complex scenarios arising from multiple civs co-located on tile
-		}
-	};
-	public BombardInfo bombardInfo = null;
-
-	public class TileInfo {
-		public Tile targetTile;
-		public HashSet<Tile> coveredTiles = [];
-		public HashSet<Tile> cityLabelsToHide = [];
-
-		public TileInfo(Tile tile) {
-			targetTile = tile;
-
-			List<TileDirection> coverage = [TileDirection.SOUTHWEST, TileDirection.SOUTH, TileDirection.SOUTHEAST];
-			foreach (var dir in coverage)
-				if (TryNeighbor(tile, dir, out var neighbor))
-					coveredTiles.Add(neighbor);
-
-			List<TileDirection> labelCoverage = [TileDirection.NORTHWEST, TileDirection.NORTH, TileDirection.NORTHEAST];
-			foreach (var dir in labelCoverage)
-				if (TryNeighbor(tile, dir, out var neighbor))
-					cityLabelsToHide.Add(neighbor);
-		}
-
-		private bool TryNeighbor(Tile tile, TileDirection dir, out Tile neighbor) {
-			neighbor = tile.neighbors[dir];
-			return neighbor != Tile.NONE;
-		}
-
-		public bool IsCovered(Tile tile) => tile == targetTile || coveredTiles.Contains(tile);
-
-		public bool HasCityLabelToCover(Tile tile) => cityLabelsToHide.Contains(tile);
-	};
-
-	public TileInfo tileInfo = null;
-
-	// When in observer mode, the number of turns to play before prompting the
-	// user to advance the turn manually. This allows for more rapid debugging
-	// without pressing the spacebar repeatedly.
-	public int turnsLeftToFastForward = 0;
-
 	[Export]
 	Control Toolbar;
 	private bool IsMovingCamera;
 	private Vector2 OldPosition;
-
-	Stopwatch loadTimer = new Stopwatch();
-	GlobalSingleton Global;
 
 	[Export]
 	private PopupOverlay popupOverlay;
@@ -139,6 +108,38 @@ public partial class Game : Node {
 	[Export]
 	public UnitSelector unitSelector;
 
+	Stopwatch loadTimer = new Stopwatch();
+
+	GlobalSingleton Global;
+
+	public Player controller; // Player that's controlling the UI.
+
+	private MapView mapView;
+
+	public enum GameState {
+		PlayerTurn,
+		ComputerTurn
+	}
+	public GameState CurrentState { get; private set; } = GameState.PlayerTurn;
+
+	public MapUnit CurrentlySelectedUnit => unitSelector.CurrentlySelectedUnit;
+	private bool HasCurrentlySelectedUnit() => CurrentlySelectedUnit != MapUnit.NONE;
+
+	// When the game is in "goto" mode, the current destination and the cost of getting
+	// there, in turns.
+	//
+	// Otherwise null.
+	public GotoInfo gotoInfo = null;
+
+	public BombardInfo bombardInfo = null;
+
+	public TileInfo tileInfo = null;
+
+	// When in observer mode, the number of turns to play before prompting the
+	// user to advance the turn manually. This allows for more rapid debugging
+	// without pressing the spacebar repeatedly.
+	public int turnsLeftToFastForward = 0;
+
 	bool errorOnLoad = false;
 
 	public override void _EnterTree() {
@@ -152,7 +153,8 @@ public partial class Game : Node {
 		Global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
 
 		try {
-			await LoadGame();
+			await InitializeGame();
+			await StartGame();
 		} catch (Exception ex) {
 			errorOnLoad = true;
 			string message = ex.Message;
@@ -166,13 +168,39 @@ public partial class Game : Node {
 		}
 	}
 
-	private async Task LoadGame() {
+	private async Task InitializeGame() {
 		// Ensure we clear out our image caches, as scenarios and games will
 		// use the same filenames but have different content for them.
 		Util.ClearCaches();
 
-		CreateGameParams options = new(GamePaths.LuaRulesDir, GamePaths.DefaultBicPath)
-			{
+		GameParams options = CreateGameParams();
+
+		await CreateGameAndAssignPlayerController(options);
+
+		foreach (var gameDataPlayer in EngineStorage.gameData.players) {
+			if (gameDataPlayer.SitsOutFirstTurn() && TurnHandling.GetTurnNumber() == 0)
+				TurnHandling.InitTurnData(gameDataPlayer, true);
+		}
+
+		InitializeMapView();
+	}
+
+	private async Task StartGame() {
+		log.Information("Now in game!");
+
+		TurnHandling.OnBeginTurn();
+
+		loadTimer.Stop();
+		TimeSpan stopwatchElapsed = loadTimer.Elapsed;
+		log.Information("Game scene load time: " + Convert.ToInt32(stopwatchElapsed.TotalMilliseconds) + " ms");
+
+		EmitSignal(SignalName.GameInitialized);
+
+		Global.ResetLoadGameFields();
+	}
+
+	private GameParams CreateGameParams() {
+		return new(GamePaths.LuaRulesDir, GamePaths.DefaultBicPath) {
 			GetPediaIconsPath = (scenarioSearchPath) => {
 				// When the game loading logic tries to load the PediaIcons file, set the
 				// scenario search path and then use our Civ3MediaPath searching logic to
@@ -192,7 +220,10 @@ public partial class Game : Node {
 				return Util.Civ3MediaPath("Text/PediaIcons.txt");
 			}
 		};
+	}
 
+	private async Task CreateGameAndAssignPlayerController(GameParams options) {
+		// Initializes the game data and returns the "human" player
 		if (Global.SaveGame != null) {
 			controller = await CreateGame.createGame(Global.SaveGame, options);
 		} else if (Global.LoadGamePath != null) {
@@ -200,18 +231,6 @@ public partial class Game : Node {
 		} else {
 			throw new InvalidOperationException("Save data was not set");
 		}
-
-		Global.ResetLoadGameFields();
-
-		InitializeMapView();
-
-		log.Information("Now in game!");
-
-		loadTimer.Stop();
-		TimeSpan stopwatchElapsed = loadTimer.Elapsed;
-		log.Information("Game scene load time: " + Convert.ToInt32(stopwatchElapsed.TotalMilliseconds) + " ms");
-
-		EmitSignal(SignalName.GameInitialized);
 	}
 
 	private void InitializeMapView() {
@@ -479,8 +498,8 @@ public partial class Game : Node {
 	}
 
 	public override void _UnhandledInput(InputEvent @event) {
-		// Don't handle mouse actions if UI elements are visible
-		if (popupOverlay.Visible || cityScreen.Visible || advisor.Visible || diplomacy.Visible || palaceScene.Visible) {
+		// Don't handle mouse actions if UI elements are visible, or it's the AI's turn
+		if (popupOverlay.Visible || cityScreen.Visible || advisor.Visible || diplomacy.Visible || palaceScene.Visible || CurrentState == GameState.ComputerTurn) {
 			IsMovingCamera = false;
 			return;
 		}
@@ -498,6 +517,7 @@ public partial class Game : Node {
 	}
 
 	private void HandleMouseButtonInput(InputEventMouseButton eventMouseButton) {
+		if (CurrentState == GameState.ComputerTurn) return;
 		if (eventMouseButton.ButtonIndex == MouseButton.Left) {
 			HandleLeftMouseButton(eventMouseButton);
 		} else if (eventMouseButton.ButtonIndex == MouseButton.Right && !eventMouseButton.IsPressed()) {

--- a/C7/Map/GotoLayer.cs
+++ b/C7/Map/GotoLayer.cs
@@ -78,7 +78,7 @@ public partial class GotoLayer : LooseLayer {
 			return;
 		}
 
-		Game.GotoInfo gotoInfo = looseView.mapView.game.gotoInfo;
+		GotoInfo gotoInfo = looseView.mapView.game.gotoInfo;
 		Tile unitOriginTile = unit.location;
 
 		if (gotoInfo.destinationTile == tile) {

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -55,6 +55,7 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 		suggestion.AddThemeFontSizeOverride("font_size", fontSize);
 
 		this.CreateUI();
+		PleaseWait();
 	}
 
 	private void CreateUI() {
@@ -79,7 +80,7 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 		nextTurnButton.TextureHover = nextTurnOnTexture;
 		nextTurnButton.SetPosition(new Vector2(0, 0));
 		AddChild(nextTurnButton);
-		nextTurnButton.Pressed += turnEnded;
+		nextTurnButton.Pressed += TurnEnded;
 
 
 		// Unit info
@@ -175,7 +176,7 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 		suggestion.Visible = true;
 	}
 
-	private void turnEnded() {
+	private void TurnEnded() {
 		log.Debug("Emitting the blinky button pressed signal");
 		EmitSignal(SignalName.BlinkyEndTurnButtonPressed);
 	}
@@ -301,7 +302,7 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 	private void HandleBoxClick() {
 		// When the turn can be ended, the click on the box is like clicking on the blinky button
 		if (timerStarted) {
-			turnEnded();
+			TurnEnded();
 			return;
 		}
 		// Otherwise we can center the camera to the unit currently active

--- a/C7/UIElements/NewGame/QuickStartSetup.cs
+++ b/C7/UIElements/NewGame/QuickStartSetup.cs
@@ -10,15 +10,15 @@ using Serilog;
 public partial class QuickStartSetup : Node {
 	private static ILogger log = LogManager.ForContext<ScenarioSetup>();
 
-	public static void Init(GlobalSingleton globalState) {
+	public static void Init(GlobalSingleton global) {
 		log.Information("Setting up a QuickStart game");
 
-		globalState.ResetLoadGameFields();
+		global.ResetLoadGameFields();
 
 		var save = GameModeLoader.Load(GamePaths.GameModesDir, GamePaths.GameMode);
 		WorldSize worldSize = GetWorldSize(save.WorldSizes);
 
-		globalState.WorldCharacteristics = new WorldCharacteristics(save) {
+		global.WorldCharacteristics = new WorldCharacteristics(save) {
 			barbarianActivity = GetBarbarianActivity(),
 			landform = GetLandform(),
 			oceanCoverage = GetOceanCoverage(),
@@ -29,7 +29,7 @@ public partial class QuickStartSetup : Node {
 			mapSeed = new Random().Next(),
 		};
 
-		globalState.SaveGame = save;
+		global.SaveGame = save;
 
 		Civilization player = GetPlayerCivilization(save.Civilizations);
 		Difficulty difficulty = GetDifficulty(save.Difficulties);
@@ -39,7 +39,7 @@ public partial class QuickStartSetup : Node {
 		GameSetup gameSetup = new() {
 			playerCivilization = player,
 			difficulty = difficulty,
-			worldCharacteristics = globalState.WorldCharacteristics,
+			worldCharacteristics = global.WorldCharacteristics,
 			opponents = opponents
 		};
 

--- a/C7/UIElements/NewGame/ScenarioSetup.cs
+++ b/C7/UIElements/NewGame/ScenarioSetup.cs
@@ -126,14 +126,14 @@ public partial class ScenarioSetup : Control {
 		thread.Start();
 	}
 
-	private void UpdateSaveAndStartGame(SaveGame save, GlobalSingleton Global) {
+	private void UpdateSaveAndStartGame(SaveGame save, GlobalSingleton global) {
 		foreach (SavePlayer sp in save.Players) {
 			sp.human = sp.civilization == this.civilization.name;
 		}
 		save.GameDifficulty = difficulty;
 
 		log.Information("saving updated scenario");
-		Global.SaveGame = save;
+		global.SaveGame = save;
 
 		log.Information("opening map");
 		CallDeferred("StartGame");

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -4,7 +4,6 @@ using C7Engine;
 using C7GameData;
 using Serilog;
 using System.Linq;
-using System.Globalization;
 
 /*
  UnitButtons contains the buttons at the bottom of the game UI when viewing the
@@ -91,6 +90,7 @@ public partial class UnitButtons : VBoxContainer {
 
 	private void AddNewButton(HBoxContainer row, string action) {
 		TextureButton button = new();
+		button.Hide();
 		TextureLoader.SetButtonTextures(button, "ui.unit_control." + action);
 		button.Pressed += () => { EmitSignal(SignalName.ActionRequested, action); };
 

--- a/C7/UnitSelector.cs
+++ b/C7/UnitSelector.cs
@@ -2,6 +2,7 @@ using C7Engine;
 using C7GameData;
 using Godot;
 using Serilog;
+using static Game;
 
 /* This class controls the unit selection during the player turn.  It
    handles automatic unit selection in the _Process method, and
@@ -33,7 +34,7 @@ public partial class UnitSelector : Node {
 	}
 
 	public override void _Process(double delta) {
-		if (game.CurrentState != Game.GameState.PlayerTurn) return;
+		if (game.CurrentState != GameState.PlayerTurn) return;
 		if (EngineStorage.HasPendingAnimations()) return;
 
 		// If no unit is selected, move to the next one

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using C7Engine.Pathing;
 using C7GameData;
-using C7GameData.Save;
 using C7GameData.AIData;
 using C7Engine.AI;
 using C7Engine.AI.StrategicAI;
@@ -94,13 +93,15 @@ namespace C7Engine {
 		}
 
 		private static async Task DoUnitActions(Player player) {
-			// Reorder the list so that settlers are last, giving our escorts a
+			// Reorder the list so that settlers are second to last, giving our escorts a
 			// chance to configure themselves without wasting a turn.
-			player.units.Sort((x, y) => (x.unitType.name == "Settler").CompareTo(y.unitType.name == "Settler"));
+			// Finally reorder so that the workers are last, so in case a settler builds a new city,
+			// they move to terraform a tile instead of wasting a turn (especially in the very first round in a new game).
+			player.units.OrderBy(x => x.unitType.isSettler).ThenBy(x => x.unitType.isWorker);
 
 			// Any time we have an unescorted settler, wake up any other units
 			// on the same tile to force us to re-evaluate whether they should
-			// be an escort. Otherwise can have perfectly fine escorts sitting
+			// be an escort. Otherwise, can have perfectly fine escorts sitting
 			// there fortified.
 			foreach (MapUnit u in player.units) {
 				if (u.currentAI is SettlerAI settlerAi && settlerAi.data.escort == null) {
@@ -110,7 +111,7 @@ namespace C7Engine {
 				}
 			}
 
-			//Do things with units.  Copy into an array first to avoid collection-was-modified exception
+			// Do things with units. Copy into an array first to avoid collection-was-modified exception
 			foreach (MapUnit unit in player.units.ToArray()) {
 				// Don't waste time recalculating behaviors for fortified units.
 				// This means we'll have to unfortify all our units after

--- a/C7Engine/AI/UnitAI/WorkerAI.cs
+++ b/C7Engine/AI/UnitAI/WorkerAI.cs
@@ -1,4 +1,3 @@
-using System;
 using C7Engine.Pathing;
 using C7GameData;
 using System.Collections.Generic;

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -527,6 +527,8 @@ namespace C7GameData {
 
 				player.governmentId = save.Governments[lead.Government].id;
 
+				player.skipFirstTurn = lead.SkipFirstTurn == 1;
+
 				// Add the starting techs for scenarios.
 				if (theBiq.LeadTech != null) {
 					for (int j = 0; j < theBiq.LeadTech[leadIndex].Length; ++j) {

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -123,7 +123,7 @@ namespace C7GameData {
 			string hPDesc = ((type.attack > 0) || (type.defense > 0)) ? $" ({this.hitPointsRemaining}/{this.maxHitPoints})" : "";
 			string displayName = this.IsCaptive() ? $" ({this.nationality.adjective}) {this.name}" : $" {this.name}";
 			string attackDesc = (type.bombard > 0) ? $"{type.attack}({type.bombard})" : type.attack.ToString();
-			string stats = $" ({attackDesc}.{type.defense}.{this.movementPoints.getMixedNumber()}/{type.movement})";
+			string stats = $" ({attackDesc}.{type.defense}.{(EngineStorage.uiControllerID == this.owner.id ? $"{this.movementPoints.getMixedNumber()}/" : "")}{type.movement})";
 			return $"{exp}{hPDesc}{displayName}{stats}".Trim();
 		}
 
@@ -661,16 +661,22 @@ namespace C7GameData {
 			// TODO: Consider friendly/neutral/enemy territory once that's implemented, barracks, the Red Cross
 		}
 
-		public void OnBeginTurn() {
+		public void OnBeginTurn(bool skipTurn = false) {
 			int maxMP = unitType.movement;
-			if (movementPoints.remaining >= maxMP) {
+			if (movementPoints.remaining >= maxMP && !skipTurn) {
 				int maxHP = maxHitPoints;
 				if (hitPointsRemaining < maxHP)
 					hitPointsRemaining += HealRateAt(location);
 				if (hitPointsRemaining > maxHP)
 					hitPointsRemaining = maxHP;
 			}
-			movementPoints.reset(maxMP);
+
+			if (skipTurn) {
+				movementPoints.skipTurn();
+			} else {
+				movementPoints.reset(maxMP);
+			}
+
 			defensiveBombardsRemaining = 1;
 		}
 

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -51,6 +51,7 @@ namespace C7GameData {
 		//We should allow multiple humans, this is a temporary measure.
 		public bool isHuman = false;
 		public bool hasPlayedThisTurn = false;
+		public bool skipFirstTurn = false;
 
 		// Has this player been defeated?
 		public bool defeated = false;
@@ -318,8 +319,7 @@ namespace C7GameData {
 		}
 
 		public bool SitsOutFirstTurn() {
-			// TODO: Scenarios can also specify that certain players sit out the first turn. E.g. WW2 in the Pacific
-			return isBarbarians;
+			return this.isBarbarians || this.skipFirstTurn;
 		}
 
 		public static bool CanMoveFreely(Player player, Tile sourceTile, Tile targetTile) {

--- a/C7Engine/C7GameData/Save/SavePlayer.cs
+++ b/C7Engine/C7GameData/Save/SavePlayer.cs
@@ -13,6 +13,7 @@ namespace C7GameData.Save {
 		public bool defeated = false;
 		public bool isIncludedInGame = true;
 		public bool canBePicked = true;
+		public bool skipFirstTurn = false;
 
 		public string civilization;
 
@@ -75,6 +76,7 @@ namespace C7GameData.Save {
 				isIncludedInGame = isIncludedInGame,
 				canBePicked = canBePicked,
 				hasPlayedThisTurn = hasPlayedCurrentTurn,
+				skipFirstTurn = skipFirstTurn,
 				defeated = defeated,
 				primaryColorIndex = primaryColorIndex,
 				secondaryColorIndex = secondaryColorIndex,

--- a/C7Engine/C7GameData/UnitPrototype.cs
+++ b/C7Engine/C7GameData/UnitPrototype.cs
@@ -88,6 +88,8 @@ namespace C7GameData {
 		public HashSet<Terraform> terraformActions = [];
 
 		public bool isWorker => terraformActions.Count > 0;
+		public bool isSettler => actions.Contains(UnitAction.BuildCity);
+
 
 		public UnitPrototype() { }
 

--- a/C7Engine/EntryPoints/CreateGame.cs
+++ b/C7Engine/EntryPoints/CreateGame.cs
@@ -6,13 +6,13 @@ using C7GameData.Save;
 
 namespace C7Engine;
 
-public class CreateGameParams {
+public class GameParams {
 	public string LuaRulesDir;
 	public string DefaultBicPath;
 
 	public Func<string, string> GetPediaIconsPath = s => s;
 
-	public CreateGameParams(string LuaRulesDir, string DefaultBicPath) {
+	public GameParams(string LuaRulesDir, string DefaultBicPath) {
 		this.LuaRulesDir = LuaRulesDir;
 		this.DefaultBicPath = DefaultBicPath;
 	}
@@ -25,12 +25,12 @@ public class CreateGame {
 		* quickly.  By keeping all the client-callable APIs in the EntryPoints folder,
 		* hopefully it won't be too much of a goose hunt to refactor it later if we decide to do so.
 		**/
-	public static async Task<Player> createGame(string loadFilePath, CreateGameParams options) {
+	public static async Task<Player> createGame(string loadFilePath, GameParams options) {
 		SaveGame save = SaveManager.LoadSave(loadFilePath, options.DefaultBicPath, options.GetPediaIconsPath);
 		return await createGame(save, options);
 	}
 
-	public static async Task<Player> createGame(SaveGame save, CreateGameParams options) {
+	public static async Task<Player> createGame(SaveGame save, GameParams options) {
 		GameData gameData = save.ToGameData(options.LuaRulesDir);
 
 		EngineStorage.gameData = gameData;
@@ -42,8 +42,6 @@ public class CreateGame {
 		};
 
 		EngineStorage.uiControllerID = humanPlayer.id;
-		TurnHandling.OnBeginTurn(); // Call for the first turn
-		await TurnHandling.AdvanceTurn();
 
 		return humanPlayer;
 	}

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -1,39 +1,49 @@
 using System.Diagnostics;
-using System.Net.NetworkInformation;
+using System.Linq;
+using System.Threading.Tasks;
+using C7GameData;
 using Serilog;
 
 namespace C7Engine {
-	using System.Threading.Tasks;
-	using C7GameData;
 
 	public class TurnHandling {
 		private static ILogger log = Log.ForContext<TurnHandling>();
 
-		internal static void OnBeginTurn() {
+		public static void OnBeginTurn() {
 			GameData gameData = EngineStorage.gameData;
 			log.Information("\n*** Beginning turn " + gameData.turn + " ***");
+		}
 
-			foreach (MapUnit mapUnit in gameData.mapUnits)
-				mapUnit.OnBeginTurn();
+		public static void InitTurnData(Player player = null, bool skipTurn = false) {
+			GameData gameData = EngineStorage.gameData;
+			if (player == null) {
+				foreach (MapUnit mapUnit in gameData.mapUnits)
+					mapUnit.OnBeginTurn(skipTurn);
+			} else {
+				foreach (MapUnit mapUnit in gameData.mapUnits.Where(u => u.owner == player))
+					mapUnit.OnBeginTurn(skipTurn);
+			}
 		}
 
 		// Implements the game loop. This method is called when the game is started and when the player signals that they're done moving.
-		internal static async Task AdvanceTurn() {
+		public static async Task AdvanceTurn() {
 			Stopwatch stopwatch = new Stopwatch();
 			stopwatch.Start();
 			GameData gameData = EngineStorage.gameData;
-			while (true) { // Loop ends with a function return once we reach the UI controller during the movement phase
+
+			// Loop ends with a function return once we reach the UI controller during the movement phase
+			while (true) {
 				bool firstTurn = GetTurnNumber() == 0;
 
 				// Movement phase
 				if (await PlayPlayerTurns(gameData, firstTurn)) {
 					stopwatch.Stop();
-					log.Information("Turn time took " + stopwatch.ElapsedMilliseconds + " milliseconds");
+					log.Debug("Turn time took " + stopwatch.ElapsedMilliseconds + " milliseconds");
 					return;
 				}
 
-				//Clear all wait queue, so if a player ended the turn without handling all waited units, they are selected
-				//at the same place in the order.  Confirmed this is what Civ3 does.
+				// Clear all wait queue, so if a player ended the turn without handling all waited units, they are selected
+				// at the same place in the order. Confirmed this is what Civ3 does.
 				UnitInteractions.ClearWaitQueue();
 
 				BarbarianInteractions.SpawnBarbarians(gameData);
@@ -63,6 +73,7 @@ namespace C7Engine {
 				// save game is loaded, and that would erase the saved information
 				// about which players have played.
 				OnBeginTurn();
+				InitTurnData();
 				foreach (Player player in gameData.players) {
 					player.hasPlayedThisTurn = false;
 				}
@@ -76,7 +87,9 @@ namespace C7Engine {
 		/// <param name="firstTurn"></param>
 		/// <returns>true when it is time for the human to take control again</returns>
 		private static async Task<bool> PlayPlayerTurns(GameData gameData, bool firstTurn) {
-			foreach (Player player in gameData.players) {
+			// Order players: Human -> AI -> Barbarian AI
+			var orderedPlayers = gameData.players.OrderByDescending(p => !p.isBarbarians).ThenByDescending(p => p.isHuman).ToList();
+			foreach (Player player in orderedPlayers) {
 				if (player.hasPlayedThisTurn || player.defeated) {
 					continue;
 				}
@@ -94,7 +107,7 @@ namespace C7Engine {
 				} else if (player.id != EngineStorage.uiControllerID) {
 					player.hasPlayedThisTurn = true;
 				}
-				//Human player check.  Let the human see what's going on even if they are in observer mode.
+				//Human player check. Let the human see what's going on even if they are in observer mode.
 				if (player.id == EngineStorage.uiControllerID) {
 					new MsgStartTurn().send();
 					return true;

--- a/EngineTests/GameData/SaveTest.cs
+++ b/EngineTests/GameData/SaveTest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using System.Threading.Tasks;
 using C7Engine;
 using C7Engine.Lua;
 using C7GameData;
@@ -184,18 +185,24 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 		}
 	}
 
-	private Player CreateHeadlessGame(string path, string biqPath, Func<string, string> getPediaIconsPath) {
-		CreateGameParams options = new(PathUtils.luaRulesDir, biqPath) {
+	private async Task<Player> CreateHeadlessGame(string path, string biqPath, Func<string, string> getPediaIconsPath) {
+		GameParams options = new(PathUtils.luaRulesDir, biqPath) {
 			GetPediaIconsPath = getPediaIconsPath
 		};
-
-		return CreateGame.createGame(path, options).Result;
+		var player = CreateGame.createGame(path, options).Result;
+		TurnHandling.OnBeginTurn();
+		TurnHandling.InitTurnData();
+		await TurnHandling.AdvanceTurn();
+		return player;
 	}
 
-	private Player CreateHeadlessGame(SaveGame game) {
-		CreateGameParams options = new(PathUtils.luaRulesDir, "");
-
-		return CreateGame.createGame(game, options).Result;
+	private async Task<Player> CreateHeadlessGame(SaveGame game) {
+		GameParams options = new(PathUtils.luaRulesDir, "");
+		var player = CreateGame.createGame(game, options).Result;
+		TurnHandling.OnBeginTurn();
+		TurnHandling.InitTurnData();
+		await TurnHandling.AdvanceTurn();
+		return player;
 	}
 
 	private C7GameData.GameData ToGameData(SaveGame game) {
@@ -236,7 +243,7 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 	[Theory]
 	[InlineData(SaveType.basic, "basic")]
 	[InlineData(SaveType.standalone, "standalone")]
-	public void SimpleGame(SaveType saveType, string outputFilePostfix) {
+	public async Task SimpleGame(SaveType saveType, string outputFilePostfix) {
 		Log.Logger = new LoggerConfiguration()
 			.WriteTo.Console(outputTemplate: "[{Level:u3}] {Timestamp:HH:mm:ss} {SourceContext}: {Message:lj} {NewLine}{Exception}")
 			.MinimumLevel.Information()
@@ -246,7 +253,7 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 
 		new MsgSetAnimationsEnabled(false).send();
 
-		Player human = CreateHeadlessGame(developerSave);
+		Player human = await CreateHeadlessGame(developerSave);
 
 		// Make all the players AI players while we run the game in headless mode.
 		human.isHuman = false;
@@ -293,8 +300,8 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 	}
 
 	[Fact]
-	public void WorldWrapDetails() {
-		Player human = CreateHeadlessGame(fixture.saveGame);
+	public async Task WorldWrapDetails() {
+		Player human = await CreateHeadlessGame(fixture.saveGame);
 		WaitForStartTurnMessage();
 
 		C7GameData.GameData gd = null;
@@ -316,8 +323,8 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 
 
 	[Fact]
-	public void TurnTimeCalculations() {
-		Player human = CreateHeadlessGame(fixture.saveGame);
+	public async Task TurnTimeCalculations() {
+		Player human = await CreateHeadlessGame(fixture.saveGame);
 		WaitForStartTurnMessage();
 
 		C7GameData.GameData gd = null;
@@ -523,7 +530,7 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 		CheckScenariosInCiv3Subfolder("Conquests/Scenarios", multiplayerScenarios, runOneTurn: false, "multiplayer");
 	}
 
-	private void CheckScenariosInCiv3Subfolder(string subfolder, string[] scenarioNamesToTest, bool runOneTurn, string basename) {
+	private async Task CheckScenariosInCiv3Subfolder(string subfolder, string[] scenarioNamesToTest, bool runOneTurn, string basename) {
 		string conquests = Path.Join(Civ3Location.GetCiv3Path(), subfolder);
 		DirectoryInfo directoryInfo = new DirectoryInfo(conquests);
 		IEnumerable<FileInfo> saveFiles = directoryInfo.EnumerateFiles().Where(fi => scenarioNamesToTest.Contains(fi.Name));
@@ -608,7 +615,7 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 
 			// Finally, ensure we can run the first turn of the scenario.
 			if (runOneTurn) {
-				Player human = CreateHeadlessGame(saveFileInfo.FullName, PathUtils.defaultBicPath, getPediaIconsPath);
+				Player human = await CreateHeadlessGame(saveFileInfo.FullName, PathUtils.defaultBicPath, getPediaIconsPath);
 
 				// Make all the players AI players while we run the game in headless mode.
 				human.isHuman = false;


### PR DESCRIPTION
This PR addresses the issue, where upon launching the game, if the player had finished their turn, the AI would immediatly take control, and the game would either get stuck in a loop, or have a black screen.

The main issue was occuring because after loading the game (game data & map), a call to advance the turn was made.

If the human player had finished their turn, either by choise, or by (game) design, that meant the loop was moving on to the next player in the list, effectively skipping the human player. 
Now that was working well when in regular play mode, but when loading in directly where the human player has finished their turn, the issue becomes clear.

So, now, no matter what, when loading a new/saved/scenario game, the human player will go first. Even if they have no units left, the have to end the turn manually with the usual methods.

### Some other things:

- Some of the `Game` class code was re-ordered, to try and make it more readable, and logically grouped where I thought it would be useful.

- Removed the PreGame entry from the `GameState` enum as it wasn't really used anywhere, and also interfered with fixing the main bug of this PR

- I added the `skipFirstTurn` player flag when loading up a .biq scenario (eample usage: `9 WWII in the Pacific.biq`)

- I disabled being able to click anything while the AI are playing their turns.

- Some class clean-up, renaming and removing unused imports, etc

- Hide all the buttons when they are created to avoid showing them all at once, they already are getting shown/hidden properly when a unit is selected.

- Added `isSettler` flag to the `UnitPrototype` class, so that we don't have to check the string name of the prototype

I hope I didn't miss anything, let me know if you have questions or comments