### PR TITLE
Unit movement point fix and HP enhancements

### DIFF
--- a/C7/Animations/AnimationManager.cs
+++ b/C7/Animations/AnimationManager.cs
@@ -142,7 +142,7 @@ public partial class AnimationManager {
 		}
 		// TODO: I wanted to add a TileDirection.INVALID enum value when implementing this,
 		// but adding an INVALID value broke stuff: https://github.com/C7-Game/Prototype/issues/397
-		return TileDirection.NORTH;
+		return TileDirection.SOUTHEAST;
 	}
 
 	private static int flicAnimationDirectionToRow(TileDirection tileDirection) {

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -178,8 +178,11 @@ public partial class Game : Node {
 		await CreateGameAndAssignPlayerController(options);
 
 		foreach (var gameDataPlayer in EngineStorage.gameData.players) {
-			if (gameDataPlayer.SitsOutFirstTurn() && TurnHandling.GetTurnNumber() == 0)
-				TurnHandling.InitTurnData(gameDataPlayer, true);
+			if (TurnHandling.GetTurnNumber() == 0)
+				if (gameDataPlayer.SitsOutFirstTurn())
+					TurnHandling.InitTurnData(gameDataPlayer, true);
+				else if (Global.SaveGame != null)
+					TurnHandling.InitTurnData(gameDataPlayer, false);
 		}
 
 		InitializeMapView();

--- a/C7/Lua/game_modes/base-ruleset.json
+++ b/C7/Lua/game_modes/base-ruleset.json
@@ -795,6 +795,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -875,6 +876,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -956,6 +958,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Russia",
         "America",
@@ -1006,6 +1009,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1076,6 +1080,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1150,6 +1155,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1224,6 +1230,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "A Barbarian Chiefdom",
         "Rome",
@@ -1301,6 +1308,7 @@
       "rateOfFire": 1,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1374,6 +1382,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1445,6 +1454,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Egypt",
         "Greece",
@@ -1519,6 +1529,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Greece",
@@ -1595,6 +1606,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "A Barbarian Chiefdom",
         "Rome",
@@ -1678,6 +1690,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1753,6 +1766,7 @@
       "rateOfFire": 1,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1826,6 +1840,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1903,6 +1918,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -1978,6 +1994,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2052,6 +2069,7 @@
       "rateOfFire": 0,
       "movement": 3,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2125,6 +2143,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2202,6 +2221,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2279,6 +2299,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2354,6 +2375,7 @@
       "rateOfFire": 0,
       "movement": 3,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2429,6 +2451,7 @@
       "rateOfFire": 1,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2504,6 +2527,7 @@
       "rateOfFire": 1,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2584,6 +2608,7 @@
       "rateOfFire": 2,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2659,6 +2684,7 @@
       "rateOfFire": 3,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2737,6 +2763,7 @@
       "rateOfFire": 3,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2811,6 +2838,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2887,6 +2915,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -2961,6 +2990,7 @@
       "rateOfFire": 0,
       "movement": 3,
       "capacity": 2,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3038,6 +3068,7 @@
       "rateOfFire": 0,
       "movement": 4,
       "capacity": 3,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3114,6 +3145,7 @@
       "rateOfFire": 2,
       "movement": 5,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3191,6 +3223,7 @@
       "rateOfFire": 0,
       "movement": 4,
       "capacity": 4,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3268,6 +3301,7 @@
       "rateOfFire": 2,
       "movement": 3,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3346,6 +3380,7 @@
       "rateOfFire": 0,
       "movement": 6,
       "capacity": 6,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3420,6 +3455,7 @@
       "rateOfFire": 0,
       "movement": 7,
       "capacity": 4,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3497,6 +3533,7 @@
       "rateOfFire": 0,
       "movement": 4,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3570,6 +3607,7 @@
       "rateOfFire": 2,
       "movement": 8,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3644,6 +3682,7 @@
       "rateOfFire": 2,
       "movement": 5,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3721,6 +3760,7 @@
       "rateOfFire": 2,
       "movement": 7,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3796,6 +3836,7 @@
       "rateOfFire": 0,
       "movement": 5,
       "capacity": 1,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3873,6 +3914,7 @@
       "rateOfFire": 1,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -3949,6 +3991,7 @@
       "rateOfFire": 3,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4021,6 +4064,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 3,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4097,6 +4141,7 @@
       "rateOfFire": 1,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4169,6 +4214,7 @@
       "rateOfFire": 2,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4242,6 +4288,7 @@
       "rateOfFire": 3,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4327,6 +4374,7 @@
       "rateOfFire": 0,
       "movement": 3,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4408,6 +4456,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 3,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -4479,6 +4528,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Aztecs"
       ],
@@ -4523,6 +4573,7 @@
       "rateOfFire": 1,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Babylon"
       ],
