### PR TITLE
Set HiDPI=false in Godot project settings

### DIFF
--- a/C7/project.godot
+++ b/C7/project.godot
@@ -26,6 +26,7 @@ LogManager="*res://LogManager.cs"
 
 window/size/window_width_override=1152
 window/size/window_height_override=768
+window/dpi/allow_hidpi=false
 window/per_pixel_transparency/allowed=true
 
 [dotnet]


### PR DESCRIPTION
I picked up a second hand 2022 MacBook Air the other day. The laptop boasts a high-DPI "Liquid Retina" display: _"13.6-inch (diagonal) LED-backlit display with IPS technology; 2560x1664 native resolution at 224 pixels per inch"_

OpenCiv3's Godot project settings for displays default to **high-DPI being enabled**, which when debugging in Godot (via Rider) results in a tiny game window, as the pixels render in true size. Setting high-DPI off gives a more useful game window, as Godot will scale things up in a reasonable way. (There are additional scaling settings to tweak, but just this one change is a big help.)

I suspect this fixes #876 and possibly #868 as well, though confirming this would require a release build or more testing with different hardware. My guess is that this flag will determine the `NSHighResolutionCapable` flag on Mac builds -- see workaround https://github.com/C7-Game/OpenCiv3/issues/876#issuecomment-3902350086 -- but to confirm I'll first have to figure out how Mac builds work.

### Before
_Compare Rider's menu text and OpenCiv3 status box text sizes._
<img width="1000" alt="Screenshot 2026-05-30 at 01 13 30" src="https://github.com/user-attachments/assets/12a9c950-4502-496f-abe7-8988db43cfdd" />

### After  
<img width="1000" alt="Screenshot 2026-05-30 at 00 52 54" src="https://github.com/user-attachments/assets/1b7ab92b-8e18-467e-ab4b-830e86880c14" />
