### PR TITLE
Civ & Unit loading fixes

### DIFF
--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -940,7 +940,8 @@ namespace C7GameData {
 
 			// import player alliances
 			for (int i = 0; i < theBiq.GameAlliance[0].Length; i++) {
-				save.Players.Where(p => p.isIncludedInGame || p.isBarbarian).ToList()[i + 1].alliance = alliances.FirstOrDefault(a => a.index == theBiq.GameAlliance[0][i])?.name;
+				var filteredPlayers = save.Players.Where(p => p.isIncludedInGame || p.isBarbarian).ToList();
+				filteredPlayers[i + 1].alliance = alliances.FirstOrDefault(a => a.index == theBiq.GameAlliance[0][i])?.name;
 			}
 
 			foreach (var saveAlliance in save.Alliances) {

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -939,8 +939,8 @@ namespace C7GameData {
 			save.Alliances = new HashSet<Alliance>(alliances.OrderBy(a => a.index).ToHashSet());
 
 			// import player alliances
+			var filteredPlayers = save.Players.Where(p => p.isIncludedInGame || p.isBarbarian).ToList();
 			for (int i = 0; i < theBiq.GameAlliance[0].Length; i++) {
-				var filteredPlayers = save.Players.Where(p => p.isIncludedInGame || p.isBarbarian).ToList();
 				filteredPlayers[i + 1].alliance = alliances.FirstOrDefault(a => a.index == theBiq.GameAlliance[0][i])?.name;
 			}
 

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -940,7 +940,7 @@ namespace C7GameData {
 
 			// import player alliances
 			for (int i = 0; i < theBiq.GameAlliance[0].Length; i++) {
-				save.Players[i + 1].alliance = alliances.FirstOrDefault(a => a.index == theBiq.GameAlliance[0][i])?.name;
+				save.Players.Where(p => p.isIncludedInGame || p.isBarbarian).ToList()[i + 1].alliance = alliances.FirstOrDefault(a => a.index == theBiq.GameAlliance[0][i])?.name;
 			}
 
 			foreach (var saveAlliance in save.Alliances) {
@@ -1063,7 +1063,11 @@ namespace C7GameData {
 			};
 
 			foreach (UNIT unit in theBiq.Unit) {
-				if (unit.Owner >= save.Players.Count) {
+				// Only barbarians can have an owner index larger than 31,
+				// as it denotes the tribe index rather that the player index.
+				// That is why we exclude barbarians (ownerType == 1) from this.
+				if (unit.Owner >= save.Players.Count && unit.OwnerType != 1) {
+					log.Warning($"Unit has owner with index {unit.Owner}, but there are only {save.Players.Count} players");
 					continue;
 				}
 


### PR DESCRIPTION
Fixed not loading civs in custom scenarios that are not part of the game.

Fixed barbarian units not loading in .biq files, because their tribe index was out of range. In .sav files the problem doesn't seem to exist.