@@ -4567,6 +4618,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Greece"
       ],
@@ -4611,6 +4663,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Zululand"
       ],
@@ -4655,6 +4708,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome"
       ],
@@ -4702,6 +4756,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Persia"
       ],
@@ -4749,6 +4804,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Egypt"
       ],
@@ -4796,6 +4852,7 @@
       "rateOfFire": 0,
       "movement": 3,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "China"
       ],
@@ -4844,6 +4901,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Iroquois"
       ],
@@ -4891,6 +4949,7 @@
       "rateOfFire": 1,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "France"
       ],
@@ -4938,6 +4997,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Japan"
       ],
@@ -4985,6 +5045,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 1,
       "producibleBy": [
         "India"
       ],
@@ -5029,6 +5090,7 @@
       "rateOfFire": 0,
       "movement": 3,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Russia"
       ],
@@ -5074,6 +5136,7 @@
       "rateOfFire": 0,
       "movement": 3,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Germany"
       ],
@@ -5122,6 +5185,7 @@
       "rateOfFire": 2,
       "movement": 5,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "England"
       ],
@@ -5170,6 +5234,7 @@
       "rateOfFire": 2,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "America"
       ],
@@ -5213,6 +5278,7 @@
       "rateOfFire": 0,
       "movement": 5,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -5290,6 +5356,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Mongols"
       ],
@@ -5337,6 +5404,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Spain"
       ],
@@ -5381,6 +5449,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Scandinavia"
       ],
@@ -5425,6 +5494,7 @@
       "rateOfFire": 0,
       "movement": 3,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Ottomans"
       ],
@@ -5470,6 +5540,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Celts"
       ],
@@ -5517,6 +5588,7 @@
       "rateOfFire": 0,
       "movement": 3,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Arabia"
       ],
@@ -5565,6 +5637,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Carthage"
       ],
@@ -5609,6 +5682,7 @@
       "rateOfFire": 1,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Korea"
       ],
@@ -5657,6 +5731,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -5733,6 +5808,7 @@
       "rateOfFire": 1,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -5806,6 +5882,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5839,6 +5916,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5875,6 +5953,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5911,6 +5990,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5947,6 +6027,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -5983,6 +6064,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6019,6 +6101,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6055,6 +6138,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6091,6 +6175,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6127,6 +6212,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6163,6 +6249,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6199,6 +6286,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6235,6 +6323,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6271,6 +6360,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6307,6 +6397,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6343,6 +6434,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6379,6 +6471,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6415,6 +6508,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6451,6 +6545,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6487,6 +6582,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6523,6 +6619,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6559,6 +6656,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6595,6 +6693,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6631,6 +6730,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6667,6 +6767,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6703,6 +6804,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Sumeria"
       ],
@@ -6747,6 +6849,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Hittites"
       ],
@@ -6793,6 +6896,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6829,6 +6933,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6865,6 +6970,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -6902,6 +7008,7 @@
       "rateOfFire": 0,
       "movement": 4,
       "capacity": 3,
+      "hpBonus": 0,
       "producibleBy": [
         "Portugal"
       ],
@@ -6949,6 +7056,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Netherlands"
       ],
@@ -6995,6 +7103,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -7032,6 +7141,7 @@
       "rateOfFire": 1,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7106,6 +7216,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -7142,6 +7253,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -7178,6 +7290,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -7214,6 +7327,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Inca"
       ],
@@ -7258,6 +7372,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Maya"
       ],
@@ -7302,6 +7417,7 @@
       "rateOfFire": 2,
       "movement": 3,
       "capacity": 2,
+      "hpBonus": 0,
       "producibleBy": [
         "Byzantines"
       ],
