### PR TITLE
Enhancement/worker actions

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -603,8 +603,7 @@ public partial class Game : Node {
 			});
 		}
 	}
-
-	// TODO: unify same parts with RightClickTileMenu->SelectUnit()
+    
 	private void HandleUnitSelection(InputEventMouseButton eventMouseButton) {
 		Tile tile = PositionToTile(eventMouseButton.Position);
 		if (tile == null) {
@@ -613,20 +612,25 @@ public partial class Game : Node {
 
 		// TODO: This should really be the top unit.
 		MapUnit toSelect = tile.unitsOnTile.FirstOrDefault();
-		if (toSelect == null || toSelect.owner != controller) {
-			return;
-		}
+        
+        if (toSelect == null || toSelect.owner != controller) {
+        	return;
+        }
+        
+        HandleSelection(toSelect);
+    }
 
-		bool canMove = unitSelector.SetSelectedUnit(toSelect);
+    public void HandleSelection(MapUnit unit) { 
+        bool canMove = unitSelector.SetSelectedUnit(unit);
 
-		if (toSelect.WorkerJob != null) {
-			return;
-		}
+        if (unit.WorkerJob != null) {
+            return;
+        }
 
-		if (!canMove) {
-            new MsgShowTemporaryPopup("This unit has already moved.", tile).send();
-		}
-	}
+        if (!canMove) {
+            new MsgShowTemporaryPopup("This unit has already moved.", unit.location).send();
+        }
+    }
 
 	private void HandleRightMouseButton(InputEventMouseButton eventMouseButton) {
 		setGotoMode(false);

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -604,12 +604,6 @@ public partial class Game : Node {
 		}
 	}
 
-	public static bool PreSelectUint(MapUnit unit) {
-		if (unit.WorkerJob != null)
-			return false;
-		return true;
-	}
-
 	// TODO: unify same parts with RightClickTileMenu->SelectUnit()
 	private void HandleUnitSelection(InputEventMouseButton eventMouseButton) {
 		Tile tile = PositionToTile(eventMouseButton.Position);
@@ -618,21 +612,19 @@ public partial class Game : Node {
 		}
 
 		// TODO: This should really be the top unit.
-		MapUnit to_select = tile.unitsOnTile.FirstOrDefault();
-		if (to_select == null || to_select.owner != controller) {
+		MapUnit toSelect = tile.unitsOnTile.FirstOrDefault();
+		if (toSelect == null || toSelect.owner != controller) {
 			return;
 		}
 
-		bool canMove = unitSelector.SetSelectedUnit(to_select);
+		bool canMove = unitSelector.SetSelectedUnit(toSelect);
 
-		if (to_select.WorkerJob != null) {
-			if (!PreSelectUint(to_select)) {
-				return;
-			}
+		if (toSelect.WorkerJob != null) {
+			return;
 		}
 
 		if (!canMove) {
-			TemporaryPopup.Show(this, "This unit has already moved.", eventMouseButton.Position);
+            new MsgShowTemporaryPopup("This unit has already moved.", tile).send();
 		}
 	}
 

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -603,7 +603,7 @@ public partial class Game : Node {
 			});
 		}
 	}
