### PR TITLE
Add basic transport load/unload

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -360,6 +360,10 @@ public partial class Game : Node {
 			case MsgUnitMoved mUUAAB:
 				EmitSignal(SignalName.UnitMoved, new ParameterWrapper<MapUnit>(mUUAAB.Unit));
 				break;
+			case MsgTransportUnloaded mTU:
+				// UnitMoved is enough to refresh UI
+				EmitSignal(SignalName.UnitMoved, new ParameterWrapper<MapUnit>(mTU.Unit));
+				break;
 		}
 	}
 
@@ -612,8 +616,6 @@ public partial class Game : Node {
 		bool canMove = unitSelector.SetSelectedUnit(unit);
 		if (!canMove) {
 			TemporaryPopup.Show(this, "This unit has already moved.", screenPosition);
-		} else {
-			unit.ResetFacingDirection();
 		}
 	}
 
@@ -998,8 +1000,9 @@ public partial class Game : Node {
 				new MsgLoadToTransport(CurrentlySelectedUnit.id).send();
 		}
 		if (currentAction == C7Action.UnitUnload) {
-			if (CurrentlySelectedUnit != MapUnit.NONE && CurrentlySelectedUnit != null)
-				new MsgUnloadFromTransport(CurrentlySelectedUnit.id).send();
+			if (CurrentlySelectedUnit != MapUnit.NONE && CurrentlySelectedUnit != null) {
+				new MsgUnloadTransport(CurrentlySelectedUnit.id).send();
+			}
 		}
 
 		Terraform terraform = C7Action.ToTerraform(currentAction);

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -959,6 +959,17 @@ public partial class Game : Node {
 			}
 		}
 
+
+		if (currentAction == C7Action.UnitLoad) {
+			// TODO: Which transport?
+			if (CurrentlySelectedUnit != MapUnit.NONE && CurrentlySelectedUnit != null)
+				new MsgLoadToTransport(CurrentlySelectedUnit.id).send();
+		}
+		if (currentAction == C7Action.UnitUnload) {
+			if (CurrentlySelectedUnit != MapUnit.NONE && CurrentlySelectedUnit != null)
+				new MsgUnloadFromTransport(CurrentlySelectedUnit.id).send();
+		}
+
 		Terraform terraform = C7Action.ToTerraform(currentAction);
 
 		if (CurrentlySelectedUnit == MapUnit.NONE || CurrentlySelectedUnit == null

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -559,7 +559,7 @@ public partial class Game : Node {
 			}
 		} else {
 			// Select unit on tile at mouse location
-			HandleUnitSelection(eventMouseButton);
+			HandleUnitSelectionTileClick(eventMouseButton);
 		}
 	}
 
@@ -572,22 +572,34 @@ public partial class Game : Node {
 		}
 	}
 
-	private void HandleUnitSelection(InputEventMouseButton eventMouseButton) {
+	private void HandleUnitSelectionTileClick(InputEventMouseButton eventMouseButton) {
+
 		Tile tile = PositionToTile(eventMouseButton.Position);
 		if (tile == null) {
 			return;
 		}
 
 		// TODO: This should really be the top unit.
-		MapUnit to_select = tile.unitsOnTile.FirstOrDefault();
-		if (to_select == null || to_select.owner != controller) {
+		MapUnit unit = tile.unitsOnTile.FirstOrDefault();
+		if (unit == null || unit.owner != controller) {
 			return;
 		}
 
-		bool canMove = unitSelector.SetSelectedUnit(to_select);
+		SelectUnit(unit, eventMouseButton.Position);
+	}
+
+	private void SelectUnit(MapUnit unit, Vector2 screenPosition) {
+		bool canMove = unitSelector.SetSelectedUnit(unit);
 		if (!canMove) {
-			TemporaryPopup.Show(this, "This unit has already moved.", eventMouseButton.Position);
+			TemporaryPopup.Show(this, "This unit has already moved.", screenPosition);
+		} else {
+			unit.ResetFacingDirection();
 		}
+	}
+
+	public void SelectUnit(MapUnit unit) {
+		var screenPos = mapView.screenLocationOfTile(unit.location);
+		SelectUnit(unit, screenPos);
 	}
 
 	private void HandleRightMouseButton(InputEventMouseButton eventMouseButton) {

--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -794,6 +794,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -838,7 +839,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -872,6 +874,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -916,7 +919,8 @@
         "disband",
         "goto",
         "explore",
-        "automate"
+        "automate",
+        "load"
       ],
       "terraformActions": [
         "Terraform-4",
@@ -951,6 +955,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Russia",
         "America",
@@ -973,7 +978,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -999,6 +1005,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1041,7 +1048,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -1067,6 +1075,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1110,7 +1119,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Rubber"
@@ -1139,6 +1149,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1182,7 +1193,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Oil",
@@ -1211,6 +1223,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "A Barbarian Chiefdom",
         "Rome",
@@ -1260,7 +1273,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -1286,6 +1300,7 @@
       "bombardRange": 0,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1331,7 +1346,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -1357,6 +1373,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1400,7 +1417,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -1426,6 +1444,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Egypt",
         "Greece",
@@ -1469,7 +1488,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Iron"
@@ -1498,6 +1518,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Greece",
@@ -1543,7 +1564,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Horses"
@@ -1572,6 +1594,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "A Barbarian Chiefdom",
         "Rome",
@@ -1624,7 +1647,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Horses"
@@ -1653,6 +1677,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1697,7 +1722,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Iron"
@@ -1726,6 +1752,7 @@
       "bombardRange": 0,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1771,7 +1798,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -1797,6 +1825,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1843,7 +1872,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Saltpeter"
@@ -1872,6 +1902,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1915,7 +1946,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Horses",
@@ -1945,6 +1977,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1991,7 +2024,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -2017,6 +2051,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2058,7 +2093,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Horses",
@@ -2088,6 +2124,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2134,7 +2171,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Rubber"
@@ -2163,6 +2201,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2208,7 +2247,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Oil",
@@ -2238,6 +2278,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2281,7 +2322,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Oil",
@@ -2311,6 +2353,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2354,7 +2397,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Oil",
@@ -2384,6 +2428,7 @@
       "bombardRange": 1,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2431,7 +2476,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -2457,6 +2503,7 @@
       "bombardRange": 1,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2505,7 +2552,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Iron",
@@ -2535,6 +2583,7 @@
       "bombardRange": 2,
       "rateOfFire": 2,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2582,7 +2631,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -2608,6 +2658,7 @@
       "bombardRange": 2,
       "rateOfFire": 3,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2655,7 +2706,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Aluminum"
@@ -2684,78 +2736,7 @@
       "bombardRange": 4,
       "rateOfFire": 3,
       "movement": 1,
-      "producibleBy": [
-        "Rome",
-        "Egypt",
-        "Greece",
-        "Babylon",
-        "Germany",
-        "Russia",
-        "China",
-        "America",
-        "Japan",
-        "France",
-        "India",
-        "Persia",
-        "Aztecs",
-        "Zululand",
-        "Iroquois",
-        "England",
-        "Mongols",
-        "Spain",
-        "Scandinavia",
-        "Ottomans",
-        "Celts",
-        "Arabia",
-        "Carthage",
-        "Korea",
-        "Sumeria",
-        "Hittites",
-        "Netherlands",
-        "Portugal",
-        "Byzantines",
-        "Inca",
-        "Maya"
-      ],
-      "unproducible": false,
-      "categories": [
-        "Land"
-      ],
-      "actions": [
-        "bombard",
-        "hold",
-        "wait",
-        "fortify",
-        "disband",
-        "goto"
-      ],
-      "requiredResources": [
-        "Aluminum"
-      ]
-    },
-    {
-      "name": "Tactical Nuke",
-      "art": {
-        "mainArt": {
-          "defaultName": "Tactical Nuke"
-        },
-        "thumbnailArt": {
-          "defaultIndex": 27
-        },
-        "pediaArt": {
-          "small": "art\\civilopedia\\icons\\units\\27icbmtacticalsmall.pcx",
-          "large": "art\\civilopedia\\icons\\units\\27icbmtacticallarge.pcx"
-        }
-      },
-      "shieldCost": 300,
-      "populationCost": 0,
-      "requiredTech": "tech-69",
-      "attack": 0,
-      "defense": 0,
-      "bombard": 0,
-      "bombardRange": 6,
-      "rateOfFire": 0,
-      "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2800,7 +2781,82 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "load"
+      ],
+      "requiredResources": [
+        "Aluminum"
+      ]
+    },
+    {
+      "name": "Tactical Nuke",
+      "art": {
+        "mainArt": {
+          "defaultName": "Tactical Nuke"
+        },
+        "thumbnailArt": {
+          "defaultIndex": 27
+        },
+        "pediaArt": {
+          "small": "art\\civilopedia\\icons\\units\\27icbmtacticalsmall.pcx",
+          "large": "art\\civilopedia\\icons\\units\\27icbmtacticallarge.pcx"
+        }
+      },
+      "shieldCost": 300,
+      "populationCost": 0,
+      "requiredTech": "tech-69",
+      "attack": 0,
+      "defense": 0,
+      "bombard": 0,
+      "bombardRange": 6,
+      "rateOfFire": 0,
+      "movement": 1,
+      "capacity": 0,
+      "producibleBy": [
+        "Rome",
+        "Egypt",
+        "Greece",
+        "Babylon",
+        "Germany",
+        "Russia",
+        "China",
+        "America",
+        "Japan",
+        "France",
+        "India",
+        "Persia",
+        "Aztecs",
+        "Zululand",
+        "Iroquois",
+        "England",
+        "Mongols",
+        "Spain",
+        "Scandinavia",
+        "Ottomans",
+        "Celts",
+        "Arabia",
+        "Carthage",
+        "Korea",
+        "Sumeria",
+        "Hittites",
+        "Netherlands",
+        "Portugal",
+        "Byzantines",
+        "Inca",
+        "Maya"
+      ],
+      "unproducible": false,
+      "categories": [
+        "Land"
+      ],
+      "actions": [
+        "bombard",
+        "hold",
+        "wait",
+        "fortify",
+        "disband",
+        "goto",
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Aluminum",
@@ -2830,6 +2886,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2903,6 +2960,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 2,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2952,7 +3010,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "unload"
       ]
     },
     {
@@ -2978,6 +3037,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 4,
+      "capacity": 3,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3026,7 +3086,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "unload"
       ]
     },
     {
@@ -3052,6 +3113,7 @@
       "bombardRange": 1,
       "rateOfFire": 2,
       "movement": 5,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3128,6 +3190,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 4,
+      "capacity": 4,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3177,7 +3240,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "unload"
       ]
     },
     {
@@ -3203,6 +3267,7 @@
       "bombardRange": 1,
       "rateOfFire": 2,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3280,6 +3345,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 6,
+      "capacity": 6,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3323,7 +3389,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "unload"
       ],
       "requiredResources": [
         "Oil"
@@ -3352,6 +3419,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 7,
+      "capacity": 4,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3386,6 +3454,9 @@
         "Maya"
       ],
       "unproducible": false,
+      "flags": [
+        "canCarryAircraft"
+      ],
       "categories": [
         "Sea"
       ],
@@ -3395,7 +3466,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "unload"
       ],
       "requiredResources": [
         "Oil"
@@ -3424,6 +3496,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 4,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3496,6 +3569,7 @@
       "bombardRange": 1,
       "rateOfFire": 2,
       "movement": 8,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3569,6 +3643,7 @@
       "bombardRange": 2,
       "rateOfFire": 2,
       "movement": 5,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3645,6 +3720,7 @@
       "bombardRange": 2,
       "rateOfFire": 2,
       "movement": 7,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3719,6 +3795,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 5,
+      "capacity": 1,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3753,6 +3830,9 @@
         "Maya"
       ],
       "unproducible": false,
+      "flags": [
+        "canCarryTacticalMissiles"
+      ],
       "categories": [
         "Sea"
       ],
@@ -3762,7 +3842,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "unload"
       ],
       "requiredResources": [
         "Uranium"
@@ -3791,6 +3872,7 @@
       "bombardRange": 0,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3836,7 +3918,8 @@
         "hold",
         "wait",
         "fortify",
-        "disband"
+        "disband",
+        "load"
       ],
       "requiredResources": [
         "Oil"
@@ -3865,6 +3948,7 @@
       "bombardRange": 0,
       "rateOfFire": 3,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3906,7 +3990,8 @@
         "hold",
         "wait",
         "fortify",
-        "disband"
+        "disband",
+        "load"
       ],
       "requiredResources": [
         "Oil"
@@ -3935,6 +4020,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 3,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3969,6 +4055,9 @@
         "Maya"
       ],
       "unproducible": false,
+      "flags": [
+        "canCarryFootUnitsOnly"
+      ],
       "categories": [
         "Air"
       ],
@@ -3976,7 +4065,8 @@
         "hold",
         "wait",
         "fortify",
-        "disband"
+        "disband",
+        "unload"
       ],
       "requiredResources": [
         "Oil",
@@ -4006,6 +4096,7 @@
       "bombardRange": 0,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4046,7 +4137,8 @@
         "hold",
         "wait",
         "fortify",
-        "disband"
+        "disband",
+        "load"
       ],
       "requiredResources": [
         "Oil",
@@ -4076,6 +4168,7 @@
       "bombardRange": 0,
       "rateOfFire": 2,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4117,7 +4210,8 @@
         "hold",
         "wait",
         "fortify",
-        "disband"
+        "disband",
+        "load"
       ],
       "requiredResources": [
         "Oil",
@@ -4147,6 +4241,7 @@
       "bombardRange": 0,
       "rateOfFire": 3,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4188,7 +4283,8 @@
         "hold",
         "wait",
         "fortify",
-        "disband"
+        "disband",
+        "load"
       ],
       "requiredResources": [
         "Oil",
@@ -4230,6 +4326,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4273,7 +4370,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -4309,6 +4407,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 3,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4352,7 +4451,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -4378,6 +4478,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Aztecs"
       ],
