### PR TITLE
Cleaning up base ruleset drift

### DIFF
--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -960,7 +960,9 @@
         "Hittites",
         "Portugal"
       ],
-      "upgradeTo": "Explorer",
+      "upgradesTo": [
+        "Explorer"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -1242,7 +1244,12 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Swordsman",
+      "upgradesTo": [
+        "Gallic Swordsman",
+        "Immortals",
+        "Legionary",
+        "Swordsman"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -1310,7 +1317,10 @@
         "Byzantines",
         "Inca"
       ],
-      "upgradeTo": "Longbowman",
+      "upgradesTo": [
+        "Berserk",
+        "Longbowman"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -1376,7 +1386,10 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Pikeman",
+      "upgradesTo": [
+        "Musketman",
+        "Pikeman"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -1443,7 +1456,9 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Medieval Infantry",
+      "upgradesTo": [
+        "Medieval Infantry"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -1514,7 +1529,10 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Horseman",
+      "upgradesTo": [
+        "Horseman",
+        "Mounted Warrior"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -1587,7 +1605,15 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Knight",
+      "upgradesTo": [
+        "Ansar Warrior",
+        "Keshik",
+        "Knight",
+        "Rider",
+        "Samurai",
+        "Three-Man Chariot",
+        "War Elephant"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -1657,7 +1683,10 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Musketman",
+      "upgradesTo": [
+        "Musketeer",
+        "Musketman"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -1729,7 +1758,9 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Guerilla",
+      "upgradesTo": [
+        "Guerilla"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -1798,7 +1829,10 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Rifleman",
+      "upgradesTo": [
+        "Rifleman",
+        "Swiss Mercenary"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -1866,7 +1900,11 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Cavalry",
+      "upgradesTo": [
+        "Cavalry",
+        "Cossack",
+        "Sipahi"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -1940,7 +1978,9 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Infantry",
+      "upgradesTo": [
+        "Infantry"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -2081,7 +2121,9 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Mech Infantry",
+      "upgradesTo": [
+        "Mech Infantry"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -2153,7 +2195,9 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Modern Armor",
+      "upgradesTo": [
+        "Modern Armor"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -2373,7 +2417,9 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Trebuchet",
+      "upgradesTo": [
+        "Trebuchet"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -2444,7 +2490,10 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Artillery",
+      "upgradesTo": [
+        "Artillery",
+        "Hwach'a"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -2519,7 +2568,9 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Radar Artillery",
+      "upgradesTo": [
+        "Radar Artillery"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -2884,7 +2935,10 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Caravel",
+      "upgradesTo": [
+        "Caravel",
+        "Carrack"
+      ],
       "unproducible": false,
       "flags": [
         "rotateBeforeAttack"
@@ -2956,7 +3010,9 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Galleon",
+      "upgradesTo": [
+        "Galleon"
+      ],
       "unproducible": false,
       "flags": [
         "rotateBeforeAttack"
@@ -3105,7 +3161,9 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Transport",
+      "upgradesTo": [
+        "Transport"
+      ],
       "unproducible": false,
       "flags": [
         "rotateBeforeAttack"
@@ -3178,7 +3236,9 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Destroyer",
+      "upgradesTo": [
+        "Destroyer"
+      ],
       "unproducible": false,
       "categories": [
         "Sea"
@@ -3764,7 +3824,10 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Jet Fighter",
+      "upgradesTo": [
+        "F-15",
+        "Jet Fighter"
+      ],
       "unproducible": false,
       "categories": [
         "Air"
@@ -4318,7 +4381,9 @@
       "producibleBy": [
         "Aztecs"
       ],
-      "upgradeTo": "Swordsman",
+      "upgradesTo": [
+        "Swordsman"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -4358,9 +4423,10 @@
       "producibleBy": [
         "Babylon"
       ],
-      "upgradeTo": "Longbowman",
+      "upgradesTo": [
+        "Longbowman"
+      ],
       "unproducible": false,
-      "variantOf": "Archer",
       "categories": [
         "Land"
       ],
@@ -4399,9 +4465,10 @@
       "producibleBy": [
         "Greece"
       ],
-      "upgradeTo": "Musketman",
+      "upgradesTo": [
+        "Musketman"
+      ],
       "unproducible": false,
-      "variantOf": "Pikeman",
       "categories": [
         "Land"
       ],
@@ -4440,9 +4507,10 @@
       "producibleBy": [
         "Zululand"
       ],
-      "upgradeTo": "Musketman",
+      "upgradesTo": [
+        "Musketman"
+      ],
       "unproducible": false,
-      "variantOf": "Spearman",
       "categories": [
         "Land"
       ],
@@ -4481,9 +4549,10 @@
       "producibleBy": [
         "Rome"
       ],
-      "upgradeTo": "Medieval Infantry",
+      "upgradesTo": [
+        "Medieval Infantry"
+      ],
       "unproducible": false,
-      "variantOf": "Swordsman",
       "categories": [
         "Land"
       ],
@@ -4525,9 +4594,10 @@
       "producibleBy": [
         "Persia"
       ],
-      "upgradeTo": "Guerilla",
+      "upgradesTo": [
+        "Guerilla"
+      ],
       "unproducible": false,
-      "variantOf": "Medieval Infantry",
       "categories": [
         "Land"
       ],
@@ -4569,9 +4639,10 @@
       "producibleBy": [
         "Egypt"
       ],
-      "upgradeTo": "Knight",
+      "upgradesTo": [
+        "Knight"
+      ],
       "unproducible": false,
-      "variantOf": "Chariot",
       "categories": [
         "Land"
       ],
@@ -4613,9 +4684,10 @@
       "producibleBy": [
         "China"
       ],
-      "upgradeTo": "Cavalry",
+      "upgradesTo": [
+        "Cavalry"
+      ],
       "unproducible": false,
-      "variantOf": "Knight",
       "categories": [
         "Land"
       ],
@@ -4658,9 +4730,10 @@
       "producibleBy": [
         "Iroquois"
       ],
-      "upgradeTo": "Knight",
+      "upgradesTo": [
+        "Knight"
+      ],
       "unproducible": false,
-      "variantOf": "Horseman",
       "categories": [
         "Land"
       ],
@@ -4702,9 +4775,10 @@
       "producibleBy": [
         "France"
       ],
-      "upgradeTo": "Rifleman",
+      "upgradesTo": [
+        "Rifleman"
+      ],
       "unproducible": false,
-      "variantOf": "Musketman",
       "categories": [
         "Land"
       ],
@@ -4746,9 +4820,10 @@
       "producibleBy": [
         "Japan"
       ],
-      "upgradeTo": "Cavalry",
+      "upgradesTo": [
+        "Cavalry"
+      ],
       "unproducible": false,
-      "variantOf": "Knight",
       "categories": [
         "Land"
       ],
@@ -4790,9 +4865,10 @@
       "producibleBy": [
         "India"
       ],
-      "upgradeTo": "Cavalry",
+      "upgradesTo": [
+        "Cavalry"
+      ],
       "unproducible": false,
-      "variantOf": "Knight",
       "categories": [
         "Land"
       ],
@@ -4832,7 +4908,6 @@
         "Russia"
       ],
       "unproducible": false,
-      "variantOf": "Cavalry",
       "categories": [
         "Land"
       ],
@@ -4875,9 +4950,10 @@
       "producibleBy": [
         "Germany"
       ],
-      "upgradeTo": "Modern Armor",
+      "upgradesTo": [
+        "Modern Armor"
+      ],
       "unproducible": false,
-      "variantOf": "Tank",
       "categories": [
         "Land"
       ],
@@ -4968,7 +5044,6 @@
         "America"
       ],
       "unproducible": false,
-      "variantOf": "Jet Fighter",
       "categories": [
         "Air"
       ],
@@ -5085,9 +5160,10 @@
       "producibleBy": [
         "Mongols"
       ],
-      "upgradeTo": "Cavalry",
+      "upgradesTo": [
+        "Cavalry"
+      ],
       "unproducible": false,
-      "variantOf": "Knight",
       "categories": [
         "Land"
       ],
@@ -5130,7 +5206,6 @@
         "Spain"
       ],
       "unproducible": false,
-      "variantOf": "Explorer",
       "categories": [
         "Land"
       ],
@@ -5172,9 +5247,10 @@
       "producibleBy": [
         "Scandinavia"
       ],
-      "upgradeTo": "Guerilla",
+      "upgradesTo": [
+        "Guerilla"
+      ],
       "unproducible": false,
-      "variantOf": "Longbowman",
       "categories": [
         "Land"
       ],
@@ -5214,7 +5290,6 @@
         "Ottomans"
       ],
       "unproducible": false,
-      "variantOf": "Cavalry",
       "categories": [
         "Land"
       ],
@@ -5257,9 +5332,10 @@
       "producibleBy": [
         "Celts"
       ],
-      "upgradeTo": "Medieval Infantry",
+      "upgradesTo": [
+        "Medieval Infantry"
+      ],
       "unproducible": false,
-      "variantOf": "Swordsman",
       "categories": [
         "Land"
       ],
@@ -5301,9 +5377,10 @@
       "producibleBy": [
         "Arabia"
       ],
-      "upgradeTo": "Cavalry",
+      "upgradesTo": [
+        "Cavalry"
+      ],
       "unproducible": false,
-      "variantOf": "Knight",
       "categories": [
         "Land"
       ],
@@ -5346,9 +5423,10 @@
       "producibleBy": [
         "Carthage"
       ],
-      "upgradeTo": "Musketman",
+      "upgradesTo": [
+        "Musketman"
+      ],
       "unproducible": false,
-      "variantOf": "Pikeman",
       "categories": [
         "Land"
       ],
@@ -5387,7 +5465,9 @@
       "producibleBy": [
         "Korea"
       ],
-      "upgradeTo": "Artillery",
+      "upgradesTo": [
+        "Artillery"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -5460,7 +5540,9 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Guerilla",
+      "upgradesTo": [
+        "Guerilla"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -5533,7 +5615,9 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "TOW Infantry",
+      "upgradesTo": [
+        "TOW Infantry"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -6420,9 +6504,10 @@
       "producibleBy": [
         "Sumeria"
       ],
-      "upgradeTo": "Pikeman",
+      "upgradesTo": [
+        "Pikeman"
+      ],
       "unproducible": false,
-      "variantOf": "Spearman",
       "categories": [
         "Land"
       ],
@@ -6461,9 +6546,10 @@
       "producibleBy": [
         "Hittites"
       ],
-      "upgradeTo": "Knight",
+      "upgradesTo": [
+        "Knight"
+      ],
       "unproducible": false,
-      "variantOf": "Chariot",
       "categories": [
         "Land"
       ],
@@ -6607,9 +6693,10 @@
       "producibleBy": [
         "Portugal"
       ],
-      "upgradeTo": "Galleon",
+      "upgradesTo": [
+        "Galleon"
+      ],
       "unproducible": false,
-      "variantOf": "Caravel",
       "flags": [
         "rotateBeforeAttack"
       ],
@@ -6651,9 +6738,10 @@
       "producibleBy": [
         "Netherlands"
       ],
-      "upgradeTo": "Rifleman",
+      "upgradesTo": [
+        "Rifleman"
+      ],
       "unproducible": false,
-      "variantOf": "Pikeman",
       "categories": [
         "Land"
       ],
@@ -6759,7 +6847,9 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Cannon",
+      "upgradesTo": [
+        "Cannon"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -6901,9 +6991,10 @@
       "producibleBy": [
         "Inca"
       ],
-      "upgradeTo": "Explorer",
+      "upgradesTo": [
+        "Explorer"
+      ],
       "unproducible": false,
-      "variantOf": "Scout",
       "categories": [
         "Land"
       ],
@@ -6942,9 +7033,10 @@
       "producibleBy": [
         "Maya"
       ],
-      "upgradeTo": "Longbowman",
+      "upgradesTo": [
+        "Longbowman"
+      ],
       "unproducible": false,
-      "variantOf": "Archer",
       "categories": [
         "Land"
       ],
@@ -6983,9 +7075,10 @@
       "producibleBy": [
         "Byzantines"
       ],
-      "upgradeTo": "Caravel",
+      "upgradesTo": [
+        "Caravel"
+      ],
       "unproducible": false,
-      "variantOf": "Galley",
       "categories": [
         "Sea"
       ],
@@ -7055,7 +7148,9 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "AEGIS Cruiser",
+      "upgradesTo": [
+        "AEGIS Cruiser"
+      ],
       "unproducible": false,
       "categories": [
         "Sea"
@@ -7202,7 +7297,10 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Galley",
+      "upgradesTo": [
+        "Dromon",
+        "Galley"
+      ],
       "unproducible": false,
       "flags": [
         "rotateBeforeAttack"
@@ -7275,7 +7373,9 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Modern Paratrooper",
+      "upgradesTo": [
+        "Modern Paratrooper"
+      ],
       "unproducible": false,
       "categories": [
         "Land"
@@ -7418,7 +7518,9 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Mobile SAM",
+      "upgradesTo": [
+        "Mobile SAM"
+      ],
       "unproducible": false,
       "categories": [
         "Land"

--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -960,7 +960,7 @@
         "Hittites",
         "Portugal"
       ],
-      "upgradeTo": "Conquistador",
+      "upgradeTo": "Explorer",
       "unproducible": false,
       "categories": [
         "Land"
@@ -1310,7 +1310,7 @@
         "Byzantines",
         "Inca"
       ],
-      "upgradeTo": "Berserk",
+      "upgradeTo": "Longbowman",
       "unproducible": false,
       "categories": [
         "Land"
@@ -1376,7 +1376,7 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Numidian Mercenary",
+      "upgradeTo": "Pikeman",
       "unproducible": false,
       "categories": [
         "Land"
@@ -1443,7 +1443,7 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Gallic Swordsman",
+      "upgradeTo": "Medieval Infantry",
       "unproducible": false,
       "categories": [
         "Land"
@@ -1587,7 +1587,7 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Mounted Warrior",
+      "upgradeTo": "Knight",
       "unproducible": false,
       "categories": [
         "Land"
@@ -1798,7 +1798,7 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Swiss Mercenary",
+      "upgradeTo": "Rifleman",
       "unproducible": false,
       "categories": [
         "Land"
@@ -1866,7 +1866,7 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Keshik",
+      "upgradeTo": "Cavalry",
       "unproducible": false,
       "categories": [
         "Land"
@@ -2008,7 +2008,6 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Sipahi",
       "unproducible": false,
       "categories": [
         "Land"
@@ -2445,7 +2444,7 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Hwach'a",
+      "upgradeTo": "Artillery",
       "unproducible": false,
       "categories": [
         "Land"
@@ -2885,7 +2884,7 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Dromon",
+      "upgradeTo": "Caravel",
       "unproducible": false,
       "flags": [
         "rotateBeforeAttack"
@@ -2957,7 +2956,7 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Carrack",
+      "upgradeTo": "Galleon",
       "unproducible": false,
       "flags": [
         "rotateBeforeAttack"
@@ -3976,7 +3975,6 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "F-15",
       "unproducible": false,
       "categories": [
         "Air"
@@ -4480,7 +4478,7 @@
       "producibleBy": [
         "Rome"
       ],
-      "upgradeTo": "Immortals",
+      "upgradeTo": "Medieval Infantry",
       "unproducible": false,
       "categories": [
         "Land"
@@ -4609,7 +4607,7 @@
       "producibleBy": [
         "China"
       ],
-      "upgradeTo": "Samurai",
+      "upgradeTo": "Cavalry",
       "unproducible": false,
       "categories": [
         "Land"
@@ -4653,7 +4651,7 @@
       "producibleBy": [
         "Iroquois"
       ],
-      "upgradeTo": "Three-Man Chariot",
+      "upgradeTo": "Knight",
       "unproducible": false,
       "categories": [
         "Land"
@@ -4739,7 +4737,7 @@
       "producibleBy": [
         "Japan"
       ],
-      "upgradeTo": "War Elephant",
+      "upgradeTo": "Cavalry",
       "unproducible": false,
       "categories": [
         "Land"
@@ -5073,7 +5071,7 @@
       "producibleBy": [
         "Mongols"
       ],
-      "upgradeTo": "Ansar Warrior",
+      "upgradeTo": "Cavalry",
       "unproducible": false,
       "categories": [
         "Land"
@@ -5159,7 +5157,7 @@
       "producibleBy": [
         "Scandinavia"
       ],
-      "upgradeTo": "Longbowman",
+      "upgradeTo": "Guerilla",
       "unproducible": false,
       "categories": [
         "Land"
@@ -5199,7 +5197,6 @@
       "producibleBy": [
         "Ottomans"
       ],
-      "upgradeTo": "Cossack",
       "unproducible": false,
       "categories": [
         "Land"
@@ -5243,7 +5240,7 @@
       "producibleBy": [
         "Celts"
       ],
-      "upgradeTo": "Legionary",
+      "upgradeTo": "Medieval Infantry",
       "unproducible": false,
       "categories": [
         "Land"
@@ -5286,7 +5283,7 @@
       "producibleBy": [
         "Arabia"
       ],
-      "upgradeTo": "Rider",
+      "upgradeTo": "Cavalry",
       "unproducible": false,
       "categories": [
         "Land"
@@ -6631,7 +6628,7 @@
       "producibleBy": [
         "Netherlands"
       ],
-      "upgradeTo": "Musketeer",
+      "upgradeTo": "Musketman",
       "unproducible": false,
       "categories": [
         "Land"
@@ -6880,7 +6877,7 @@
       "producibleBy": [
         "Inca"
       ],
-      "upgradeTo": "Conquistador",
+      "upgradeTo": "Explorer",
       "unproducible": false,
       "categories": [
         "Land"
@@ -6920,7 +6917,7 @@
       "producibleBy": [
         "Maya"
       ],
-      "upgradeTo": "Berserk",
+      "upgradeTo": "Longbowman",
       "unproducible": false,
       "categories": [
         "Land"

--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -1387,8 +1387,8 @@
         "Maya"
       ],
       "upgradesTo": [
-        "Musketman",
-        "Pikeman"
+        "Pikeman",
+        "Swiss Mercenary"
       ],
       "unproducible": false,
       "categories": [
@@ -1830,8 +1830,7 @@
         "Maya"
       ],
       "upgradesTo": [
-        "Rifleman",
-        "Swiss Mercenary"
+        "Rifleman"
       ],
       "unproducible": false,
       "categories": [
@@ -6739,7 +6738,7 @@
         "Netherlands"
       ],
       "upgradesTo": [
-        "Rifleman"
+        "Musketman"
       ],
       "unproducible": false,
       "categories": [

--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -960,7 +960,7 @@
         "Hittites",
         "Portugal"
       ],
-      "upgradeTo": "Explorer",
+      "upgradeTo": "Conquistador",
       "unproducible": false,
       "categories": [
         "Land"
@@ -1310,7 +1310,7 @@
         "Byzantines",
         "Inca"
       ],
-      "upgradeTo": "Longbowman",
+      "upgradeTo": "Berserk",
       "unproducible": false,
       "categories": [
         "Land"
@@ -1376,7 +1376,7 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Pikeman",
+      "upgradeTo": "Numidian Mercenary",
       "unproducible": false,
       "categories": [
         "Land"
@@ -1443,7 +1443,7 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Medieval Infantry",
+      "upgradeTo": "Gallic Swordsman",
       "unproducible": false,
       "categories": [
         "Land"
@@ -1587,7 +1587,7 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Knight",
+      "upgradeTo": "Mounted Warrior",
       "unproducible": false,
       "categories": [
         "Land"
@@ -1798,7 +1798,7 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Rifleman",
+      "upgradeTo": "Swiss Mercenary",
       "unproducible": false,
       "categories": [
         "Land"
@@ -1866,7 +1866,7 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Cavalry",
+      "upgradeTo": "Keshik",
       "unproducible": false,
       "categories": [
         "Land"
@@ -2008,6 +2008,7 @@
         "Inca",
         "Maya"
       ],
+      "upgradeTo": "Sipahi",
       "unproducible": false,
       "categories": [
         "Land"
@@ -2435,6 +2436,7 @@
         "Celts",
         "Arabia",
         "Carthage",
+        "Korea",
         "Sumeria",
         "Hittites",
         "Netherlands",
@@ -2443,7 +2445,7 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Artillery",
+      "upgradeTo": "Hwach'a",
       "unproducible": false,
       "categories": [
         "Land"
@@ -2556,9 +2558,6 @@
       "bombardRange": 2,
       "rateOfFire": 3,
       "movement": 2,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2593,6 +2592,9 @@
         "Maya"
       ],
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Land"
       ],
@@ -2851,9 +2853,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 3,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2886,8 +2885,11 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Caravel",
+      "upgradeTo": "Dromon",
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -2923,9 +2925,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 4,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2958,8 +2957,11 @@
         "Inca",
         "Maya"
       ],
-      "upgradeTo": "Galleon",
+      "upgradeTo": "Carrack",
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -2995,9 +2997,6 @@
       "bombardRange": 1,
       "rateOfFire": 2,
       "movement": 5,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3031,6 +3030,9 @@
         "Maya"
       ],
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -3071,9 +3073,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 4,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3109,6 +3108,9 @@
       ],
       "upgradeTo": "Transport",
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -3508,9 +3510,6 @@
       "bombardRange": 2,
       "rateOfFire": 2,
       "movement": 5,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3545,6 +3544,9 @@
         "Maya"
       ],
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -3974,6 +3976,7 @@
         "Inca",
         "Maya"
       ],
+      "upgradeTo": "F-15",
       "unproducible": false,
       "categories": [
         "Air"
@@ -4477,7 +4480,7 @@
       "producibleBy": [
         "Rome"
       ],
-      "upgradeTo": "Medieval Infantry",
+      "upgradeTo": "Immortals",
       "unproducible": false,
       "categories": [
         "Land"
@@ -4606,7 +4609,7 @@
       "producibleBy": [
         "China"
       ],
-      "upgradeTo": "Cavalry",
+      "upgradeTo": "Samurai",
       "unproducible": false,
       "categories": [
         "Land"
@@ -4650,7 +4653,7 @@
       "producibleBy": [
         "Iroquois"
       ],
-      "upgradeTo": "Knight",
+      "upgradeTo": "Three-Man Chariot",
       "unproducible": false,
       "categories": [
         "Land"
@@ -4736,7 +4739,7 @@
       "producibleBy": [
         "Japan"
       ],
-      "upgradeTo": "Cavalry",
+      "upgradeTo": "War Elephant",
       "unproducible": false,
       "categories": [
         "Land"
@@ -4903,13 +4906,13 @@
       "bombardRange": 1,
       "rateOfFire": 2,
       "movement": 5,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
       "producibleBy": [
         "England"
       ],
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -4991,9 +4994,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 5,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -5028,6 +5028,9 @@
         "Maya"
       ],
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -5070,7 +5073,7 @@
       "producibleBy": [
         "Mongols"
       ],
-      "upgradeTo": "Cavalry",
+      "upgradeTo": "Ansar Warrior",
       "unproducible": false,
       "categories": [
         "Land"
@@ -5113,6 +5116,7 @@
       "producibleBy": [
         "Spain"
       ],
+      "upgradeTo": "Explorer",
       "unproducible": false,
       "categories": [
         "Land"
@@ -5155,7 +5159,7 @@
       "producibleBy": [
         "Scandinavia"
       ],
-      "upgradeTo": "Guerilla",
+      "upgradeTo": "Longbowman",
       "unproducible": false,
       "categories": [
         "Land"
@@ -5195,6 +5199,7 @@
       "producibleBy": [
         "Ottomans"
       ],
+      "upgradeTo": "Cossack",
       "unproducible": false,
       "categories": [
         "Land"
@@ -5238,7 +5243,7 @@
       "producibleBy": [
         "Celts"
       ],
-      "upgradeTo": "Medieval Infantry",
+      "upgradeTo": "Legionary",
       "unproducible": false,
       "categories": [
         "Land"
@@ -5281,7 +5286,7 @@
       "producibleBy": [
         "Arabia"
       ],
-      "upgradeTo": "Cavalry",
+      "upgradeTo": "Rider",
       "unproducible": false,
       "categories": [
         "Land"
@@ -5340,7 +5345,7 @@
       ]
     },
     {
-      "name": "Hwach\u0027a",
+      "name": "Hwach'a",
       "art": {
         "mainArt": {
           "defaultName": "Hwacha"
@@ -5547,7 +5552,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -5580,7 +5584,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -5615,7 +5618,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -5650,7 +5652,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -5685,7 +5686,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -5720,7 +5720,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -5755,7 +5754,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -5790,7 +5788,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -5825,7 +5822,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -5860,7 +5856,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -5895,7 +5890,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -5930,7 +5924,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -5965,7 +5958,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6000,7 +5992,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6035,7 +6026,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6070,7 +6060,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6105,7 +6094,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6140,7 +6128,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6175,7 +6162,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6210,7 +6196,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6245,7 +6230,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6280,7 +6264,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6294,7 +6277,7 @@
       ]
     },
     {
-      "name": "Joan d\u0027Arc",
+      "name": "Joan d'Arc",
       "art": {
         "mainArt": {
           "defaultName": "King French"
@@ -6315,7 +6298,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6350,7 +6332,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6385,7 +6366,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6502,7 +6482,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6537,7 +6516,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6572,7 +6550,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6608,14 +6585,14 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 4,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
       "producibleBy": [
         "Portugal"
       ],
       "upgradeTo": "Galleon",
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -6654,7 +6631,7 @@
       "producibleBy": [
         "Netherlands"
       ],
-      "upgradeTo": "Rifleman",
+      "upgradeTo": "Musketeer",
       "unproducible": false,
       "categories": [
         "Land"
@@ -6693,7 +6670,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6799,7 +6775,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6834,7 +6809,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6869,7 +6843,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -6907,7 +6880,7 @@
       "producibleBy": [
         "Inca"
       ],
-      "upgradeTo": "Explorer",
+      "upgradeTo": "Conquistador",
       "unproducible": false,
       "categories": [
         "Land"
@@ -6947,7 +6920,7 @@
       "producibleBy": [
         "Maya"
       ],
-      "upgradeTo": "Longbowman",
+      "upgradeTo": "Berserk",
       "unproducible": false,
       "categories": [
         "Land"
@@ -7098,7 +7071,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 1,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -7137,7 +7109,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "producibleBy": [],
       "unproducible": true,
       "categories": [
         "Land"
@@ -7174,10 +7145,6 @@
       "bombardRange": 0,
       "rateOfFire": 0,
       "movement": 2,
-      "flags": [
-        "rotateBeforeAttack"
-      ],
-      "upgradeTo": "Galley",
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7211,7 +7178,11 @@
         "Inca",
         "Maya"
       ],
+      "upgradeTo": "Galley",
       "unproducible": false,
+      "flags": [
+        "rotateBeforeAttack"
+      ],
       "categories": [
         "Sea"
       ],
@@ -8157,7 +8128,7 @@
       ]
     },
     {
-      "name": "Sun Tzu\u0027s Art of War",
+      "name": "Sun Tzu's Art of War",
       "shieldCost": 600,
       "populationCost": 0,
       "requiredTech": "tech-23",
@@ -8191,7 +8162,7 @@
       ]
     },
     {
-      "name": "Magellan\u0027s Voyage",
+      "name": "Magellan's Voyage",
       "shieldCost": 400,
       "populationCost": 0,
       "requiredTech": "tech-37",
@@ -8215,7 +8186,7 @@
       ]
     },
     {
-      "name": "Copernicus\u0027 Observatory",
+      "name": "Copernicus' Observatory",
       "shieldCost": 400,
       "populationCost": 0,
       "requiredTech": "tech-33",
@@ -8231,7 +8202,7 @@
       ]
     },
     {
-      "name": "Shakespeare\u0027s Theater",
+      "name": "Shakespeare's Theater",
       "shieldCost": 450,
       "populationCost": 0,
       "requiredTech": "tech-40",
@@ -8250,7 +8221,7 @@
       ]
     },
     {
-      "name": "Leonardo\u0027s Workshop",
+      "name": "Leonardo's Workshop",
       "shieldCost": 600,
       "populationCost": 0,
       "requiredTech": "tech-27",
@@ -8266,7 +8237,7 @@
       ]
     },
     {
-      "name": "JS Bach\u0027s Cathedral",
+      "name": "JS Bach's Cathedral",
       "shieldCost": 600,
       "populationCost": 0,
       "requiredTech": "tech-29",
@@ -8282,7 +8253,7 @@
       ]
     },
     {
-      "name": "Newton\u0027s University",
+      "name": "Newton's University",
       "shieldCost": 400,
       "populationCost": 0,
       "requiredTech": "tech-41",
@@ -8298,7 +8269,7 @@
       ]
     },
     {
-      "name": "Smith\u0027s Trading Company",
+      "name": "Smith's Trading Company",
       "shieldCost": 600,
       "populationCost": 0,
       "requiredTech": "tech-36",
@@ -9341,7 +9312,7 @@
         "St. Petersburg",
         "Novgorod",
         "Rostov",
-        "Yaroslavl\u0027",
+        "Yaroslavl'",
         "Yekaterinburg",
         "Yakutsk",
         "Vladivostok",
@@ -9350,31 +9321,31 @@
         "Krasnoyarsk",
         "Khabarovsk",
         "Bryansk",
-        "Tver\u0027",
-        "Kazan\u0027",
+        "Tver'",
+        "Kazan'",
         "Novosibirsk",
         "Magadan",
         "Murmansk",
         "Irkutsk",
         "Chita",
         "Samara",
-        "Arkhangel\u0027sk",
+        "Arkhangel'sk",
         "Chelyabinsk",
-        "Tobol\u0027sk",
+        "Tobol'sk",
         "Vologda",
         "Omsk",
-        "Astrakhan\u0027",
+        "Astrakhan'",
         "Kursk",
         "Saratov",
         "Tula",
         "Vladimir",
-        "Perm\u0027",
+        "Perm'",
         "Voronezh",
         "Pskov",
         "Staraya Russa",
         "Kostroma",
         "Nizhniy Novgorod",
-        "Suzdal\u0027",
+        "Suzdal'",
         "Magnitogorsk"
       ],
       "startingTechs": [
@@ -9541,7 +9512,7 @@
       "name": "France",
       "noun": "French",
       "adjective": "French",
-      "leader": "Joan d\u0027Arc",
+      "leader": "Joan d'Arc",
       "primaryColorIndex": 7,
       "secondaryColorIndex": 7,
       "leaderGender": "female",
@@ -9953,7 +9924,7 @@
         "Almeria",
         "Leon",
         "Zamora",
-        "M\u00E9rida",
+        "Mérida",
         "Lugo",
         "Alicante",
         "Cadiz",
@@ -10168,7 +10139,7 @@
         "Taif",
         "Hama",
         "Tabuk",
-        "Sana\u0027a",
+        "Sana'a",
         "Shihr"
       ],
       "startingTechs": [
@@ -10245,18 +10216,18 @@
       "leaderArtFile": "art\\advisors\\x_Wang Kon advisor.pcx",
       "cityNames": [
         "Seoul",
-        "P\u0027yongyang",
+        "P'yongyang",
         "Wonsan",
         "Pusan",
-        "Namp\u0027o",
+        "Namp'o",
         "Cheju",
         "Hyangsan",
         "Ulsan",
-        "Inch\u0027on",
+        "Inch'on",
         "Pyongsong",
         "Taejon",
         "Paegam",
-        "Manp\u0027o",
+        "Manp'o",
         "Kaesong",
         "Chonju",
         "Sariwon",
@@ -10264,13 +10235,13 @@
         "Haeju",
         "Taegu",
         "Chinje",
-        "Tokch\u0027on",
-        "Ch\u0027ongfu",
+        "Tokch'on",
+        "Ch'ongfu",
         "Taegwon",
-        "Sokch\u0027o",
+        "Sokch'o",
         "Hamhung",
         "Iri",
-        "Huich\u0027on",
+        "Huich'on",
         "Namwon",
         "Kumgang",
         "Oijongbu"
@@ -10439,34 +10410,34 @@
       "cityNames": [
         "Lisbon",
         "Oporto",
-        "Guimar\u00E3es",
+        "Guimarães",
         "Lagos",
         "Emerita",
         "Sagres",
         "Coimbra",
         "Leiria",
-        "\u00C9vora",
+        "Évora",
         "Braga",
         "Faro",
         "Rio Janeiro",
-        "S\u00E3o Paulo",
+        "São Paulo",
         "Luanda",
-        "Alc\u00E1cer do Sal",
+        "Alcácer do Sal",
         "Guarda",
         "Castelo Branco",
         "Badajoz",
-        "Louren\u00E7o Marques",
+        "Lourenço Marques",
         "Viseu",
-        "S\u00E3o Mamede",
+        "São Mamede",
         "Ourique",
         "Goa",
         "Diu",
         "Tavira",
         "Cacela",
-        "Alcoba\u00E7a",
+        "Alcobaça",
         "Bissau",
-        "\u00D3bidos",
-        "Nazar\u00E9",
+        "Óbidos",
+        "Nazaré",
         "Avis",
         "Praia",
         "Tomar",
@@ -10589,27 +10560,27 @@
       "cultureGroupKey": "American",
       "leaderArtFile": "art\\advisors\\x2_Smoke-Jaguar_advisor.pcx",
       "cityNames": [
-        "Chich\u00E9n Itza",
-        "Cop\u00E1n",
+        "Chichén Itza",
+        "Copán",
         "Palenque",
         "Tikal",
-        "Yaxchil\u00E1n",
+        "Yaxchilán",
         "Bonampak",
         "Lagartero",
-        "Quirigu\u00E1",
+        "Quiriguá",
         "Calakmul",
         "Lazapa",
-        "Kaminaljuy\u00FA",
+        "Kaminaljuyú",
         "Piedras Negras",
-        "Uaxact\u00FAn",
+        "Uaxactún",
         "Cuello",
-        "Tul\u00FAm",
-        "Cob\u00E1",
+        "Tulúm",
+        "Cobá",
         "Dzibilchaltun",
         "Uxmal",
-        "Mayap\u00E1n",
-        "Kab\u00E1h",
-        "Ak\u00E9",
+        "Mayapán",
+        "Kabáh",
+        "Aké",
         "Xcalumkin",
         "Ek Balam",
         "Tazumal",
@@ -12439,7 +12410,7 @@
       "militaryLaw": 1
     }
   ],
-  "worldSizes" : [
+  "worldSizes": [
     {
       "name": "Tiny",
       "length": 80,
@@ -12467,9 +12438,9 @@
       "width": 100,
       "optimalNumberOfCities": 20,
       "techRate": 240,
-      "distanceBetweenCivs": 12,      
+      "distanceBetweenCivs": 12,
       "numberOfCivs": 8,
-      "isDefault" : true
+      "isDefault": true
     },
     {
       "name": "Large",

--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -1387,8 +1387,8 @@
         "Maya"
       ],
       "upgradesTo": [
-        "Pikeman",
-        "Swiss Mercenary"
+        "Musketman",
+        "Pikeman"
       ],
       "unproducible": false,
       "categories": [
@@ -1830,7 +1830,8 @@
         "Maya"
       ],
       "upgradesTo": [
-        "Rifleman"
+        "Rifleman",
+        "Swiss Mercenary"
       ],
       "unproducible": false,
       "categories": [
@@ -6738,7 +6739,7 @@
         "Netherlands"
       ],
       "upgradesTo": [
-        "Musketman"
+        "Rifleman"
       ],
       "unproducible": false,
       "categories": [

--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -4360,6 +4360,7 @@
       ],
       "upgradeTo": "Longbowman",
       "unproducible": false,
+      "variantOf": "Archer",
       "categories": [
         "Land"
       ],
@@ -4400,6 +4401,7 @@
       ],
       "upgradeTo": "Musketman",
       "unproducible": false,
+      "variantOf": "Pikeman",
       "categories": [
         "Land"
       ],
@@ -4440,6 +4442,7 @@
       ],
       "upgradeTo": "Musketman",
       "unproducible": false,
+      "variantOf": "Spearman",
       "categories": [
         "Land"
       ],
@@ -4480,6 +4483,7 @@
       ],
       "upgradeTo": "Medieval Infantry",
       "unproducible": false,
+      "variantOf": "Swordsman",
       "categories": [
         "Land"
       ],
@@ -4521,8 +4525,9 @@
       "producibleBy": [
         "Persia"
       ],
-      "upgradeTo": "Medieval Infantry",
+      "upgradeTo": "Guerilla",
       "unproducible": false,
+      "variantOf": "Medieval Infantry",
       "categories": [
         "Land"
       ],
@@ -4566,6 +4571,7 @@
       ],
       "upgradeTo": "Knight",
       "unproducible": false,
+      "variantOf": "Chariot",
       "categories": [
         "Land"
       ],
@@ -4609,6 +4615,7 @@
       ],
       "upgradeTo": "Cavalry",
       "unproducible": false,
+      "variantOf": "Knight",
       "categories": [
         "Land"
       ],
@@ -4653,6 +4660,7 @@
       ],
       "upgradeTo": "Knight",
       "unproducible": false,
+      "variantOf": "Horseman",
       "categories": [
         "Land"
       ],
@@ -4696,6 +4704,7 @@
       ],
       "upgradeTo": "Rifleman",
       "unproducible": false,
+      "variantOf": "Musketman",
       "categories": [
         "Land"
       ],
@@ -4739,6 +4748,7 @@
       ],
       "upgradeTo": "Cavalry",
       "unproducible": false,
+      "variantOf": "Knight",
       "categories": [
         "Land"
       ],
@@ -4782,6 +4792,7 @@
       ],
       "upgradeTo": "Cavalry",
       "unproducible": false,
+      "variantOf": "Knight",
       "categories": [
         "Land"
       ],
@@ -4821,6 +4832,7 @@
         "Russia"
       ],
       "unproducible": false,
+      "variantOf": "Cavalry",
       "categories": [
         "Land"
       ],
@@ -4865,6 +4877,7 @@
       ],
       "upgradeTo": "Modern Armor",
       "unproducible": false,
+      "variantOf": "Tank",
       "categories": [
         "Land"
       ],
@@ -4955,6 +4968,7 @@
         "America"
       ],
       "unproducible": false,
+      "variantOf": "Jet Fighter",
       "categories": [
         "Air"
       ],
@@ -5073,6 +5087,7 @@
       ],
       "upgradeTo": "Cavalry",
       "unproducible": false,
+      "variantOf": "Knight",
       "categories": [
         "Land"
       ],
@@ -5114,8 +5129,8 @@
       "producibleBy": [
         "Spain"
       ],
-      "upgradeTo": "Explorer",
       "unproducible": false,
+      "variantOf": "Explorer",
       "categories": [
         "Land"
       ],
@@ -5159,6 +5174,7 @@
       ],
       "upgradeTo": "Guerilla",
       "unproducible": false,
+      "variantOf": "Longbowman",
       "categories": [
         "Land"
       ],
@@ -5198,6 +5214,7 @@
         "Ottomans"
       ],
       "unproducible": false,
+      "variantOf": "Cavalry",
       "categories": [
         "Land"
       ],
@@ -5242,6 +5259,7 @@
       ],
       "upgradeTo": "Medieval Infantry",
       "unproducible": false,
+      "variantOf": "Swordsman",
       "categories": [
         "Land"
       ],
@@ -5285,6 +5303,7 @@
       ],
       "upgradeTo": "Cavalry",
       "unproducible": false,
+      "variantOf": "Knight",
       "categories": [
         "Land"
       ],
@@ -5327,8 +5346,9 @@
       "producibleBy": [
         "Carthage"
       ],
-      "upgradeTo": "Pikeman",
+      "upgradeTo": "Musketman",
       "unproducible": false,
+      "variantOf": "Pikeman",
       "categories": [
         "Land"
       ],
@@ -6402,6 +6422,7 @@
       ],
       "upgradeTo": "Pikeman",
       "unproducible": false,
+      "variantOf": "Spearman",
       "categories": [
         "Land"
       ],
@@ -6442,6 +6463,7 @@
       ],
       "upgradeTo": "Knight",
       "unproducible": false,
+      "variantOf": "Chariot",
       "categories": [
         "Land"
       ],
@@ -6587,6 +6609,7 @@
       ],
       "upgradeTo": "Galleon",
       "unproducible": false,
+      "variantOf": "Caravel",
       "flags": [
         "rotateBeforeAttack"
       ],
@@ -6628,8 +6651,9 @@
       "producibleBy": [
         "Netherlands"
       ],
-      "upgradeTo": "Musketman",
+      "upgradeTo": "Rifleman",
       "unproducible": false,
+      "variantOf": "Pikeman",
       "categories": [
         "Land"
       ],
@@ -6879,6 +6903,7 @@
       ],
       "upgradeTo": "Explorer",
       "unproducible": false,
+      "variantOf": "Scout",
       "categories": [
         "Land"
       ],
@@ -6919,6 +6944,7 @@
       ],
       "upgradeTo": "Longbowman",
       "unproducible": false,
+      "variantOf": "Archer",
       "categories": [
         "Land"
       ],
@@ -6959,6 +6985,7 @@
       ],
       "upgradeTo": "Caravel",
       "unproducible": false,
+      "variantOf": "Galley",
       "categories": [
         "Sea"
       ],

--- a/C7/Lua/game_modes/standalone.lua
+++ b/C7/Lua/game_modes/standalone.lua
@@ -51,15 +51,15 @@ return function(civ3_game_mode)
     -- Only preserve a unit if we have an art replacement for it
     if replacement_art then
       unit_prototype.art.mainArt.defaultName = replacement_art
-      
+
       -- TODO: these are just placeholders until we have some proper art
       unit_prototype.art.pediaArt.large = "art\\civilopedia\\icons\\units\\unit_large.png"
       unit_prototype.art.pediaArt.small = "art\\civilopedia\\icons\\units\\unit_small.png"
 
       -- Remove the unit upgrade if we don't have a sprite for it
-      local upgrade = unit_prototype.upgradeTo
+      local upgrade = unit_prototype.upgradesTo
       if not unit_replacement_art_map[upgrade] then
-        unit_prototype.upgradeTo = nil
+        unit_prototype.upgradesTo = nil
       end
 
       table.insert(updated_unit_prototypes, unit_prototype)

--- a/C7Engine/C7GameData/Civilization.cs
+++ b/C7Engine/C7GameData/Civilization.cs
@@ -96,29 +96,8 @@ namespace C7GameData {
 
 		public SettlerTileAdjustments Adjustments = new();
 
-		// This method is primarily here to satisfy the weird upgrade chains from the .biq and .sav files
 		public List<UnitPrototype> GetUpgradeChain(UnitPrototype unit) {
-
-			// TODO: Needs something extra for the Abbasids scenario: Ansar Warrior variants get overlooked
-
-			HashSet<UnitPrototype> result = [];
-			var current = unit;
-
-			var queue =  new Queue<UnitPrototype>();
-			queue.Enqueue(current.upgradeTo);
-			while (queue.Count > 0) {
-				var upgrade = queue.Dequeue();
-				if (upgrade == null) continue;
-
-				if (upgrade.producibleBy.Contains(this))
-					result.Add(upgrade);
-
-				foreach (var variant in upgrade.variants) {
-					queue.Enqueue(variant);
-				}
-			}
-
-			return result.ToList();
+			return unit.upgradesTo.Where(x => x.producibleBy.Contains(this)).ToList();
 		}
 
 		public bool IsUnitAvailable(UnitPrototype unit) {

--- a/C7Engine/C7GameData/Civilization.cs
+++ b/C7Engine/C7GameData/Civilization.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
 
 namespace C7GameData {
@@ -48,7 +49,7 @@ namespace C7GameData {
 		public CultureGroup cultureGroup { get; private set; }
 
 		// This is null during gameplay to discourage usage, and instead use the cultureGroup
-		// It's only used for saving/loading 
+		// It's only used for saving/loading
 		public string cultureGroupKey;
 
 		public void SetCultureGroup(int index, string cultureGroupName) {
@@ -97,29 +98,27 @@ namespace C7GameData {
 
 		// This method is primarily here to satisfy the weird upgrade chains from the .biq and .sav files
 		public List<UnitPrototype> GetUpgradeChain(UnitPrototype unit) {
-			List<UnitPrototype> result = [];
+
+			// TODO: Needs something extra for the Abbasids scenario: Ansar Warrior variants get overlooked
+
+			HashSet<UnitPrototype> result = [];
 			var current = unit;
 
-			while (true) {
-				var upgrade = current.upgradeTo;
-				if (upgrade == null) break;
+			var queue =  new Queue<UnitPrototype>();
+			queue.Enqueue(current.upgradeTo);
+			while (queue.Count > 0) {
+				var upgrade = queue.Dequeue();
+				if (upgrade == null) continue;
 
-				var upgradeIsAvailable = upgrade.producibleBy.Contains(this) && !result.Contains(upgrade);
-
-				if (upgradeIsAvailable) {
+				if (upgrade.producibleBy.Contains(this))
 					result.Add(upgrade);
-				}
-				current = upgrade;
 
-			}
-
-			for (int i = result.Count - 1; i >= 0; i--) {
-				if (!result[i].producibleBy.Contains(this)) {
-					result.Remove(result[i]);
+				foreach (var variant in upgrade.variants) {
+					queue.Enqueue(variant);
 				}
 			}
 
-			return result;
+			return result.ToList();
 		}
 
 		public bool IsUnitAvailable(UnitPrototype unit) {

--- a/C7Engine/C7GameData/Civilization.cs
+++ b/C7Engine/C7GameData/Civilization.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json.Serialization;
 
 namespace C7GameData {
@@ -95,22 +94,5 @@ namespace C7GameData {
 		}
 
 		public SettlerTileAdjustments Adjustments = new();
-
-		public List<UnitPrototype> GetUpgradeChain(UnitPrototype unit) {
-			return unit.upgradesTo.Where(x => x.producibleBy.Contains(this)).ToList();
-		}
-
-		public bool IsUnitAvailable(UnitPrototype unit) {
-			if (unit.unproducible) {
-				return false;
-			}
-
-			if (!unit.producibleBy.Contains(this)) {
-				return false;
-			}
-
-			return true;
-		}
 	}
-
 }

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -1305,19 +1305,10 @@ namespace C7GameData {
 			var idx = new Dictionary<string, UnitNode>();
 			var civCount = civilizations.Count;
 
-			var unusual = new HashSet<Tuple<SaveUnitPrototype, SaveUnitPrototype>>();
-
 			foreach (Tuple<SaveUnitPrototype, SaveUnitPrototype> pair in upgradePairs) {
 				var a = idx.TryGetValue(pair.Item1.name, out var nodeA) ? nodeA : new UnitNode(pair.Item1, civCount);
 				var b = pair.Item2 == null ? null :
 					idx.TryGetValue(pair.Item2.name, out var nodeB) ? nodeB : new UnitNode(pair.Item2, civCount);
-
-				// Detect cases where the upgrade relation leads to "wrong results".
-				// We handle these cases separately later.
-				if (UnusualUpgradeRelation(a, b)) {
-					unusual.Add(pair);
-					continue;
-				}
 
 				a.next = b;
 				idx[a.name] = a;
@@ -1327,49 +1318,7 @@ namespace C7GameData {
 				}
 			}
 
-			foreach (var pair in unusual) {
-				var a = idx[pair.Item1.name];
-				var b = idx[pair.Item2.name];
-				AddReverseUpgrade(a, b);
-			}
-
 			return idx;
-		}
-
-		/// <summary>
-		/// Manipulate the unit upgrade linked lists to apply an upgrade relation in reverse.
-		/// </summary>
-		private static void AddReverseUpgrade(UnitNode a, UnitNode b) {
-			// From:	X -> a -> b -> Y
-			// To:		X -> b -> a -> Y
-
-			b.next?.prev.Remove(b);
-			a.next = b.next;
-			b.next?.prev.Add(a);
-
-			b.next = a;
-			foreach (UnitNode aPrev in a.prev) {
-				aPrev.next = b;
-				b.prev.Add(aPrev);
-			}
-			a.prev.Clear();
-			a.prev.Add(b);
-		}
-
-		/// <summary>
-		/// Detect cases where Civ3 save/scenario declares an unexpected unit upgrade relation,
-		/// with "Musketman -> Swiss Mercenary" being the main motivation. In the game, the Swiss
-		/// Mercenary should upgrade to the Musketman, but the unit prototype data gives the
-		/// relation backwards.
-		/// </summary>
-		/// <param name="a"></param>
-		/// <param name="b"></param>
-		/// <returns></returns>
-		private static bool UnusualUpgradeRelation(UnitNode a, UnitNode b) {
-			// TODO: Look into a more robust approach based on resource needs and required tech.
-
-			// Shield value heuristic: higher cost -> lower cost indicates reverse relation
-			return a.shieldCost > (b?.shieldCost ?? int.MaxValue);
 		}
 
 		/// This method builds a Dictionary of unit upgrades based on Civ3 data.

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -946,7 +946,7 @@ namespace C7GameData {
 
 				// The owner index is into the list of civs, and we have a 1:1
 				// mapping of players and civs.
-				// The exception to this are barbarian units (unit.OwnerType == 1), 
+				// The exception to this are barbarian units (unit.OwnerType == 1),
 				// where the owner points to the tribe (city name in other civs), rather than the player/civ
 				// TODO: implement tribes for barbarians
 				int owner = unit.OwnerType == 1 ? 0 : unit.Owner;
@@ -1224,32 +1224,72 @@ namespace C7GameData {
 		}
 
 		private void ImportUnitUpgrades() {
-			Dictionary<SaveUnitPrototype, SaveUnitPrototype> upgradeDict = BuildUpgradeDict();
+			List<Tuple<SaveUnitPrototype, SaveUnitPrototype>> upgradePairs = ResolveUpgradePairs();
+
+			// a collection where each unit maps to all of its upgrade targets
+			// the targets are in a list sorted (descending) by number of civ able to produce the unit
+			Dictionary<SaveUnitPrototype, List<SaveUnitPrototype>> upgradeSet =
+				upgradePairs
+				.GroupBy(x => x.Item1)
+				.ToDictionary(x => x.Key, y => y
+						.Select(uu => uu.Item2)
+						.Where(u => u != null)
+						.OrderByDescending(u => u.producibleBy.Count)
+						.ThenBy(u => u.name)
+						.ToList());
 
 			foreach (SaveUnitPrototype proto in save.UnitPrototypes) {
-				proto.upgradeTo = upgradeDict[proto]?.name;
+				// Push upgrade targets to a stack
+				List<SaveUnitPrototype> upgradeTargets = upgradeSet[proto];
+				var upgradeStack =  new Stack<SaveUnitPrototype>();
+				upgradeTargets.ForEach(upgradeStack.Push);
+
+				proto.upgradeTo = null; // default case
+
+				// While targets in stack, find a non-unique unit for the upgrade target
+				while (upgradeStack.Count > 0) {
+					var candidate = upgradeStack.Pop();
+					if (candidate.IsUniqueUnit()) {
+						if (upgradeSet.TryGetValue(candidate, out List<SaveUnitPrototype> uniqueUpgradeTo)) {
+							uniqueUpgradeTo.ForEach(upgradeStack.Push);
+						}
+					} else { // found a reasonable upgrade target
+						proto.upgradeTo = candidate.name;
+						break;
+					}
+				}
 			}
+
+			// HACK: Scheme above results in "Swiss Mercenary" -> "Rifleman", but we want -> "Musketman"
+			var swiss = save.UnitPrototypes.FirstOrDefault(u => u.name == "Swiss Mercenary");
+			if (swiss != null)
+				swiss.upgradeTo = "Musketman";
+
+			// HACK: Scheme above results in "Berserk" -> "Longbowman", but we want -> "Guerilla"
+			var berserk = save.UnitPrototypes.FirstOrDefault(u => u.name == "Berserk");
+			if (berserk != null)
+				berserk.upgradeTo = "Guerilla";
 		}
 
 		// This method builds a Dictionary of unit upgrades based on the CIV3 data.
 		// The dictionary represents the raw upgrade relationships as defined in the game files.
-		private Dictionary<SaveUnitPrototype, SaveUnitPrototype> BuildUpgradeDict() {
+		private List<Tuple<SaveUnitPrototype, SaveUnitPrototype>> ResolveUpgradePairs() {
 			PRTO[] Prto = biq.Prto ?? defaultBiq.Prto;
 			var unitPrototypeDict = save.UnitPrototypes.ToDictionary(b => b.name);
 
-			Dictionary<SaveUnitPrototype, SaveUnitPrototype> upgradeDict = [];
+			List<Tuple<SaveUnitPrototype, SaveUnitPrototype>> upgradePairs = [];
 
 			foreach (PRTO prto in Prto) {
 				SaveUnitPrototype upgradeFrom = unitPrototypeDict[prto.Name];
 				if (prto.UpgradeTo != -1) {
 					SaveUnitPrototype upgradeTo = unitPrototypeDict[Prto[prto.UpgradeTo].Name];
-					upgradeDict[upgradeFrom] = upgradeTo;
+					upgradePairs.Add(new Tuple<SaveUnitPrototype, SaveUnitPrototype>(upgradeFrom, upgradeTo));
 				} else {
-					upgradeDict[upgradeFrom] = null;
+					upgradePairs.Add(new Tuple<SaveUnitPrototype, SaveUnitPrototype>(upgradeFrom, null));
 				}
 			}
 
-			return upgradeDict;
+			return upgradePairs;
 		}
 
 		private void ImportBuildings() {

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -1228,6 +1228,7 @@ namespace C7GameData {
 			private readonly int _civCount;
 			private SaveUnitPrototype proto { get; }
 			public string name => proto.name;
+			public int shieldCost => proto.shieldCost;
 			public bool producibleBy(string civ) => proto.producibleBy.Contains(civ);
 
 			public HashSet<UnitNode> prev { get; set; } = [];
@@ -1304,10 +1305,20 @@ namespace C7GameData {
 			var idx = new Dictionary<string, UnitNode>();
 			var civCount = civilizations.Count;
 
+			var unusual = new HashSet<Tuple<SaveUnitPrototype, SaveUnitPrototype>>();
+
 			foreach (Tuple<SaveUnitPrototype, SaveUnitPrototype> pair in upgradePairs) {
 				var a = idx.TryGetValue(pair.Item1.name, out var nodeA) ? nodeA : new UnitNode(pair.Item1, civCount);
 				var b = pair.Item2 == null ? null :
 					idx.TryGetValue(pair.Item2.name, out var nodeB) ? nodeB : new UnitNode(pair.Item2, civCount);
+
+				// Detect cases where the upgrade relation leads to "wrong results".
+				// We handle these cases separately later.
+				if (UnusualUpgradeRelation(a, b)) {
+					unusual.Add(pair);
+					continue;
+				}
+
 				a.next = b;
 				idx[a.name] = a;
 				if (b != null) {
@@ -1316,7 +1327,49 @@ namespace C7GameData {
 				}
 			}
 
+			foreach (var pair in unusual) {
+				var a = idx[pair.Item1.name];
+				var b = idx[pair.Item2.name];
+				AddReverseUpgrade(a, b);
+			}
+
 			return idx;
+		}
+
+		/// <summary>
+		/// Manipulate the unit upgrade linked lists to apply an upgrade relation in reverse.
+		/// </summary>
+		private static void AddReverseUpgrade(UnitNode a, UnitNode b) {
+			// From:	X -> a -> b -> Y
+			// To:		X -> b -> a -> Y
+
+			b.next?.prev.Remove(b);
+			a.next = b.next;
+			b.next?.prev.Add(a);
+
+			b.next = a;
+			foreach (UnitNode aPrev in a.prev) {
+				aPrev.next = b;
+				b.prev.Add(aPrev);
+			}
+			a.prev.Clear();
+			a.prev.Add(b);
+		}
+
+		/// <summary>
+		/// Detect cases where Civ3 save/scenario declares an unexpected unit upgrade relation,
+		/// with "Musketman -> Swiss Mercenary" being the main motivation. In the game, the Swiss
+		/// Mercenary should upgrade to the Musketman, but the unit prototype data gives the
+		/// relation backwards.
+		/// </summary>
+		/// <param name="a"></param>
+		/// <param name="b"></param>
+		/// <returns></returns>
+		private static bool UnusualUpgradeRelation(UnitNode a, UnitNode b) {
+			// TODO: Look into a more robust approach based on resource needs and required tech.
+
+			// Shield value heuristic: higher cost -> lower cost indicates reverse relation
+			return a.shieldCost > (b?.shieldCost ?? int.MaxValue);
 		}
 
 		/// This method builds a Dictionary of unit upgrades based on Civ3 data.

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -1225,36 +1225,89 @@ namespace C7GameData {
 		}
 
 		private class UnitNode {
-			private SaveUnitPrototype proto { get; set; }
+			private readonly int _civCount;
+			private SaveUnitPrototype proto { get; }
 			public string name => proto.name;
-			public bool isUniqueUnit => proto.IsUniqueUnit();
 			public bool producibleBy(string civ) => proto.producibleBy.Contains(civ);
-			public string uniqueCiv => proto.producibleBy.Single();
 
 			public HashSet<UnitNode> prev { get; set; } = [];
 			public UnitNode next { get; set; } = null;
 
-			public UnitNode(SaveUnitPrototype proto) {
+			public UnitNode(SaveUnitPrototype proto, int civCount) {
+				_civCount = civCount;
 				this.proto = proto;
 			}
 
+			private bool IsCommon() => proto.producibleBy.Count > (_civCount / 2);
+
 			public override string ToString() {
 				var tail = next == null ? " -| " : $" -> {next}";
-				var uu = this.proto.IsUniqueUnit();
-				return uu ? $"({name}){tail}" : $"{name}{tail}";
+				return IsCommon() ? $"{name}{tail}" : $"({name}){tail}";
 			}
 		}
 
 		private void ImportUnitUpgrades() {
 			List<Tuple<SaveUnitPrototype, SaveUnitPrototype>> upgradePairs = ResolveUpgradePairs();
+			var civs = save.Civilizations.ToList();
 
-			// Build upgrade chains as linked lists
+			// Build upgrade chains as linked lists, indexed by name
+			Dictionary<string, UnitNode> idx = BuildUnitUpgradeChains(upgradePairs, civs);
+
+			// Resolve upgrade mappings for each unit, per civilization
+			// By evaluating the unit upgrade chains in the context of every civilization,
+			// we capture the full picture of how any particular unit can upgrade by any civ.
+			// This full "closure" is the record we store in the save file and base ruleset.
+
+			var upgradeBook = new Dictionary<string, HashSet<string>>();
+
+			foreach (KeyValuePair<string, UnitNode> kv in idx) {
+				var name = kv.Key;
+
+				if (!upgradeBook.ContainsKey(name))
+					upgradeBook[name] = new HashSet<string>();
+
+				foreach (Civilization civ in civs) {
+					var node = kv.Value;
+
+					if (!node.producibleBy(civ.name))
+						continue;
+
+					var upgrade = node.next;
+					while (upgrade != null && !upgrade.producibleBy(civ.name)) {
+						upgrade = upgrade.next;
+					}
+
+					if (upgrade != null)
+						upgradeBook[name].Add(upgrade.name);
+				}
+			}
+
+			// Apply
+			foreach (SaveUnitPrototype proto in save.UnitPrototypes) {
+				if (upgradeBook.TryGetValue(proto.name, out HashSet<string> target)) {
+					proto.upgradesTo = target.OrderBy(x => x).ToList();
+				} else {
+					throw new DataException($"Missing upgrade for {proto.name}");
+				}
+			}
+		}
+
+		/// This function takes pairs of units in the save game format (complex upgrade chain relations)
+		/// and creates a name->Node mapping for further processing. The big idea here
+		/// is to reuse the same object, effectively gathering all references relating to
+		/// a particular unit in one object. And then building a nice index to these nodes.
+		///
+		/// See https://forums.civfanatics.com/threads/how-to-upgrade-regular-units-to-uus.108396/
+		private static Dictionary<string, UnitNode> BuildUnitUpgradeChains(
+			List<Tuple<SaveUnitPrototype, SaveUnitPrototype>> upgradePairs,
+			List<Civilization> civilizations) {
 			var idx = new Dictionary<string, UnitNode>();
+			var civCount = civilizations.Count;
 
 			foreach (Tuple<SaveUnitPrototype, SaveUnitPrototype> pair in upgradePairs) {
-				var a = idx.TryGetValue(pair.Item1.name, out var nodeA) ? nodeA : new UnitNode(pair.Item1);
+				var a = idx.TryGetValue(pair.Item1.name, out var nodeA) ? nodeA : new UnitNode(pair.Item1, civCount);
 				var b = pair.Item2 == null ? null :
-					idx.TryGetValue(pair.Item2.name, out var nodeB) ? nodeB : new UnitNode(pair.Item2);
+					idx.TryGetValue(pair.Item2.name, out var nodeB) ? nodeB : new UnitNode(pair.Item2, civCount);
 				a.next = b;
 				idx[a.name] = a;
 				if (b != null) {
@@ -1263,113 +1316,11 @@ namespace C7GameData {
 				}
 			}
 
-			// Resolve upgrade mappings and the replacement mapping for unique units
-			var upgradeBook = new Dictionary<string, string>();
-
-			// Regular units
-			foreach (KeyValuePair<string, UnitNode> kv in idx) {
-				var name = kv.Key;
-				var node = kv.Value;
-
-				if (node.isUniqueUnit)
-					continue;
-
-				var upgrade = node.next;
-				while (upgrade != null && upgrade.isUniqueUnit) {
-					upgrade = upgrade.next;
-				}
-				upgradeBook[name] = upgrade?.name;
-			}
-
-			// Unique units
-			var uniqueUnits = idx.Values.Where(x => x.isUniqueUnit).ToList();
-
-			foreach (var unitNode in uniqueUnits) {
-				var name = unitNode.name;
-				var civ = unitNode.uniqueCiv;
-
-				var upgrade = unitNode.next;
-				while (upgrade != null && !upgrade.producibleBy(civ)) {
-					upgrade = upgrade.next;
-				}
-
-				upgradeBook[name] = upgrade?.name;
-			}
-
-			// Variants
-			var variantBook = CreateVariantBook(uniqueUnits);
-
-			// Apply
-			foreach (SaveUnitPrototype proto in save.UnitPrototypes) {
-				if (upgradeBook.TryGetValue(proto.name, out string target)) {
-					proto.upgradeTo = target;
-				} else {
-					throw new DataException($"Missing upgrade for {proto.name}");
-				}
-
-				if (variantBook.TryGetValue(proto.name, out string variant)) {
-					proto.variantOf = variant;
-				} else {
-					if (proto.IsUniqueUnit())
-						throw new DataException($"Missing variant for {proto.name}");
-				}
-			}
+			return idx;
 		}
 
-
-		private static Dictionary<string, string> CreateVariantBook(List<UnitNode> uniqueUnits) {
-			// WIP - doesn't quite work;
-			// need to rethink approach because Enkidu Warrior replace BOTH warrior and spearman
-
-			var variantBook = new Dictionary<string, string>();
-
-			foreach (var unitNode in uniqueUnits) {
-				var name = unitNode.name;
-				var civ = unitNode.uniqueCiv;
-
-				var backwardsStack = new Stack<UnitNode>();
-
-				var next = unitNode.next;
-				if (next != null && !next.isUniqueUnit && !next.producibleBy(civ)) {
-					variantBook[name] = next.name;
-					continue;
-				}
-
-				foreach (var upgradePrev in unitNode.next?.prev ?? []) {
-					if (upgradePrev != unitNode)
-						backwardsStack.Push(upgradePrev);
-				}
-				foreach (var prev in unitNode.prev ?? []) {
-					backwardsStack.Push(prev);
-				}
-
-				while (backwardsStack.Count > 0) {
-					var current = backwardsStack.Pop();
-
-					if (!current.isUniqueUnit && !current.producibleBy(civ)) {
-						variantBook[name] = current.name;
-						break;
-					}
-
-					foreach (var prev in current.prev ?? []) {
-						backwardsStack.Push(prev);
-					}
-				}
-
-				if (!variantBook.ContainsKey(name)) { // special cases
-													  // Hwach'aa
-													  // Jaguar Warrior
-													  // Man-o-war
-													  // (Enkidu W)
-					variantBook[name] = null; // TODO: heuristic?
-				}
-			}
-
-			return variantBook;
-		}
-
-		// This method builds a Dictionary of unit upgrades based on the CIV3 data.
-		// The dictionary represents the raw upgrade relationships as defined in the game files.
+		/// This method builds a Dictionary of unit upgrades based on Civ3 data.
+		/// The dictionary represents the raw upgrade relationships as they are defined in a save game file.
 		private List<Tuple<SaveUnitPrototype, SaveUnitPrototype>> ResolveUpgradePairs() {
 			PRTO[] Prto = biq.Prto ?? defaultBiq.Prto;
 			var unitPrototypeDict = save.UnitPrototypes.ToDictionary(b => b.name);

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using Serilog;
 using QueryCiv3;
@@ -1223,52 +1224,148 @@ namespace C7GameData {
 			}
 		}
 
+		private class UnitNode {
+			private SaveUnitPrototype proto { get; set; }
+			public string name => proto.name;
+			public bool isUniqueUnit => proto.IsUniqueUnit();
+			public bool producibleBy(string civ) => proto.producibleBy.Contains(civ);
+			public string uniqueCiv => proto.producibleBy.Single();
+
+			public HashSet<UnitNode> prev { get; set; } = [];
+			public UnitNode next { get; set; } = null;
+
+			public UnitNode(SaveUnitPrototype proto) {
+				this.proto = proto;
+			}
+
+			public override string ToString() {
+				var tail = next == null ? " -| " : $" -> {next}";
+				var uu = this.proto.IsUniqueUnit();
+				return uu ? $"({name}){tail}" : $"{name}{tail}";
+			}
+		}
+
 		private void ImportUnitUpgrades() {
 			List<Tuple<SaveUnitPrototype, SaveUnitPrototype>> upgradePairs = ResolveUpgradePairs();
 
-			// a collection where each unit maps to all of its upgrade targets
-			// the targets are in a list sorted (descending) by number of civ able to produce the unit
-			Dictionary<SaveUnitPrototype, List<SaveUnitPrototype>> upgradeSet =
-				upgradePairs
-				.GroupBy(x => x.Item1)
-				.ToDictionary(x => x.Key, y => y
-						.Select(uu => uu.Item2)
-						.Where(u => u != null)
-						.OrderByDescending(u => u.producibleBy.Count)
-						.ThenBy(u => u.name)
-						.ToList());
+			// Build upgrade chains as linked lists
+			var idx = new Dictionary<string, UnitNode>();
 
-			foreach (SaveUnitPrototype proto in save.UnitPrototypes) {
-				// Push upgrade targets to a stack
-				List<SaveUnitPrototype> upgradeTargets = upgradeSet[proto];
-				var upgradeStack =  new Stack<SaveUnitPrototype>();
-				upgradeTargets.ForEach(upgradeStack.Push);
-
-				proto.upgradeTo = null; // default case
-
-				// While targets in stack, find a non-unique unit for the upgrade target
-				while (upgradeStack.Count > 0) {
-					var candidate = upgradeStack.Pop();
-					if (candidate.IsUniqueUnit()) {
-						if (upgradeSet.TryGetValue(candidate, out List<SaveUnitPrototype> uniqueUpgradeTo)) {
-							uniqueUpgradeTo.ForEach(upgradeStack.Push);
-						}
-					} else { // found a reasonable upgrade target
-						proto.upgradeTo = candidate.name;
-						break;
-					}
+			foreach (Tuple<SaveUnitPrototype, SaveUnitPrototype> pair in upgradePairs) {
+				var a = idx.TryGetValue(pair.Item1.name, out var nodeA) ? nodeA : new UnitNode(pair.Item1);
+				var b = pair.Item2 == null ? null :
+					idx.TryGetValue(pair.Item2.name, out var nodeB) ? nodeB : new UnitNode(pair.Item2);
+				a.next = b;
+				idx[a.name] = a;
+				if (b != null) {
+					b.prev.Add(a);
+					idx[b.name] = b;
 				}
 			}
 
-			// HACK: Scheme above results in "Swiss Mercenary" -> "Rifleman", but we want -> "Musketman"
-			var swiss = save.UnitPrototypes.FirstOrDefault(u => u.name == "Swiss Mercenary");
-			if (swiss != null)
-				swiss.upgradeTo = "Musketman";
+			// Resolve upgrade mappings and the replacement mapping for unique units
+			var upgradeBook = new Dictionary<string, string>();
 
-			// HACK: Scheme above results in "Berserk" -> "Longbowman", but we want -> "Guerilla"
-			var berserk = save.UnitPrototypes.FirstOrDefault(u => u.name == "Berserk");
-			if (berserk != null)
-				berserk.upgradeTo = "Guerilla";
+			// Regular units
+			foreach (KeyValuePair<string, UnitNode> kv in idx) {
+				var name = kv.Key;
+				var node = kv.Value;
+
+				if (node.isUniqueUnit)
+					continue;
+
+				var upgrade = node.next;
+				while (upgrade != null && upgrade.isUniqueUnit) {
+					upgrade = upgrade.next;
+				}
+				upgradeBook[name] = upgrade?.name;
+			}
+
+			// Unique units
+			var uniqueUnits = idx.Values.Where(x => x.isUniqueUnit).ToList();
+
+			foreach (var unitNode in uniqueUnits) {
+				var name = unitNode.name;
+				var civ = unitNode.uniqueCiv;
+
+				var upgrade = unitNode.next;
+				while (upgrade != null && !upgrade.producibleBy(civ)) {
+					upgrade = upgrade.next;
+				}
+
+				upgradeBook[name] = upgrade?.name;
+			}
+
+			// Variants
+			var variantBook = CreateVariantBook(uniqueUnits);
+
+			// Apply
+			foreach (SaveUnitPrototype proto in save.UnitPrototypes) {
+				if (upgradeBook.TryGetValue(proto.name, out string target)) {
+					proto.upgradeTo = target;
+				} else {
+					throw new DataException($"Missing upgrade for {proto.name}");
+				}
+
+				if (variantBook.TryGetValue(proto.name, out string variant)) {
+					proto.variantOf = variant;
+				} else {
+					if (proto.IsUniqueUnit())
+						throw new DataException($"Missing variant for {proto.name}");
+				}
+			}
+		}
+
+
+		private static Dictionary<string, string> CreateVariantBook(List<UnitNode> uniqueUnits) {
+			// WIP - doesn't quite work;
+			// need to rethink approach because Enkidu Warrior replace BOTH warrior and spearman
+
+			var variantBook = new Dictionary<string, string>();
+
+			foreach (var unitNode in uniqueUnits) {
+				var name = unitNode.name;
+				var civ = unitNode.uniqueCiv;
+
+				var backwardsStack = new Stack<UnitNode>();
+
+				var next = unitNode.next;
+				if (next != null && !next.isUniqueUnit && !next.producibleBy(civ)) {
+					variantBook[name] = next.name;
+					continue;
+				}
+
+				foreach (var upgradePrev in unitNode.next?.prev ?? []) {
+					if (upgradePrev != unitNode)
+						backwardsStack.Push(upgradePrev);
+				}
+				foreach (var prev in unitNode.prev ?? []) {
+					backwardsStack.Push(prev);
+				}
+
+				while (backwardsStack.Count > 0) {
+					var current = backwardsStack.Pop();
+
+					if (!current.isUniqueUnit && !current.producibleBy(civ)) {
+						variantBook[name] = current.name;
+						break;
+					}
+
+					foreach (var prev in current.prev ?? []) {
+						backwardsStack.Push(prev);
+					}
+				}
+
+				if (!variantBook.ContainsKey(name)) { // special cases
+													  // Hwach'aa
+													  // Jaguar Warrior
+													  // Man-o-war
+													  // (Enkidu W)
+					variantBook[name] = null; // TODO: heuristic?
+				}
+			}
+
+			return variantBook;
 		}
 
 		// This method builds a Dictionary of unit upgrades based on the CIV3 data.
@@ -1288,6 +1385,8 @@ namespace C7GameData {
 					upgradePairs.Add(new Tuple<SaveUnitPrototype, SaveUnitPrototype>(upgradeFrom, null));
 				}
 			}
+
+			// Note: duplicate pairs are due to "OtherStrategy", alternate AI strategy for unit
 
 			return upgradePairs;
 		}

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -295,6 +295,11 @@ namespace C7GameData.Save {
 					proto.upgradeTo = unitPrototypeDict[saveProto.upgradeTo];
 				}
 
+				if (saveProto.variantOf != null) {
+					proto.variantOf = unitPrototypeDict[saveProto.variantOf];
+					proto.variantOf.variants.Add(proto);
+				}
+
 				if (saveProto.requiredTech != null) {
 					proto.requiredTech = techDict[saveProto.requiredTech];
 				}

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -291,13 +291,8 @@ namespace C7GameData.Save {
 			foreach (SaveUnitPrototype saveProto in UnitPrototypes) {
 				UnitPrototype proto = unitPrototypeDict[saveProto.name];
 
-				if (saveProto.upgradeTo != null) {
-					proto.upgradeTo = unitPrototypeDict[saveProto.upgradeTo];
-				}
-
-				if (saveProto.variantOf != null) {
-					proto.variantOf = unitPrototypeDict[saveProto.variantOf];
-					proto.variantOf.variants.Add(proto);
+				if ((saveProto.upgradesTo ?? []).Any()) {
+					proto.upgradesTo = saveProto.upgradesTo.Select(x => unitPrototypeDict[x]).ToList();
 				}
 
 				if (saveProto.requiredTech != null) {

--- a/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
+++ b/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
@@ -21,10 +21,8 @@ namespace C7GameData.Save {
 
 		public HashSet<string> producibleBy = [];
 
-		public string upgradeTo;
+		public List<string> upgradesTo;
 		public bool unproducible;
-
-		public string variantOf; // TODO: multiple, e.g., Enkidu Warrior replaces Warrior AND Spearman
 
 		// Assorted boolean flags for the unit prototype. They're stored in
 		// this set rather than as booleans to avoid bloating the json file.
@@ -51,11 +49,8 @@ namespace C7GameData.Save {
 			if (proto.requiredTech != null)
 				requiredTech = proto.requiredTech.id;
 
-			if (proto.upgradeTo != null)
-				upgradeTo = proto.upgradeTo.name;
-
-			if (proto.variantOf != null)
-				variantOf = proto.variantOf.name;
+			if (proto.upgradesTo != null)
+				upgradesTo = proto.upgradesTo?.Select(x => x.name).OrderBy(x => x).ToList() ?? [];
 
 			categories = new HashSet<string>(proto.categories);
 			actions = proto.actions;
@@ -66,10 +61,5 @@ namespace C7GameData.Save {
 			terraformActions = proto.terraformActions.Select(r => r.Id).ToHashSet();
 			producibleBy = proto.producibleBy.Select(r => r.name).ToHashSet();
 		}
-
-		public bool IsUniqueUnit() => producibleBy.Count == 1;
-
-		// TODO: missiles and transports, leader/army/princess?
-		public bool IsNonCombatUnit() => attack == 0 & bombard == 0;
 	}
 }

--- a/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
+++ b/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
@@ -24,6 +24,8 @@ namespace C7GameData.Save {
 		public string upgradeTo;
 		public bool unproducible;
 
+		public string variantOf; // TODO: multiple, e.g., Enkidu Warrior replaces Warrior AND Spearman
+
 		// Assorted boolean flags for the unit prototype. They're stored in
 		// this set rather than as booleans to avoid bloating the json file.
 		public HashSet<Flag> flags = [];
@@ -52,6 +54,9 @@ namespace C7GameData.Save {
 			if (proto.upgradeTo != null)
 				upgradeTo = proto.upgradeTo.name;
 
+			if (proto.variantOf != null)
+				variantOf = proto.variantOf.name;
+
 			categories = new HashSet<string>(proto.categories);
 			actions = proto.actions;
 			attributes = new HashSet<string>(proto.attributes);
@@ -63,5 +68,8 @@ namespace C7GameData.Save {
 		}
 
 		public bool IsUniqueUnit() => producibleBy.Count == 1;
+
+		// TODO: missiles and transports, leader/army/princess?
+		public bool IsNonCombatUnit() => attack == 0 & bombard == 0;
 	}
 }

--- a/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
+++ b/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
@@ -61,5 +61,7 @@ namespace C7GameData.Save {
 			terraformActions = proto.terraformActions.Select(r => r.Id).ToHashSet();
 			producibleBy = proto.producibleBy.Select(r => r.name).ToHashSet();
 		}
+
+		public bool IsUniqueUnit() => producibleBy.Count == 1;
 	}
 }

--- a/C7Engine/C7GameData/UnitPrototype.cs
+++ b/C7Engine/C7GameData/UnitPrototype.cs
@@ -152,6 +152,7 @@ namespace C7GameData {
 			return instance;
 		}
 
+		/// Immediate upgrade target, given a civilization.
 		private UnitPrototype GetUnitUpgrade(Civilization civ) {
 			var match = upgradesTo.Where(x => x.producibleBy.Contains(civ)).ToList();
 			if (match.Count > 1)
@@ -159,80 +160,34 @@ namespace C7GameData {
 			return match.FirstOrDefault();
 		}
 
+		/// The upgrade chain: a unit upgrade series as an ordered collection of unit prototypes,
+		/// for a particular civilization, starting from this unit.
+		///
+		/// Note: must be unique and stable: in-game every unit has at most one direct upgrade target.
+		private List<UnitPrototype> GetUpgradeChain(Civilization civ) {
+			var chain = new List<UnitPrototype>();
+			var current = this.GetUnitUpgrade(civ);
+			while (current != null) {
+				chain.Add(current);
+				current = current.GetUnitUpgrade(civ);
+			}
+			return chain;
+		}
+
+		/// Whether a given city can produce this unit, given available resources.
 		public bool CanProduce(City city, HashSet<Resource> accessibleResources) {
-			var unitUpgradeChain = city.owner.civilization.GetUpgradeChain(this);
-			return city.owner.civilization.IsUnitAvailable(this)
+			var civ = city.owner.civilization;
+			return this.IsAvailableTo(civ)
 				   && this.MeetsProductionRequirements(city, accessibleResources)
 				   && !this.IsUnitObsolete(city, accessibleResources);
 		}
 
-		// TODO: Consider golden ages when determining whether a unit is obsolete.
-		// If a golden age has not yet been triggered and a unit can trigger one,
-		// it shouldn't be marked as obsolete, even if its upgrade is available.
-		private bool IsUnitObsolete(City city, HashSet<Resource> accessibleResources) {
-			if (EngineStorage.gameData.rules.AllowLesserUnitProduction) return false;
-
-			if (this.GetProducibleUpgrade(city, accessibleResources) == null) return false;
-
-			return true;
+		/// Whether a Civ could build this unit, if it had a suitable city and necessary resources.
+		private bool IsAvailableTo(Civilization civ) {
+			return !this.unproducible && this.producibleBy.Contains(civ);
 		}
 
-		// For example, if we want to check if the Trebuchet is obsolete for the Koreans,
-		// what we can do, because we don't want to hardcode anywhere that
-		// the Hwacha is the "replacement" to the Cannon (which is Trebuchet's upgrade)
-		// we can check if the upgrade (Artillery) of the upgrade (Cannon) of our unit (Trebuchet)
-		// has other units that upgrade to it and are available to the Koreans.
-		// This is how we get that, since we can built a Hwacha,
-		// which upgrades to Artillery, that the Trebuchet is obsolete.
-		private List<UnitPrototype> GetUnitsThatUpgradeToThisUpgrade() {
-			var unitProtos = EngineStorage.gameData.unitPrototypes;
-
-			HashSet<UnitPrototype> upgradeUpgrades = (upgradesTo ?? [])
-				.SelectMany(x => x.upgradesTo ?? [])
-				.ToHashSet();
-
-			List<UnitPrototype> allUnits = unitProtos.Where(p
-				=> (p.upgradesTo ?? []).Intersect(upgradeUpgrades).Any())
-				.Except([this])
-				.ToList();
-
-			return allUnits;
-		}
-
-		// This should be the method we use to get the "true" upgrade of a given unit
-		public UnitPrototype GetProducibleUpgrade(City city, HashSet<Resource> accessibleResources) {
-			UnitPrototype upgrade = this.GetUnitUpgrade(city.owner.civilization);
-			if (upgrade == null) return null;
-
-			var unitUpgradeChain = city.owner.civilization.GetUpgradeChain(this);
-
-			var potentialUnits = this.GetUnitsThatUpgradeToThisUpgrade();
-
-			var units = unitUpgradeChain.Union(potentialUnits);
-
-			var producibleUnits = units.Where(uu =>
-				uu.MeetsProductionRequirements(city, accessibleResources)
-				&& uu.producibleBy.Contains(city.owner.civilization)
-			);
-
-			// picking the last item, as when trying to get the upgrade for a Warrior,
-			// and Medieval Infantry is available, we don't want to return the Swordsman
-			var unitUpgrade = SortInUpgradeOrder(producibleUnits).LastOrDefault();
-
-			return unitUpgrade;
-		}
-
-
-		private List<UnitPrototype> SortInUpgradeOrder(IEnumerable<UnitPrototype> units) {
-			var sorted = units.ToList();
-			sorted.Sort((a, b) => {
-				if (a.upgradesTo.Contains(b)) return -1;
-				if (b.upgradesTo.Contains(a)) return 1;
-				return 0;
-			});
-			return sorted;
-		}
-
+		/// Whether this unit can be built in this city (by the owner), given this particular set of resources.
 		private bool MeetsProductionRequirements(City city, HashSet<Resource> accessibleResources) {
 			if (!city.owner.HasRequiredTechnology(this)) {
 				return false;
@@ -247,6 +202,81 @@ namespace C7GameData {
 			}
 
 			return true;
+		}
+
+		/// A unit is obsolete if a unit in its upgrade chain can be produced (in this city
+		/// with the given resources).
+		///
+		/// "AllowLesserUnitProduction" removes unit obsolescence.
+		private bool IsUnitObsolete(City city, HashSet<Resource> accessibleResources) {
+			// TODO: Consider golden ages when determining whether a unit is obsolete.
+			// If a golden age has not yet been triggered and a unit can trigger one,
+			// it shouldn't be marked as obsolete, even if its upgrade is available.
+
+			if (EngineStorage.gameData.rules.AllowLesserUnitProduction) return false;
+
+			if (this.GetProducibleUpgrade(city, accessibleResources) == null) return false;
+
+			return true;
+		}
+
+		/// The "true" upgrade for any given in-game unit. The unique unit prototype available to
+		/// this unit for this civ, in this city, with the given resources.
+		public UnitPrototype GetProducibleUpgrade(City city, HashSet<Resource> accessibleResources) {
+			var civ = city.owner.civilization;
+
+			var unitUpgradeChain = this.GetUpgradeChain(civ);
+			if (!unitUpgradeChain.Any())
+				return null;
+
+			// We expand the upgrade chain with "siblings", units that join the chain from nearby "branches"
+			var potentialUnits = this.GetUnitsThatUpgradeTo(this.upgradesTo);
+			var units = unitUpgradeChain.Union(potentialUnits);
+
+			// Filter down to units we can produce
+			var producibleUnits = units.Where(uu =>
+				uu.MeetsProductionRequirements(city, accessibleResources)
+				&& uu.producibleBy.Contains(civ)
+			).ToList();
+
+			// Select the best unit we can upgrade to. Say we are upgrading a Warrior: if Medieval Infantry
+			// is available, we don't want to upgrade to a mere Swordsman.
+			var unitUpgrade = SortInUpgradeOrder(producibleUnits).LastOrDefault();
+
+			return unitUpgrade;
+		}
+
+		// For example, if we want to check if the Trebuchet is obsolete for the Koreans,
+		// what we can do, because we don't want to hardcode anywhere that
+		// the Hwacha is the "replacement" to the Cannon (which is Trebuchet's upgrade)
+		// we can check if the upgrade (Artillery) of the upgrade (Cannon) of our unit (Trebuchet)
+		// has other units that upgrade to it and are available to the Koreans.
+		// This is how we get that, since we can build a Hwacha,
+		// which upgrades to Artillery, that the Trebuchet is obsolete.
+		private List<UnitPrototype> GetUnitsThatUpgradeTo(ICollection<UnitPrototype> units) {
+			var unitProtos = EngineStorage.gameData.unitPrototypes;
+
+			HashSet<UnitPrototype> upgradeUpgrades = (units ?? [])
+				.SelectMany(x => x.upgradesTo ?? [])
+				.ToHashSet();
+
+			List<UnitPrototype> allUnits = unitProtos.Where(p
+					=> (p.upgradesTo ?? []).Intersect(upgradeUpgrades).Any())
+				.Except([this])
+				.ToList();
+
+			return allUnits;
+		}
+
+		/// Sort by the upgrade relation: if a upgrades to b, a is "smaller than" b
+		private List<UnitPrototype> SortInUpgradeOrder(IEnumerable<UnitPrototype> units) {
+			var sorted = units.ToList();
+			sorted.Sort((a, b) => {
+				if (a.upgradesTo.Contains(b)) return -1;
+				if (b.upgradesTo.Contains(a)) return 1;
+				return 0;
+			});
+			return sorted;
 		}
 	}
 }

--- a/C7Engine/C7GameData/UnitPrototype.cs
+++ b/C7Engine/C7GameData/UnitPrototype.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Runtime.InteropServices.JavaScript;
+using Serilog;
 
 namespace C7GameData {
 	using System;
@@ -63,10 +65,8 @@ namespace C7GameData {
 		public int rateOfFire { get; set; }
 		public int movement { get; set; }
 		public HashSet<Civilization> producibleBy { get; set; } = [];
-		public UnitPrototype upgradeTo;
+		public List<UnitPrototype> upgradesTo = [];
 		public bool unproducible;
-		public UnitPrototype variantOf;
-		public List<UnitPrototype> variants = [];
 		public HashSet<SaveUnitPrototype.Flag> flags = [];
 		public bool rotateBeforeAttack {
 			get => flags.Contains(SaveUnitPrototype.Flag.RotateBeforeAttack);
@@ -153,14 +153,10 @@ namespace C7GameData {
 		}
 
 		private UnitPrototype GetUnitUpgrade(Civilization civ) {
-			while (true) {
-				if (upgradeTo == null) return null;
-				if (!upgradeTo.producibleBy.Contains(civ)) {
-					upgradeTo.GetUnitUpgrade(civ);
-				}
-
-				return upgradeTo;
-			}
+			var match = upgradesTo.Where(x => x.producibleBy.Contains(civ)).ToList();
+			if (match.Count > 1)
+				Log.Warning($"Unexpected upgrade chain: more than one valid target for upgrading {name} with {civ.name}.");
+			return match.FirstOrDefault();
 		}
 
 		public bool CanProduce(City city, HashSet<Resource> accessibleResources) {
@@ -189,9 +185,17 @@ namespace C7GameData {
 		// This is how we get that, since we can built a Hwacha,
 		// which upgrades to Artillery, that the Trebuchet is obsolete.
 		private List<UnitPrototype> GetUnitsThatUpgradeToThisUpgrade() {
-			List<UnitPrototype> allUnits = EngineStorage.gameData.unitPrototypes.Where(
-				p => p.upgradeTo != null && p.upgradeTo == this.upgradeTo?.upgradeTo
-					).ToList();
+			var unitProtos = EngineStorage.gameData.unitPrototypes;
+
+			HashSet<UnitPrototype> upgradeUpgrades = (upgradesTo ?? [])
+				.SelectMany(x => x.upgradesTo ?? [])
+				.ToHashSet();
+
+			List<UnitPrototype> allUnits = unitProtos.Where(p
+				=> (p.upgradesTo ?? []).Intersect(upgradeUpgrades).Any())
+				.Except([this])
+				.ToList();
+
 			return allUnits;
 		}
 
@@ -204,16 +208,29 @@ namespace C7GameData {
 
 			var potentialUnits = this.GetUnitsThatUpgradeToThisUpgrade();
 
-			var units = unitUpgradeChain.Concat(potentialUnits.Where(uu => !unitUpgradeChain.Contains(uu)));
+			var units = unitUpgradeChain.Union(potentialUnits);
 
-			// picking the last item, as when trying to get the upgrade for a Warrior,
-			// and Medieval Infantry is available, we don't want to return the Swordsman
-			var unitUpgrade = units.LastOrDefault(uu =>
+			var producibleUnits = units.Where(uu =>
 				uu.MeetsProductionRequirements(city, accessibleResources)
 				&& uu.producibleBy.Contains(city.owner.civilization)
 			);
 
+			// picking the last item, as when trying to get the upgrade for a Warrior,
+			// and Medieval Infantry is available, we don't want to return the Swordsman
+			var unitUpgrade = SortInUpgradeOrder(producibleUnits).LastOrDefault();
+
 			return unitUpgrade;
+		}
+
+
+		private List<UnitPrototype> SortInUpgradeOrder(IEnumerable<UnitPrototype> units) {
+			var sorted = units.ToList();
+			sorted.Sort((a, b) => {
+				if (a.upgradesTo.Contains(b)) return -1;
+				if (b.upgradesTo.Contains(a)) return 1;
+				return 0;
+			});
+			return sorted;
 		}
 
 		private bool MeetsProductionRequirements(City city, HashSet<Resource> accessibleResources) {

--- a/C7Engine/C7GameData/UnitPrototype.cs
+++ b/C7Engine/C7GameData/UnitPrototype.cs
@@ -65,6 +65,8 @@ namespace C7GameData {
 		public HashSet<Civilization> producibleBy { get; set; } = [];
 		public UnitPrototype upgradeTo;
 		public bool unproducible;
+		public UnitPrototype variantOf;
+		public List<UnitPrototype> variants = [];
 		public HashSet<SaveUnitPrototype.Flag> flags = [];
 		public bool rotateBeforeAttack {
 			get => flags.Contains(SaveUnitPrototype.Flag.RotateBeforeAttack);

--- a/EngineTests/EngineTests.csproj
+++ b/EngineTests/EngineTests.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="18.5.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\C7Engine\C7Engine.csproj" />

--- a/EngineTests/GameData/AmbReaderTest.cs
+++ b/EngineTests/GameData/AmbReaderTest.cs
@@ -8,9 +8,10 @@ using Xunit;
 namespace EngineTests.GameData;
 
 public class AmbReaderTest {
-	[Fact]
+
+	[SkippableFact]
 	public void WorkerRunAmbTest() {
-		if (Civ3TestData.ShouldSkipCiv3DependentTests()) { return; }
+		Skip.If(Civ3TestData.ShouldSkipCiv3DependentTests(), "No Civ3 install found.");
 
 		string path = Path.Combine(Civ3Location.GetCiv3Path(), "Art", "Units", "Worker", "WorkerRun.amb");
 

--- a/EngineTests/GameData/MultiTurnDealsTest.cs
+++ b/EngineTests/GameData/MultiTurnDealsTest.cs
@@ -10,11 +10,10 @@ namespace EngineTests.GameData;
 
 public class MultiTurnDealTest : RemoteSaveLoader {
 	private const string SAVES_FOLDER = "saves/multi-turn-deals";
-	[Fact]
+
+	[SkippableFact]
 	public async void TestMultiTurnDeal_Save_A() {
-		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
-			return;
-		}
+		Skip.If(Civ3TestData.ShouldSkipCiv3DependentTests(), "No Civ3 install found.");
 
 		// Save game deal details
 		// Round: 47
@@ -89,11 +88,9 @@ public class MultiTurnDealTest : RemoteSaveLoader {
 		});
 	}
 
-	[Fact]
+	[SkippableFact]
 	public async void TestMultiTurnDeal_Save_B() {
-		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
-			return;
-		}
+		Skip.If(Civ3TestData.ShouldSkipCiv3DependentTests(), "No Civ3 install found.");
 
 		// Save game deal details
 		// Round: 99
@@ -193,11 +190,9 @@ public class MultiTurnDealTest : RemoteSaveLoader {
 		});
 	}
 
-	[Fact]
+	[SkippableFact]
 	public async void TestMultiTurnDeal_Save_C() {
-		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
-			return;
-		}
+		Skip.If(Civ3TestData.ShouldSkipCiv3DependentTests(), "No Civ3 install found.");
 
 		// Save game deal details
 		// Round: 99
@@ -343,11 +338,9 @@ public class MultiTurnDealTest : RemoteSaveLoader {
 		});
 	}
 
-	[Fact]
+	[SkippableFact]
 	public async void TestMultiTurnDeal_Save_D() {
-		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
-			return;
-		}
+		Skip.If(Civ3TestData.ShouldSkipCiv3DependentTests(), "No Civ3 install found.");
 
 		// Save game deal details
 		// Round: 98
@@ -448,11 +441,9 @@ public class MultiTurnDealTest : RemoteSaveLoader {
 
 	}
 
-	[Fact]
+	[SkippableFact]
 	public async void TestMultiTurnDeal_Save_E() {
-		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
-			return;
-		}
+		Skip.If(Civ3TestData.ShouldSkipCiv3DependentTests(), "No Civ3 install found.");
 
 		// Save game deal details
 		// Round: 0
@@ -602,11 +593,9 @@ public class MultiTurnDealTest : RemoteSaveLoader {
 		});
 	}
 
-	[Fact]
+	[SkippableFact]
 	public async void TestMultiTurnDeal_Save_F() {
-		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
-			return;
-		}
+		Skip.If(Civ3TestData.ShouldSkipCiv3DependentTests(), "No Civ3 install found.");
 
 		// Save game deal details
 		// Round: 1

--- a/EngineTests/GameData/SaveTest.cs
+++ b/EngineTests/GameData/SaveTest.cs
@@ -458,9 +458,9 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 	}
 
 
-	[Fact]
+	[SkippableFact]
 	public async void LoadSampleSaves() {
-		if (Civ3TestData.ShouldSkipCiv3DependentTests()) { return; }
+		Skip.If(Civ3TestData.ShouldSkipCiv3DependentTests(), "No Civ3 install found.");
 
 		string savesPath = PathUtils.getDataPath("saves");
 		Directory.CreateDirectory(savesPath);
@@ -496,9 +496,9 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 		Assert.True(i > 0);
 	}
 
-	[Fact]
+	[SkippableFact]
 	public void LoadAllConquestScenarios() {
-		if (Civ3TestData.ShouldSkipCiv3DependentTests()) { return; }
+		Skip.If(Civ3TestData.ShouldSkipCiv3DependentTests(), "No Civ3 install found.");
 
 		string[] singleplayerScenarios = {
 			"1 Mesopotamia.biq",

--- a/EngineTests/GameData/UnitPrototypeTest.cs
+++ b/EngineTests/GameData/UnitPrototypeTest.cs
@@ -20,8 +20,6 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 
 		Skip.If(Civ3TestData.ShouldSkipCiv3DependentTests(), "No Civ3 install found.");
 
-		#region setup
-
 		string saveName = "Conquests 16 Players.SAV";
 		string uri = "https://www.dropbox.com/scl/fi/gmxbx1mtrammzfc6vly1g/Conquests-16-Players.SAV?rlkey=2z1es5aetqva4ymv59qduq1at&st=d0udmb3w&dl=1";
 
@@ -31,6 +29,29 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 		Assert.NotNull(game);
 		Assert.True(File.Exists(savePath));
 
+		TestUnitAvailabilityAndUpgrades(game);
+	}
+
+	[SkippableFact]
+	public async void UnitAvailability_JSON() {
+		// This tests a Conquests game with Conquests rules from a .json file
+
+		Skip.If(Civ3TestData.ShouldSkipCiv3DependentTests(), "No Civ3 install found.");
+
+		string saveName = "Conquests 16 Players.json";
+		string uri = "https://www.dropbox.com/scl/fi/g1qxuvc6xptg1l6hx9s21/Conquests-16-Players.json?rlkey=bkq158od7469pibhtw44g04if&st=tqax1064&dl=1";
+
+		(SaveGame game, Exception ex, string savePath) = await LoadGameAndData(saveName, SAVES_FOLDER, uri);
+
+		Assert.Null(ex);
+		Assert.NotNull(game);
+		Assert.True(File.Exists(savePath));
+
+		TestUnitAvailabilityAndUpgrades(game);
+	}
+
+	private void TestUnitAvailabilityAndUpgrades(SaveGame game) {
+		#region Setup
 		C7GameData.GameData gd = game.ToGameData(PathUtils.luaRulesDir);
 		EngineStorage.InitializeGameDataForTests(gd);
 
@@ -49,6 +70,21 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 		var kor = new Player() { civilization = koreans };
 		var hittites = gd.civilizations.FirstOrDefault(c => c.name == "Hittites");
 		var hit = new Player() { civilization = hittites };
+		var persians = gd.civilizations.FirstOrDefault(c => c.name == "Persia");
+		var per = new Player() { civilization = persians };
+		var sumerians = gd.civilizations.FirstOrDefault(c => c.name == "Sumeria");
+		var sum = new Player() { civilization = sumerians };
+		var spanish = gd.civilizations.FirstOrDefault(c => c.name == "Spain");
+		var span = new Player() { civilization = spanish };
+
+		Assert.NotNull(netherlands);
+		Assert.NotNull(americans);
+		Assert.NotNull(ottomans);
+		Assert.NotNull(russians);
+		Assert.NotNull(koreans);
+		Assert.NotNull(hittites);
+		Assert.NotNull(persians);
+		Assert.NotNull(sumerians);
 
 		// setup resources
 		var noResources = new HashSet<Resource>(){};
@@ -63,12 +99,14 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 		// setup techs
 		var wheel = gd.techs.FirstOrDefault(t => t.Name == "The Wheel");
 		var bronze = gd.techs.FirstOrDefault(t => t.Name == "Bronze Working");
+		var ironWorking = gd.techs.FirstOrDefault(t => t.Name == "Iron Working");
 		var horsebackRiding = gd.techs.FirstOrDefault(t => t.Name == "Horseback Riding");
 		var mathematics = gd.techs.FirstOrDefault(t => t.Name == "Mathematics");
 		var feudalism = gd.techs.FirstOrDefault(t => t.Name == "Feudalism");
 		var engineering = gd.techs.FirstOrDefault(t => t.Name == "Engineering");
 		var chivalry = gd.techs.FirstOrDefault(t => t.Name == "Chivalry");
 		var metallurgy = gd.techs.FirstOrDefault(t => t.Name == "Metallurgy");
+		var astronomy = gd.techs.FirstOrDefault(t => t.Name == "Astronomy");
 		var milTradition = gd.techs.FirstOrDefault(t => t.Name == "Military Tradition");
 		var nationalism = gd.techs.FirstOrDefault(t => t.Name == "Nationalism");
 		var flight = gd.techs.FirstOrDefault(t => t.Name == "Flight");
@@ -76,7 +114,13 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 		var rocketry = gd.techs.FirstOrDefault(t => t.Name == "Rocketry");
 
 		// setup some unit prototypes
+		var warrior = protos.FirstOrDefault(p => p.name == "Warrior");
 		var spearman = protos.FirstOrDefault(p => p.name == "Spearman");
+		var enkidu = protos.FirstOrDefault(p => p.name == "Enkidu Warrior");
+		var swordsman = protos.FirstOrDefault(p => p.name == "Swordsman");
+		var immortals = protos.FirstOrDefault(p => p.name == "Immortals");
+		var pikeman = protos.FirstOrDefault(p => p.name == "Pikeman");
+		var medInfantry = protos.FirstOrDefault(p => p.name == "Medieval Infantry");
 		var swiss = protos.FirstOrDefault(p => p.name == "Swiss Mercenary");
 		var horseman = protos.FirstOrDefault(p => p.name == "Horseman");
 		var chariot = protos.FirstOrDefault(p => p.name == "Chariot");
@@ -90,12 +134,15 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 		var cannon = protos.FirstOrDefault(p => p.name == "Cannon");
 		var rifleman = protos.FirstOrDefault(p => p.name == "Rifleman");
 		var hwacha = protos.FirstOrDefault(p => p.name == "Hwach'a");
+		var scout = protos.FirstOrDefault(p => p.name == "Scout");
+		var conquistador = protos.FirstOrDefault(p => p.name == "Conquistador");
+		var explorer = protos.FirstOrDefault(p => p.name == "Explorer");
 		var artillery = protos.FirstOrDefault(p => p.name == "Artillery");
 		var fighter = protos.FirstOrDefault(p => p.name == "Fighter");
 		var jet = protos.FirstOrDefault(p => p.name == "Jet Fighter");
 		var f15 = protos.FirstOrDefault(p => p.name == "F-15");
 		var musketman = protos.FirstOrDefault(p => p.name == "Musketman");
-
+		var guerilla = protos.FirstOrDefault(p => p.name == "Guerilla");
 		#endregion
 
 		#region Ottomans
@@ -193,9 +240,14 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 		City moscow = new City(moscowTile, rus, "Moscow", gd.ids.CreateID("Moscow"));
 
 		Assert.True(horseman.producibleBy.Contains(russians));
+		Assert.True(scout.producibleBy.Contains(russians));
+		Assert.True(explorer.producibleBy.Contains(russians));
 		Assert.True(knight.producibleBy.Contains(russians));
 		Assert.True(cossack.producibleBy.Contains(russians));
 		Assert.False(cavalry.producibleBy.Contains(russians));
+
+		Assert.True(scout.CanProduce(moscow, noResources));
+		Assert.Null(scout.GetProducibleUpgrade(moscow, noResources));
 
 		rus.knownTechs.Add(horsebackRiding.id);
 
@@ -221,6 +273,11 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 		Assert.False(cavalry.CanProduce(moscow, new HashSet<Resource>() { horses, iron, saltpeter }));
 
 		Assert.True(cossack.GetProducibleUpgrade(moscow, new HashSet<Resource>() { horses, iron, saltpeter }) == null);
+
+		rus.knownTechs.Add(astronomy.id);
+		Assert.False(scout.CanProduce(moscow, noResources));
+		Assert.True(explorer.CanProduce(moscow, noResources));
+		Assert.Equal(explorer, scout.GetProducibleUpgrade(moscow, noResources));
 		#endregion
 
 		#region Korean
@@ -300,181 +357,87 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 
 		Assert.True(fighter.GetProducibleUpgrade(seattle, new HashSet<Resource>() { oil, aluminum }) == f15);
 		#endregion
-	}
 
-	[SkippableFact]
-	public async void UnitAvailability_JSON() {
-		// This tests a Conquests game with Conquests rules from a .json file
+		#region Persians
+		Tile persepolisTile = new Tile(ID.None("tile"));
+		City persepolis = new City(persepolisTile, per, "Persepolis", gd.ids.CreateID("Persepolis"));
 
-		Skip.If(Civ3TestData.ShouldSkipCiv3DependentTests(), "No Civ3 install found.");
+		Assert.False(swordsman.producibleBy.Contains(persians));
+		Assert.True(immortals.producibleBy.Contains(persians));
 
-		#region setup
+		per.knownTechs.Add(ironWorking.id);
 
-		string saveName = "Conquests 16 Players.json";
-		string uri = "https://www.dropbox.com/scl/fi/g1qxuvc6xptg1l6hx9s21/Conquests-16-Players.json?rlkey=bkq158od7469pibhtw44g04if&st=k2fg3ev5&dl=1";
+		// Can't build swordsman even without iron (duh)
+		Assert.False(swordsman.CanProduce(persepolis, noResources));
+		Assert.False(swordsman.CanProduce(persepolis, new HashSet<Resource>() { iron }));
+		Assert.True(immortals.CanProduce(persepolis, new HashSet<Resource>() { iron }));
 
-		(SaveGame game, Exception ex, string savePath) = await LoadGameAndData(saveName, SAVES_FOLDER, uri);
+		Assert.Null(immortals.GetProducibleUpgrade(persepolis, noResources));
 
-		Assert.Null(ex);
-		Assert.NotNull(game);
-		Assert.True(File.Exists(savePath));
+		per.knownTechs.Add(feudalism.id);
+		Assert.False(swordsman.CanProduce(persepolis, noResources));
+		Assert.False(swordsman.CanProduce(persepolis, new HashSet<Resource>() { iron }));
+		Assert.False(medInfantry.CanProduce(persepolis, new HashSet<Resource>() { iron }));
+		Assert.True(immortals.CanProduce(persepolis, new HashSet<Resource>() { iron }));
 
-		C7GameData.GameData gd = game.ToGameData(PathUtils.luaRulesDir);
-		EngineStorage.InitializeGameDataForTests(gd);
+		Assert.Null(immortals.GetProducibleUpgrade(persepolis, noResources));
 
-		List<UnitPrototype> protos = gd.unitPrototypes;
+		per.knownTechs.Add(replaceableParts.id);
+		Assert.False(immortals.CanProduce(persepolis, new HashSet<Resource>() { iron }));
+		Assert.True(guerilla.CanProduce(persepolis, noResources));
+		Assert.True(guerilla.CanProduce(persepolis, new HashSet<Resource>() { iron }));
+		Assert.Equal(guerilla, immortals.GetProducibleUpgrade(persepolis, noResources));
+		#endregion
 
-		// setup civilizations and players
-		var americans = gd.civilizations.FirstOrDefault(c => c.name == "America");
-		var amer = new Player() { civilization = americans };
-		var ottomans = gd.civilizations.FirstOrDefault(c => c.name == "Ottomans");
-		var otto = new Player() { civilization = ottomans };
-		var russians = gd.civilizations.FirstOrDefault(c => c.name == "Russia");
-		var rus = new Player() { civilization = russians };
-		var koreans = gd.civilizations.FirstOrDefault(c => c.name == "Korea");
-		var kor = new Player() { civilization = koreans };
-		var hittites = gd.civilizations.FirstOrDefault(c => c.name == "Hittites");
-		var hit = new Player() { civilization = hittites };
+		#region Sumerians
+		Tile sumerTile = new Tile(ID.None("tile"));
+		City sumer = new City(sumerTile, sum, "Sumer", gd.ids.CreateID("Sumer"));
 
-		// setup resources
-		var noResources = new HashSet<Resource>(){};
-		var horses = gd.Resources.FirstOrDefault(r => r.Key == "Horses");
-		var iron = gd.Resources.FirstOrDefault(r => r.Key == "Iron");
-		var saltpeter = gd.Resources.FirstOrDefault(r => r.Key == "Saltpeter");
-		var rubber = gd.Resources.FirstOrDefault(r => r.Key == "Rubber");
-		var oil = gd.Resources.FirstOrDefault(r => r.Key == "Oil");
-		var aluminum = gd.Resources.FirstOrDefault(r => r.Key == "Aluminum");
+		Assert.DoesNotContain(sumerians, warrior.producibleBy);
+		Assert.DoesNotContain(sumerians, spearman.producibleBy);
+		Assert.Contains(sumerians, enkidu.producibleBy);
 
-		// setup techs
-		var wheel = gd.techs.FirstOrDefault(t => t.Name == "The Wheel");
-		var horsebackRiding = gd.techs.FirstOrDefault(t => t.Name == "Horseback Riding");
-		var mathematics = gd.techs.FirstOrDefault(t => t.Name == "Mathematics");
-		var engineering = gd.techs.FirstOrDefault(t => t.Name == "Engineering");
-		var chivalry = gd.techs.FirstOrDefault(t => t.Name == "Chivalry");
-		var metallurgy = gd.techs.FirstOrDefault(t => t.Name == "Metallurgy");
-		var milTradition = gd.techs.FirstOrDefault(t => t.Name == "Military Tradition");
-		var flight = gd.techs.FirstOrDefault(t => t.Name == "Flight");
-		var replaceableParts = gd.techs.FirstOrDefault(t => t.Name == "Replaceable Parts");
-		var rocketry = gd.techs.FirstOrDefault(t => t.Name == "Rocketry");
+		Assert.False(warrior.CanProduce(sumer, noResources));
+		Assert.False(spearman.CanProduce(sumer, noResources));
+		Assert.True(enkidu.CanProduce(sumer, noResources));
 
-		// setup some unit prototypes
-		var horseman = protos.FirstOrDefault(p => p.name == "Horseman");
-		var chariot = protos.FirstOrDefault(p => p.name == "Chariot");
-		var threeManChariot = protos.FirstOrDefault(p => p.name == "Three-Man Chariot");
-		var knight = protos.FirstOrDefault(p => p.name == "Knight");
-		var cavalry = protos.FirstOrDefault(p => p.name == "Cavalry");
-		var sipahi = protos.FirstOrDefault(p => p.name == "Sipahi");
-		var cossack = protos.FirstOrDefault(p => p.name == "Cossack");
-		var catapult = protos.FirstOrDefault(p => p.name == "Catapult");
-		var trebuchet = protos.FirstOrDefault(p => p.name == "Trebuchet");
-		var cannon = protos.FirstOrDefault(p => p.name == "Cannon");
-		var hwacha = protos.FirstOrDefault(p => p.name == "Hwach'a");
-		var artillery = protos.FirstOrDefault(p => p.name == "Artillery");
-		var fighter = protos.FirstOrDefault(p => p.name == "Fighter");
-		var jet = protos.FirstOrDefault(p => p.name == "Jet Fighter");
-		var f15 = protos.FirstOrDefault(p => p.name == "F-15");
+		Assert.Null(enkidu.GetProducibleUpgrade(sumer, noResources));
+
+		sum.knownTechs.Add(bronze.id);
+		Assert.False(warrior.CanProduce(sumer, noResources));
+		Assert.False(spearman.CanProduce(sumer, noResources));
+		Assert.True(enkidu.CanProduce(sumer, noResources));
+
+		Assert.Null(enkidu.GetProducibleUpgrade(sumer, noResources));
+
+		sum.knownTechs.Add(feudalism.id);
+		Assert.False(warrior.CanProduce(sumer, noResources));
+		Assert.False(spearman.CanProduce(sumer, noResources));
+		Assert.True(enkidu.CanProduce(sumer, noResources));
+		Assert.False(enkidu.CanProduce(sumer, new HashSet<Resource>() { iron }));
+		Assert.True(pikeman.CanProduce(sumer, new HashSet<Resource>() { iron }));
+		Assert.False(pikeman.CanProduce(sumer, noResources));
+
+		Assert.Null(enkidu.GetProducibleUpgrade(sumer, noResources));
+		Assert.Equal(pikeman, enkidu.GetProducibleUpgrade(sumer, new HashSet<Resource>() { iron }));
 
 		#endregion
 
-		#region Hittites
-		Tile hattusasTile = new Tile(ID.None("tile"));
-		City hattusas = new City(hattusasTile, hit, "Hattusas", gd.ids.CreateID("Hattusas"));
+		#region Spanish
+		Tile madridTile = new Tile(ID.None("tile"));
+		City madrid = new City(madridTile, span, "Madrid", gd.ids.CreateID("Madrid"));
 
-		Assert.True(horseman.producibleBy.Contains(hittites));
-		Assert.False(chariot.producibleBy.Contains(hittites));
-		Assert.True(threeManChariot.producibleBy.Contains(hittites));
+		Assert.DoesNotContain(spanish, scout.producibleBy);
+		Assert.DoesNotContain(spanish, explorer.producibleBy);
+		Assert.Contains(spanish, conquistador.producibleBy);
 
+		Assert.False(conquistador.CanProduce(madrid, noResources));
+		Assert.False(conquistador.CanProduce(madrid, new HashSet<Resource>() { horses }));
 
-		hit.knownTechs.Add(wheel.id);
-
-		Assert.False(horseman.CanProduce(hattusas, new HashSet<Resource>() { horses }));
-		Assert.False(chariot.CanProduce(hattusas, new HashSet<Resource>() { horses }));
-		Assert.True(threeManChariot.CanProduce(hattusas, new HashSet<Resource>() { horses }));
-
-		#endregion
-
-		#region Russians
-		Tile moscowTile = new Tile(ID.None("tile"));
-		City moscow = new City(moscowTile, rus, "Moscow", gd.ids.CreateID("Moscow"));
-
-		Assert.True(horseman.producibleBy.Contains(russians));
-		Assert.True(knight.producibleBy.Contains(russians));
-		Assert.True(cossack.producibleBy.Contains(russians));
-		Assert.False(cavalry.producibleBy.Contains(russians));
-
-		rus.knownTechs.Add(horsebackRiding.id);
-
-		Assert.True(horseman.CanProduce(moscow, new HashSet<Resource>() { horses, iron }));
-		Assert.False(knight.CanProduce(moscow, new HashSet<Resource>() { horses, iron, saltpeter }));
-		Assert.False(sipahi.CanProduce(moscow, new HashSet<Resource>() { horses, iron, saltpeter }));
-		Assert.False(cavalry.CanProduce(moscow, new HashSet<Resource>() { horses, iron, saltpeter }));
-
-		rus.knownTechs.Add(chivalry.id);
-		// The Horseman is now obsolete
-		Assert.False(horseman.CanProduce(moscow, new HashSet<Resource>() { horses, iron }));
-		Assert.True(horseman.GetProducibleUpgrade(moscow, new HashSet<Resource>() { horses, iron }) == knight);
-
-		// even though we have saltpeter, we don't know Military Tradition, so the Knight is not yet obsolete
-		Assert.True(knight.CanProduce(moscow, new HashSet<Resource>() { horses, iron, saltpeter }));
-		Assert.False(cavalry.CanProduce(moscow, new HashSet<Resource>() { horses, iron, saltpeter }));
-		Assert.False(cossack.CanProduce(moscow, new HashSet<Resource>() { horses, iron, saltpeter }));
-
-		rus.knownTechs.Add(milTradition.id);
-		// the Knight is now obsolete
-		Assert.False(knight.CanProduce(moscow, new HashSet<Resource>() { horses, iron, saltpeter }));
-		Assert.True(knight.GetProducibleUpgrade(moscow, new HashSet<Resource>() { horses, iron, saltpeter }) == cossack);
-		Assert.False(cavalry.CanProduce(moscow, new HashSet<Resource>() { horses, iron, saltpeter }));
-
-		Assert.True(cossack.GetProducibleUpgrade(moscow, new HashSet<Resource>() { horses, iron, saltpeter }) == null);
-		#endregion
-
-		#region Korean
-		Tile seoulTile = new Tile(ID.None("tile"));
-		City seoul = new City(seoulTile, kor, "Seoul", gd.ids.CreateID("Seoul"));
-
-		// In conquests they both the Cannon and the Hwacha are permitted in the rules for the Koreans,
-		// maybe an oversight in the original rules, but it's there.
-		// We only care that the Trebuchet can upgrade to a Hwacha and not to a Cannon
-		Assert.True(catapult.producibleBy.Contains(koreans));
-		Assert.True(trebuchet.producibleBy.Contains(koreans));
-		Assert.True(cannon.producibleBy.Contains(koreans));
-		Assert.True(hwacha.producibleBy.Contains(koreans));
-
-		Assert.False(catapult.CanProduce(seoul, noResources));
-		Assert.False(trebuchet.CanProduce(seoul, noResources));
-		Assert.False(cannon.CanProduce(seoul, noResources));
-		Assert.False(hwacha.CanProduce(seoul, noResources));
-
-		kor.knownTechs.Add(mathematics.id);
-
-		Assert.True(catapult.CanProduce(seoul, noResources));
-		Assert.False(trebuchet.CanProduce(seoul, noResources));
-		Assert.False(cannon.CanProduce(seoul, noResources));
-		Assert.False(hwacha.CanProduce(seoul, noResources));
-
-		kor.knownTechs.Add(engineering.id);
-
-		Assert.False(catapult.CanProduce(seoul, noResources));
-		Assert.True(trebuchet.CanProduce(seoul, noResources));
-		Assert.False(cannon.CanProduce(seoul, noResources));
-		Assert.False(hwacha.CanProduce(seoul, noResources));
-
-		Assert.True(catapult.GetProducibleUpgrade(seoul, noResources) == trebuchet);
-
-		kor.knownTechs.Add(metallurgy.id);
-
-		Assert.False(catapult.CanProduce(seoul, new HashSet<Resource>() { saltpeter }));
-		Assert.False(trebuchet.CanProduce(seoul, new HashSet<Resource>() { saltpeter }));
-		Assert.False(cannon.CanProduce(seoul, new HashSet<Resource>() { saltpeter }));
-		Assert.True(hwacha.CanProduce(seoul, new HashSet<Resource>() { saltpeter }));
-
-		Assert.True(trebuchet.GetProducibleUpgrade(seoul, new HashSet<Resource>() { saltpeter }) == hwacha);
-		Assert.False(trebuchet.GetProducibleUpgrade(seoul, new HashSet<Resource>() { saltpeter }) == cannon);
-
-		kor.knownTechs.Add(replaceableParts.id);
-		Assert.False(hwacha.CanProduce(seoul, new HashSet<Resource>() { saltpeter }));
-		Assert.True(artillery.CanProduce(seoul, new HashSet<Resource>() { }));
-		Assert.True(hwacha.GetProducibleUpgrade(seoul, new HashSet<Resource>() { }) == artillery);
+		span.knownTechs.Add(astronomy.id);
+		Assert.False(conquistador.CanProduce(madrid, noResources));
+		Assert.True(conquistador.CanProduce(madrid, new HashSet<Resource>() { horses }));
+		Assert.Null(conquistador.GetProducibleUpgrade(madrid, noResources));
 
 		#endregion
 	}

--- a/EngineTests/GameData/UnitPrototypeTest.cs
+++ b/EngineTests/GameData/UnitPrototypeTest.cs
@@ -58,6 +58,7 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 		var rubber = gd.Resources.FirstOrDefault(r => r.Key == "Rubber");
 		var oil = gd.Resources.FirstOrDefault(r => r.Key == "Oil");
 		var aluminum = gd.Resources.FirstOrDefault(r => r.Key == "Aluminum");
+		var gunpowder = gd.techs.FirstOrDefault(t => t.Name == "Gunpowder");
 
 		// setup techs
 		var wheel = gd.techs.FirstOrDefault(t => t.Name == "The Wheel");
@@ -93,6 +94,7 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 		var fighter = protos.FirstOrDefault(p => p.name == "Fighter");
 		var jet = protos.FirstOrDefault(p => p.name == "Jet Fighter");
 		var f15 = protos.FirstOrDefault(p => p.name == "F-15");
+		var musketman = protos.FirstOrDefault(p => p.name == "Musketman");
 
 		#endregion
 
@@ -145,6 +147,17 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 		Assert.True(swiss.CanProduce(amsterdam, new HashSet<Resource>() { iron }));
 		// if the city has iron then we can't produce Spearman anymore, as we can produce their upgrade, the Swiss Mercenary
 		Assert.False(spearman.CanProduce(amsterdam, new HashSet<Resource>() { iron }));
+
+		nether.knownTechs.Add(gunpowder.id);
+		Assert.True(swiss.CanProduce(amsterdam, new HashSet<Resource>() { iron }));
+		Assert.False(swiss.CanProduce(amsterdam, new HashSet<Resource>() { saltpeter }));
+		Assert.True(swiss.CanProduce(amsterdam, new HashSet<Resource>() { iron, saltpeter }));
+		Assert.True(musketman.CanProduce(amsterdam, new HashSet<Resource>() { saltpeter }));
+		Assert.False(musketman.CanProduce(amsterdam, new HashSet<Resource>() { iron, saltpeter }));
+		Assert.False(rifleman.CanProduce(amsterdam, new HashSet<Resource>() { iron, saltpeter }));
+
+		Assert.Null(swiss.GetProducibleUpgrade(amsterdam, new HashSet<Resource>() { iron, saltpeter }));
+		Assert.False(swiss.GetProducibleUpgrade(amsterdam, new HashSet<Resource>() { iron, saltpeter }) == musketman);
 
 		nether.knownTechs.Add(nationalism.id);
 		Assert.True(rifleman.CanProduce(amsterdam, noResources));

--- a/EngineTests/GameData/UnitPrototypeTest.cs
+++ b/EngineTests/GameData/UnitPrototypeTest.cs
@@ -37,6 +37,8 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 		List<UnitPrototype> protos = gd.unitPrototypes;
 
 		// setup civilizations and players
+		var netherlands = gd.civilizations.FirstOrDefault(c => c.name == "Netherlands");
+		var nether = new Player() { civilization = netherlands };
 		var americans = gd.civilizations.FirstOrDefault(c => c.name == "America");
 		var amer = new Player() { civilization = americans };
 		var ottomans = gd.civilizations.FirstOrDefault(c => c.name == "Ottomans");
@@ -59,17 +61,22 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 
 		// setup techs
 		var wheel = gd.techs.FirstOrDefault(t => t.Name == "The Wheel");
+		var bronze = gd.techs.FirstOrDefault(t => t.Name == "Bronze Working");
 		var horsebackRiding = gd.techs.FirstOrDefault(t => t.Name == "Horseback Riding");
 		var mathematics = gd.techs.FirstOrDefault(t => t.Name == "Mathematics");
+		var feudalism = gd.techs.FirstOrDefault(t => t.Name == "Feudalism");
 		var engineering = gd.techs.FirstOrDefault(t => t.Name == "Engineering");
 		var chivalry = gd.techs.FirstOrDefault(t => t.Name == "Chivalry");
 		var metallurgy = gd.techs.FirstOrDefault(t => t.Name == "Metallurgy");
 		var milTradition = gd.techs.FirstOrDefault(t => t.Name == "Military Tradition");
+		var nationalism = gd.techs.FirstOrDefault(t => t.Name == "Nationalism");
 		var flight = gd.techs.FirstOrDefault(t => t.Name == "Flight");
 		var replaceableParts = gd.techs.FirstOrDefault(t => t.Name == "Replaceable Parts");
 		var rocketry = gd.techs.FirstOrDefault(t => t.Name == "Rocketry");
 
 		// setup some unit prototypes
+		var spearman = protos.FirstOrDefault(p => p.name == "Spearman");
+		var swiss = protos.FirstOrDefault(p => p.name == "Swiss Mercenary");
 		var horseman = protos.FirstOrDefault(p => p.name == "Horseman");
 		var chariot = protos.FirstOrDefault(p => p.name == "Chariot");
 		var threeManChariot = protos.FirstOrDefault(p => p.name == "Three-Man Chariot");
@@ -80,6 +87,7 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 		var catapult = protos.FirstOrDefault(p => p.name == "Catapult");
 		var trebuchet = protos.FirstOrDefault(p => p.name == "Trebuchet");
 		var cannon = protos.FirstOrDefault(p => p.name == "Cannon");
+		var rifleman = protos.FirstOrDefault(p => p.name == "Rifleman");
 		var hwacha = protos.FirstOrDefault(p => p.name == "Hwach'a");
 		var artillery = protos.FirstOrDefault(p => p.name == "Artillery");
 		var fighter = protos.FirstOrDefault(p => p.name == "Fighter");
@@ -120,6 +128,34 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 		Assert.False(cavalry.CanProduce(ankara, new HashSet<Resource>() { horses, iron, saltpeter }));
 
 		Assert.True(sipahi.GetProducibleUpgrade(ankara, new HashSet<Resource>() { horses, iron, saltpeter }) == null);
+		#endregion
+
+		#region Netherlands
+		Tile amsterdamTile = new Tile(ID.None("tile"));
+		City amsterdam = new City(amsterdamTile, nether, "Amsterdam", gd.ids.CreateID("Amsterdam"));
+
+		Assert.True(spearman.producibleBy.Contains(netherlands));
+
+		nether.knownTechs.Add(bronze.id);
+
+		Assert.True(spearman.CanProduce(amsterdam, noResources));
+
+		nether.knownTechs.Add(feudalism.id);
+		Assert.True(spearman.CanProduce(amsterdam, noResources));
+		Assert.True(swiss.CanProduce(amsterdam, new HashSet<Resource>() { iron }));
+		// if the city has iron then we can't produce Spearman anymore, as we can produce their upgrade, the Swiss Mercenary
+		Assert.False(spearman.CanProduce(amsterdam, new HashSet<Resource>() { iron }));
+
+		nether.knownTechs.Add(nationalism.id);
+		Assert.True(rifleman.CanProduce(amsterdam, noResources));
+
+		Assert.True(spearman.GetProducibleUpgrade(amsterdam, new HashSet<Resource>() { iron, saltpeter }) == rifleman);
+		Assert.False(spearman.GetProducibleUpgrade(amsterdam, new HashSet<Resource>() { iron, saltpeter }) == swiss);
+
+		Assert.False(spearman.CanProduce(amsterdam, new HashSet<Resource>() { iron, saltpeter }));
+		Assert.False(swiss.CanProduce(amsterdam, new HashSet<Resource>() { iron, saltpeter }));
+		Assert.True(swiss.GetProducibleUpgrade(amsterdam, new HashSet<Resource>() { iron, saltpeter }) == rifleman);
+		Assert.True(rifleman.CanProduce(amsterdam, new HashSet<Resource>() { iron, saltpeter }));
 		#endregion
 
 		#region Hittites

--- a/EngineTests/GameData/UnitPrototypeTest.cs
+++ b/EngineTests/GameData/UnitPrototypeTest.cs
@@ -13,14 +13,14 @@ namespace EngineTests.GameData;
 
 public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 	private const string SAVES_FOLDER = "saves/unit-availability";
-	[Fact]
+
+	[SkippableFact]
 	public async void UnitAvailability_SAV() {
 		// This tests a Conquests game with Conquests rules from a .SAV file
 
+		Skip.If(Civ3TestData.ShouldSkipCiv3DependentTests(), "No Civ3 install found.");
+
 		#region setup
-		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
-			return;
-		}
 
 		string saveName = "Conquests 16 Players.SAV";
 		string uri = "https://www.dropbox.com/scl/fi/gmxbx1mtrammzfc6vly1g/Conquests-16-Players.SAV?rlkey=2z1es5aetqva4ymv59qduq1at&st=d0udmb3w&dl=1";
@@ -253,13 +253,13 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 		#endregion
 	}
 
-	[Fact]
+	[SkippableFact]
 	public async void UnitAvailability_JSON() {
 		// This tests a Conquests game with Conquests rules from a .json file
+
+		Skip.If(Civ3TestData.ShouldSkipCiv3DependentTests(), "No Civ3 install found.");
+
 		#region setup
-		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
-			return;
-		}
 
 		string saveName = "Conquests 16 Players.json";
 		string uri = "https://www.dropbox.com/scl/fi/g1qxuvc6xptg1l6hx9s21/Conquests-16-Players.json?rlkey=bkq158od7469pibhtw44g04if&st=k2fg3ev5&dl=1";
@@ -434,16 +434,17 @@ public class UnitPrototypeConquestsTest : RemoteSaveLoader {
 
 public class UnitPrototypeScenarioTest : RemoteSaveLoader {
 	private const string SAVES_FOLDER = "saves/unit-availability";
-	[Fact]
-	public async void UnitAvailability_SAV() {
-		// This tests a Conquests scenario with custom rules 
 
-		#region setup
+	[SkippableFact]
+	public async void UnitAvailability_SAV() {
+		// This tests a Conquests scenario with custom rules
+
 		// Civ3 isn't installed in CI, so we can't load the default BIC. Local
 		// contributors without Civ3 assets configured should skip this too.
-		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
-			return;
-		}
+		Skip.If(Civ3TestData.ShouldSkipCiv3DependentTests(), "No Civ3 install found.");
+
+		#region setup
+
 		string scenarioBiqPath = Path.Combine(Civ3Location.GetCiv3Path(), "Conquests", "Conquests", "4 Middle Ages.biq");
 		string scenarioPediaPath = Path.Combine(Civ3Location.GetCiv3Path(), "Conquests", "Conquests", "Middle Ages", "Text", "PediaIcons.txt");
 


### PR DESCRIPTION
**EDIT:** From draft to a fix

- Made a script for applying changes in saved game `unitPrototype` to the matching base ruleset field.
- Revised the unitPrototype Civ3 load logic
- Misc fixes in base ruleset 

~~This draft PR is not intended to be merged as is, just a way to document "drift" between what the save files are given and what the base ruleset provides. The diff/drift here is based on latest Development branch as of this writing.~~

## Issues

Notable issues when reading a Civ3 save in OC3, saving the game in standard OC3 json save file format, and then applying `unitPrototype` on top of the OC3 base ruleset:
- Unique units replacing `upgradeTo` paths
- flag placement (`rotateBeforeAttack`): the field order in code doesn't match current ruleset order, resulting in this add/remove noise
- blank `producibleBy` getting removed
- Unicode encoding of city names, etc.
- Whitespace