### PR TITLE
AI tweaks to civ economy management

### DIFF
--- a/C7Engine/AI/ChooseProducible.cs
+++ b/C7Engine/AI/ChooseProducible.cs
@@ -56,6 +56,11 @@ namespace C7Engine {
 			// I am not sure how civ III does this, although I guess we should consider stuff like
 			// no more buildings to build, reached unit cap, very bad economy with no other options,
 			// the WealthNever and WealthOften flags from RACE, etc
+
+			if (HasWeakEconomy(player)) {
+				return 100 - player.gold;
+			}
+
 			return -1000f;
 		}
 
@@ -134,6 +139,10 @@ namespace C7Engine {
 			// still in the expansion phase.
 			if (unitSupportCost > 0 && !atWar && !stats.inExpansionPhase) {
 				score -= unitSupportCost / 2;
+
+				if (HasWeakEconomy(player)) {
+					score -= unitSupportCost * 2;
+				}
 			}
 
 			////////////////////////////////////////////////////////////////////
@@ -288,6 +297,11 @@ namespace C7Engine {
 				score += 20;
 			}
 
+			// Penalize buildings if economy is weak
+			if (HasWeakEconomy(player)) {
+				score -= 10 * building.maintenanceCost;
+			}
+
 			return score;
 		}
 
@@ -373,6 +387,10 @@ namespace C7Engine {
 				}
 			}
 			return result;
+		}
+
+		public static bool HasWeakEconomy(Player player) {
+			return player.luxuryRate == 0 && player.scienceRate == 0 && player.gold < 100;
 		}
 	}
 }

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -401,7 +401,7 @@ namespace C7Engine {
 			// Now max out the science slider and then decrease it (increasing
 			// the tax rate) until we're not losing money.
 			player.scienceRate = MAX_SLIDER_VALUE - player.luxuryRate;
-			while (player.CalculateGoldPerTurn() < 0 && player.scienceRate > 0) {
+			while (player.scienceRate > 0 && !BudgetIsTolerable(player)) {
 				player.scienceRate--;
 				player.taxRate++;
 			}
@@ -440,6 +440,12 @@ namespace C7Engine {
 					CityTileAssignmentAI.AssignNewCitizenToTile(EngineStorage.gameData, newResident, manageMoods: true);
 				}
 			}
+		}
+
+		public static bool BudgetIsTolerable(Player player) {
+			var gpt = player.CalculateGoldPerTurn();
+			var tolerableDeficit = gpt > player.gold * -0.1;
+			return gpt > 0 || tolerableDeficit;
 		}
 	}
 }

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -121,6 +121,8 @@ namespace C7GameData {
 			}
 		}
 
+		private int lastGoldPerTurn = 0;
+
 		/// <summary>
 		/// Sets the current gold amount of the player. If the add parameter is true, the gold gets appended.<br/>
 		/// </summary>
@@ -751,7 +753,7 @@ namespace C7GameData {
 				}
 
 				// If that wasn't sufficient, go after luxuries.
-				if (scienceRate > 0) {
+				if (luxuryRate > 0) {
 					--luxuryRate;
 					++taxRate;
 					continue;
@@ -761,7 +763,8 @@ namespace C7GameData {
 				throw new Exception($"{this} was unable to get the budget under control despite being under the unit support cap and zeroing out the sliders (gold={gold}, gpt={CalculateGoldPerTurn()})");
 			}
 
-			gold += CalculateGoldPerTurn();
+			lastGoldPerTurn = CalculateGoldPerTurn();
+			gold += lastGoldPerTurn;
 		}
 
 		public void HandleCityUpdates(GameData gameData) {


### PR DESCRIPTION
A few tweaks to AI handling of the economy:
- Adjust production choices so Wealth is picked when the economy is in a bad shape
- Let AI run a deficit on some turns, if the economy can tolerate it
- Fix bug in finance update, let sliders fall all the way to try and keep the civ in the game

With these fixes I regularly get tiny pangea games to 2000AD and beyond without anyone crashing their economy.