@@ -4394,7 +4495,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -4420,6 +4522,7 @@
       "bombardRange": 0,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Babylon"
       ],
@@ -4436,7 +4539,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -4462,6 +4566,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Greece"
       ],
@@ -4478,7 +4583,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -4504,6 +4610,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Zululand"
       ],
@@ -4520,7 +4627,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -4546,6 +4654,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome"
       ],
@@ -4562,7 +4671,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Iron"
@@ -4591,6 +4701,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Persia"
       ],
@@ -4607,7 +4718,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Iron"
@@ -4636,6 +4748,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Egypt"
       ],
@@ -4652,7 +4765,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Horses"
@@ -4681,6 +4795,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "China"
       ],
@@ -4697,7 +4812,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Horses",
@@ -4727,6 +4843,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Iroquois"
       ],
@@ -4743,7 +4860,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Horses"
@@ -4772,6 +4890,7 @@
       "bombardRange": 0,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "France"
       ],
@@ -4788,7 +4907,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Saltpeter"
@@ -4817,6 +4937,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Japan"
       ],
@@ -4833,7 +4954,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Iron"
@@ -4862,6 +4984,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "India"
       ],
@@ -4878,7 +5001,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -4904,6 +5028,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "Russia"
       ],
@@ -4917,7 +5042,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Horses",
@@ -4947,6 +5073,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "Germany"
       ],
@@ -4963,7 +5090,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Oil",
@@ -4993,6 +5121,7 @@
       "bombardRange": 1,
       "rateOfFire": 2,
       "movement": 5,
+      "capacity": 0,
       "producibleBy": [
         "England"
       ],
@@ -5040,6 +5169,7 @@
       "bombardRange": 0,
       "rateOfFire": 2,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "America"
       ],
@@ -5051,7 +5181,8 @@
         "hold",
         "wait",
         "fortify",
-        "disband"
+        "disband",
+        "load"
       ],
       "requiredResources": [
         "Oil",
@@ -5081,6 +5212,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 5,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -5157,6 +5289,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Mongols"
       ],
@@ -5173,7 +5306,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Horses"
@@ -5202,6 +5336,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Spain"
       ],
@@ -5215,7 +5350,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Horses"
@@ -5244,6 +5380,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Scandinavia"
       ],
@@ -5260,7 +5397,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -5286,6 +5424,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "Ottomans"
       ],
@@ -5299,7 +5438,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Horses",
@@ -5329,6 +5469,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Celts"
       ],
@@ -5345,7 +5486,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Iron"
@@ -5374,6 +5516,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "Arabia"
       ],
@@ -5390,7 +5533,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Horses",
@@ -5420,6 +5564,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Carthage"
       ],
@@ -5436,7 +5581,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -5462,6 +5608,7 @@
       "bombardRange": 1,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Korea"
       ],
@@ -5479,7 +5626,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Saltpeter"
@@ -5508,6 +5656,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -5553,7 +5702,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Iron"
@@ -5582,6 +5732,7 @@
       "bombardRange": 0,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -5628,7 +5779,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -5653,6 +5805,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5685,6 +5838,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5694,7 +5848,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -5719,6 +5874,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5728,7 +5884,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -5753,6 +5910,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5762,7 +5920,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -5787,6 +5946,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5796,7 +5956,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -5821,6 +5982,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5830,7 +5992,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -5855,6 +6018,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5864,7 +6028,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -5889,6 +6054,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5898,7 +6064,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -5923,6 +6090,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5932,7 +6100,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -5957,6 +6126,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5966,7 +6136,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -5991,6 +6162,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6000,7 +6172,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6025,6 +6198,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6034,7 +6208,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6059,6 +6234,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6068,7 +6244,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6093,6 +6270,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6102,7 +6280,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6127,6 +6306,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6136,7 +6316,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6161,6 +6342,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6170,7 +6352,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6195,6 +6378,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6204,7 +6388,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6229,6 +6414,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6238,7 +6424,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6263,6 +6450,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6272,7 +6460,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6297,6 +6486,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6306,7 +6496,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6331,6 +6522,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6340,7 +6532,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6365,6 +6558,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6374,7 +6568,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6399,6 +6594,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6408,7 +6604,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6433,6 +6630,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6442,7 +6640,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6467,6 +6666,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6476,7 +6676,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6501,6 +6702,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Sumeria"
       ],
@@ -6517,7 +6719,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6543,6 +6746,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Hittites"
       ],
@@ -6559,7 +6763,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Horses"
@@ -6587,6 +6792,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6596,7 +6802,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6621,6 +6828,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6630,7 +6838,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6655,6 +6864,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6664,7 +6874,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6690,6 +6901,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 4,
+      "capacity": 3,
       "producibleBy": [
         "Portugal"
       ],
@@ -6709,7 +6921,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "unload"
       ]
     },
     {
@@ -6735,6 +6948,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Netherlands"
       ],
@@ -6751,7 +6965,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Iron"
@@ -6779,6 +6994,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6788,7 +7004,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6814,6 +7031,7 @@
       "bombardRange": 1,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -6861,7 +7079,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6886,6 +7105,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6895,7 +7115,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6920,6 +7141,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6929,7 +7151,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6954,6 +7177,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6963,7 +7187,8 @@
         "wait",
         "fortify",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -6988,6 +7213,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Inca"
       ],
@@ -7004,7 +7230,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -7030,6 +7257,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Maya"
       ],
@@ -7046,7 +7274,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -7072,6 +7301,7 @@
       "bombardRange": 1,
       "rateOfFire": 2,
       "movement": 3,
+      "capacity": 2,
       "producibleBy": [
         "Byzantines"
       ],
@@ -7089,7 +7319,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "unload"
       ]
     },
     {
@@ -7115,6 +7346,7 @@
       "bombardRange": 1,
       "rateOfFire": 2,
       "movement": 6,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7190,6 +7422,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -7200,7 +7433,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "terraformActions": [
         "Terraform-3"
@@ -7228,6 +7462,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -7238,7 +7473,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -7264,6 +7500,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7340,6 +7577,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7386,7 +7624,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ],
       "requiredResources": [
         "Oil",
@@ -7416,6 +7655,7 @@
       "bombardRange": 0,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7459,7 +7699,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -7485,6 +7726,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7531,7 +7773,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     },
     {
@@ -7557,6 +7800,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7600,7 +7844,8 @@
         "fortify",
         "disband",
         "goto",
-        "explore"
+        "explore",
+        "load"
       ]
     }
   ],

--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -794,6 +794,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -872,6 +873,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -951,6 +953,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Russia",
         "America",
@@ -997,6 +1000,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1065,6 +1069,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1137,6 +1142,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1209,6 +1215,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "A Barbarian Chiefdom",
         "Rome",
@@ -1279,6 +1286,7 @@
       "bombardRange": 0,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1347,6 +1355,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1413,6 +1422,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Egypt",
         "Greece",
@@ -1483,6 +1493,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Greece",
@@ -1554,6 +1565,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "A Barbarian Chiefdom",
         "Rome",
@@ -1627,6 +1639,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1697,6 +1710,7 @@
       "bombardRange": 0,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1766,6 +1780,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1838,6 +1853,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1907,6 +1923,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1977,6 +1994,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2048,6 +2066,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2121,6 +2140,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2194,6 +2214,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2267,6 +2288,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2340,6 +2362,7 @@
       "bombardRange": 1,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2411,6 +2434,7 @@
       "bombardRange": 1,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2485,6 +2509,7 @@
       "bombardRange": 2,
       "rateOfFire": 2,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2556,9 +2581,7 @@
       "bombardRange": 2,
       "rateOfFire": 3,
       "movement": 2,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2593,6 +2616,9 @@
         "Maya"
       ],
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Land"
       ],
@@ -2632,6 +2658,7 @@
       "bombardRange": 4,
       "rateOfFire": 3,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2704,6 +2731,7 @@
       "bombardRange": 6,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2778,6 +2806,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2851,9 +2880,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
+      "capacity": 2,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2888,6 +2915,9 @@
       ],
       "upgradeTo": "Caravel",
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -2923,9 +2953,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 4,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
+      "capacity": 3,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2960,6 +2988,9 @@
       ],
       "upgradeTo": "Galleon",
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -2995,9 +3026,7 @@
       "bombardRange": 1,
       "rateOfFire": 2,
       "movement": 5,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3031,6 +3060,9 @@
         "Maya"
       ],
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -3071,9 +3103,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 4,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
+      "capacity": 4,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3109,6 +3139,9 @@
       ],
       "upgradeTo": "Transport",
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -3144,6 +3177,7 @@
       "bombardRange": 1,
       "rateOfFire": 2,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3219,6 +3253,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 6,
+      "capacity": 6,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3291,6 +3326,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 7,
+      "capacity": 4,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3363,6 +3399,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 4,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3435,6 +3472,7 @@
       "bombardRange": 1,
       "rateOfFire": 2,
       "movement": 8,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3508,9 +3546,7 @@
       "bombardRange": 2,
       "rateOfFire": 2,
       "movement": 5,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3545,6 +3581,9 @@
         "Maya"
       ],
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -3584,6 +3623,7 @@
       "bombardRange": 2,
       "rateOfFire": 2,
       "movement": 7,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3658,6 +3698,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 5,
+      "capacity": 1,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3730,6 +3771,7 @@
       "bombardRange": 0,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3801,6 +3843,7 @@
       "bombardRange": 0,
       "rateOfFire": 3,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3871,6 +3914,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 3,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3942,6 +3986,7 @@
       "bombardRange": 0,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4012,6 +4057,7 @@
       "bombardRange": 0,
       "rateOfFire": 2,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4083,6 +4129,7 @@
       "bombardRange": 0,
       "rateOfFire": 3,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4166,6 +4213,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4245,6 +4293,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 3,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4314,6 +4363,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Aztecs"
       ],
@@ -4354,6 +4404,7 @@
       "bombardRange": 0,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Babylon"
       ],
@@ -4394,6 +4445,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Greece"
       ],
@@ -4434,6 +4486,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Zululand"
       ],
@@ -4474,6 +4527,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome"
       ],
@@ -4517,6 +4571,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Persia"
       ],
@@ -4560,6 +4615,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Egypt"
       ],
@@ -4603,6 +4659,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "China"
       ],
@@ -4647,6 +4704,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Iroquois"
       ],
@@ -4690,6 +4748,7 @@
       "bombardRange": 0,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "France"
       ],
@@ -4733,6 +4792,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Japan"
       ],
@@ -4776,6 +4836,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "India"
       ],
@@ -4816,6 +4877,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "Russia"
       ],
@@ -4859,6 +4921,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "Germany"
       ],
@@ -4903,13 +4966,14 @@
       "bombardRange": 1,
       "rateOfFire": 2,
       "movement": 5,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
+      "capacity": 0,
       "producibleBy": [
         "England"
       ],
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -4950,6 +5014,7 @@
       "bombardRange": 0,
       "rateOfFire": 2,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "America"
       ],
@@ -4991,9 +5056,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 5,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -5028,6 +5091,9 @@
         "Maya"
       ],
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -5067,6 +5133,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Mongols"
       ],
@@ -5110,6 +5177,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Spain"
       ],
@@ -5152,6 +5220,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Scandinavia"
       ],
@@ -5192,6 +5261,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "Ottomans"
       ],
@@ -5235,6 +5305,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Celts"
       ],
@@ -5278,6 +5349,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
+      "capacity": 0,
       "producibleBy": [
         "Arabia"
       ],
@@ -5322,6 +5394,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Carthage"
       ],
@@ -5362,6 +5435,7 @@
       "bombardRange": 1,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Korea"
       ],
@@ -5406,6 +5480,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -5478,6 +5553,7 @@
       "bombardRange": 0,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -5547,7 +5623,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5580,7 +5656,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5615,7 +5691,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5650,7 +5726,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5685,7 +5761,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5720,7 +5796,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5755,7 +5831,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5790,7 +5866,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5825,7 +5901,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5860,7 +5936,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5895,7 +5971,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5930,7 +6006,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5965,7 +6041,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6000,7 +6076,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6035,7 +6111,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6070,7 +6146,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6105,7 +6181,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6140,7 +6216,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6175,7 +6251,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6210,7 +6286,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6245,7 +6321,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6280,7 +6356,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6315,7 +6391,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6350,7 +6426,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6385,7 +6461,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6420,6 +6496,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Sumeria"
       ],
@@ -6460,6 +6537,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Hittites"
       ],
@@ -6502,7 +6580,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6537,7 +6615,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6572,7 +6650,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6608,14 +6686,15 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 4,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
+      "capacity": 3,
       "producibleBy": [
         "Portugal"
       ],
       "upgradeTo": "Galleon",
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -6651,6 +6730,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Netherlands"
       ],
@@ -6693,7 +6773,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6729,6 +6809,7 @@
       "bombardRange": 1,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -6799,7 +6880,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6834,7 +6915,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6869,7 +6950,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6904,6 +6985,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Inca"
       ],
@@ -6944,6 +7026,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Maya"
       ],
@@ -6984,6 +7067,7 @@
       "bombardRange": 1,
       "rateOfFire": 2,
       "movement": 3,
+      "capacity": 2,
       "producibleBy": [
         "Byzantines"
       ],
@@ -7025,6 +7109,7 @@
       "bombardRange": 1,
       "rateOfFire": 2,
       "movement": 6,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7098,7 +7183,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -7137,7 +7222,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
