### PR TITLE
Air units movement adjustment

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -1057,7 +1057,11 @@ public partial class Game : Node {
 			// Figure out what unit is in goto mode. If the tile we're hovering over is
 			// different than the tile the unit is on, calculate the path to move there.
 			MapUnit unit = tile == null ? null : gameData.GetUnit(CurrentlySelectedUnit.id);
-			if (unit != null && unit.location != tile) {
+
+			// Units like the Bomber don't have a go-to action
+			if (unit != null && !unit.GetAvailableActions().Contains(UnitAction.Goto)) {
+				result = null;
+			} else if (unit != null && unit.location != tile) {
 				result.path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, tile, unit);
 				result.moveCost =
 					result.path.PathCost(unit.owner, unit.location, unit.unitType.movement, unit.movementPoints.remaining);

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -70,6 +70,9 @@ namespace C7GameData {
 		public bool IsWaterUnit() {
 			return this.unitType.categories.Contains("Sea");
 		}
+		public bool IsAirUnit() {
+			return this.unitType.categories.Contains("Air");
+		}
 
 		public bool CanDefendOnLand() {
 			return IsLandUnit() && unitType.defense > 0;
@@ -730,6 +733,11 @@ namespace C7GameData {
 
 		// Generalized check to see whether a given tile is accessible to the unit in a given context.
 		public bool CanEnterTile(Tile tile, TileProbe probe) {
+			// TODO: Perhaps this is not sufficient, but it is for now,
+			// since otherwise we can move air units on land and sea
+			if (this.IsAirUnit())
+				return false;
+
 			if (this.owner.isHuman && !this.owner.HasExploredTile(tile))
 				return true;
 


### PR DESCRIPTION
A simple PR to disable go-to for air units, and disallow them from entering any tile when using the numpad.