@@ -7347,6 +7463,7 @@
       "rateOfFire": 2,
       "movement": 6,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7423,6 +7540,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "unproducible": true,
       "categories": [
         "Land"
@@ -7463,6 +7581,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 1,
       "unproducible": true,
       "categories": [
         "Land"
@@ -7501,6 +7620,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7578,6 +7698,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7656,6 +7777,7 @@
       "rateOfFire": 1,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7727,6 +7849,7 @@
       "rateOfFire": 0,
       "movement": 1,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",
@@ -7801,6 +7924,7 @@
       "rateOfFire": 0,
       "movement": 2,
       "capacity": 0,
+      "hpBonus": 0,
       "producibleBy": [
         "Rome",
         "Egypt",

--- a/C7/Map/UnitLayer.cs
+++ b/C7/Map/UnitLayer.cs
@@ -18,10 +18,10 @@ public partial class UnitLayer : LooseLayer {
 		unitMovementIndicators = TextureLoader.Load("ui.unit_control.movement_indicators");
 	}
 
-	public Color getHPColor(float fractionRemaining) {
-		if (fractionRemaining >= 0.67f) {
+	public static Color GetHpColor(float remaining, float total) {
+		if (remaining >= 0.67f) {
 			return Color.Color8(0, 255, 0);
-		} else if (fractionRemaining >= 0.34f) {
+		} else if (remaining >= 0.34f && total > 2) {
 			return Color.Color8(255, 255, 0);
 		} else {
 			return Color.Color8(255, 0, 0);
@@ -304,9 +304,9 @@ public partial class UnitLayer : LooseLayer {
 		Rect2 hpIndBackgroundRect = new Rect2(hpStartingLocation - new Vector2(0, offsetXFromCenter), Vector2.One);
 		if (unit.unitType.attack > 0 || unit.unitType.defense > 0) {
 			hpIndBackgroundRect = new Rect2((hpStartingLocation - new Vector2(0, hpBarTotal) - new Vector2(0, offsetYFromCenter)), new Vector2(hpIndWidth, hpBarTotal));
-			float hpFraction = (float)unit.hitPointsRemaining / unit.maxHitPoints;
+			float hpFraction = (float)unit.hitPointsRemaining / maxHp;
 			looseView.DrawRect(hpIndBackgroundRect, Color.Color8(0, 0, 0));
-			Color hpColor = getHPColor(hpFraction);
+			Color hpColor = GetHpColor(hpFraction, maxHp);
 			for (int i = 0; i < unit.hitPointsRemaining; i++) {
 				Rect2 hpContentsRect = new Rect2(hpIndBackgroundRect.Position + new Vector2(0, hpBarTotal) - new Vector2(0, hpIndHeight + (hpIndHeight+lineWidth)*i), new Vector2(hpIndWidth, hpIndHeight));
 				looseView.DrawRect(hpContentsRect, hpColor);

--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -273,14 +273,17 @@ namespace C7GameData {
 		internal void SpawnUnit(Player player, UnitPrototype proto, Tile tile) {
 			// TODO: consolidate unit spawning routines (here) 
 
+			var defaultExpLevel = this.defaultExperienceLevel;
+			var barbExpLevel = this.experienceLevels.First(e => e.baseHitPoints == this.barbarianInfo.maxHitpoints);
+
 			MapUnit newUnit = proto.GetInstance(this.GenerateID(proto.name), proto, player, location: tile);
-			// TODO: make this a conscript.
-			newUnit.experienceLevelKey = defaultExperienceLevelKey;
-			newUnit.experienceLevel = defaultExperienceLevel;
-			newUnit.hitPointsRemaining = 3;
+
+			newUnit.experienceLevel = player.isBarbarians ? barbExpLevel : defaultExpLevel;
+			newUnit.experienceLevelKey = player.isBarbarians ? barbExpLevel.key : defaultExpLevel.key;
+			newUnit.hitPointsRemaining = player.isBarbarians ? barbExpLevel.baseHitPoints : defaultExpLevel.baseHitPoints;
 
 			tile.unitsOnTile.Add(newUnit);
-			mapUnits.Add(newUnit);
+			this.mapUnits.Add(newUnit);
 			player.units.Add(newUnit);
 
 			log.Debug("New unit of type {type} added at {tile} for player {player}",

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -906,12 +906,16 @@ namespace C7GameData {
 					currentLocation = new TileLocation(unit.X, unit.Y),
 					previousLocation = new TileLocation(unit.PreviousX, unit.PreviousY),
 					experience = experience.key,
-					hitPointsRemaining = experience.baseHitPoints - unit.Damage, // TODO: include bonus hitpoints from unit type
-					movePointsRemaining = (float)prototype.Movement - (unit.MovementUsed / 3f),
+					hitPointsRemaining = experience.baseHitPoints,
+					movePointsRemaining = prototype.Movement,
 					WorkerProgressTowardsJob = unit.WorkerProgressTowardsJob,
 					WorkerJob = (unit.WorkerJob==-1) ? null: save.TerraForms[unit.WorkerJob].Id,
 					isAutomated = unit.IsAutomated,
 				};
+				// since this is a .sav unit, we need to adjust things like the hp, remaining moves, etc
+				// TODO: there are surely more things to add here, e.x. has this unit used its defensive bombardment this round?
+				saveUnit.hitPointsRemaining += prototype.HPBonus - unit.Damage;
+				saveUnit.movePointsRemaining -= (unit.MovementUsed / 3f);
 				if (unit.Fortified) {
 					saveUnit.action = "fortified";
 				}
@@ -950,7 +954,7 @@ namespace C7GameData {
 					currentLocation = new TileLocation(x, y),
 					previousLocation = new TileLocation(x, y),
 					experience = experienceLevel,
-					hitPointsRemaining = hitPoints, // TODO: include bonus hitpoints from unit type
+					hitPointsRemaining = hitPoints + prototype.HPBonus,
 					movePointsRemaining = (float)prototype.Movement,
 				};
 				return saveUnit;
@@ -1208,6 +1212,7 @@ namespace C7GameData {
 				prototype.defense = prto.Defense;
 				prototype.movement = prto.Movement;
 				prototype.capacity = prto.Capacity;
+				prototype.hpBonus = prto.HPBonus;
 				prototype.shieldCost = prto.ShieldCost;
 				prototype.populationCost = prto.PopulationCost;
 				prototype.bombard = prto.BombardStrength;
@@ -1240,7 +1245,7 @@ namespace C7GameData {
 				prototype.producibleBy = ImportUnitAvailability(prto);
 
 				//Temporary check until #330 is finished
-				if (!save.UnitPrototypes.Where(p => p.name == prototype.name).Any()) {
+				if (!save.UnitPrototypes.Any(p => p.name == prototype.name)) {
 					save.UnitPrototypes.Add(prototype);
 				}
 			}

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -37,7 +37,7 @@ namespace C7GameData {
 		public int hitPointsRemaining { get; set; }
 		public int maxHitPoints {
 			get {
-				return experienceLevel.baseHitPoints; // TODO: Include bonus HP from unit type
+				return this.experienceLevel.baseHitPoints + this.unitType.hpBonus;
 			}
 		}
 		public bool isFortified { get; set; }
@@ -47,7 +47,7 @@ namespace C7GameData {
 		//sentry, etc. will come later.  For now, let's just have a couple things so we can cycle through units that aren't fortified.
 		public int defensiveBombardsRemaining;
 
-		public TileDirection facingDirection;
+		public TileDirection facingDirection = TileDirection.SOUTHEAST;
 
 		public float WorkerProgressTowardsJob { get; set; }
 		public Terraform WorkerJob { get; set; }

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -61,7 +61,7 @@ namespace C7GameData.Save {
 				Inflows = data.Inflows.ConvertAll(inflow => new SaveInflow(inflow)),
 				GreatWondersBuilt = data.GreatWondersBuilt,
 				BarbarianInfo = data.barbarianInfo,
-				Units = data.mapUnits.ConvertAll(unit => new SaveUnit(unit, data.map)),
+				Units = data.mapUnits.ConvertAll(unit => new SaveUnit(unit)),
 				UnitPrototypes = data.unitPrototypes.ConvertAll(proto => new SaveUnitPrototype(proto)),
 				Players = data.players.ConvertAll(player => new SavePlayer(player)),
 				Cities = data.cities.ConvertAll(city => new SaveCity(city)),

--- a/C7Engine/C7GameData/Save/SaveUnit.cs
+++ b/C7Engine/C7GameData/Save/SaveUnit.cs
@@ -15,7 +15,7 @@ namespace C7GameData.Save {
 		public int hitPointsRemaining;
 		public float movePointsRemaining;
 		public string action; // "fortified"
-		public TileDirection facingDirection;
+		public TileDirection facingDirection = TileDirection.SOUTHEAST;
 		public string experience;
 		public float WorkerProgressTowardsJob;
 		public ID WorkerJob;
@@ -27,7 +27,7 @@ namespace C7GameData.Save {
 
 		public SaveUnit() { }
 
-		public SaveUnit(MapUnit unit, GameMap map) {
+		public SaveUnit(MapUnit unit) {
 			id = unit.id;
 			name = unit.name;
 			nationality = unit.nationality.name;

--- a/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
+++ b/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
@@ -22,6 +22,7 @@ namespace C7GameData.Save {
 		public int rateOfFire { get; set; }
 		public int movement { get; set; }
 		public int capacity { get; set; }
+		public int hpBonus { get; set; }
 
 		public HashSet<string> producibleBy = [];
 
@@ -46,10 +47,10 @@ namespace C7GameData.Save {
 
 		public SaveUnitPrototype(UnitPrototype proto) {
 			(name, art, shieldCost, populationCost, unproducible,
-			attack, defense, bombard, bombardRange, rateOfFire, movement, capacity) =
+			attack, defense, bombard, bombardRange, rateOfFire, movement, capacity, hpBonus) =
 			(proto.name, proto.art, proto.shieldCost, proto.populationCost, proto.unproducible,
 			 proto.attack, proto.defense, proto.bombard, proto.bombardRange, proto.rateOfFire, proto.movement,
-			 proto.capacity);
+			 proto.capacity, proto.hpBonus);
 
 			if (proto.requiredTech != null)
 				requiredTech = proto.requiredTech.id;

--- a/C7Engine/C7GameData/UnitPrototype.cs
+++ b/C7Engine/C7GameData/UnitPrototype.cs
@@ -67,6 +67,7 @@ namespace C7GameData {
 		public int rateOfFire { get; set; }
 		public int movement { get; set; }
 		public int capacity { get; set; }
+		public int hpBonus { get; set; }
 		public HashSet<Civilization> producibleBy { get; set; } = [];
 		public List<UnitPrototype> upgradesTo = [];
 		public bool unproducible;
@@ -105,8 +106,8 @@ namespace C7GameData {
 			(attack, defense, bombard, bombardRange, rateOfFire)
 				= (proto.attack, proto.defense, proto.bombard, proto.bombardRange, proto.rateOfFire);
 
-			(movement, capacity, unproducible) =
-				(proto.movement, proto.capacity, proto.unproducible);
+			(movement, capacity, hpBonus, unproducible) =
+				(proto.movement, proto.capacity, proto.hpBonus, proto.unproducible);
 
 			categories = new HashSet<string>(proto.categories);
 			actions = proto.actions;

--- a/C7Engine/GameSetup.cs
+++ b/C7Engine/GameSetup.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using C7GameData;
 using C7GameData.Save;
 using Serilog;
@@ -106,6 +107,13 @@ public class GameSetup {
 	}
 
 	private void AddUnit(SaveGame save, SavePlayer player, string unitType, TileLocation location) {
+		var defaultExpLevelKey = save.DefaultExperienceLevel;
+
+		var defaultExpLevel = save.ExperienceLevels.First(e => e.key == defaultExpLevelKey);
+		var barbExpLevel = save.ExperienceLevels.First(e => e.baseHitPoints == save.BarbarianInfo.maxHitpoints);
+
+		var proto = save.UnitPrototypes.First(p => p.name == unitType);
+
 		SaveUnit unit = new() {
 			id = ids.CreateID(unitType),
 			name = unitType,
@@ -115,12 +123,11 @@ public class GameSetup {
 			previousLocation = new TileLocation(-1, -1),
 			currentLocation = location,
 
-			// TODO: stop hardcoding these
-			hitPointsRemaining = 3,
-			movePointsRemaining = 1,
-			experience = "Regular",
+			hitPointsRemaining = (player.isBarbarian ? barbExpLevel.baseHitPoints : defaultExpLevel.baseHitPoints) + proto.hpBonus,
+			movePointsRemaining = proto.movement,
+			experience = player.isBarbarian ? barbExpLevel.key : defaultExpLevel.key,
 
-			facingDirection = TileDirection.NORTH,
+			facingDirection = TileDirection.SOUTHEAST,
 		};
 		save.Units.Add(unit);
 	}


### PR DESCRIPTION
1. Fixes the problem where in the beginning of a new game a scout for example only had 1 move left instead of 2. This was the fault of how I was initializing the data in `Game.cs`
2. Added bonus HP for all units. So now, a veteran Ancient Cavalry will have 5 hp instead of 4, an elite AC 6, etc..
3. Now barbarians spawn with the appropriate HP (which is configurable in the json)
4. Changed the default spawning direction to South
5. The HP bar for conscript units will go from green to red, instead of from green to orange.