-    
+
 	private void HandleUnitSelection(InputEventMouseButton eventMouseButton) {
 		Tile tile = PositionToTile(eventMouseButton.Position);
 		if (tile == null) {
@@ -612,25 +612,25 @@ public partial class Game : Node {
 
 		// TODO: This should really be the top unit.
 		MapUnit toSelect = tile.unitsOnTile.FirstOrDefault();
-        
-        if (toSelect == null || toSelect.owner != controller) {
-        	return;
-        }
-        
-        HandleSelection(toSelect);
-    }
 
-    public void HandleSelection(MapUnit unit) { 
-        bool canMove = unitSelector.SetSelectedUnit(unit);
+		if (toSelect == null || toSelect.owner != controller) {
+			return;
+		}
 
-        if (unit.WorkerJob != null) {
-            return;
-        }
+		HandleSelection(toSelect);
+	}
 
-        if (!canMove) {
-            new MsgShowTemporaryPopup("This unit has already moved.", unit.location).send();
-        }
-    }
+	public void HandleSelection(MapUnit unit) {
+		bool canMove = unitSelector.SetSelectedUnit(unit);
+
+		if (unit.WorkerJob != null) {
+			return;
+		}
+
+		if (!canMove) {
+			new MsgShowTemporaryPopup("This unit has already moved.", unit.location).send();
+		}
+	}
 
 	private void HandleRightMouseButton(InputEventMouseButton eventMouseButton) {
 		setGotoMode(false);

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -344,6 +344,18 @@ public partial class Game : Node {
 						PopupOverlay.PopupCategory.Advisor);
 				}
 				break;
+			case MsgDisplayStopWorkerActionPopup mDSWA:
+				popupOverlay.ShowPopup(
+					new ConfirmationPopup(
+						$"This worker has been ordered to {C7Action.ToTooltip(mDSWA.workerJob.UIAction)} and will be done in {mDSWA.turnsLeft} turns." +
+						$"\nDo you want them to stop?",
+						"Yes, there is more important work to do!",
+						"No, carry on.",
+						() => {
+							new MsgDoStopWorkerAction(mDSWA.worker).send();
+						}),
+					PopupOverlay.PopupCategory.Advisor);
+				break;
 			case MsgWarDeclaration mWD:
 				popupOverlay.ShowPopup(
 					new InformationalPopup($"The {mWD.aggressor.civilization.noun} declared war on the {mWD.opponent.civilization.noun}"),
@@ -592,6 +604,13 @@ public partial class Game : Node {
 		}
 	}
 
+	public static bool PreSelectUint(MapUnit unit) {
+		if (unit.WorkerJob != null)
+			return false;
+		return true;
+	}
+
+	// TODO: unify same parts with RightClickTileMenu->SelectUnit()
 	private void HandleUnitSelection(InputEventMouseButton eventMouseButton) {
 		Tile tile = PositionToTile(eventMouseButton.Position);
 		if (tile == null) {
@@ -605,6 +624,13 @@ public partial class Game : Node {
 		}
 
 		bool canMove = unitSelector.SetSelectedUnit(to_select);
+
+		if (to_select.WorkerJob != null) {
+			if (!PreSelectUint(to_select)) {
+				return;
+			}
+		}
+
 		if (!canMove) {
 			TemporaryPopup.Show(this, "This unit has already moved.", eventMouseButton.Position);
 		}

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -100,10 +100,6 @@ public partial class RightClickMenu : VBoxContainer {
 			this.AcceptEvent();
 		}
 	}
-
-	public void ShowCannotMovePopup() {
-		TemporaryPopup.Show(GetParent(), "This unit has already moved.", position);
-	}
 }
 
 public partial class RightClickTileMenu : RightClickMenu {
@@ -215,12 +211,13 @@ public partial class RightClickTileMenu : RightClickMenu {
 			if (toSelect != null && toSelect.owner == game.controller) {
 
 				bool canMove = game.unitSelector.SetSelectedUnit(toSelect);
-				if (!Game.PreSelectUint(toSelect)) {
+                
+				if (toSelect.WorkerJob != null) {
 					return;
 				}
 
 				if (!canMove) {
-					ShowCannotMovePopup();
+                    new MsgShowTemporaryPopup("This unit has already moved.", toSelect.location).send();
 				}
 
 				new MsgSetFortification(toSelect.id, false).send();
@@ -245,7 +242,7 @@ public partial class RightClickTileMenu : RightClickMenu {
 					if (!hasSelectedUnit && !isFortify) {
 						bool canMove = game.unitSelector.SetSelectedUnit(unit);
 						if (!canMove) {
-							ShowCannotMovePopup();
+                            new MsgShowTemporaryPopup("This unit has already moved.", tile).send();
 						}
 					}
 				}

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -284,7 +284,7 @@ public partial class RightClickTileMenu : RightClickMenu {
 			MapUnit toSelect = gameData.mapUnits.Find(u => u.id == id);
 
 			if (toSelect != null && toSelect.owner == game.controller) {
-				game.HandleSelection(toSelect);
+				game.SelectUnit(toSelect);
 
 				new MsgSetFortification(toSelect.id, false).send();
 				ResetItems(toSelect.location, new Dictionary<ID, bool>() { { toSelect.id, false } });

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -202,23 +202,13 @@ public partial class RightClickTileMenu : RightClickMenu {
 				AddItem($"Contact {nonPlayerUnits[0].owner.civilization.name}", contactCiv);
 		}
 	}
-
-	// TODO: unify same parts with Game->HandleUnitSelection()
+    
 	public void SelectUnit(ID id) {
 		EngineStorage.ReadGameData((GameData gameData) => {
 			MapUnit toSelect = gameData.mapUnits.Find(u => u.id == id);
 
 			if (toSelect != null && toSelect.owner == game.controller) {
-
-				bool canMove = game.unitSelector.SetSelectedUnit(toSelect);
-                
-				if (toSelect.WorkerJob != null) {
-					return;
-				}
-
-				if (!canMove) {
-                    new MsgShowTemporaryPopup("This unit has already moved.", toSelect.location).send();
-				}
+                game.HandleSelection(toSelect);
 
 				new MsgSetFortification(toSelect.id, false).send();
 				ResetItems(toSelect.location, new Dictionary<ID, bool>() { { toSelect.id, false } });

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -207,11 +207,18 @@ public partial class RightClickTileMenu : RightClickMenu {
 		}
 	}
 
+	// TODO: unify same parts with Game->HandleUnitSelection()
 	public void SelectUnit(ID id) {
 		EngineStorage.ReadGameData((GameData gameData) => {
 			MapUnit toSelect = gameData.mapUnits.Find(u => u.id == id);
+
 			if (toSelect != null && toSelect.owner == game.controller) {
+
 				bool canMove = game.unitSelector.SetSelectedUnit(toSelect);
+				if (!Game.PreSelectUint(toSelect)) {
+					return;
+				}
+
 				if (!canMove) {
 					ShowCannotMovePopup();
 				}

--- a/C7/UIElements/RightClickMenu.cs
+++ b/C7/UIElements/RightClickMenu.cs
@@ -202,13 +202,13 @@ public partial class RightClickTileMenu : RightClickMenu {
 				AddItem($"Contact {nonPlayerUnits[0].owner.civilization.name}", contactCiv);
 		}
 	}
-    
+
 	public void SelectUnit(ID id) {
 		EngineStorage.ReadGameData((GameData gameData) => {
 			MapUnit toSelect = gameData.mapUnits.Find(u => u.id == id);
 
 			if (toSelect != null && toSelect.owner == game.controller) {
-                game.HandleSelection(toSelect);
+				game.HandleSelection(toSelect);
 
 				new MsgSetFortification(toSelect.id, false).send();
 				ResetItems(toSelect.location, new Dictionary<ID, bool>() { { toSelect.id, false } });
@@ -232,7 +232,7 @@ public partial class RightClickTileMenu : RightClickMenu {
 					if (!hasSelectedUnit && !isFortify) {
 						bool canMove = game.unitSelector.SetSelectedUnit(unit);
 						if (!canMove) {
-                            new MsgShowTemporaryPopup("This unit has already moved.", tile).send();
+							new MsgShowTemporaryPopup("This unit has already moved.", tile).send();
 						}
 					}
 				}

--- a/C7/UnitSelector.cs
+++ b/C7/UnitSelector.cs
@@ -81,9 +81,11 @@ public partial class UnitSelector : Node {
 			unit.path = TilePath.NONE;
 		}
 
-		// Allow cancellation of active worker jobs by clicking on the unit.
+		// Ask for confirmation to cancel an active worker's job by clicking on the unit.
 		if (unit.WorkerJob != null) {
-			unit.resetWorkerJob();
+			var turnsToFinish = unit.TurnsToCompleteTerraform(unit.WorkerJob);
+			new MsgDisplayStopWorkerActionPopup(unit, unit.WorkerJob, turnsToFinish).send();
+			return unit.WorkerJob == null && unit.movementPoints.remaining >= 1.0f;
 		}
 
 		// Allow cancellation automation via clicking on the unit.

--- a/C7Engine/C7GameData/AIData/WorkerAIData.cs
+++ b/C7Engine/C7GameData/AIData/WorkerAIData.cs
@@ -5,7 +5,7 @@ namespace C7GameData.AIData {
 		public TilePath pathToDestination;
 
 		public override string ToString() {
-			return workerMove + " at " + destination;
+			return workerMove.UIAction + " at " + destination;
 		}
 	}
 }

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -191,7 +191,7 @@ namespace C7GameData {
 			// worker that would take 2 turns. In order for the job to take the
 			// expected 4 turns we need to multiply by the movement cost of the
 			// terrain. This also makes roading hills/mountains more expensive.
-			return workerJob.TurnsToComplete * tile.overlayTerrainType.movementCost;
+			return tile.overlayTerrainType.movementCost * workerJob.TurnsToComplete;
 		}
 
 		public async Task animateAsync(MapUnit.AnimatedAction action, AnimationEnding ending = AnimationEnding.Stop) {
@@ -1012,8 +1012,11 @@ namespace C7GameData {
 			movementPoints.onConsumeAll();
 
 			// See if this worker finished the job.
-			var turnsToFinish = this.TurnsToCompleteTerraform(this.WorkerJob);
-			if (turnsToFinish == 1) {
+            var terraformProgress = this.SumWorkerProgress(this.location, this.WorkerJob);
+            var turnProgress = this.location.GetCurrentUnaccountedJobProgress(terraform);
+            var totalCost = (float)GetWorkerJobCost(this.location, this.WorkerJob);
+            
+			if (terraformProgress + turnProgress == totalCost) {
 				location.FinishWorkerJob(WorkerJob);
 			}
 

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -892,12 +892,12 @@ namespace C7GameData {
 
 		public int TurnsToCompleteTerraform(Terraform t) {
 			// Figure out how much work remains to do on this particular job.
-			int remainingTerraformCost = GetWorkerJobCost(location, t) - (int)SumWorkerProgress(location, t);
+			int remainingTerraformCost = GetWorkerJobCost(location, t) - (int)this.SumWorkerProgress(location, t);
 
 			// Figure out how fast all of the wokers doing this particular
 			// terraform will work.
-			float combinedWorkerSpeed = workerSpeed();
-			foreach (MapUnit unit in location.unitsOnTile) {
+			float combinedWorkerSpeed = this.workerSpeed();
+			foreach (MapUnit unit in location.unitsOnTile.Where(u => u.id != this.id)) {
 				if (unit.WorkerJob == t) {
 					combinedWorkerSpeed += unit.workerSpeed();
 				}
@@ -917,9 +917,18 @@ namespace C7GameData {
 				return;
 			}
 
-			// Check to see if we have a worker job, and if so, contribute our
-			// work towards it. We do this before any automation logic, so that
-			// automated units properly contribute their efforts.
+			if (isAutomated) {
+				// workers contribute their work at the end of the turn, not when assigned
+				if (this.unitType.isWorker && WorkerJob != null) {
+					return;
+				}
+				playAutomatedTurn();
+				return;
+			}
+		}
+
+		public async Task PerformEndOfTurnAction() {
+			// Busy Worker
 			if (WorkerJob != null) {
 				WorkerProgressTowardsJob += workerSpeed();
 				movementPoints.onConsumeAll();
@@ -928,11 +937,6 @@ namespace C7GameData {
 				if ((int)SumWorkerProgress(location, WorkerJob) >= GetWorkerJobCost(location, WorkerJob)) {
 					location.FinishWorkerJob(WorkerJob);
 				}
-			}
-
-			if (isAutomated) {
-				playAutomatedTurn();
-				return;
 			}
 		}
 
@@ -994,6 +998,7 @@ namespace C7GameData {
 			return unitType.terraformActions.Contains(terraform) && terraform.MeetsRequirements(owner, tile);
 		}
 
+		// entry point for "manual" job assignment
 		public void PerformTerraformAction(Terraform terraform) {
 			if (!canPerformTerraformAction(terraform)) {
 				log.Warning($"can't perform {terraform.Name} by {this}");
@@ -1003,6 +1008,14 @@ namespace C7GameData {
 
 			if (terraform.Animation is AnimatedAction animation)
 				animate(animation, AnimationEnding.Repeat);
+
+			movementPoints.onConsumeAll();
+
+			// See if this worker finished the job.
+			var turnsToFinish = this.TurnsToCompleteTerraform(this.WorkerJob);
+			if (turnsToFinish == 1) {
+				location.FinishWorkerJob(WorkerJob);
+			}
 
 			wake();
 			_ = PerformBusyAction();

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -1012,10 +1012,10 @@ namespace C7GameData {
 			movementPoints.onConsumeAll();
 
 			// See if this worker finished the job.
-            var terraformProgress = this.SumWorkerProgress(this.location, this.WorkerJob);
-            var turnProgress = this.location.GetCurrentUnaccountedJobProgress(terraform);
-            var totalCost = (float)GetWorkerJobCost(this.location, this.WorkerJob);
-            
+			var terraformProgress = this.SumWorkerProgress(this.location, this.WorkerJob);
+			var turnProgress = this.location.GetCurrentUnaccountedJobProgress(terraform);
+			var totalCost = (float)GetWorkerJobCost(this.location, this.WorkerJob);
+
 			if (terraformProgress + turnProgress == totalCost) {
 				location.FinishWorkerJob(WorkerJob);
 			}

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -772,6 +772,10 @@ namespace C7GameData {
 			currentWorkerJob.OnComplete(player, this);
 		}
 
+        public float GetCurrentUnaccountedJobProgress(Terraform currentWorkerJob) {
+            return unitsOnTile.Where(unit => currentWorkerJob == unit.WorkerJob).Sum(unit => unit.workerSpeed());
+        }
+
 		public async Task AnimateAsync(AnimatedEffect effect) {
 			if (!EngineStorage.animationsEnabled) return;
 

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -772,9 +772,9 @@ namespace C7GameData {
 			currentWorkerJob.OnComplete(player, this);
 		}
 
-        public float GetCurrentUnaccountedJobProgress(Terraform currentWorkerJob) {
-            return unitsOnTile.Where(unit => currentWorkerJob == unit.WorkerJob).Sum(unit => unit.workerSpeed());
-        }
+		public float GetCurrentUnaccountedJobProgress(Terraform currentWorkerJob) {
+			return unitsOnTile.Where(unit => currentWorkerJob == unit.WorkerJob).Sum(unit => unit.workerSpeed());
+		}
 
 		public async Task AnimateAsync(AnimatedEffect effect) {
 			if (!EngineStorage.animationsEnabled) return;

--- a/C7Engine/C7GameData/UnitPrototype.cs
+++ b/C7Engine/C7GameData/UnitPrototype.cs
@@ -89,7 +89,8 @@ namespace C7GameData {
 
 		public HashSet<Terraform> terraformActions = [];
 
-		public bool isWorker => terraformActions.Count > 0;
+		// terraformActions.Count > 0 is not enough, as for example the Crusader unit can build a Fortress
+		public bool isWorker => terraformActions.Count > 0 && actions.Contains(UnitAction.Automate);
 		public bool isSettler => actions.Contains(UnitAction.BuildCity);
 
 

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -314,6 +314,8 @@ namespace C7Engine {
 		public override async void process() {
 			Player controller = EngineStorage.gameData.GetPlayer(EngineStorage.uiControllerID);
 
+			TurnHandling.OnEndTurn(controller);
+
 			// Reorder the unit list so that non-busy units will be selected
 			// first.
 			controller.units.Sort((x, y) => x.IsBusy().CompareTo(y.IsBusy()));
@@ -342,6 +344,18 @@ namespace C7Engine {
 
 		public override void process() {
 			city.HurryProduction();
+		}
+	}
+
+	public class MsgDoStopWorkerAction : MessageToEngine {
+		private MapUnit worker;
+		public MsgDoStopWorkerAction(MapUnit worker) {
+			this.worker = worker;
+		}
+
+		public override void process() {
+			this.worker.resetWorkerJob();
+			this.worker.isAutomated = false;
 		}
 	}
 

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -356,7 +356,8 @@ namespace C7Engine {
 		public override void process() {
 			this.worker.resetWorkerJob();
 			this.worker.isAutomated = false;
-            new MsgShowTemporaryPopup("This unit has already moved.", this.worker.location).send();
+            if(!this.worker.movementPoints.canMove)
+                new MsgShowTemporaryPopup("This unit has already moved.", this.worker.location).send();
         }
 	}
 

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -356,9 +356,9 @@ namespace C7Engine {
 		public override void process() {
 			this.worker.resetWorkerJob();
 			this.worker.isAutomated = false;
-            if(!this.worker.movementPoints.canMove)
-                new MsgShowTemporaryPopup("This unit has already moved.", this.worker.location).send();
-        }
+			if (!this.worker.movementPoints.canMove)
+				new MsgShowTemporaryPopup("This unit has already moved.", this.worker.location).send();
+		}
 	}
 
 	public class MsgSetAnimationsEnabled : MessageToEngine {

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -356,7 +356,8 @@ namespace C7Engine {
 		public override void process() {
 			this.worker.resetWorkerJob();
 			this.worker.isAutomated = false;
-		}
+            new MsgShowTemporaryPopup("This unit has already moved.", this.worker.location).send();
+        }
 	}
 
 	public class MsgSetAnimationsEnabled : MessageToEngine {

--- a/C7Engine/EntryPoints/MessageToUI.cs
+++ b/C7Engine/EntryPoints/MessageToUI.cs
@@ -101,6 +101,18 @@ namespace C7Engine {
 		}
 	}
 
+	public class MsgDisplayStopWorkerActionPopup : MessageToUI {
+		public MapUnit worker;
+		public Terraform workerJob;
+		public float turnsLeft;
+
+		public MsgDisplayStopWorkerActionPopup(MapUnit worker, Terraform workerJob, float turnsLeft) {
+			this.worker = worker;
+			this.workerJob = workerJob;
+			this.turnsLeft = turnsLeft;
+		}
+	}
+
 	public class MsgShowCityScreen : MessageToUI {
 		public City city;
 

--- a/C7Engine/EntryPoints/TurnHandling.cs
+++ b/C7Engine/EntryPoints/TurnHandling.cs
@@ -14,6 +14,15 @@ namespace C7Engine {
 			log.Information("\n*** Beginning turn " + gameData.turn + " ***");
 		}
 
+		public static void OnEndTurn(Player player) {
+			GameData gameData = EngineStorage.gameData;
+
+			var busyWorkers = gameData.mapUnits.Where(u => u.owner.id == player.id && u.WorkerJob != null);
+			foreach (MapUnit busyWorker in busyWorkers)
+				if (busyWorker.WorkerJob != null)
+					_ = busyWorker.PerformEndOfTurnAction();
+		}
+
 		public static void InitTurnData(Player player = null, bool skipTurn = false) {
 			GameData gameData = EngineStorage.gameData;
 			if (player == null) {
@@ -100,13 +109,15 @@ namespace C7Engine {
 
 				if (player.isBarbarians) {
 					await BarbarianAI.PlayTurn(player, gameData);
-					player.hasPlayedThisTurn = true;
 				} else if (!player.isHuman) {
 					await PlayerAI.PlayTurn(player, gameData);
-					player.hasPlayedThisTurn = true;
-				} else if (player.id != EngineStorage.uiControllerID) {
+				}
+
+				if (player.id != EngineStorage.uiControllerID) {
+					OnEndTurn(player);
 					player.hasPlayedThisTurn = true;
 				}
+
 				//Human player check. Let the human see what's going on even if they are in observer mode.
 				if (player.id == EngineStorage.uiControllerID) {
 					new MsgStartTurn().send();


### PR DESCRIPTION
1. Added a confirmation popup whenever a worker that is working a job to verify we want to stop them from working anymore.
2. "This unit has already moved" message is now unified and using the MsgShowTemporaryPopup message.
3. Workers now contribute their efforts at the end of the turn instead of right away, except when the terraforming action can be completed on the same turn. 
For example, if 2 workers are assigned on turn 10 to work on a road (0 terraforming progress), and a third one is assigned to road the tile as well, the road will be completed. Same with a mine and 6 workers, etc..
4. Unified the HandleUnitSelection method code that was duplicated in Game and RightClickMenu classes.
5. isWorker in UnitPrototype was refined