### PR TITLE
Locked Alliances implementation

### DIFF
--- a/C7/UIElements/Diplomacy/TalkScreen.cs
+++ b/C7/UIElements/Diplomacy/TalkScreen.cs
@@ -41,25 +41,41 @@ public partial class TalkScreen : TextureRect {
 			leaderName = opponentPlayer.civilization.leader;
 		});
 
+		int offset = 500;
+		int gap = 20;
+
 		Button proposeDeal = new();
 		proposeDeal.Text = "We would like to propose a deal...";
-		proposeDeal.SetPosition(new Vector2(512 - 205, 500));
+		proposeDeal.SetPosition(new Vector2(512 - 205, offset));
 		proposeDeal.Theme = fontTheme;
 		proposeDeal.Pressed += () => {
 			GetParent<Diplomacy>().ShowDealScreenForPlayer(humanPlayerId, opponentPlayerId);
 		};
 		AddChild(proposeDeal);
+		offset += gap;
 
-		Button declareWar = new();
-		declareWar.Text = "That's it! Prepare for WAR!";
-		declareWar.SetPosition(new Vector2(512 - 205, 520));
-		declareWar.Theme = fontTheme;
-		declareWar.Pressed += DeclareWar;
-		AddChild(declareWar);
+		EngineStorage.ReadGameData((GameData gD) => {
+			if (!gD.AreInLockedPeace(gD.GetPlayer(humanPlayerId), gD.GetPlayer(opponentPlayerId))) {
+				Button declareWar = new();
+				declareWar.Text = "That's it! Prepare for WAR!";
+				declareWar.SetPosition(new Vector2(512 - 205, offset));
+				declareWar.Theme = fontTheme;
+				declareWar.Pressed += DeclareWar;
+				AddChild(declareWar);
+			} else {
+				Button tradeWorldMaps = new();
+				tradeWorldMaps.Text = "Care to trade World Maps?";
+				tradeWorldMaps.SetPosition(new Vector2(512 - 205, offset));
+				tradeWorldMaps.Theme = fontTheme;
+				tradeWorldMaps.Pressed += TradeWorldMaps;
+				AddChild(tradeWorldMaps);
+			}
+			offset += gap;
+		});
 
 		Button goodbye = new();
 		goodbye.Text = $"That's it. Goodbye, {leaderName}";
-		goodbye.SetPosition(new Vector2(512 - 205, 540));
+		goodbye.SetPosition(new Vector2(512 - 205, offset));
 		goodbye.Theme = fontTheme;
 		goodbye.Pressed += () => { GetParent<Diplomacy>().Hide(); };
 		AddChild(goodbye);
@@ -75,5 +91,12 @@ public partial class TalkScreen : TextureRect {
 					GetParent<Diplomacy>().Hide();
 				}), PopupOverlay.PopupCategory.Advisor);
 		});
+	}
+
+	private void TradeWorldMaps() {
+		var weGive = new TradeOffer();
+		var theyGive = new TradeOffer();
+		// TODO: make maps tradeable, and (pre)add them to this deal/ call the method that adds them
+		GetParent<Diplomacy>().ShowDealScreenForPlayer(humanPlayerId, opponentPlayerId, weGive, theyGive);
 	}
 }