+      "capacity": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -7174,10 +7259,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
-      "upgradeTo": "Galley",
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7211,7 +7293,11 @@
         "Inca",
         "Maya"
       ],
+      "upgradeTo": "Galley",
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -7247,6 +7333,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7321,6 +7408,7 @@
       "bombardRange": 0,
       "rateOfFire": 1,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7390,6 +7478,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7460,6 +7549,7 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
+      "capacity": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -12439,7 +12529,7 @@
       "militaryLaw": 1
     }
   ],
-  "worldSizes" : [
+  "worldSizes": [
     {
       "name": "Tiny",
       "length": 80,
@@ -12467,9 +12557,9 @@
       "width": 100,
       "optimalNumberOfCities": 20,
       "techRate": 240,
-      "distanceBetweenCivs": 12,      
+      "distanceBetweenCivs": 12,
       "numberOfCivs": 8,
-      "isDefault" : true
+      "isDefault": true
     },
     {
       "name": "Large",

--- a/C7/Lua/texture_configs/c7.lua
+++ b/C7/Lua/texture_configs/c7.lua
@@ -103,7 +103,8 @@ local c7_texture_list = {
   "Art/Units/units_32.png",
   "Art/city screen/buildings-small.png",
   "Art/city screen/buildings-large.png",
-  "Art/Cursor.png"
+  "Art/Cursor.png",
+  "Art/interface/box trans color.png"
 }
 
 -- Build lookup table from c7_texture_list without extensions

--- a/C7/Lua/texture_configs/civ3.lua
+++ b/C7/Lua/texture_configs/civ3.lua
@@ -420,6 +420,13 @@ textures.lower_left_infobox = {
     },
 }
 
+textures.transport_infobox = {
+    box = {
+      path = INTERFACE .. "box trans color.pcx",
+      alpha = INTERFACE .. "box trans alpha.pcx",
+    },
+}
+
 textures.tileinfo = {
       box = {
         path = TILEINFO

--- a/C7/Lua/texture_configs/civ3/unit_control.lua
+++ b/C7/Lua/texture_configs/civ3/unit_control.lua
@@ -29,7 +29,10 @@ local unit_control = {
   unit_disband = make_entry(3, 0),
   unit_goto = make_entry(4, 0),
   unit_explore = make_entry(5, 0),
+  -- unit_sentry = make_entry(6, 0),  
+  unit_load = make_entry(7, 0),
   
+  unit_unload = make_entry(0, 1),
   unit_bombard = make_entry(3, 1),
 
   unit_build_city = make_entry(5, 2),

--- a/C7/Map/UnitLayer.cs
+++ b/C7/Map/UnitLayer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using C7.Textures;
 using C7GameData;
 using Godot;
@@ -210,10 +211,15 @@ public partial class UnitLayer : LooseLayer {
 	public MapUnit selectUnitToDisplay(LooseView looseView, Tile tile, List<MapUnit> units) {
 		// From the list, pick out which units are (1) the strongest defender vs the currently selected unit, (2) the currently selected unit
 		// itself if it's in the list, and (3) any unit that is playing an animation that the player would want to see.
-		MapUnit bestDefender = units[0], selected = null, transporter = null, doingInterestingAnimation = null;
+		// If every regular defender is in some transport, the best defender _is_ a transport
+
+		MapUnit bestDefender = units.First(u => u.loadedOnUnitId == null);
+		MapUnit selected = null, transporter = null, doingInterestingAnimation = null;
 		var currentlySelectedUnit = looseView.mapView.game.CurrentlySelectedUnit;
 
 		foreach (var u in units) {
+			if (u.loadedOnUnitId != null && u != currentlySelectedUnit) continue;
+
 			if (u == currentlySelectedUnit) {
 				selected = u;
 				break;

--- a/C7/Map/UnitLayer.cs
+++ b/C7/Map/UnitLayer.cs
@@ -207,10 +207,10 @@ public partial class UnitLayer : LooseLayer {
 	}
 
 	// Returns which unit should be drawn from among a list of units. The list is assumed to be non-empty.
-	public MapUnit selectUnitToDisplay(LooseView looseView, List<MapUnit> units) {
+	public MapUnit selectUnitToDisplay(LooseView looseView, Tile tile, List<MapUnit> units) {
 		// From the list, pick out which units are (1) the strongest defender vs the currently selected unit, (2) the currently selected unit
 		// itself if it's in the list, and (3) any unit that is playing an animation that the player would want to see.
-		MapUnit bestDefender = units[0], selected = null, doingInterestingAnimation = null;
+		MapUnit bestDefender = units[0], selected = null, transporter = null, doingInterestingAnimation = null;
 		var currentlySelectedUnit = looseView.mapView.game.CurrentlySelectedUnit;
 
 		foreach (var u in units) {
@@ -228,8 +228,16 @@ public partial class UnitLayer : LooseLayer {
 				bestDefender = u;
 		}
 
-		// Prefer showing the selected unit, secondly show one doing a relevant animation, otherwise show the top defender
-		return selected ?? doingInterestingAnimation ?? bestDefender;
+		// On water, show the transport of the best defender (hopefully stable)
+		if (tile.IsWater()) {
+			foreach (var u in units) {
+				if (u.CanTransport() && bestDefender.IsLoadedIn(u))
+					transporter = u;
+			}
+		}
+
+		// Prefer showing the selected unit, then animation, then transport, otherwise show the top defender
+		return selected ?? doingInterestingAnimation ?? transporter ?? bestDefender;
 	}
 
 	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
@@ -254,7 +262,7 @@ public partial class UnitLayer : LooseLayer {
 
 		var white = Color.Color8(255, 255, 255);
 
-		MapUnit unit = selectUnitToDisplay(looseView, tile.unitsOnTile);
+		MapUnit unit = selectUnitToDisplay(looseView, tile, tile.unitsOnTile);
 		MapUnit.Appearance appearance = looseView.mapView.game.animationController.animTracker.getUnitAppearance(unit);
 		Vector2 animOffset = new Vector2(appearance.offsetX, appearance.offsetY) * MapView.cellSize;
 

--- a/C7/Map/UnitLayer.cs
+++ b/C7/Map/UnitLayer.cs
@@ -213,7 +213,7 @@ public partial class UnitLayer : LooseLayer {
 		// itself if it's in the list, and (3) any unit that is playing an animation that the player would want to see.
 		// If every regular defender is in some transport, the best defender _is_ a transport
 
-		MapUnit bestDefender = units.First(u => u.loadedOnUnitId == null);
+		MapUnit bestDefender = units.FirstOrDefault(u => u.loadedOnUnitId == null) ?? units[0];
 		MapUnit selected = null, transporter = null, doingInterestingAnimation = null;
 		var currentlySelectedUnit = looseView.mapView.game.CurrentlySelectedUnit;
 

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -661,7 +661,7 @@ public partial class MapView : Node2D {
 		lowerRightInfoBox.CenterCameraOnActiveUnit += OnCenterCameraOnUnit;
 
 		var canvasControl = GetNode<Control>("/root/C7Game/CanvasLayer/Control");
-		
+
 		miniMap = new MiniMap(this);
 		canvasControl.AddChild(miniMap);
 

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -667,7 +667,6 @@ public partial class MapView : Node2D {
 
 		transportInfoBox = new TransportInfoBox(game);
 		canvasControl.AddChild(transportInfoBox);
-		// TODO: transportInfoBox.Hide();
 	}
 
 	public override void _ExitTree() {

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -651,16 +651,23 @@ public partial class MapView : Node2D {
 	const float MIN_SCALE = 0.1f;
 	const float MAX_SCALE = 4.0f;
 
+	private TransportInfoBox transportInfoBox;
 	private LowerRightInfoBox lowerRightInfoBox;
 	private MiniMap miniMap;
 
 	public override void _Ready() {
 		lowerRightInfoBox = GetNode<LowerRightInfoBox>("/root/C7Game/CanvasLayer/Control/GameStatus/LowerRightInfoBox");
+		lowerRightInfoBox.game = game;
 		lowerRightInfoBox.CenterCameraOnActiveUnit += OnCenterCameraOnUnit;
 
-		miniMap = new MiniMap(this);
 		var canvasControl = GetNode<Control>("/root/C7Game/CanvasLayer/Control");
+		
+		miniMap = new MiniMap(this);
 		canvasControl.AddChild(miniMap);
+
+		transportInfoBox = new TransportInfoBox(game);
+		canvasControl.AddChild(transportInfoBox);
+		// TODO: transportInfoBox.Hide();
 	}
 
 	public override void _ExitTree() {

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -1,4 +1,3 @@
-using C7.Textures;
 using Godot;
 using C7GameData;
 using Serilog;
@@ -8,6 +7,8 @@ using C7Engine;
 [Tool]
 public partial class LowerRightInfoBox : Civ3TextureRect {
 	private ILogger log = LogManager.ForContext<LowerRightInfoBox>();
+
+	public Game game { get; set; }
 
 	private const int fontSize = 12;
 	private const float offsetUnitThumbnailX = 14;
@@ -276,26 +277,17 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 			return;
 		}
 
-		string key = AnimationManager.GetUnitDefaultThumbnailKey(unit);
-		ImageTexture baseFrame = AnimationManager.AnimationThumbnails[key];
-		ImageTexture tintFrame = AnimationManager.AnimationTintThumbnails[key];
-
-		ShaderMaterial material = PlayerTextureUtil.GetShaderMaterialForUnit(unit.owner.GetPlayerColor());
-
-		// Add the base sprite.
-		unitPlaceholder = new Sprite2D();
-		unitPlaceholder.Texture = baseFrame;
-		unitPlaceholder.Position = new Vector2(
+		(unitPlaceholder, unitTintPlaceholder) = StatusUtils.GetUnitSprites(game, unit);
+		
+		var unitSpritePosition = new Vector2(
 			boxRightRectangle.Texture.GetWidth() / 2f - offsetUnitThumbnailX,
 			boxRightRectangle.Texture.GetHeight() / 2f - offsetUnitThumbnailY);
-		this.AddChild(unitPlaceholder);
-
-		// Add the tint sprite, hooking up the shader.
-		unitTintPlaceholder = new Sprite2D();
-		unitTintPlaceholder.Texture = tintFrame;
-		unitTintPlaceholder.Material = material;
-		unitTintPlaceholder.Position = unitPlaceholder.Position;
-		this.AddChild(unitTintPlaceholder);
+		
+		unitPlaceholder.Position = unitSpritePosition; 
+		AddChild(unitPlaceholder);
+		
+		unitTintPlaceholder.Position = unitSpritePosition;
+		AddChild(unitTintPlaceholder);
 	}
 
 	private void HandleBoxClick() {

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -278,14 +278,14 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 		}
 
 		(unitPlaceholder, unitTintPlaceholder) = StatusUtils.GetUnitSprites(game, unit);
-		
+
 		var unitSpritePosition = new Vector2(
 			boxRightRectangle.Texture.GetWidth() / 2f - offsetUnitThumbnailX,
 			boxRightRectangle.Texture.GetHeight() / 2f - offsetUnitThumbnailY);
-		
-		unitPlaceholder.Position = unitSpritePosition; 
+
+		unitPlaceholder.Position = unitSpritePosition;
 		AddChild(unitPlaceholder);
-		
+
 		unitTintPlaceholder.Position = unitSpritePosition;
 		AddChild(unitTintPlaceholder);
 	}

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -277,7 +277,7 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 			return;
 		}
 
-		(unitPlaceholder, unitTintPlaceholder) = StatusUtils.GetUnitSprites(game, unit);
+		(unitPlaceholder, unitTintPlaceholder) = SpriteUtils.GetUnitSprites(game, unit);
 
 		var unitSpritePosition = new Vector2(
 			boxRightRectangle.Texture.GetWidth() / 2f - offsetUnitThumbnailX,

--- a/C7/UIElements/GameStatus/StatusUtils.cs
+++ b/C7/UIElements/GameStatus/StatusUtils.cs
@@ -2,26 +2,24 @@ using C7.Textures;
 using C7GameData;
 using Godot;
 
-public static class StatusUtils
-{
-    public static (Sprite2D unitSprite, Sprite2D unitTintSprite) GetUnitSprites(Game game, MapUnit unit)
-    {
-        var am = game.animationController.civ3AnimData;
-        
-        var (baseFrame, tintFrame) = am.GetAnimationFrameAndTintTextures(unit);
-        
-        var color = unit.owner.GetPlayerColor();
-        ShaderMaterial material = PlayerTextureUtil.GetShaderMaterialForUnit(color);
+public static class StatusUtils {
+	public static (Sprite2D unitSprite, Sprite2D unitTintSprite) GetUnitSprites(Game game, MapUnit unit) {
+		var am = game.animationController.civ3AnimData;
 
-        // Add the base sprite.
-        var unitSprite = new Sprite2D();
-        unitSprite.Texture = baseFrame;
+		var (baseFrame, tintFrame) = am.GetAnimationFrameAndTintTextures(unit);
 
-        // Add the tint sprite, hooking up the shader.
-        var unitTintSprite = new Sprite2D();
-        unitTintSprite.Texture = tintFrame;
-        unitTintSprite.Material = material;
-		
-        return (unitSprite, unitTintSprite);
-    }
+		var color = unit.owner.GetPlayerColor();
+		ShaderMaterial material = PlayerTextureUtil.GetShaderMaterialForUnit(color);
+
+		// Add the base sprite.
+		var unitSprite = new Sprite2D();
+		unitSprite.Texture = baseFrame;
+
+		// Add the tint sprite, hooking up the shader.
+		var unitTintSprite = new Sprite2D();
+		unitTintSprite.Texture = tintFrame;
+		unitTintSprite.Material = material;
+
+		return (unitSprite, unitTintSprite);
+	}
 }

--- a/C7/UIElements/GameStatus/StatusUtils.cs
+++ b/C7/UIElements/GameStatus/StatusUtils.cs
@@ -1,0 +1,27 @@
+using C7.Textures;
+using C7GameData;
+using Godot;
+
+public static class StatusUtils
+{
+    public static (Sprite2D unitSprite, Sprite2D unitTintSprite) GetUnitSprites(Game game, MapUnit unit)
+    {
+        var am = game.animationController.civ3AnimData;
+        
+        var (baseFrame, tintFrame) = am.GetAnimationFrameAndTintTextures(unit);
+        
+        var color = unit.owner.GetPlayerColor();
+        ShaderMaterial material = PlayerTextureUtil.GetShaderMaterialForUnit(color);
+
+        // Add the base sprite.
+        var unitSprite = new Sprite2D();
+        unitSprite.Texture = baseFrame;
+
+        // Add the tint sprite, hooking up the shader.
+        var unitTintSprite = new Sprite2D();
+        unitTintSprite.Texture = tintFrame;
+        unitTintSprite.Material = material;
+		
+        return (unitSprite, unitTintSprite);
+    }
+}

--- a/C7/UIElements/GameStatus/TransportInfoBox.cs
+++ b/C7/UIElements/GameStatus/TransportInfoBox.cs
@@ -23,6 +23,7 @@ public partial class TransportInfoBox : Civ3TextureRect {
 	private TextureRect boxTransportRect = new();
 
 	private Dictionary<ID, bool> unitTracker = new();
+	private int cachedCapacity = 0;
 
 	public TransportInfoBox(Game game) {
 		_game = game;
@@ -49,12 +50,17 @@ public partial class TransportInfoBox : Civ3TextureRect {
 			var unit = _game.CurrentlySelectedUnit;
 			if (unit == null || unit == MapUnit.NONE || !unit.CanTransport()) {
 				Visible = false;
-				ClearUnitSprites();
+				Reset();
 				return;
 			}
 
 			if (!unitTracker.TryGetValue(unit.id, out _))
-				ClearUnitSprites();
+				Reset();
+			else if (unit.FreeCapacity() != cachedCapacity) {
+				// UI update post load/unload
+				Reset();
+				cachedCapacity = unit.FreeCapacity();
+			}
 
 			Visible = true;
 			var loadedUnits = gD.mapUnits.Where(u => u.IsLoadedIn(unit));
@@ -73,7 +79,7 @@ public partial class TransportInfoBox : Civ3TextureRect {
 		SetPosition(frameOffset + new Vector2(vp.X - boxSize.X, vp.Y - boxSize.Y));
 	}
 
-	private void ClearUnitSprites() {
+	private void Reset() {
 		unitTracker.Clear();
 		foreach (var c in GetChildren().Where(c => c is Button))
 			c.QueueFree();
@@ -125,7 +131,7 @@ public partial class TransportInfoBox : Civ3TextureRect {
 				line.Width = 3f;
 				line.DefaultColor = TextureLoader.LoadColor(unit.owner.GetPlayerColor());
 
-				// draw lines at normal scale, let parent scale things down 
+				// draw lines at normal scale, let parent scale things down
 				line.AddPoint(new Vector2(0, 0));
 				line.AddPoint(new Vector2(unitButtonSize.X, 0));
 				line.AddPoint(new Vector2(unitButtonSize.X, unitButtonSize.Y));

--- a/C7/UIElements/GameStatus/TransportInfoBox.cs
+++ b/C7/UIElements/GameStatus/TransportInfoBox.cs
@@ -17,9 +17,9 @@ public partial class TransportInfoBox : Civ3TextureRect {
 	private Vector2 transportUnitsAnchor = new(70f, 45f);
 
 	private TextureRect boxTransportRect = new();
-	
+
 	private Dictionary<ID, Tuple<Sprite2D, Sprite2D>> unitSpritesCache = new();
-	
+
 	private Vector2I frameOffset = new (-20, -175);
 
 	public TransportInfoBox(Game game) {
@@ -107,7 +107,7 @@ public partial class TransportInfoBox : Civ3TextureRect {
 			// unitSprite.Pressed += HandleBoxClick; // TODO: this won't work, need click targets
 		}
 	}
-	
+
 	private void HandleBoxClick() {
 		// TODO: Select unit based on click inside TransportInfoBox
 		// EmitSignal(SignalName.CenterCameraOnActiveUnit);

--- a/C7/UIElements/GameStatus/TransportInfoBox.cs
+++ b/C7/UIElements/GameStatus/TransportInfoBox.cs
@@ -14,16 +14,22 @@ public partial class TransportInfoBox : Civ3TextureRect {
 
 	private readonly Game _game;
 
+	private Vector2I frameOffset = new (-27, -180);
 	private Vector2 transportUnitsAnchor = new(70f, 45f);
+	private Vector2 miniatureScale = new(0.7f, 0.7f);
+	private Vector2 unitButtonSize = new(50, 50);
+	// Note: the draw area for the box is a bit more than 200x100
 
 	private TextureRect boxTransportRect = new();
 
-	private Dictionary<ID, Tuple<Sprite2D, Sprite2D>> unitSpritesCache = new();
+	private Dictionary<ID, bool> unitTracker = new();
 
-	private Vector2I frameOffset = new (-20, -175);
+
 
 	public TransportInfoBox(Game game) {
 		_game = game;
+
+		MouseFilter = MouseFilterEnum.Stop;
 	}
 
 	public override void _Ready() {
@@ -49,6 +55,9 @@ public partial class TransportInfoBox : Civ3TextureRect {
 				return;
 			}
 
+			if (!unitTracker.TryGetValue(unit.id, out _))
+				ClearUnitSprites();
+
 			Visible = true;
 			var loadedUnits = gD.mapUnits.Where(u => u.IsLoadedIn(unit));
 			var transportUnits = new List<MapUnit>([unit]).Concat(loadedUnits).ToList();
@@ -67,8 +76,8 @@ public partial class TransportInfoBox : Civ3TextureRect {
 	}
 
 	private void ClearUnitSprites() {
-		unitSpritesCache.Clear();
-		foreach (var c in GetChildren().Where(c => c is Sprite2D))
+		unitTracker.Clear();
+		foreach (var c in GetChildren().Where(c => c is TextureButton))
 			c.QueueFree();
 	}
 
@@ -82,33 +91,69 @@ public partial class TransportInfoBox : Civ3TextureRect {
 			return;
 
 		foreach (var (unit, idx) in units.Select((x, i) => (x, i))) {
-			if (unitSpritesCache.TryGetValue(unit.id, out var sprites)) {
+			if (unitTracker.TryGetValue(unit.id, out _)) {
 				continue;
 			}
 
-			(var unitSprite, var unitTintSprite) = StatusUtils.GetUnitSprites(_game, unit);
-			unitSpritesCache[unit.id] = new Tuple<Sprite2D, Sprite2D>(unitSprite, unitTintSprite);
+			// Get sprites
+			var (unitSprite, unitTintSprite) = SpriteUtils.GetUnitSprites(_game, unit);
+			unitTracker[unit.id] = true;
 
-			var unitSpritePosition = transportUnitsAnchor;
-			var unitSpriteDrawWidth = boxTransportRect.Texture.GetWidth() - transportUnitsAnchor.X;
+			// Resize sprites
+			unitSprite.SetScale(miniatureScale);
+			unitTintSprite.SetScale(miniatureScale);
 
-			unitSpritePosition.X += idx * unitSprite.Texture.GetWidth();
+			// Create button
+			TextureButton unitButton = new();
+			unitButton.SetSize(unitButtonSize);
+			unitButton.Pressed += () => HandleBoxClick(unit);
+			AddChild(unitButton);
 
-			while (unitSpritePosition.X > unitSpriteDrawWidth) {
-				unitSpritePosition.X -= unitSpriteDrawWidth;
-				unitSpritePosition.Y += unitSprite.Texture.GetHeight();
+			// Position button
+			var pos = CalculateUnitButtonPosition(idx);
+			unitButton.SetPosition(pos);
+
+			// Add sprites
+			unitButton.AddChild(unitSprite);
+			unitButton.AddChild(unitTintSprite);
+
+			// Draw a box around the transport unit
+			if (idx == 0) {
+				var line = new Line2D();
+
+				line.Width = 3f;
+				line.DefaultColor = TextureLoader.LoadColor(unit.owner.GetPlayerColor());
+				line.Position = unitButtonSize / -2f;
+
+				// draw lines at normal scale, let parent scale things down 
+				line.AddPoint(new Vector2(0, 0));
+				line.AddPoint(new Vector2(unitButtonSize.X, 0));
+				line.AddPoint(new Vector2(unitButtonSize.X, unitButtonSize.Y));
+				line.AddPoint(new Vector2(0, unitButtonSize.Y));
+				line.AddPoint(new Vector2(0, 0));
+
+				// parent to button
+				unitButton.AddChild(line);
 			}
-
-			unitSprite.Position = unitSpritePosition;
-			AddChild(unitSprite);
-			unitTintSprite.Position = unitSpritePosition;
-			AddChild(unitTintSprite);
-
-			// unitSprite.Pressed += HandleBoxClick; // TODO: this won't work, need click targets
 		}
 	}
 
-	private void HandleBoxClick() {
+	private Vector2 CalculateUnitButtonPosition(int idx) {
+		// TODO: common baseline
+
+		var drawAreaWidth = boxTransportRect.Texture.GetWidth() - transportUnitsAnchor.X;
+		var columns = (int) Math.Floor(drawAreaWidth / unitButtonSize.X);
+
+		var unitSpritePosition = transportUnitsAnchor;
+
+		unitSpritePosition.X += (idx % columns) * unitButtonSize.X;
+		unitSpritePosition.Y += ((int)Math.Floor(idx / (1f * columns))) * unitButtonSize.Y;
+
+		return unitSpritePosition;
+	}
+
+	private void HandleBoxClick(MapUnit unit) {
+		Log.Information("Unit Box click: {MapUnit}", unit);
 		// TODO: Select unit based on click inside TransportInfoBox
 		// EmitSignal(SignalName.CenterCameraOnActiveUnit);
 	}

--- a/C7/UIElements/GameStatus/TransportInfoBox.cs
+++ b/C7/UIElements/GameStatus/TransportInfoBox.cs
@@ -11,7 +11,7 @@ using C7Engine;
 [Tool]
 public partial class TransportInfoBox : Civ3TextureRect {
 	private ILogger log = LogManager.ForContext<TransportInfoBox>();
-	
+
 	private readonly Game _game;
 
 	private Vector2 transportUnitsAnchor = new Vector2(70f, 45f);
@@ -23,18 +23,17 @@ public partial class TransportInfoBox : Civ3TextureRect {
 	private Label unitType = new();
 
 	private Dictionary<ID, Tuple<Sprite2D, Sprite2D>> unitSpritesCache = new();
-	
+
 	private float extraXOffset = 7;
 	private Vector2I frameOffset = new (-20, -175);
 
-	public TransportInfoBox(Game game)
-	{
+	public TransportInfoBox(Game game) {
 		_game = game;
 	}
 
 	public override void _Ready() {
 		ImageTexture boxTransport = TextureLoader.Load("transport_infobox.box");
-		
+
 		boxTransportRect = new TextureRect();
 		boxTransportRect.Texture = boxTransport;
 		boxTransportRect.SetPosition(new Vector2(0, 0));
@@ -47,17 +46,16 @@ public partial class TransportInfoBox : Civ3TextureRect {
 		// AddChild(boxTransportRectButton);
 		// boxTransportRectButton.Pressed += HandleBoxClick;
 	}
-	
+
 	public override void _Process(double delta) {
 		if (Engine.IsEditorHint())
 			return;
 
 		RepositionFrame();
-		
+
 		EngineStorage.ReadGameData((GameData gD) => {
 			var unit = _game.CurrentlySelectedUnit;
-			if (unit == null || unit == MapUnit.NONE || !unit.CanTransport())
-			{
+			if (unit == null || unit == MapUnit.NONE || !unit.CanTransport()) {
 				Visible = false;
 				ClearUnitSprites();
 				return;
@@ -66,28 +64,26 @@ public partial class TransportInfoBox : Civ3TextureRect {
 			Visible = true;
 			var loadedUnits = gD.mapUnits.Where(u => u.IsLoadedIn(unit));
 			var transportUnits = new List<MapUnit>([unit]).Concat(loadedUnits).ToList();
-			
+
 			UpdateUnitGraphic(transportUnits);
 		});
 
 		base._Process(delta);
 	}
 
-	private void RepositionFrame()
-	{
+	private void RepositionFrame() {
 		// Position frame and map relative to viewport
 		var boxSize = boxTransportRect.Texture.GetSize();
 		var vp = GetViewportRect().Size;
 		SetPosition(frameOffset + new Vector2(vp.X - boxSize.X, vp.Y - boxSize.Y));
 	}
 
-	private void ClearUnitSprites()
-	{
+	private void ClearUnitSprites() {
 		unitSpritesCache.Clear();
-		foreach (var c  in GetChildren().Where(c => c is Sprite2D))
+		foreach (var c in GetChildren().Where(c => c is Sprite2D))
 			c.QueueFree();
 	}
-	
+
 	private void UpdateUnitGraphic(ICollection<MapUnit> units) {
 		if (!units.Any(u => u != MapUnit.NONE && u != null)) {
 			return;
@@ -97,12 +93,11 @@ public partial class TransportInfoBox : Civ3TextureRect {
 		if (!AnimationManager.AnimationThumbnails.Any())
 			return;
 
-		foreach (var (unit, idx) in units.Select((x,i) => (x,i)))
-		{
+		foreach (var (unit, idx) in units.Select((x, i) => (x, i))) {
 			if (unitSpritesCache.TryGetValue(unit.id, out var sprites)) {
 				continue;
 			}
-			
+
 			(var unitSprite, var unitTintSprite) = StatusUtils.GetUnitSprites(_game, unit);
 			unitSpritesCache[unit.id] = new Tuple<Sprite2D, Sprite2D>(unitSprite, unitTintSprite);
 
@@ -111,22 +106,21 @@ public partial class TransportInfoBox : Civ3TextureRect {
 
 			unitSpritePosition.X += idx * unitSprite.Texture.GetWidth();
 
-			while (unitSpritePosition.X > unitSpriteDrawWidth)
-			{
+			while (unitSpritePosition.X > unitSpriteDrawWidth) {
 				unitSpritePosition.X -= unitSpriteDrawWidth;
 				unitSpritePosition.Y += unitSprite.Texture.GetHeight();
 			}
-			
+
 			unitSprite.Position = unitSpritePosition;
 			AddChild(unitSprite);
 			unitTintSprite.Position = unitSpritePosition;
 			AddChild(unitTintSprite);
-			
+
 			// unitSprite.Pressed += HandleBoxClick; // TODO: this won't work
 		}
 	}
-	
-	
+
+
 
 	private void HandleBoxClick() {
 		// EmitSignal(SignalName.CenterCameraOnActiveUnit);

--- a/C7/UIElements/GameStatus/TransportInfoBox.cs
+++ b/C7/UIElements/GameStatus/TransportInfoBox.cs
@@ -24,8 +24,6 @@ public partial class TransportInfoBox : Civ3TextureRect {
 
 	private Dictionary<ID, bool> unitTracker = new();
 
-
-
 	public TransportInfoBox(Game game) {
 		_game = game;
 
@@ -77,7 +75,7 @@ public partial class TransportInfoBox : Civ3TextureRect {
 
 	private void ClearUnitSprites() {
 		unitTracker.Clear();
-		foreach (var c in GetChildren().Where(c => c is TextureButton))
+		foreach (var c in GetChildren().Where(c => c is Button))
 			c.QueueFree();
 	}
 
@@ -99,14 +97,14 @@ public partial class TransportInfoBox : Civ3TextureRect {
 			var (unitSprite, unitTintSprite) = SpriteUtils.GetUnitSprites(_game, unit);
 			unitTracker[unit.id] = true;
 
-			// Resize sprites
+			// Resize sprites (tint is a child of the main sprite and is scaled with parent)
 			unitSprite.SetScale(miniatureScale);
-			unitTintSprite.SetScale(miniatureScale);
 
 			// Create button
-			TextureButton unitButton = new();
+			Button unitButton = new();
 			unitButton.SetSize(unitButtonSize);
-			unitButton.Pressed += () => HandleBoxClick(unit);
+			unitButton.ActionMode = BaseButton.ActionModeEnum.Press;
+			unitButton.Pressed += () => HandleUnitClick(unit);
 			AddChild(unitButton);
 
 			// Position button
@@ -115,7 +113,10 @@ public partial class TransportInfoBox : Civ3TextureRect {
 
 			// Add sprites
 			unitButton.AddChild(unitSprite);
-			unitButton.AddChild(unitTintSprite);
+			unitSprite.AddChild(unitTintSprite);
+
+			// Draw sprites centered on the button
+			unitSprite.Position += unitButtonSize / 2;
 
 			// Draw a box around the transport unit
 			if (idx == 0) {
@@ -123,7 +124,6 @@ public partial class TransportInfoBox : Civ3TextureRect {
 
 				line.Width = 3f;
 				line.DefaultColor = TextureLoader.LoadColor(unit.owner.GetPlayerColor());
-				line.Position = unitButtonSize / -2f;
 
 				// draw lines at normal scale, let parent scale things down 
 				line.AddPoint(new Vector2(0, 0));
@@ -139,22 +139,22 @@ public partial class TransportInfoBox : Civ3TextureRect {
 	}
 
 	private Vector2 CalculateUnitButtonPosition(int idx) {
-		// TODO: common baseline
-
 		var drawAreaWidth = boxTransportRect.Texture.GetWidth() - transportUnitsAnchor.X;
 		var columns = (int) Math.Floor(drawAreaWidth / unitButtonSize.X);
 
 		var unitSpritePosition = transportUnitsAnchor;
 
+		// offset based on index
 		unitSpritePosition.X += (idx % columns) * unitButtonSize.X;
 		unitSpritePosition.Y += ((int)Math.Floor(idx / (1f * columns))) * unitButtonSize.Y;
+
+		// from centered to draw corner
+		unitSpritePosition -= unitButtonSize / 2;
 
 		return unitSpritePosition;
 	}
 
-	private void HandleBoxClick(MapUnit unit) {
-		Log.Information("Unit Box click: {MapUnit}", unit);
-		// TODO: Select unit based on click inside TransportInfoBox
-		// EmitSignal(SignalName.CenterCameraOnActiveUnit);
+	private void HandleUnitClick(MapUnit unit) {
+		_game.SelectUnit(unit);
 	}
 }

--- a/C7/UIElements/GameStatus/TransportInfoBox.cs
+++ b/C7/UIElements/GameStatus/TransportInfoBox.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using C7.Textures;
+using Godot;
+using C7GameData;
+using Serilog;
+using C7Engine;
+
+[GlobalClass]
+[Tool]
+public partial class TransportInfoBox : Civ3TextureRect {
+	private ILogger log = LogManager.ForContext<TransportInfoBox>();
+	
+	private readonly Game _game;
+
+	private Vector2 transportUnitsAnchor = new Vector2(70f, 45f);
+
+	private TextureRect boxTransportRect = new();
+	private TextureButton boxTransportRectButton = new();
+
+	private Label unitRank = new();
+	private Label unitType = new();
+
+	private Dictionary<ID, Tuple<Sprite2D, Sprite2D>> unitSpritesCache = new();
+	
+	private float extraXOffset = 7;
+	private Vector2I frameOffset = new (-20, -175);
+
+	public TransportInfoBox(Game game)
+	{
+		_game = game;
+	}
+
+	public override void _Ready() {
+		ImageTexture boxTransport = TextureLoader.Load("transport_infobox.box");
+		
+		boxTransportRect = new TextureRect();
+		boxTransportRect.Texture = boxTransport;
+		boxTransportRect.SetPosition(new Vector2(0, 0));
+		AddChild(boxTransportRect);
+
+		// // An "invisible" button covering the inside area of the box so we can register the click
+		// // and center the camera on the unit or end the turn
+		// boxTransportRectButton.SetSize(new Vector2(228, 108));
+		// boxTransportRectButton.SetPosition(new Vector2(40, 17));
+		// AddChild(boxTransportRectButton);
+		// boxTransportRectButton.Pressed += HandleBoxClick;
+	}
+	
+	public override void _Process(double delta) {
+		if (Engine.IsEditorHint())
+			return;
+
+		RepositionFrame();
+		
+		EngineStorage.ReadGameData((GameData gD) => {
+			var unit = _game.CurrentlySelectedUnit;
+			if (unit == null || unit == MapUnit.NONE || !unit.CanTransport())
+			{
+				Visible = false;
+				ClearUnitSprites();
+				return;
+			}
+
+			Visible = true;
+			var loadedUnits = gD.mapUnits.Where(u => u.IsLoadedIn(unit));
+			var transportUnits = new List<MapUnit>([unit]).Concat(loadedUnits).ToList();
+			
+			UpdateUnitGraphic(transportUnits);
+		});
+
+		base._Process(delta);
+	}
+
+	private void RepositionFrame()
+	{
+		// Position frame and map relative to viewport
+		var boxSize = boxTransportRect.Texture.GetSize();
+		var vp = GetViewportRect().Size;
+		SetPosition(frameOffset + new Vector2(vp.X - boxSize.X, vp.Y - boxSize.Y));
+	}
+
+	private void ClearUnitSprites()
+	{
+		unitSpritesCache.Clear();
+		foreach (var c  in GetChildren().Where(c => c is Sprite2D))
+			c.QueueFree();
+	}
+	
+	private void UpdateUnitGraphic(ICollection<MapUnit> units) {
+		if (!units.Any(u => u != MapUnit.NONE && u != null)) {
+			return;
+		}
+
+		// Wait for game to load unit graphics
+		if (!AnimationManager.AnimationThumbnails.Any())
+			return;
+
+		foreach (var (unit, idx) in units.Select((x,i) => (x,i)))
+		{
+			if (unitSpritesCache.TryGetValue(unit.id, out var sprites)) {
+				continue;
+			}
+			
+			(var unitSprite, var unitTintSprite) = StatusUtils.GetUnitSprites(_game, unit);
+			unitSpritesCache[unit.id] = new Tuple<Sprite2D, Sprite2D>(unitSprite, unitTintSprite);
+
+			var unitSpritePosition = transportUnitsAnchor;
+			var unitSpriteDrawWidth = boxTransportRect.Texture.GetWidth() - transportUnitsAnchor.X;
+
+			unitSpritePosition.X += idx * unitSprite.Texture.GetWidth();
+
+			while (unitSpritePosition.X > unitSpriteDrawWidth)
+			{
+				unitSpritePosition.X -= unitSpriteDrawWidth;
+				unitSpritePosition.Y += unitSprite.Texture.GetHeight();
+			}
+			
+			unitSprite.Position = unitSpritePosition;
+			AddChild(unitSprite);
+			unitTintSprite.Position = unitSpritePosition;
+			AddChild(unitTintSprite);
+			
+			// unitSprite.Pressed += HandleBoxClick; // TODO: this won't work
+		}
+	}
+	
+	
+
+	private void HandleBoxClick() {
+		// EmitSignal(SignalName.CenterCameraOnActiveUnit);
+	}
+}

--- a/C7/UIElements/GameStatus/TransportInfoBox.cs
+++ b/C7/UIElements/GameStatus/TransportInfoBox.cs
@@ -14,17 +14,12 @@ public partial class TransportInfoBox : Civ3TextureRect {
 
 	private readonly Game _game;
 
-	private Vector2 transportUnitsAnchor = new Vector2(70f, 45f);
+	private Vector2 transportUnitsAnchor = new(70f, 45f);
 
 	private TextureRect boxTransportRect = new();
-	private TextureButton boxTransportRectButton = new();
-
-	private Label unitRank = new();
-	private Label unitType = new();
-
+	
 	private Dictionary<ID, Tuple<Sprite2D, Sprite2D>> unitSpritesCache = new();
-
-	private float extraXOffset = 7;
+	
 	private Vector2I frameOffset = new (-20, -175);
 
 	public TransportInfoBox(Game game) {
@@ -38,13 +33,6 @@ public partial class TransportInfoBox : Civ3TextureRect {
 		boxTransportRect.Texture = boxTransport;
 		boxTransportRect.SetPosition(new Vector2(0, 0));
 		AddChild(boxTransportRect);
-
-		// // An "invisible" button covering the inside area of the box so we can register the click
-		// // and center the camera on the unit or end the turn
-		// boxTransportRectButton.SetSize(new Vector2(228, 108));
-		// boxTransportRectButton.SetPosition(new Vector2(40, 17));
-		// AddChild(boxTransportRectButton);
-		// boxTransportRectButton.Pressed += HandleBoxClick;
 	}
 
 	public override void _Process(double delta) {
@@ -116,13 +104,12 @@ public partial class TransportInfoBox : Civ3TextureRect {
 			unitTintSprite.Position = unitSpritePosition;
 			AddChild(unitTintSprite);
 
-			// unitSprite.Pressed += HandleBoxClick; // TODO: this won't work
+			// unitSprite.Pressed += HandleBoxClick; // TODO: this won't work, need click targets
 		}
 	}
-
-
-
+	
 	private void HandleBoxClick() {
+		// TODO: Select unit based on click inside TransportInfoBox
 		// EmitSignal(SignalName.CenterCameraOnActiveUnit);
 	}
 }

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -3,6 +3,7 @@ using Godot;
 using C7GameData;
 using C7Engine;
 using System;
+using System.Linq;
 
 public partial class RightClickMenu : VBoxContainer {
 	protected Game game;
@@ -64,7 +65,7 @@ public partial class RightClickMenu : VBoxContainer {
 		};
 	}
 
-	public void AddItem(string text, System.Action action, Texture2D icon = null) {
+	public Button AddItem(string text, System.Action action, Texture2D icon = null) {
 		Button button = new Button();
 		button.Text = text;
 		if (icon != null) {
@@ -75,6 +76,7 @@ public partial class RightClickMenu : VBoxContainer {
 			button.Pressed += action;
 		}
 		this.AddChild(button);
+		return button;
 	}
 
 	public void RemoveAll() {
@@ -118,11 +120,23 @@ public partial class RightClickTileMenu : RightClickMenu {
 		return uiStates[unit.id];
 	}
 
+	private bool isUnitLoadedOnTransport(MapUnit unit) => unit.IsLoaded();
+
 	private string getUnitAction(MapUnit unit, bool isFortified) {
 		if (unit.owner == game.controller) {
 			return isFortified ? "Wake" : "Activate";
 		}
 		return "Contact";
+	}
+
+	private static StyleBoxFlat AltItemStyleBox(Color color) {
+		return new StyleBoxFlat() {
+			BgColor = color,
+			ContentMarginLeft = 20f,
+			ContentMarginTop = 2f,
+			ContentMarginRight = 4f,
+			ContentMarginBottom = 2f
+		};
 	}
 
 	// uiUpdatedUnitStates maps unit guid to a boolean that is true if they were fortified
@@ -146,11 +160,21 @@ public partial class RightClickTileMenu : RightClickMenu {
 		List<MapUnit> playerUnits = tile.unitsOnTile.FindAll(unit => unit.owner.id == game.controller.id || observerMode);
 		List<MapUnit> nonPlayerUnits = tile.unitsOnTile.FindAll(unit => unit.owner.id != game.controller.id && !observerMode);
 
+		// Sort by transport group
+		playerUnits = playerUnits
+			.GroupBy(u => u.CanTransport() ? u.id : u.loadedOnUnitId)
+			.OrderBy(x => x.Key)
+			.SelectMany(g => g.OrderBy(u => u.CanTransport() ? int.MinValue : 0))
+			.ToList();
+
 		foreach (MapUnit unit in playerUnits) {
 			bool isFortified = isUnitFortified(unit, uiUpdatedUnitStates);
 			fortifiedCount += isFortified ? 1 : 0;
 			string actionName = getUnitAction(unit, isFortified);
-			AddItem($"{actionName} {unit.Describe()}", () => SelectUnit(unit.id));
+			var menuItem = AddItem($"{actionName} {unit.Describe()}", () => SelectUnit(unit.id));
+
+			if (isUnitLoadedOnTransport(unit))
+				ApplyAltItemOverrides(menuItem);
 		}
 		int unfortifiedCount = playerUnits.Count - fortifiedCount;
 
@@ -205,6 +229,17 @@ public partial class RightClickTileMenu : RightClickMenu {
 			if (!nonPlayerUnits[0].owner.isBarbarians)
 				AddItem($"Contact {nonPlayerUnits[0].owner.civilization.name}", contactCiv);
 		}
+	}
+
+	private static void ApplyAltItemOverrides(Button menuItem) {
+		var grey = Color.Color8(64, 64, 64, 255);
+		menuItem.AddThemeColorOverride("font_color", grey);
+		menuItem.AddThemeColorOverride("font_hover_color", grey);
+		menuItem.AddThemeColorOverride("font_pressed_color", grey);
+		menuItem.AddThemeColorOverride("font_focus_color", grey);
+		menuItem.AddThemeStyleboxOverride("normal", AltItemStyleBox(Color.Color8(255, 247, 222, 255)));
+		menuItem.AddThemeStyleboxOverride("hover", AltItemStyleBox(Color.Color8(255, 189, 107, 255)));
+		menuItem.AddThemeStyleboxOverride("pressed", AltItemStyleBox(Color.Color8(140, 200, 200, 255)));
 	}
 
 	public void SelectUnit(ID id) {

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -162,8 +162,7 @@ public partial class RightClickTileMenu : RightClickMenu {
 
 		// Sort by transport group
 		playerUnits = playerUnits
-			.GroupBy(u => u.CanTransport() ? u.id : u.loadedOnUnitId)
-			.OrderBy(x => x.Key)
+			.GroupBy(u => u.CanTransport() ? u.id : u.loadedOnUnitId ?? ID.None("Other"))
 			.SelectMany(g => g.OrderBy(u => u.CanTransport() ? int.MinValue : 0))
 			.ToList();
 

--- a/C7/UIElements/SpriteUtils.cs
+++ b/C7/UIElements/SpriteUtils.cs
@@ -2,7 +2,7 @@ using C7.Textures;
 using C7GameData;
 using Godot;
 
-public static class StatusUtils {
+public static class SpriteUtils {
 	public static (Sprite2D unitSprite, Sprite2D unitTintSprite) GetUnitSprites(Game game, MapUnit unit) {
 		var am = game.animationController.civ3AnimData;
 

--- a/C7/UIElements/UnitButtons/UnitButtons.cs
+++ b/C7/UIElements/UnitButtons/UnitButtons.cs
@@ -56,8 +56,8 @@ public partial class UnitButtons : VBoxContainer {
 		// AddNewButton(primaryControls, C7Action.UnitSentryEnemyOnly);
 
 		//   ******* SPECIALIZED CONTROLS *************
-		// AddNewButton(specializedControls, "load");
-		// AddNewButton(specializedControls, "unload");
+		AddNewButton(specializedControls, C7Action.UnitLoad);
+		AddNewButton(specializedControls, C7Action.UnitUnload);
 		// AddNewButton(specializedControls, "pillage");
 		AddNewButton(specializedControls, C7Action.UnitBombard);
 		// AddNewButton(specializedControls, "autobombard");

--- a/C7/project.godot
+++ b/C7/project.godot
@@ -206,6 +206,16 @@ unit_bombard={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":66,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+unit_load={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":76,"key_label":0,"unicode":108,"location":0,"echo":false,"script":null)
+]
+}
+unit_unload={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":85,"key_label":0,"unicode":117,"location":0,"echo":false,"script":null)
+]
+}
 
 [mono]
 

--- a/C7Engine/Actions.cs
+++ b/C7Engine/Actions.cs
@@ -45,11 +45,15 @@ public static class C7Action {
 	public const string UnitSentry = "unit_sentry";
 	public const string UnitSentryEnemyOnly = "unit_sentry_enemy_only";
 	public const string UnitWait = "unit_wait";
+	public const string UnitLoad = "unit_load";
+	public const string UnitUnload = "unit_unload";
 
 	private static readonly Dictionary<string, UnitAction> toUnitAction = new() {
 		[UnitBuildCity] = UnitAction.BuildCity,
 		[UnitBombard] = UnitAction.Bombard,
 		[UnitHold] = UnitAction.Hold,
+		[UnitLoad] = UnitAction.Load,
+		[UnitUnload] = UnitAction.Unload,
 		[UnitWait] = UnitAction.Wait,
 		[UnitFortify] = UnitAction.Fortify,
 		[UnitDisband] = UnitAction.Disband,
@@ -83,6 +87,8 @@ public static class C7Action {
 		[UnitSentry] = "Sentry",
 		[UnitSentryEnemyOnly] = "Sentry Enemy Only",
 		[UnitWait] = "Wait",
+		[UnitLoad] = "Load",
+		[UnitUnload] = "Unload"
 	};
 
 	public static UnitAction? ToUnitAction(string action) {

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -1144,6 +1144,8 @@ namespace C7GameData {
 			if (prto.GoTo) yield return UnitAction.Goto;
 			if (prto.Explore) yield return UnitAction.Explore;
 			if (prto.Automate) yield return UnitAction.Automate;
+			if (prto.Load) yield return UnitAction.Load;
+			if (prto.Unload) yield return UnitAction.Unload;
 		}
 
 		private static IEnumerable<TerraformKey> GetUnitTerraforms(PRTO prto) {

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -1144,8 +1144,8 @@ namespace C7GameData {
 			if (prto.GoTo) yield return UnitAction.Goto;
 			if (prto.Explore) yield return UnitAction.Explore;
 			if (prto.Automate) yield return UnitAction.Automate;
-			if (prto.Load) yield return UnitAction.Load;
-			if (prto.Unload) yield return UnitAction.Unload;
+			// if (prto.Load) yield return UnitAction.Load;
+			// if (prto.Unload) yield return UnitAction.Unload;
 		}
 
 		private static IEnumerable<TerraformKey> GetUnitTerraforms(PRTO prto) {

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -1151,8 +1151,8 @@ namespace C7GameData {
 			if (prto.GoTo) yield return UnitAction.Goto;
 			if (prto.Explore) yield return UnitAction.Explore;
 			if (prto.Automate) yield return UnitAction.Automate;
-			// if (prto.Load) yield return UnitAction.Load;
-			// if (prto.Unload) yield return UnitAction.Unload;
+			if (prto.Load) yield return UnitAction.Load;
+			if (prto.Unload) yield return UnitAction.Unload;
 		}
 
 		private static IEnumerable<TerraformKey> GetUnitTerraforms(PRTO prto) {
@@ -1213,9 +1213,12 @@ namespace C7GameData {
 				prototype.bombard = prto.BombardStrength;
 				prototype.bombardRange = prto.BombardRange;
 				prototype.rateOfFire = prto.RateOfFire;
-				if (prto.TurnToAttack) {
-					prototype.flags.Add(SaveUnitPrototype.Flag.RotateBeforeAttack);
-				}
+
+				if (prto.TurnToAttack) prototype.flags.Add(SaveUnitPrototype.Flag.RotateBeforeAttack);
+
+				if (prto.CanCarryFootUnitsOnly) prototype.flags.Add(SaveUnitPrototype.Flag.CanCarryFootUnitsOnly);
+				if (prto.CanCarryAircraft) prototype.flags.Add(SaveUnitPrototype.Flag.CanCarryAircraft);
+				if (prto.CanCarryTacticalMissiles) prototype.flags.Add(SaveUnitPrototype.Flag.CanCarryTacticalMissiles);
 
 				prototype.actions.UnionWith(GetUnitActions(prto));
 				prototype.terraformActions.UnionWith(GetUnitTerraforms(prto).Select(tfKey => terraformIdByCiv3Key[tfKey]));

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -883,7 +883,11 @@ namespace C7GameData {
 			};
 		}
 
-		private void ImportSavUnits() {
+		private void ImportSavUnits()
+		{
+			var shadowIdMap = new Dictionary<int, ID>();
+			var loadMap = new Dictionary<ID, int>();
+			
 			foreach (QueryCiv3.Sav.UNIT unit in savData.Unit) {
 				if (unit.OwnerID < 0 || unit.OwnerID >= save.Players.Count) {
 					continue;
@@ -910,7 +914,17 @@ namespace C7GameData {
 					saveUnit.action = "fortified";
 				}
 
+				shadowIdMap[unit.ID] = saveUnit.id;
+				if (unit.LoadedOnUnitId > 0)
+					loadMap[saveUnit.id] = unit.LoadedOnUnitId;
+				
 				save.Units.Add(saveUnit);
+			}
+
+			foreach (var saveUnit in save.Units)
+			{
+				if (loadMap.TryGetValue(saveUnit.id, out var loadedOnUnitId))
+					saveUnit.loadedOnUnitId = shadowIdMap[loadedOnUnitId];
 			}
 		}
 
@@ -1186,6 +1200,7 @@ namespace C7GameData {
 				prototype.attack = prto.Attack;
 				prototype.defense = prto.Defense;
 				prototype.movement = prto.Movement;
+				prototype.capacity = prto.Capacity;
 				prototype.shieldCost = prto.ShieldCost;
 				prototype.populationCost = prto.PopulationCost;
 				prototype.bombard = prto.BombardStrength;

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -920,6 +920,10 @@ namespace C7GameData {
 				save.Units.Add(saveUnit);
 			}
 
+			// Civ3 saves have their own ID scheme.
+			// Here we translate one "loaded on" reference to another using information
+			// gathered above. Note that we can't be sure to be able to resolve identifiers
+			// until we have scanned all units. Hence a second pass for these mappings.
 			foreach (var saveUnit in save.Units) {
 				if (loadMap.TryGetValue(saveUnit.id, out var loadedOnUnitId))
 					saveUnit.loadedOnUnitId = shadowIdMap[loadedOnUnitId];

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -883,11 +883,10 @@ namespace C7GameData {
 			};
 		}
 
-		private void ImportSavUnits()
-		{
+		private void ImportSavUnits() {
 			var shadowIdMap = new Dictionary<int, ID>();
 			var loadMap = new Dictionary<ID, int>();
-			
+
 			foreach (QueryCiv3.Sav.UNIT unit in savData.Unit) {
 				if (unit.OwnerID < 0 || unit.OwnerID >= save.Players.Count) {
 					continue;
@@ -917,12 +916,11 @@ namespace C7GameData {
 				shadowIdMap[unit.ID] = saveUnit.id;
 				if (unit.LoadedOnUnitId > 0)
 					loadMap[saveUnit.id] = unit.LoadedOnUnitId;
-				
+
 				save.Units.Add(saveUnit);
 			}
 
-			foreach (var saveUnit in save.Units)
-			{
+			foreach (var saveUnit in save.Units) {
 				if (loadMap.TryGetValue(saveUnit.id, out var loadedOnUnitId))
 					saveUnit.loadedOnUnitId = shadowIdMap[loadedOnUnitId];
 			}

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -754,8 +754,15 @@ namespace C7GameData {
 				}
 				return false;
 			}
+
 			// TODO: to be modified to allow boarding on ships,
 			// that have the capacity and can take units of this kind
+			if (CanBoardTransportOnTile(tile))
+				return true;
+
+			if (CanUnboardTransportToTile(tile))
+				return true;
+
 			if (this.IsLandUnit() && !tile.IsLand())
 				return false;
 
@@ -809,6 +816,67 @@ namespace C7GameData {
 
 			return true;
 		}
+
+		private bool CanBoardTransportOnTile(Tile tile) {
+			var availableTransports = tile.unitsOnTile.Where(u => u.CanTransport());
+			foreach (var transport in availableTransports) {
+				if (transport.CanLoad(this))
+					return true;
+			}
+
+			return false;
+		}
+
+		private MapUnit SelectTransportToBoard(Tile tile) {
+			// TODO: Let human player choose via UI which transport to load unit in
+
+			var availableTransports = tile.unitsOnTile
+				.Where(u => u.CanTransport())
+				.Where(u => !u.IsFull());
+
+			// Sort candidates by free capacity, but prefer transports that already have units
+			availableTransports = availableTransports
+				.OrderBy(t => !t.IsEmpty())
+				.ThenByDescending(t => t.FreeCapacity());
+
+			foreach (var transport in availableTransports) {
+				if (transport.CanLoad(this))
+					return transport;
+			}
+
+			return null;
+		}
+
+		private MapUnit FindTransportToUnboard(Tile tile, ID transport) {
+			return tile.unitsOnTile.FirstOrDefault(t => t.id == transport);
+		}
+
+		private bool CanLoad(MapUnit mapUnit) {
+			if (owner != mapUnit.owner)
+				return false;
+
+			var hasRoom = !IsFull();
+
+			// TODO: type restrictions: only subs can carry nukes, etc.
+			var suitableUnit = mapUnit.IsLandUnit();  // only land units in transports for now
+			return hasRoom && suitableUnit;
+		}
+
+		private bool CanUnboardTransportToTile(Tile tile) {
+			var isLoaded = this.loadedOnUnitId != null;
+			var isValidLanding = tile.IsLand() && this.IsLandUnit(); // TODO: other cases
+																	 // TODO: transport chaining?
+
+			return isLoaded && isValidLanding;
+		}
+
+		private int FreeCapacity() {
+			var loaded = this.location.unitsOnTile.Where(u => u.IsLoadedIn(this)).ToList();
+			return this.unitType.capacity - loaded.Count;
+		}
+
+		private bool IsEmpty() => unitType.capacity > 0 && FreeCapacity() == unitType.capacity;
+		private bool IsFull() => unitType.capacity > 0 && FreeCapacity() == 0;
 
 		private static bool HasHostileUnits(Tile tile, Player player) {
 			foreach (MapUnit other in tile.unitsOnTile) {
@@ -872,12 +940,12 @@ namespace C7GameData {
 				facingDirection = dir;
 				float movementCost = TilePath.GetMovementCost(this.owner, location, dir, newLoc);
 
-				// Leave old tile 
+				// Leave old tile
 				if (!location.unitsOnTile.Remove(this))
 					throw new System.Exception("Failed to remove unit from tile it's supposed to be on");
 
+				// Move transported units, too
 				if (CanTransport()) {
-					// Move transported units
 					var transported = location.unitsOnTile
 						.Where(u => u.IsLoadedIn(this)).ToList();
 
@@ -887,6 +955,22 @@ namespace C7GameData {
 						newLoc.unitsOnTile.Add(tu);
 						tu.location = newLoc;
 					}
+				}
+
+				// Board transport, as needed
+				if (CanBoardTransportOnTile(newLoc)) {
+					var t = SelectTransportToBoard(newLoc);
+					if (t == null)
+						throw new System.Exception("Failed to find a transport to move to");
+					t.board(this);
+				}
+
+				// Unboard transport, as needed
+				if (CanUnboardTransportToTile(newLoc)) {
+					var t = FindTransportToUnboard(this.location, this.loadedOnUnitId);
+					if (t == null)
+						throw new System.Exception("Failed to find the transport to unboard from");
+					t.unboard(this);
 				}
 
 				// Enter new tile
@@ -903,6 +987,25 @@ namespace C7GameData {
 				movementPoints.onUnitMove(movementCost);
 			}
 			return true;
+		}
+
+
+		/// <summary>
+		/// Boards unit into this transport
+		/// </summary>
+		/// <param name="mapUnit">The unit to load on a transport</param>
+		private void board(MapUnit mapUnit) {
+			mapUnit.loadedOnUnitId = this.id;
+			// TODO: consume moves?
+		}
+
+		/// <summary>
+		/// Unloads a unit from this transport
+		/// </summary>
+		/// <param name="mapUnit">The unit to unload from a transport</param>
+		private void unboard(MapUnit mapUnit) {
+			mapUnit.loadedOnUnitId = null;
+			// TODO: consume moves?
 		}
 
 		private float SumWorkerProgress(Tile tile, Terraform workerJob) {

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -977,7 +977,8 @@ namespace C7GameData {
 		}
 
 		public void TryBoardingTransportOnTile(Tile newLoc) {
-			if (!CanBoardTransportOnTile(newLoc))
+			var enteringCity = newLoc.HasCity && newLoc != location;
+			if (enteringCity || !CanBoardTransportOnTile(newLoc))
 				return;
 
 			var t = SelectTransportToBoard(newLoc);

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -985,8 +985,11 @@ namespace C7GameData {
 		}
 
 		public void BoardTransport(MapUnit t) {
-			if (t == null)
-				throw new System.Exception("Failed to find a transport to move to");
+			if (t == null) {
+				// TODO: throw new System.Exception("Failed to find a transport to move to");
+				Log.Warning("Failed to find a transport to board");
+				return;
+			}
 			t.board(this);
 			isFortified = true;
 			if (this.owner.isHuman)
@@ -1002,8 +1005,11 @@ namespace C7GameData {
 		}
 
 		public void UnboardTransport(MapUnit t) {
-			if (t == null)
-				throw new System.Exception("Failed to find the transport to unboard from");
+			if (t == null) {
+				// TODO: throw new System.Exception("Failed to find the transport to unboard from");
+				Log.Warning("Failed to find a transport to unboard");
+				return;
+			}
 			t.unboard(this);
 			wake();
 			if (this.owner.isHuman)

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -90,7 +90,11 @@ namespace C7GameData {
 		}
 
 		public bool CanTransport() {
-			return this.unitType.capacity > 0;
+			return this.unitType.capacity > 0 && this.unitType.actions.Contains(UnitAction.Unload);
+		}
+
+		public bool IsLoadable() {
+			return this.unitType.actions.Contains(UnitAction.Load);
 		}
 
 		public bool IsLoaded() {
@@ -865,9 +869,12 @@ namespace C7GameData {
 			if (owner != mapUnit.owner)
 				return false;
 
+			if (!mapUnit.IsLoadable())
+				return false;
+
 			var hasRoom = !IsFull();
 
-			// TODO: type restrictions: only subs can carry nukes, etc.
+			// TODO: type restrictions: only subs can carry nukes, carriers take aircraft, etc.
 			var suitableUnit = mapUnit.IsLandUnit();  // only land units in transports for now
 			return hasRoom && suitableUnit;
 		}

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -51,6 +51,8 @@ namespace C7GameData {
 
 		public float WorkerProgressTowardsJob { get; set; }
 		public Terraform WorkerJob { get; set; }
+		
+		public ID loadedOnUnitId { get; set; }
 
 		public UnitAI currentAI;
 
@@ -85,6 +87,15 @@ namespace C7GameData {
 
 		public bool IsCaptive() {
 			return !string.Equals(this.nationality.name, this.owner.civilization.name, StringComparison.CurrentCultureIgnoreCase);
+		}
+		
+		public bool CanTransport() {
+			return this.unitType.capacity > 0;
+		}
+		
+		public bool IsLoadedIn(MapUnit transport)
+		{
+			return transport.id == this.loadedOnUnitId;
 		}
 
 		public override string ToString() {

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -957,23 +957,8 @@ namespace C7GameData {
 					}
 				}
 
-				// Board transport, as needed
-				if (CanBoardTransportOnTile(newLoc)) {
-					var t = SelectTransportToBoard(newLoc);
-					if (t == null)
-						throw new System.Exception("Failed to find a transport to move to");
-					t.board(this);
-					isFortified = true;
-				}
-
-				// Unboard transport, as needed
-				if (CanUnboardTransportToTile(newLoc)) {
-					var t = FindTransportToUnboard(this.location, this.loadedOnUnitId);
-					if (t == null)
-						throw new System.Exception("Failed to find the transport to unboard from");
-					t.unboard(this);
-					wake();
-				}
+				TryBoardingTransportOnTile(newLoc);
+				TryUnboardingTransportToTile(newLoc);
 
 				// Enter new tile
 				// Make sure the unit is on the new location before claiming we have entered the tile
@@ -991,6 +976,39 @@ namespace C7GameData {
 			return true;
 		}
 
+		public void TryBoardingTransportOnTile(Tile newLoc) {
+			if (!CanBoardTransportOnTile(newLoc))
+				return;
+
+			var t = SelectTransportToBoard(newLoc);
+			BoardTransport(t);
+		}
+
+		public void BoardTransport(MapUnit t) {
+			if (t == null)
+				throw new System.Exception("Failed to find a transport to move to");
+			t.board(this);
+			isFortified = true;
+			if (this.owner.isHuman)
+				new MsgUnitMoved(this).send();
+		}
+
+		public void TryUnboardingTransportToTile(Tile newLoc) {
+			if (!CanUnboardTransportToTile(newLoc))
+				return;
+
+			var t = FindTransportToUnboard(this.location, this.loadedOnUnitId);
+			UnboardTransport(t);
+		}
+
+		public void UnboardTransport(MapUnit t) {
+			if (t == null)
+				throw new System.Exception("Failed to find the transport to unboard from");
+			t.unboard(this);
+			wake();
+			if (this.owner.isHuman)
+				new MsgUnitMoved(this).send();
+		}
 
 		/// <summary>
 		/// Boards unit into this transport
@@ -1235,6 +1253,13 @@ namespace C7GameData {
 			}
 			if (canAutomate()) {
 				result.Add(UnitAction.Automate);
+			}
+
+			if (CanBoardTransportOnTile(this.location) && this.loadedOnUnitId == null) {
+				result.Add(UnitAction.Load);
+			}
+			if (CanUnboardTransportToTile(this.location) && this.location.HasCity) {
+				result.Add(UnitAction.Unload);
 			}
 
 			// Eventually we will have advanced actions too, whose availability will rely on their base actions' availability.

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -224,13 +224,17 @@ namespace C7GameData {
 		}
 
 		public void fortify() {
-			facingDirection = TileDirection.SOUTHEAST;
+			ResetFacingDirection();
 			isFortified = true;
 			animate(MapUnit.AnimatedAction.FORTIFY);
 		}
 
 		public void wake() {
 			isFortified = false;
+		}
+
+		public void ResetFacingDirection() {
+			facingDirection = TileDirection.SOUTHEAST;
 		}
 
 		public IEnumerable<StrengthBonus> ListStrengthBonusesVersus(MapUnit opponent, CombatRole role, TileDirection? attackDirection) {

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -963,6 +963,7 @@ namespace C7GameData {
 					if (t == null)
 						throw new System.Exception("Failed to find a transport to move to");
 					t.board(this);
+					isFortified = true;
 				}
 
 				// Unboard transport, as needed
@@ -971,6 +972,7 @@ namespace C7GameData {
 					if (t == null)
 						throw new System.Exception("Failed to find the transport to unboard from");
 					t.unboard(this);
+					wake();
 				}
 
 				// Enter new tile

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -769,12 +769,10 @@ namespace C7GameData {
 				return false;
 			}
 
-			// TODO: to be modified to allow boarding on ships,
-			// that have the capacity and can take units of this kind
 			if (CanBoardTransportOnTile(tile))
 				return true;
 
-			if (CanUnboardTransportToTile(tile))
+			if (CanUnloadToTile(tile))
 				return true;
 
 			if (this.IsLandUnit() && !tile.IsLand())
@@ -832,6 +830,9 @@ namespace C7GameData {
 		}
 
 		private bool CanBoardTransportOnTile(Tile tile) {
+			if (!IsLoadable())
+				return false;
+
 			var availableTransports = tile.unitsOnTile.Where(u => u.CanTransport());
 			foreach (var transport in availableTransports) {
 				if (transport.CanLoad(this))
@@ -839,6 +840,10 @@ namespace C7GameData {
 			}
 
 			return false;
+		}
+
+		private bool CanUnboardTransportToTile(Tile tile) {
+			return IsLoadable() && IsLoaded() && tile.IsLand();
 		}
 
 		private MapUnit SelectTransportToBoard(Tile tile) {
@@ -879,15 +884,18 @@ namespace C7GameData {
 			return hasRoom && suitableUnit;
 		}
 
-		private bool CanUnboardTransportToTile(Tile tile) {
-			var isLoaded = this.loadedOnUnitId != null;
-			var isValidLanding = tile.IsLand() && this.IsLandUnit(); // TODO: other cases
-																	 // TODO: transport chaining?
+		// TODO: Transport chaining
+		// TODO: Amphibious assault
 
-			return isLoaded && isValidLanding;
+		private bool CanUnloadToTile(Tile tile) {
+			if (!CanTransport())
+				return false;
+
+			var isValidLanding = tile.IsLand();
+			return !IsEmpty() && isValidLanding;
 		}
 
-		private int FreeCapacity() {
+		public int FreeCapacity() {
 			var loaded = this.location.unitsOnTile.Where(u => u.IsLoadedIn(this)).ToList();
 			return this.unitType.capacity - loaded.Count;
 		}
@@ -1002,6 +1010,14 @@ namespace C7GameData {
 			BoardTransport(t);
 		}
 
+		public void TryUnboardingTransportToTile(Tile newLoc) {
+			if (!CanUnboardTransportToTile(newLoc))
+				return;
+
+			var t = FindTransportToUnboard(this.location, this.loadedOnUnitId);
+			UnboardTransport(t);
+		}
+
 		public void BoardTransport(MapUnit t) {
 			if (t == null) {
 				// TODO: throw new System.Exception("Failed to find a transport to move to");
@@ -1010,16 +1026,9 @@ namespace C7GameData {
 			}
 			t.board(this);
 			isFortified = true;
+			ResetFacingDirection();
 			if (this.owner.isHuman)
 				new MsgUnitMoved(this).send();
-		}
-
-		public void TryUnboardingTransportToTile(Tile newLoc) {
-			if (!CanUnboardTransportToTile(newLoc))
-				return;
-
-			var t = FindTransportToUnboard(this.location, this.loadedOnUnitId);
-			UnboardTransport(t);
 		}
 
 		public void UnboardTransport(MapUnit t) {
@@ -1282,7 +1291,7 @@ namespace C7GameData {
 			if (CanBoardTransportOnTile(this.location) && this.loadedOnUnitId == null) {
 				result.Add(UnitAction.Load);
 			}
-			if (CanUnboardTransportToTile(this.location) && this.location.HasCity) {
+			if (CanUnloadToTile(this.location) && this.location.HasCity) {
 				result.Add(UnitAction.Unload);
 			}
 

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -51,7 +51,7 @@ namespace C7GameData {
 
 		public float WorkerProgressTowardsJob { get; set; }
 		public Terraform WorkerJob { get; set; }
-		
+
 		public ID loadedOnUnitId { get; set; }
 
 		public UnitAI currentAI;
@@ -88,13 +88,16 @@ namespace C7GameData {
 		public bool IsCaptive() {
 			return !string.Equals(this.nationality.name, this.owner.civilization.name, StringComparison.CurrentCultureIgnoreCase);
 		}
-		
+
 		public bool CanTransport() {
 			return this.unitType.capacity > 0;
 		}
-		
-		public bool IsLoadedIn(MapUnit transport)
-		{
+
+		public bool IsLoaded() {
+			return this.loadedOnUnitId != null;
+		}
+
+		public bool IsLoadedIn(MapUnit transport) {
 			return transport.id == this.loadedOnUnitId;
 		}
 
@@ -868,8 +871,25 @@ namespace C7GameData {
 
 				facingDirection = dir;
 				float movementCost = TilePath.GetMovementCost(this.owner, location, dir, newLoc);
+
+				// Leave old tile 
 				if (!location.unitsOnTile.Remove(this))
 					throw new System.Exception("Failed to remove unit from tile it's supposed to be on");
+
+				if (CanTransport()) {
+					// Move transported units
+					var transported = location.unitsOnTile
+						.Where(u => u.IsLoadedIn(this)).ToList();
+
+					foreach (var tu in transported) {
+						if (!location.unitsOnTile.Remove(tu))
+							throw new System.Exception("Failed to remove unit from tile during transport move");
+						newLoc.unitsOnTile.Add(tu);
+						tu.location = newLoc;
+					}
+				}
+
+				// Enter new tile
 				// Make sure the unit is on the new location before claiming we have entered the tile
 				newLoc.unitsOnTile.Add(this);
 				location = newLoc;

--- a/C7Engine/C7GameData/Save/SaveUnit.cs
+++ b/C7Engine/C7GameData/Save/SaveUnit.cs
@@ -37,6 +37,7 @@ namespace C7GameData.Save {
 				previousLocation = new TileLocation(unit.previousLocation);
 			}
 			currentLocation = new TileLocation(unit.location);
+			loadedOnUnitId = unit.loadedOnUnitId;
 			if (unit.path?.PathLength() > 0) {
 				path = unit.path.path.ToList().ConvertAll(tile => new TileLocation(tile));
 			}

--- a/C7Engine/C7GameData/Save/SaveUnit.cs
+++ b/C7Engine/C7GameData/Save/SaveUnit.cs
@@ -19,6 +19,7 @@ namespace C7GameData.Save {
 		public string experience;
 		public float WorkerProgressTowardsJob;
 		public ID WorkerJob;
+		public ID loadedOnUnitId;
 
 		// True for multiple types of automation, including worker automation
 		// and automated exploring.
@@ -58,6 +59,7 @@ namespace C7GameData.Save {
 				experienceLevel = experienceLevels.Find(el => el.key == experience),
 				owner = players.Find(player => player.id == owner),
 				location = map.tileAt(currentLocation.X, currentLocation.Y),
+				loadedOnUnitId = loadedOnUnitId,
 				previousLocation = currentLocation.X == - 1 ? Tile.NONE : map.tileAt(previousLocation.X, previousLocation.Y),
 				hitPointsRemaining = hitPointsRemaining,
 				movementPoints = new MovementPoints(),

--- a/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
+++ b/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
@@ -5,6 +5,9 @@ namespace C7GameData.Save {
 	public class SaveUnitPrototype {
 		public enum Flag {
 			RotateBeforeAttack,
+			CanCarryFootUnitsOnly,
+			CanCarryAircraft,
+			CanCarryTacticalMissiles
 		}
 
 		public string name { get; set; }

--- a/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
+++ b/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
@@ -18,6 +18,7 @@ namespace C7GameData.Save {
 		public int bombardRange { get; set; }
 		public int rateOfFire { get; set; }
 		public int movement { get; set; }
+		public int capacity { get; set; }
 
 		public HashSet<string> producibleBy = [];
 
@@ -42,9 +43,10 @@ namespace C7GameData.Save {
 
 		public SaveUnitPrototype(UnitPrototype proto) {
 			(name, art, shieldCost, populationCost, unproducible,
-			attack, defense, bombard, bombardRange, rateOfFire, movement) =
+			attack, defense, bombard, bombardRange, rateOfFire, movement, capacity) =
 			(proto.name, proto.art, proto.shieldCost, proto.populationCost, proto.unproducible,
-			 proto.attack, proto.defense, proto.bombard, proto.bombardRange, proto.rateOfFire, proto.movement);
+			 proto.attack, proto.defense, proto.bombard, proto.bombardRange, proto.rateOfFire, proto.movement,
+			 proto.capacity);
 
 			if (proto.requiredTech != null)
 				requiredTech = proto.requiredTech.id;

--- a/C7Engine/C7GameData/UnitPrototype.cs
+++ b/C7Engine/C7GameData/UnitPrototype.cs
@@ -92,14 +92,13 @@ namespace C7GameData {
 
 		public UnitPrototype() { }
 
-		public UnitPrototype(SaveUnitPrototype proto, IEnumerable<Terraform> terraforms)
-		{
+		public UnitPrototype(SaveUnitPrototype proto, IEnumerable<Terraform> terraforms) {
 			(name, art, shieldCost, populationCost)
 				= (proto.name, proto.art, proto.shieldCost, proto.populationCost);
 
 			(attack, defense, bombard, bombardRange, rateOfFire)
 				= (proto.attack, proto.defense, proto.bombard, proto.bombardRange, proto.rateOfFire);
-				
+
 			(movement, capacity, unproducible) =
 				(proto.movement, proto.capacity, proto.unproducible);
 

--- a/C7Engine/C7GameData/UnitPrototype.cs
+++ b/C7Engine/C7GameData/UnitPrototype.cs
@@ -15,7 +15,9 @@ namespace C7GameData {
 		Disband,
 		Goto,
 		Explore,
-		Automate
+		Automate,
+		Load,
+		Unload
 	}
 
 	public struct ItemContext(UnitPrototype proto, Player player) {

--- a/C7Engine/C7GameData/UnitPrototype.cs
+++ b/C7Engine/C7GameData/UnitPrototype.cs
@@ -62,6 +62,7 @@ namespace C7GameData {
 		public int bombardRange { get; set; }
 		public int rateOfFire { get; set; }
 		public int movement { get; set; }
+		public int capacity { get; set; }
 		public HashSet<Civilization> producibleBy { get; set; } = [];
 		public UnitPrototype upgradeTo;
 		public bool unproducible;
@@ -91,10 +92,16 @@ namespace C7GameData {
 
 		public UnitPrototype() { }
 
-		public UnitPrototype(SaveUnitPrototype proto, IEnumerable<Terraform> terraforms) {
-			(name, art, shieldCost, populationCost, attack, defense, bombard, bombardRange, rateOfFire, movement, unproducible) =
-			(proto.name, proto.art, proto.shieldCost, proto.populationCost,
-			 proto.attack, proto.defense, proto.bombard, proto.bombardRange, proto.rateOfFire, proto.movement, proto.unproducible);
+		public UnitPrototype(SaveUnitPrototype proto, IEnumerable<Terraform> terraforms)
+		{
+			(name, art, shieldCost, populationCost)
+				= (proto.name, proto.art, proto.shieldCost, proto.populationCost);
+
+			(attack, defense, bombard, bombardRange, rateOfFire)
+				= (proto.attack, proto.defense, proto.bombard, proto.bombardRange, proto.rateOfFire);
+				
+			(movement, capacity, unproducible) =
+				(proto.movement, proto.capacity, proto.unproducible);
 
 			categories = new HashSet<string>(proto.categories);
 			actions = proto.actions;

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -119,23 +119,23 @@ namespace C7Engine {
 		}
 	}
 
-	public class MsgUnloadFromTransport : MessageToEngine {
-		private ID unitID;
+	public class MsgUnloadTransport : MessageToEngine {
 		private ID transportUnitId;
 
-		public MsgUnloadFromTransport(ID unitID, ID transportUnitId = null) {
-			this.unitID = unitID;
+		public MsgUnloadTransport(ID transportUnitId) {
 			this.transportUnitId = transportUnitId;
 		}
 
 		public override void process() {
-			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
-			MapUnit transportUnit;
-			if (this.transportUnitId != null) {
-				transportUnit = EngineStorage.gameData.GetUnit(transportUnitId);
-				unit.UnboardTransport(transportUnit);
-			} else
-				unit.TryUnboardingTransportToTile(unit.location);
+			// TODO: more selective unload, let human player choose
+			MapUnit transportUnit = EngineStorage.gameData.GetUnit(transportUnitId);
+			foreach (MapUnit unit in transportUnit.location.unitsOnTile) {
+				if (unit.loadedOnUnitId == transportUnit.id) {
+					unit.UnboardTransport(transportUnit);
+				}
+			}
+			new
+				MsgTransportUnloaded(transportUnit).send();
 		}
 	}
 

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -99,6 +99,46 @@ namespace C7Engine {
 		}
 	}
 
+	public class MsgLoadToTransport : MessageToEngine {
+		private ID unitID;
+		private ID transportUnitId;
+
+		public MsgLoadToTransport(ID unitID, ID transportUnitId = null) {
+			this.unitID = unitID;
+			this.transportUnitId = transportUnitId;
+		}
+
+		public override void process() {
+			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
+			MapUnit transportUnit;
+			if (this.transportUnitId != null) {
+				transportUnit = EngineStorage.gameData.GetUnit(transportUnitId);
+				unit.BoardTransport(transportUnit);
+			} else
+				unit.TryBoardingTransportOnTile(unit.location);
+		}
+	}
+
+	public class MsgUnloadFromTransport : MessageToEngine {
+		private ID unitID;
+		private ID transportUnitId;
+
+		public MsgUnloadFromTransport(ID unitID, ID transportUnitId = null) {
+			this.unitID = unitID;
+			this.transportUnitId = transportUnitId;
+		}
+
+		public override void process() {
+			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
+			MapUnit transportUnit;
+			if (this.transportUnitId != null) {
+				transportUnit = EngineStorage.gameData.GetUnit(transportUnitId);
+				unit.UnboardTransport(transportUnit);
+			} else
+				unit.TryUnboardingTransportToTile(unit.location);
+		}
+	}
+
 	// A generic class that allows the UI to have the game engine run some
 	// action, assumed to be on a unit.
 	//

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -148,4 +148,11 @@ namespace C7Engine {
 			this.Unit = unit;
 		}
 	}
+
+	public class MsgTransportUnloaded : MessageToUI {
+		public MapUnit Unit;
+		public MsgTransportUnloaded(MapUnit unit) {
+			this.Unit = unit;
+		}
+	}
 }

--- a/QueryCiv3/BiqSections/Prto.cs
+++ b/QueryCiv3/BiqSections/Prto.cs
@@ -92,13 +92,13 @@ namespace QueryCiv3.Biq {
 		public bool Amphibious { get => Util.GetFlag(Flags1[0], 6); }
 		public bool Submarine { get => Util.GetFlag(Flags1[0], 7); }
 
-		public bool AircraftCarrier { get => Util.GetFlag(Flags1[1], 0); }
+		public bool CanCarryAircraft { get => Util.GetFlag(Flags1[1], 0); }
 		public bool Draft { get => Util.GetFlag(Flags1[1], 1); }
 		public bool Immobile { get => Util.GetFlag(Flags1[1], 2); }
 		public bool SinkInSea { get => Util.GetFlag(Flags1[1], 3); }
 		public bool SinkInOcean { get => Util.GetFlag(Flags1[1], 4); }
 		// unused
-		public bool CarryFootUnitsOnly { get => Util.GetFlag(Flags1[1], 6); }
+		public bool CanCarryFootUnitsOnly { get => Util.GetFlag(Flags1[1], 6); }
 		public bool StartsGoldenAge { get => Util.GetFlag(Flags1[1], 7); }
 
 		public bool NuclearWeapon { get => Util.GetFlag(Flags1[2], 0); }


### PR DESCRIPTION
Add basic support for transport mechanic: loading and unloading units from a vehicle with transport capacity.

- Add UI element to show transport contents
- Extend C7 and unit actions with load/unload
- Add engine message for load/unload
- Load unit load status from Civ3 saves
- Adjust MapUnit `move(..)` to allow load/unload
- Adjust MapUnit `move(..)` so transports can move other units
- Adjust tile unit display to prioritise transport over strongest defender, when out to sea
- Adjust tile context menu to highlight transport-loaded units
- Add load and unload buttons, with keyboard shortcuts (`L`/`U`)
- Extend base ruleset with capacity (+patch missing/misplaced things)

## Manual

**Loading and Unloading**
You can have a ship wait until it is loaded to capacity with units by clicking the Load order or pressing [L]. Boarding a
ship uses up all a unit’s movement points for the turn. If you attempt to move a naval unit into a land square that does not contain a port city, any passengers who have not already moved this turn are offered the option to disembark and make landfall. You can also order a ship to unload all its passengers by clicking the Unload order or pressing [L].

## Demo

<img width="800" height="500" alt="transport_basic" src="https://github.com/user-attachments/assets/6993dbe8-d7a7-48b7-9558-3ef054bad6ae" />