--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -34,6 +34,8 @@ namespace C7GameData {
 
 		internal List<Civilization> civilizations = new List<Civilization>();
 		internal HashSet<CultureGroup> cultureGroups = new HashSet<CultureGroup>();
+		internal HashSet<Alliance> alliances;
+		internal Dictionary<Alliance, Alliance> allianceWars = new Dictionary<Alliance, Alliance>();
 
 		public List<ExperienceLevel> experienceLevels = new List<ExperienceLevel>();
 		public List<Tech> techs = new();
@@ -124,6 +126,25 @@ namespace C7GameData {
 				return experienceLevels[n + 1];
 			else
 				return null;
+		}
+
+		// Players are in an active locked war (can't make peace)
+		private bool AreInLockedWar(Alliance one, Alliance other) {
+			return allianceWars.Any(
+				kvp => (one != null && other != null) &&
+					((kvp.Key.name == one.name && kvp.Value.name == other.name)
+					|| (kvp.Key.name == other.name && kvp.Value.name == one.name)));
+		}
+		public bool AreInLockedWar(Player one, Player other) {
+			return AreInLockedWar(one.alliance, other.alliance);
+		}
+
+		// Both players are part of the same alliance (can't declare war)
+		private bool AreInLockedPeace(Alliance one, Alliance other) {
+			return one != null && other != null && one == other;
+		}
+		public bool AreInLockedPeace(Player one, Player other) {
+			return AreInLockedPeace(one.alliance, other.alliance);
 		}
 
 		public void UpdateTileOwners() {

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -213,6 +213,8 @@ namespace C7GameData {
 			ImportBicLeaders();
 			ImportBicUnits();
 			ImportBicCities();
+			ImportEmbassies();
+			ImportAlliances();
 
 			SetMapDimensions(biq, save);
 			SetWorldWrap(biq, save);
@@ -884,6 +886,108 @@ namespace C7GameData {
 				isBarbarian = civ.isBarbarian,
 				eraCivilopediaName = era,
 			};
+		}
+
+		private void ImportEmbassies() {
+			BiqData theBiq = biq.Race is null ? defaultBiq : biq;
+
+			List<SavePlayer> playerWithEmbassies = new List<SavePlayer>();
+
+			for (int i = 0; i < theBiq.Lead.Length; ++i) {
+				var lead = theBiq.Lead[i];
+				if (lead.StartEmbassies == 1) {
+					var player = save.Players[lead.Civ];
+					if (!player.isBarbarian)
+						playerWithEmbassies.Add(player);
+				}
+			}
+
+			// TODO: create actual embassies
+
+			// In scenarios where there isn't any actual information about player relationships,
+			// the entry point of these relationships seems to be the embassies.
+			// Players that start with embassies, are aware of each other.
+			// Information about players at war, is given in alliances data.
+			foreach (var playerWithEmbassy in playerWithEmbassies) {
+				foreach (var other in playerWithEmbassies.Except(new List<SavePlayer> { playerWithEmbassy })) {
+					var pr = new PlayerRelationship() {
+						warDeclarationCount = 0,
+						warDeclarationWithRoPActiveCount = 0,
+						wasSneakAttacked = false,
+						refuseContactUntilTurn = -1,
+					};
+					playerWithEmbassy.playerRelationships.Add(other.id.ToString(), pr);
+
+					// simple peace deal, that could be removed if in a locked war (check ImportAlliances())
+					pr.multiTurnDeals.Add(MultiTurnDeal.DEFAULT_PEACE);
+				}
+			}
+		}
+
+		private void ImportAlliances() {
+			BiqData theBiq = biq.Race is null ? defaultBiq : biq;
+
+			// import alliances names and indexes
+			HashSet<Alliance> alliances = new HashSet<Alliance>() {
+                // new (0, theBiq.Game[0].AllianceNames[0]), // no alliance, not sure if it's necessary
+                new (1, theBiq.Game[0].AllianceNames[1]),
+				new (2, theBiq.Game[0].AllianceNames[2]),
+				new (3, theBiq.Game[0].AllianceNames[3]),
+				new (4, theBiq.Game[0].AllianceNames[4]),
+			};
+
+			save.Alliances = new HashSet<Alliance>(alliances.OrderBy(a => a.index).ToHashSet());
+
+			// import player alliances
+			for (int i = 0; i < theBiq.GameAlliance[0].Length; i++) {
+				save.Players[i + 1].alliance = alliances.FirstOrDefault(a => a.index == theBiq.GameAlliance[0][i])?.name;
+				// if(save.Players[i + 1].alliance == string.Empty)
+				//     save.Players[i + 1].alliance = null;
+			}
+
+			foreach (var saveAlliance in save.Alliances) {
+				foreach (var savePlayer in save.Players.Where(p => p.alliance == saveAlliance.name)) {
+					foreach (var otherSavePlayer in save.Players.Where(p => p.alliance == saveAlliance.name && p.id != savePlayer.id)) {
+						var relationship = savePlayer.playerRelationships.TryGetValue(otherSavePlayer.id.ToString(), out var otherPlayerRelationship);
+						if (relationship) {
+							log.Information($"Players {savePlayer.civilization} and {otherSavePlayer.civilization}" +
+											$" are in the same alliance: {saveAlliance.name}, and have a Mutual Protection Pact");
+							otherPlayerRelationship.multiTurnDeals.Add(MultiTurnDeal.DEFAULT_MUTUAL_PROTECTION_PACT);
+						}
+					}
+				}
+			}
+
+			// import alliances war info
+
+			// alliance no
+			// skip first alliance as it means "no alliance"
+			for (int a = 1; a < 5; a++) {
+				// entry in each alliance
+				for (int e = 0; e < 5; e++) {
+					var wwa = theBiq.Game[0].WarWithAlliance[a, e];
+
+					if (wwa != 0) {
+						save.AllianceWars.TryAdd(
+							alliances.First(al => al.name == theBiq.Game[0].AllianceNames[a]).name,
+							alliances.First(al => al.name == theBiq.Game[0].AllianceNames[e]).name
+							);
+					}
+				}
+			}
+
+			// "Declare" war for rival alliances
+			foreach (KeyValuePair<string, string> kvp in save.AllianceWars) {
+				var playerAllianceA = save.Players.Where(p => p.alliance == kvp.Key).ToList();
+				var playerAllianceB = save.Players.Where(p => p.alliance == kvp.Value).ToList();
+
+				foreach (var playerInAllianceA in playerAllianceA) {
+					foreach (var playerInAllianceB in playerAllianceB) {
+						playerInAllianceA.playerRelationships[playerInAllianceB.id.ToString()].multiTurnDeals = new List<MultiTurnDeal>();
+						playerInAllianceB.playerRelationships[playerInAllianceA.id.ToString()].multiTurnDeals = new List<MultiTurnDeal>();
+					}
+				}
+			}
 		}
 
 		private void ImportSavUnits() {

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -941,8 +941,6 @@ namespace C7GameData {
 			// import player alliances
 			for (int i = 0; i < theBiq.GameAlliance[0].Length; i++) {
 				save.Players[i + 1].alliance = alliances.FirstOrDefault(a => a.index == theBiq.GameAlliance[0][i])?.name;
-				// if(save.Players[i + 1].alliance == string.Empty)
-				//     save.Players[i + 1].alliance = null;
 			}
 
 			foreach (var saveAlliance in save.Alliances) {

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -1,3 +1,5 @@
+using static C7GameData.PlayerRelationship;
+
 namespace C7GameData {
 	using Serilog;
 	using System.Collections.Generic;
@@ -821,6 +823,14 @@ namespace C7GameData {
 				}
 			}
 
+			var tileOwner = tile.OwningPlayer();
+
+			if (tile.HasCity && tileOwner != this.owner) {
+				if (EngineStorage.gameData.AreInLockedPeace(tileOwner, this.owner)) {
+					return false;
+				}
+			}
+
 			// If we allow declaring war on this move, then it doesn't matter if
 			// there are units belonging to another player on the tile.
 			// TODO: unbreakable alliances
@@ -933,14 +943,14 @@ namespace C7GameData {
 
 		private static bool HasHostileUnits(Tile tile, Player player) {
 			foreach (MapUnit other in tile.unitsOnTile) {
-				if (player != other.owner && !player.IsAtPeaceWith(other.owner))
+				if (player != other.owner && AtWar(player, other.owner))
 					return true;
 			}
 			return false;
 		}
 
 		private static bool HasHostileCity(Tile tile, Player player) {
-			return tile.HasCity && !player.IsAtPeaceWith(tile.cityAtTile.owner);
+			return tile.HasCity && AtWar(player, tile.cityAtTile.owner);
 		}
 
 		/// <summary>

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -40,6 +40,17 @@ namespace C7GameData {
 			return corrupted + taxes + beakers + happiness + wealthProduction;
 		}
 	}
+
+	public class Alliance {
+		public int index;
+		public string name;
+
+		public Alliance(int index, string name) {
+			this.index = index;
+			this.name = name;
+		}
+	}
+
 	public class Player {
 		private static ILogger log = Log.ForContext<Player>();
 
@@ -157,6 +168,8 @@ namespace C7GameData {
 		// be awarded after researching a tech (like Philosophy) or after
 		// completing a wonder (like Theory of Evolution).
 		public int freeTechsRemaining = 0;
+
+		public Alliance alliance;
 
 		public int EraIndex() {
 			return GetEraIndex(eraCivilopediaName);
@@ -310,6 +323,8 @@ namespace C7GameData {
 
 		public bool WillAcceptCommunicationFrom(Player other, int currentTurn) {
 			EnsureRelationshipExists(other);
+
+			if (EngineStorage.gameData.AreInLockedWar(this, other)) return false;
 
 			PlayerRelationship pr = playerRelationships[other.id];
 			if (AtPeace(this, other)) {

--- a/C7Engine/C7GameData/PlayerRelationship.cs
+++ b/C7Engine/C7GameData/PlayerRelationship.cs
@@ -211,6 +211,8 @@ public class PlayerRelationship {
 					.Where(mtd => mtd != null
 							  && mtd.dealSubType != DealSubType.Peace
 							  && mtd.TurnsRemaining(currentTurn) <= 0)
+					.Where(mtd => mtd.dealSubType != DealSubType.MutualProtectionPact
+								   && !EngineStorage.gameData.AreInLockedPeace(player, other))
 					.ToList();
 
 				foreach (MultiTurnDeal deadDeal in deadDeals) {
@@ -267,6 +269,9 @@ public class MultiTurnDeal {
 	// A multi turn peace deal that is from the start of the game without end.
 	// Used for when a civ meets another civ to establish the initial peace.
 	public static MultiTurnDeal DEFAULT_PEACE => new MultiTurnDeal(DealType.DiplomaticAgreement, DealSubType.Peace,
+			DealDetails.Exchange, 0, null, 0, 0, null);
+
+	public static MultiTurnDeal DEFAULT_MUTUAL_PROTECTION_PACT => new MultiTurnDeal(DealType.DiplomaticAgreement, DealSubType.MutualProtectionPact,
 			DealDetails.Exchange, 0, null, 0, 0, null);
 
 	/// <summary>

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -54,6 +54,7 @@ namespace C7GameData.Save {
 				TurnNumber = data.turn,
 				Civilizations = data.civilizations,
 				CultureGroups = data.cultureGroups,
+				Alliances = data.alliances == null ? null : [..data.alliances],
 				Map = new SaveMap(data.map),
 				TerrainTypes = data.terrainTypes,
 				Resources = data.Resources,
@@ -92,6 +93,10 @@ namespace C7GameData.Save {
 			save.HealRates["hostile_field"] = data.healRateInHostileField;
 			save.HealRates["city"] = data.healRateInCity;
 
+			foreach (KeyValuePair<Alliance, Alliance> kvp in data.allianceWars) {
+				save.AllianceWars.TryAdd(kvp.Key.name, kvp.Value.name);
+			}
+
 			return save;
 		}
 
@@ -124,6 +129,8 @@ namespace C7GameData.Save {
 			ConvertStrengthBonuses(data);
 			ConvertHealRates(data);
 			ConvertCultureGroups(data);
+			ConvertAlliances(data);
+			ConvertAllianceWars(data);
 
 			data.defaultExperienceLevelKey = DefaultExperienceLevel;
 			data.defaultExperienceLevel = data.experienceLevels.Find(el => el.key == DefaultExperienceLevel);
@@ -171,6 +178,7 @@ namespace C7GameData.Save {
 				scenarioSearchPath = ScenarioSearchPath,
 				civilizations = Civilizations,
 				cultureGroups = CultureGroups,
+				alliances = Alliances == null ? null : [.. Alliances],
 				citizenTypes = CitizenTypes,
 				governments = Governments,
 				worldSizes = WorldSizes,
@@ -193,7 +201,7 @@ namespace C7GameData.Save {
 			data.map = Map.ToGameMap(data);
 
 			// players need game map to populate tile knowledge
-			data.players = Players.ConvertAll(player => player.ToPlayer(data.map, Civilizations, data.governments, data.techs, data.rules));
+			data.players = Players.ConvertAll(player => player.ToPlayer(data.map, Civilizations, data.governments, data.techs, data.rules, data.alliances));
 		}
 
 		private void ConvertTerrainImprovements(GameData gameData) {
@@ -390,6 +398,20 @@ namespace C7GameData.Save {
 			}
 		}
 
+		private void ConvertAlliances(GameData data) {
+			foreach (var dataPlayer in data.players) {
+				if (dataPlayer.alliance is null) continue; // null for barbarians
+				Alliance alliance = data.alliances.FirstOrDefault(a => a.name == dataPlayer.alliance.name);
+				dataPlayer.alliance = alliance;
+			}
+		}
+
+		private void ConvertAllianceWars(GameData data) {
+			foreach (var allianceWar in AllianceWars) {
+				data.allianceWars.TryAdd(data.alliances.FirstOrDefault(a => a.name == allianceWar.Key), data.alliances.FirstOrDefault(a => a.name == allianceWar.Value));
+			}
+		}
+
 		public string Version = "0.0.0";
 		public int Seed = -1;
 		public int TurnNumber = 0;
@@ -409,6 +431,8 @@ namespace C7GameData.Save {
 		public string DefaultExperienceLevel; // key
 		public List<Civilization> Civilizations = new List<Civilization>();
 		public HashSet<CultureGroup> CultureGroups = new HashSet<CultureGroup>();
+		public HashSet<Alliance> Alliances;
+		public Dictionary<string, string> AllianceWars = new Dictionary<string, string>();
 		public List<StrengthBonus> StrengthBonuses = new List<StrengthBonus>();
 		public Dictionary<string, int> HealRates = new Dictionary<string, int>();
 		public Rules Rules = new();

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -431,7 +431,7 @@ namespace C7GameData.Save {
 		public string DefaultExperienceLevel; // key
 		public List<Civilization> Civilizations = new List<Civilization>();
 		public HashSet<CultureGroup> CultureGroups = new HashSet<CultureGroup>();
-        public HashSet<Alliance> Alliances = new HashSet<Alliance>();
+		public HashSet<Alliance> Alliances = new HashSet<Alliance>();
 		public Dictionary<string, string> AllianceWars = new Dictionary<string, string>();
 		public List<StrengthBonus> StrengthBonuses = new List<StrengthBonus>();
 		public Dictionary<string, int> HealRates = new Dictionary<string, int>();

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -54,7 +54,7 @@ namespace C7GameData.Save {
 				TurnNumber = data.turn,
 				Civilizations = data.civilizations,
 				CultureGroups = data.cultureGroups,
-				Alliances = data.alliances == null ? null : [..data.alliances],
+				Alliances = data.alliances,
 				Map = new SaveMap(data.map),
 				TerrainTypes = data.terrainTypes,
 				Resources = data.Resources,
@@ -178,7 +178,7 @@ namespace C7GameData.Save {
 				scenarioSearchPath = ScenarioSearchPath,
 				civilizations = Civilizations,
 				cultureGroups = CultureGroups,
-				alliances = Alliances == null ? null : [.. Alliances],
+				alliances = Alliances,
 				citizenTypes = CitizenTypes,
 				governments = Governments,
 				worldSizes = WorldSizes,
@@ -431,7 +431,7 @@ namespace C7GameData.Save {
 		public string DefaultExperienceLevel; // key
 		public List<Civilization> Civilizations = new List<Civilization>();
 		public HashSet<CultureGroup> CultureGroups = new HashSet<CultureGroup>();
-		public HashSet<Alliance> Alliances;
+        public HashSet<Alliance> Alliances = new HashSet<Alliance>();
 		public Dictionary<string, string> AllianceWars = new Dictionary<string, string>();
 		public List<StrengthBonus> StrengthBonuses = new List<StrengthBonus>();
 		public Dictionary<string, int> HealRates = new Dictionary<string, int>();

--- a/C7Engine/C7GameData/Save/SavePlayer.cs
+++ b/C7Engine/C7GameData/Save/SavePlayer.cs
@@ -64,17 +64,20 @@ namespace C7GameData.Save {
 		// The current government of the player.
 		public ID governmentId;
 
+		public string alliance;
+
 		// Used when importing from .biq, to make it easier to distinguish barbarians from other players.
 		// It's not meant to be saved in the json.
 		[JsonIgnore]
 		public bool isBarbarian { get; init; }
 
-		public Player ToPlayer(GameMap map, List<Civilization> civilizations, List<Government> governments, List<Tech> techs, Rules rules) {
+		public Player ToPlayer(GameMap map, List<Civilization> civilizations, List<Government> governments, List<Tech> techs, Rules rules, HashSet<Alliance> alliances) {
 			Player player = new Player{
 				id = id,
 				isHuman = human,
 				isIncludedInGame = isIncludedInGame,
 				canBePicked = canBePicked,
+				alliance = alliance is not null ? alliances.First(a => a.name == alliance) : null,
 				hasPlayedThisTurn = hasPlayedCurrentTurn,
 				skipFirstTurn = skipFirstTurn,
 				defeated = defeated,
@@ -129,6 +132,7 @@ namespace C7GameData.Save {
 			id = player.id;
 			isIncludedInGame = player.isIncludedInGame;
 			canBePicked = player.canBePicked;
+			alliance = (player.isBarbarians || player.alliance == null) ? null : player.alliance.name;
 			primaryColorIndex = player.primaryColorIndex;
 			secondaryColorIndex = player.secondaryColorIndex;
 			human = player.isHuman;

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -483,7 +483,7 @@ namespace C7GameData {
 
 		//Convenience method for printing the yield
 		public string YieldString(Player player) {
-			return $"{foodYield(player).yield}/{productionYield(player).yield}/{commerceYield(player).yield})";
+			return $"{foodYield(player).yield}/{productionYield(player).yield}/{commerceYield(player).yield}";
 		}
 
 		public Player? OwningPlayer() {

--- a/EngineTests/GameData/SaveTest.cs
+++ b/EngineTests/GameData/SaveTest.cs
@@ -177,6 +177,8 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 						continue;
 					case MsgShowTemporaryPopup mSTP:
 						continue;
+					case MsgCityDestroyed mCD:
+						continue;
 					default:
 						throw new Exception($"{msg}");
 						continue;
@@ -497,7 +499,7 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 	}
 
 	[SkippableFact]
-	public void LoadAllConquestScenarios() {
+	public async Task LoadAllConquestScenarios() {
 		Skip.If(Civ3TestData.ShouldSkipCiv3DependentTests(), "No Civ3 install found.");
 
 		string[] singleplayerScenarios = {
@@ -526,8 +528,8 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 		};
 		// Only bother running one turn of the newer scenarios, just to keep the
 		// tests faster.
-		CheckScenariosInCiv3Subfolder("Conquests/Conquests", singleplayerScenarios, runOneTurn: true, "singleplayer");
-		CheckScenariosInCiv3Subfolder("Conquests/Scenarios", multiplayerScenarios, runOneTurn: false, "multiplayer");
+		await CheckScenariosInCiv3Subfolder("Conquests/Conquests", singleplayerScenarios, runOneTurn: true, "singleplayer");
+		await CheckScenariosInCiv3Subfolder("Conquests/Scenarios", multiplayerScenarios, runOneTurn: false, "multiplayer");
 	}
 
 	private async Task CheckScenariosInCiv3Subfolder(string subfolder, string[] scenarioNamesToTest, bool runOneTurn, string basename) {
@@ -551,6 +553,8 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 				return Path.GetFullPath(Path.Combine(Civ3Location.GetCiv3Path(), subfolder, relativeModPath, "Text", "PediaIcons.txt"));
 			};
 
+			EngineStorage.animationsEnabled = false;
+
 			Exception ex = Record.Exception(() => {
 				game = ImportCiv3.ImportBiq(saveFileInfo.FullName, PathUtils.defaultBicPath, getPediaIconsPath);
 			});
@@ -563,6 +567,7 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 			Assert.NotNull(gd);
 
 			CheckPlayableCivs(name, game);
+			CheckAlliances(name, gd);
 
 			// Check that the human player has at least one settler or city in
 			// each scenario, when looking at the SaveGame.
@@ -737,6 +742,69 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 			Assert.Contains(game.Civilizations, c => c.name == "Portugal");
 			Assert.Contains(game.Civilizations, c => c.name == "Netherlands");
 			Assert.Contains(game.Civilizations, c => c.name == "Kingdom of Naples");
+		}
+	}
+
+	private void CheckAlliances(string name, C7GameData.GameData gd) {
+		var players = gd.players;
+
+		if (name.Equals("8 Napoleonic Europe.biq")) {
+			var france = players.First(p => p.civilization.name == "France");
+			var denmark = players.First(p => p.civilization.name == "Denmark");
+			var britain = players.First(p => p.civilization.name == "Britain");
+			var netherlands = players.First(p => p.civilization.name == "Netherlands");
+			var portugal = players.First(p => p.civilization.name == "Portugal");
+			var naples = players.First(p => p.civilization.name == "Kingdom of Naples");
+			var austria = players.First(p => p.civilization.name == "Austria");
+			var spain = players.First(p => p.civilization.name == "Spain");
+
+			Assert.True(france.alliance.name == "French Coalition");
+			Assert.True(denmark.alliance.name == "French Coalition");
+
+			Assert.True(austria.alliance == null);
+			Assert.True(spain.alliance == null);
+
+			Assert.False(gd.AreInLockedPeace(austria, spain));
+			Assert.False(gd.AreInLockedWar(austria, spain));
+
+			Assert.True(britain.alliance.name == "English Coalition");
+			Assert.True(netherlands.alliance.name == "English Coalition");
+			Assert.True(portugal.alliance.name == "English Coalition");
+			Assert.True(naples.alliance.name == "English Coalition");
+
+			Assert.True(gd.AreInLockedPeace(france, denmark));
+			Assert.True(gd.AreInLockedPeace(britain, portugal));
+			Assert.True(gd.AreInLockedWar(france, britain));
+			Assert.True(gd.AreInLockedWar(denmark, naples));
+
+			Assert.True(france.playerRelationships[britain.id].AtWar());
+			Assert.True(denmark.playerRelationships[naples.id].AtWar());
+		}
+
+		if (name.Equals("9 WWII in the Pacific.biq")) {
+			var usa = players.First(p => p.civilization.name == "United States");
+			var china = players.First(p => p.civilization.name == "China");
+			var commonwealth = players.First(p => p.civilization.name == "Commonwealth");
+			var netherlands = players.First(p => p.civilization.name == "Netherlands");
+			var japan = players.First(p => p.civilization.name == "Japan");
+
+			Assert.True(usa.alliance.name == "Allies");
+			Assert.True(china.alliance.name == "Allies");
+			Assert.True(commonwealth.alliance.name == "Allies");
+			Assert.True(netherlands.alliance.name == "Allies");
+
+			Assert.True(japan.alliance.name == "Japanese Empire");
+
+			Assert.True(gd.AreInLockedPeace(usa, china));
+			Assert.True(gd.AreInLockedPeace(netherlands, china));
+			Assert.True(gd.AreInLockedPeace(usa, commonwealth));
+
+			Assert.True(gd.AreInLockedWar(netherlands, japan));
+			Assert.True(gd.AreInLockedWar(china, japan));
+			Assert.True(gd.AreInLockedWar(usa, japan));
+
+			Assert.True(usa.playerRelationships[japan.id].AtWar());
+			Assert.True(china.playerRelationships[japan.id].AtWar());
 		}
 	}
 }


### PR DESCRIPTION
1. Implemented the locked alliance/war mechanic.
2. Players in locked alliance/war now are aware of each other, and are unable to make peace or war with their enemies/allies respectively.
3. There is no option in the editor to say "USA has a relationship/knows about the existance of China" for example. The alliances produce a "Mutual Protection Pact" agreement by default as far as I could tell, but I think embassies are how players know of each other.
4. Replaced "Declare war" entry in diplomacy screen when talking to an ally to "Trade World maps". This is not replaced when players are not at war, only when in locked peace.
5. There some random minor code cleanup as per usual
6. In test I added "EngineStorage.animationsEnabled = false;" because there was a bug and the test looped infinitely (we should keep this in mind for future tests too, or somehow disable animation entirely for every unit test)

