### PR TITLE
Intent based movement

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -8,6 +8,7 @@ using C7Engine.Pathing;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using static C7GameData.MapUnit;
 
 public class GotoInfo {
 	public Tile destinationTile = null;
@@ -16,6 +17,7 @@ public class GotoInfo {
 	public HashSet<System.Numerics.Vector2> pathCoords;
 	public bool attackingMove = false;
 	public Player requiresWarDeclarationOnPlayer = null;
+	public Intent intent = Intent.Disabled;
 };
 
 public class TileInfo {
@@ -516,7 +518,7 @@ public partial class Game : Node {
 
 	public override void _Input(InputEvent @event) {
 		if (@event is InputEventKey e && e.Pressed && !e.IsAction(C7Action.UnitGoto)) {
-			this.setGotoMode(false);
+			this.SetGotoMode(false);
 		}
 	}
 
@@ -592,8 +594,8 @@ public partial class Game : Node {
 
 	private void OnSingleLeftMouseButtonClick(InputEventMouseButton eventMouseButton) {
 		if (gotoInfo != null) {
-			HandleGotoClick(gotoInfo);
-			setGotoMode(false);
+			this.ResolveMovement(gotoInfo);
+			this.SetGotoMode(false);
 		} else if (bombardInfo != null) {
 			Tile tile = PositionToTile(eventMouseButton.Position);
 			if (bombardInfo.bombardingUnit.canBombardTile(tile)) {
@@ -650,7 +652,7 @@ public partial class Game : Node {
 	}
 
 	private void HandleRightMouseButton(InputEventMouseButton eventMouseButton) {
-		setGotoMode(false);
+		this.SetGotoMode(false);
 
 		Tile tile = PositionToTile(eventMouseButton.Position);
 		if (tile != null) {
@@ -901,7 +903,9 @@ public partial class Game : Node {
 			TileDirection? dir = C7Action.ToTileDirection(currentAction);
 
 			if (dir.HasValue) {
-				new MsgMoveUnit(CurrentlySelectedUnit.id, dir.Value).send();
+				this.gotoInfo = GetGotoInfo(CurrentlySelectedUnit.location.GetTileAtNeighborIndex((int)(dir) + 1));
+				this.ResolveMovement(this.gotoInfo);
+				this.SetGotoMode(false);
 			}
 		}
 
@@ -973,7 +977,7 @@ public partial class Game : Node {
 		// toggles the go to state, but must be detoggled in _*Input methods if
 		// it is not the input being pressed.
 		if (currentAction == C7Action.UnitGoto) {
-			setGotoMode(true);
+			this.SetGotoMode(true);
 		}
 
 		if (currentAction == C7Action.UnitExplore && CurrentlySelectedUnit != MapUnit.NONE) {
@@ -1046,11 +1050,12 @@ public partial class Game : Node {
 		new MsgStartWorkerJob(CurrentlySelectedUnit.id, terraform).send();
 	}
 
-	private void setGotoMode(bool isOn) {
+	private void SetGotoMode(bool isOn) {
 		if (isOn) {
-			gotoInfo = new();
+			this.gotoInfo = new();
 		} else {
-			gotoInfo = null;
+			this.gotoInfo = null;
+			this.lastTile = null;
 		}
 	}
 
@@ -1060,8 +1065,27 @@ public partial class Game : Node {
 			Input.SetCustomMouseCursor(null);
 	}
 
-	private void HandleGotoClick(GotoInfo info) {
-		if (info == null || info.moveCost == -1) {
+	private void ResolveMovement(GotoInfo info) {
+		if (info == null) {
+			return;
+		}
+
+		log.Debug($"Resolve movement intent: {info.intent}");
+
+		if (info.intent == Intent.NoticeUnit) {
+			new MsgShowTemporaryPopup($"Non-combat units may not attack.", info.destinationTile).send();
+			return;
+		}
+		if (info.intent == Intent.NoticeCity) {
+			new MsgShowTemporaryPopup($"Only combat units can capture cities and improvements.", info.destinationTile).send();
+			return;
+		}
+		if (info.intent == Intent.NoticeAlliance) {
+			new MsgShowTemporaryPopup($"No aggression against alliance.", info.destinationTile).send();
+			return;
+		}
+
+		if (info.moveCost == -1) {
 			return;
 		}
 
@@ -1071,9 +1095,10 @@ public partial class Game : Node {
 			// war for them, clear out the player, and call this method again.
 			if (info.requiresWarDeclarationOnPlayer != null) {
 				GotoInfo stashed = info;
-				MaybeDeclareWar(stashed.requiresWarDeclarationOnPlayer, gameData.turn, () => {
+				this.MaybeDeclareWar(stashed.requiresWarDeclarationOnPlayer, gameData.turn, () => {
 					stashed.requiresWarDeclarationOnPlayer = null;
-					HandleGotoClick(stashed);
+					this.ResolveMovement(stashed);
+					this.SetGotoMode(false);
 				});
 			} else {
 				new MsgSetUnitPath(CurrentlySelectedUnit.id, info.path).send();
@@ -1098,11 +1123,21 @@ public partial class Game : Node {
 		// Figure out which tile it was.
 		EngineStorage.ReadGameData((GameData gameData) => {
 			Tile tile = mapView.tileOnScreenAt(gameData.map, mousePos);
-			if (tile == lastTile) {
-				result = gotoInfo;
+			result = GetGotoInfo(tile);
+		});
+
+		return result;
+	}
+
+	private GotoInfo GetGotoInfo(Tile tile) {
+		GotoInfo result = new();
+
+		EngineStorage.ReadGameData((GameData gameData) => {
+			if (tile == this.lastTile && this.gotoInfo != null) {
+				result = this.gotoInfo;
 				return;
 			}
-			lastTile = result.destinationTile = tile;
+			this.lastTile = result.destinationTile = tile;
 
 			// Figure out what unit is in goto mode. If the tile we're hovering over is
 			// different than the tile the unit is on, calculate the path to move there.
@@ -1120,9 +1155,11 @@ public partial class Game : Node {
 				// If we couldn't path onto the tile, but the tile is next to us and
 				// we could enter the tile if combat is allowed (or if we could
 				// declare war with the move) mark the path.
-				if (result.moveCost == -1
-					&& unit.location.distanceTo(tile) == 1
-					&& unit.CanEnterTile(tile, TileProbe.DeclareWarProbe())) {
+				var distanceToTile = unit.location.distanceTo(tile);
+				var canEnterForcefully = unit.CanEnterForcefully(tile, out Intent intent);
+				result.intent = intent;
+
+				if (distanceToTile == 1 && canEnterForcefully) {
 					Queue<Tile> pathQueue = new();
 					pathQueue.Enqueue(tile);
 
@@ -1130,11 +1167,11 @@ public partial class Game : Node {
 					result.moveCost = result.path.PathCost(unit.owner, unit.location, unit.unitType.movement,
 						unit.movementPoints.remaining);
 					result.pathCoords = result.path.GetPathCoords();
-					result.attackingMove = true;
 
 					// If we couldn't enter this tile without a war declaration,
 					// record which civ we need to declare war on.
-					if (!unit.CanEnterTile(tile, TileProbe.MoveAggroProbe())) {
+					if (intent == Intent.WarDeclaration) {
+						result.attackingMove = true;
 						if (tile.cityAtTile != null) {
 							result.requiresWarDeclarationOnPlayer = tile.cityAtTile.owner;
 						} else {

--- a/C7/Map/GotoLayer.cs
+++ b/C7/Map/GotoLayer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using C7GameData;
 using Godot;
+using static C7GameData.MapUnit;
 
 // The layer responsible for drawing the cursor when the player is selecting a
 // move via the "goto" command.
@@ -53,7 +54,7 @@ public partial class GotoLayer : LooseLayer {
 
 		staticCursorRect.Position = position - new Vector2(staticCursor.GetWidth(), staticCursor.GetHeight()) / 2;
 
-		gotoLabel.Theme = attackingMove ? redFontTheme : whiteFontTheme;
+		gotoLabel.Theme = whiteFontTheme;
 		gotoLabel.Text = moves > 0 || !attackingMove ? moves.ToString() : " ";
 		Vector2 labelSize = gotoLabelFont.GetStringSize(gotoLabel.Text);
 		gotoLabel.Position = position - labelSize / 2;
@@ -72,7 +73,7 @@ public partial class GotoLayer : LooseLayer {
 	}
 
 	private GotoInfo lastGotoInfo = null;
-	private bool lastCanEnter = false;
+	private Intent lastintent = Intent.Disabled;
 
 	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
 		MapUnit unit = looseView.mapView.game.CurrentlySelectedUnit;
@@ -88,16 +89,24 @@ public partial class GotoLayer : LooseLayer {
 			DrawStaticGoToCursor(looseView, tileCenter, 0, true);
 		}
 
-		bool canEnter;
+		Intent intent = lastintent;
 
-		if (gotoInfo == lastGotoInfo)
-			canEnter = lastCanEnter;
-		else {
-			lastCanEnter = canEnter = unit.CanEnterTile(gotoInfo.destinationTile, TileProbe.DeclareWarProbe());
+		if (gotoInfo == lastGotoInfo) {
+			intent = lastintent;
+		} else {
+			unit.CanEnterForcefully(gotoInfo.destinationTile, out var outIntent);
+			lastintent = intent = outIntent;
 			lastGotoInfo = gotoInfo;
 		}
 
-		if (gotoInfo.path == null || !canEnter)
+		if (gotoInfo.path == null) return;
+
+		if (gotoInfo.path.path.Count <= 1
+								   && (intent == Intent.Fight
+									   || intent == Intent.WarDeclaration
+									   || intent == Intent.NoticeAlliance
+									   || intent == Intent.NoticeCity
+									   || intent == Intent.NoticeUnit))
 			return;
 
 		List<Tile> tiles = new List<Tile>();

--- a/C7/Map/UnitLayer.cs
+++ b/C7/Map/UnitLayer.cs
@@ -273,7 +273,7 @@ public partial class UnitLayer : LooseLayer {
 		Vector2 animOffset = new Vector2(appearance.offsetX, appearance.offsetY) * MapView.cellSize;
 
 		// If the unit we're about to draw is currently selected, draw the cursor first underneath it
-		if ((unit != MapUnit.NONE) && (unit == looseView.mapView.game.CurrentlySelectedUnit)) {
+		if (unit != MapUnit.NONE && unit == looseView.mapView.game.CurrentlySelectedUnit) {
 			drawCursor(looseView, tileCenter + animOffset);
 		}
 

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -525,7 +525,7 @@ public partial class LooseView : Node2D {
 			}
 
 			if (stopwatch.ElapsedMilliseconds > 100) {
-				log.Information($"-> End draw: {stopwatch.ElapsedMilliseconds} milliseconds");
+				log.Warning($"-> End draw: {stopwatch.ElapsedMilliseconds} milliseconds");
 			}
 
 			if (!gD.observerMode) {

--- a/C7/UIElements/Advisors/TechBox.cs
+++ b/C7/UIElements/Advisors/TechBox.cs
@@ -153,7 +153,7 @@ public partial class TechBox : TextureButton {
 		smallFontTheme.SetColor("font_color", "Label", new Color(0.71f, 0.35f, 0.13f));
 
 		var customTheme = new Theme();
-		customTheme.SetStylebox("panel", "TooltipPanel", TemporaryPopup.TooltipStyleBox());
+		customTheme.SetStylebox("panel", "TooltipPanel", TemporaryPopup.PopupTechStyleBox());
 		customTheme.SetColor("font_color", "TooltipLabel", Colors.Black);
 		customTheme.SetFontSize("font_size", "TooltipLabel", 12);
 		this.Theme = customTheme;

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -191,7 +191,7 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 		if (unit.location.HasCity && unit.owner == unit.location.cityAtTile.owner) {
 			terrainType.Text = unit.location.cityAtTile.name;
 		}
-		if (unit.HasRank()) {
+		if (unit.IsCombatUnit()) {
 			showRank = true;
 			unitRank.Text = unit.experienceLevel.displayName;
 			attackDefenseMovement.SetPosition(new Vector2(0, 46));

--- a/C7/UIElements/Popups/TemporaryPopup.cs
+++ b/C7/UIElements/Popups/TemporaryPopup.cs
@@ -1,5 +1,4 @@
 using Godot;
-using System;
 using System.Threading.Tasks;
 
 public partial class TemporaryPopup : Label {
@@ -12,6 +11,7 @@ public partial class TemporaryPopup : Label {
 
 		AddThemeStyleboxOverride("normal", PopupStyleBox());
 		AddThemeColorOverride("font_color", Colors.White);
+		AddThemeFontSizeOverride("font_size", 12);
 	}
 
 	// A stylebox that works well for temporary popups or tooltips in game.

--- a/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
+++ b/C7Engine/AI/Pathing/PathingAlgorithmChooser.cs
@@ -26,14 +26,8 @@ namespace C7Engine.Pathing {
 					return from.distanceTo(to);
 				},
 				(Tile neighbor, Tile destination) => {
-					// Only allow a potentially attacking move for the last step,
-					// to allow pathing to attack. We don't want to try and path
-					// through opponents on the way to our destination though,
-					// as we can get stuck.
-					var probe = neighbor == destination ? TileProbe.MoveAggroProbe() : TileProbe.MoveNonAggroProbe();
-					return unit.CanEnterTile(neighbor, probe);
-				}
-			);
+					return neighbor == destination ? unit.CanEnterForcefully(neighbor) : unit.CanEnterPeacefully(neighbor);
+				});
 		}
 	}
 }

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -242,7 +242,7 @@ namespace C7Engine {
 			}
 
 			List<Tile> reachableBarbCampsTiles = player.tileKnowledge.AllKnownTiles()
-				.Where(t => unit.CanEnterTile(t, TileProbe.MoveAggroProbe()) && t.hasBarbarianCamp).ToList();
+				.Where(t => unit.CanEnter(t) && t.hasBarbarianCamp).ToList();
 
 			Tile closestBarbCamp = Tile.NONE;
 			int closestBarbDistance = int.MaxValue;

--- a/C7Engine/AI/UnitAI/CombatAI.cs
+++ b/C7Engine/AI/UnitAI/CombatAI.cs
@@ -81,7 +81,7 @@ namespace C7Engine.AI.UnitAI {
 			}
 
 			// Move along the path, initiating combat if we reach our target.
-			return this.TryToMoveAlongPath(unit, ref data.path, TileProbe.MoveAggroProbe());
+			return this.TryToMoveAlongPath(unit, ref data.path);
 		}
 
 		public string SummarizePlan() {

--- a/C7Engine/AI/UnitAI/DefenderAI.cs
+++ b/C7Engine/AI/UnitAI/DefenderAI.cs
@@ -53,7 +53,7 @@ namespace C7Engine.AI.UnitAI {
 				return C7GameData.UnitAI.Result.Done;
 			} else {
 				log.Debug("Moving defender towards " + data.destination);
-				return this.TryToMoveAlongPath(unit, ref data.pathToDestination, TileProbe.MoveNonAggroProbe());
+				return this.TryToMoveAlongPath(unit, ref data.pathToDestination);
 			}
 		}
 

--- a/C7Engine/AI/UnitAI/EscortAI.cs
+++ b/C7Engine/AI/UnitAI/EscortAI.cs
@@ -80,7 +80,7 @@ namespace C7Engine {
 
 			// Move to the unit we're escorting.
 			TilePath path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, data.unitToEscort.location, unit);
-			result = this.TryToMoveAlongPath(unit, ref path, TileProbe.MoveNonAggroProbe());
+			result = this.TryToMoveAlongPath(unit, ref path);
 			if (result != UnitAI.Result.InProgress) {
 				return result;
 			}

--- a/C7Engine/AI/UnitAI/ExplorerAI.cs
+++ b/C7Engine/AI/UnitAI/ExplorerAI.cs
@@ -51,7 +51,7 @@ namespace C7Engine {
 				return UnitAI.Result.Done;
 			}
 
-			return this.TryToMoveAlongPath(unit, ref data.pathToDestination, TileProbe.MoveNonAggroProbe());
+			return this.TryToMoveAlongPath(unit, ref data.pathToDestination);
 		}
 
 		public string SummarizePlan() {

--- a/C7Engine/AI/UnitAI/SettlerAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerAI.cs
@@ -65,7 +65,7 @@ namespace C7Engine {
 						unit.movementPoints.onConsumeAll();
 						return C7GameData.UnitAI.Result.InProgress;
 					} else {
-						return this.TryToMoveAlongPath(unit, ref data.pathToDestination, TileProbe.MoveNonAggroProbe());
+						return this.TryToMoveAlongPath(unit, ref data.pathToDestination);
 					}
 					break;
 				case SettlerAIData.SettlerGoal.JOIN_CITY:

--- a/C7Engine/AI/UnitAI/WorkerAI.cs
+++ b/C7Engine/AI/UnitAI/WorkerAI.cs
@@ -78,7 +78,7 @@ namespace C7Engine {
 				return PerformWorkerMove(unit, improvement);
 			}
 
-			return this.TryToMoveAlongPath(unit, ref data.pathToDestination, TileProbe.MoveNonAggroProbe());
+			return this.TryToMoveAlongPath(unit, ref data.pathToDestination);
 		}
 
 		private static Terraform? GetTileImprovement(Tile t, MapUnit unit) {

--- a/C7Engine/AI/UnitAiExtension.cs
+++ b/C7Engine/AI/UnitAiExtension.cs
@@ -13,17 +13,17 @@ namespace C7Engine {
 		// Attempts to move the supplied unit along the given path.
 		//
 		// `path` is a ref so that the path can be recalculated if necessary.
-		public static MoveResult TryToMoveAlongPath(this UnitAI unitAi, MapUnit unit, ref TilePath path, TileProbe probe) {
+		public static MoveResult TryToMoveAlongPath(this UnitAI unitAi, MapUnit unit, ref TilePath path) {
 			if (!unit.movementPoints.canMove) {
 				return UnitAI.Result.InProgress;
 			}
 			Tile nextTile = path.Next();
-			if (nextTile == Tile.NONE || !unit.CanEnterTile(nextTile, probe)) {
+			if (nextTile == Tile.NONE || !unit.CanEnterForcefully(nextTile)) {
 				log.Information($"Attempting to repath {unit} from {unit.location} to {path.destination}");
 				// Attempt to repath. If we succeed, return inprogress so we get
 				// called again.
 				path = PathingAlgorithmChooser.GetAlgorithm(unit).PathFrom(unit.location, path.destination, unit);
-				if ((path?.PathLength() ?? -1) == -1 || path.PeekNext() == Tile.NONE || !unit.CanEnterTile(path.PeekNext(), probe)) {
+				if ((path?.PathLength() ?? -1) == -1 || path.PeekNext() == Tile.NONE || !unit.CanEnterForcefully(path.PeekNext())) {
 					return UnitAI.Result.Error;
 				}
 

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -825,11 +825,11 @@ namespace C7GameData {
 			if (this.IsLandUnit() && !tile.IsLand())
 				return Intent.Disabled;
 
-			var hasOtherOwnersCity = HasOtherOwnersCity(tile, unitOwner);
+			var hasForeignCity = HasForeignCity(tile, unitOwner);
 			var isHumanOwner = this.owner.isHuman;
 			var isActiveTile = this.owner.tileKnowledge.isActiveTile(tile);
 
-			if (isHumanOwner && !isActiveTile && hasOtherOwnersCity) {
+			if (isHumanOwner && !isActiveTile && hasForeignCity) {
 				return Intent.Disabled;
 			}
 
@@ -838,23 +838,23 @@ namespace C7GameData {
 			}
 
 			var hasHostileUnits = HasHostileUnits(tile, unitOwner);
-			var hasOtherOwnersUnits = HasOtherOwnersUnits(tile, unitOwner);
-			var otherUnitsOwner = OtherUnitsOwner(tile);
+			var hasForeignUnits = HasForeignUnits(tile, unitOwner);
+			var foreignOwner = ForeignOwner(tile);
 			var hasHostileCity = HasHostileCity(tile, unitOwner);
 			var cityOwner = tile.cityAtTile?.owner;
 			var hasBarbCamp = tile.hasBarbarianCamp;
 			var isCombatUnit = this.IsCombatUnit();
 			var distanceToTile = this.location.distanceTo(tile);
 
-			if (isHumanOwner && (hasOtherOwnersCity || hasHostileCity || hasOtherOwnersUnits || hasHostileUnits) && distanceToTile > 1) {
+			if (isHumanOwner && (hasForeignCity || hasHostileCity || hasForeignUnits || hasHostileUnits) && distanceToTile > 1) {
 				return Intent.Disabled;
 			}
 
 			if (!isCombatUnit) {
-				if (hasOtherOwnersUnits || hasHostileUnits) {
+				if (hasForeignUnits || hasHostileUnits) {
 					return Intent.NoticeUnit;
 				}
-				if (hasOtherOwnersCity || hasHostileCity || hasBarbCamp) {
+				if (hasForeignCity || hasHostileCity || hasBarbCamp) {
 					return Intent.NoticeCity;
 				}
 			}
@@ -865,9 +865,9 @@ namespace C7GameData {
 				if (hasHostileUnits || hasHostileCity) {
 					return Intent.Fight;
 				}
-				if (hasOtherOwnersUnits) {
+				if (hasForeignUnits) {
 					if (distanceToTile == 1) {
-						if (EngineStorage.gameData.AreInLockedPeace(unitOwner, otherUnitsOwner)) {
+						if (EngineStorage.gameData.AreInLockedPeace(unitOwner, foreignOwner)) {
 							return Intent.NoticeAlliance;
 						}
 						return Intent.WarDeclaration;
@@ -877,7 +877,7 @@ namespace C7GameData {
 						return Intent.Disabled;
 					}
 				}
-				if (hasOtherOwnersCity) {
+				if (hasForeignCity) {
 					if (distanceToTile == 1) {
 						if (EngineStorage.gameData.AreInLockedPeace(unitOwner, cityOwner)) {
 							return Intent.NoticeAlliance;
@@ -891,14 +891,6 @@ namespace C7GameData {
 			return Intent.MoveFreely;
 		}
 
-		public bool CanEnter(Tile tile) {
-			return CanEnter(tile, out _);
-		}
-		public bool CanEnter(Tile tile, out Intent intent) {
-			intent = this.ResolveIntent(tile);
-			return intent == Intent.MoveFreely || intent == Intent.Fight || intent == Intent.Load || intent == Intent.Unload;
-		}
-
 		public bool CanEnterPeacefully(Tile tile) {
 			return CanEnterPeacefully(tile, out _);
 		}
@@ -907,12 +899,22 @@ namespace C7GameData {
 			return intent == Intent.MoveFreely || intent == Intent.Load || intent == Intent.Unload;
 		}
 
+		public bool CanEnter(Tile tile) {
+			return CanEnter(tile, out _);
+		}
+		public bool CanEnter(Tile tile, out Intent intent) {
+			var canEnterPeacefully = CanEnterPeacefully(tile, out var it);
+			intent = it;
+			return canEnterPeacefully || it == Intent.Fight;
+		}
+
 		public bool CanEnterForcefully(Tile tile) {
 			return CanEnterForcefully(tile, out _);
 		}
 		public bool CanEnterForcefully(Tile tile, out Intent intent) {
-			intent = this.ResolveIntent(tile);
-			return intent == Intent.MoveFreely || intent == Intent.Fight || intent == Intent.Load || intent == Intent.Unload || intent == Intent.WarDeclaration;
+			var canEnter = CanEnter(tile, out var it);
+			intent = it;
+			return canEnter || it == Intent.WarDeclaration;
 		}
 
 		private bool CanBoardTransportOnTile(Tile tile) {
@@ -996,7 +998,7 @@ namespace C7GameData {
 			}
 			return false;
 		}
-		private static bool HasOtherOwnersUnits(Tile tile, Player player) {
+		private static bool HasForeignUnits(Tile tile, Player player) {
 			foreach (MapUnit other in tile.unitsOnTile) {
 				if (player != other.owner)
 					return true;
@@ -1004,14 +1006,14 @@ namespace C7GameData {
 			return false;
 		}
 
-		private static Player OtherUnitsOwner(Tile tile) {
+		private static Player ForeignOwner(Tile tile) {
 			return tile.unitsOnTile.FirstOrDefault()?.owner;
 		}
 
 		private static bool HasHostileCity(Tile tile, Player player) {
 			return tile.HasCity && AtWar(player, tile.cityAtTile.owner);
 		}
-		private static bool HasOtherOwnersCity(Tile tile, Player player) {
+		private static bool HasForeignCity(Tile tile, Player player) {
 			return tile.HasCity && tile.cityAtTile.owner != player;
 		}
 		private static bool HasOwnCity(Tile tile, Player player) {

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -82,7 +82,7 @@ namespace C7GameData {
 			return IsLandUnit() && unitType.defense > 0;
 		}
 
-		public bool HasRank() {
+		public bool IsCombatUnit() {
 			return this.unitType.attack > 0 || this.unitType.defense > 0;
 		}
 
@@ -142,7 +142,7 @@ namespace C7GameData {
 
 		public string Describe() {
 			UnitPrototype type = this.unitType;
-			string exp = this.HasRank() ? $"{this.experienceLevel.displayName}" : "";
+			string exp = this.IsCombatUnit() ? $"{this.experienceLevel.displayName}" : "";
 			string hPDesc = ((type.attack > 0) || (type.defense > 0)) ? $" ({this.hitPointsRemaining}/{this.maxHitPoints})" : "";
 			string displayName = this.IsCaptive() ? $" ({this.nationality.adjective}) {this.name}" : $" {this.name}";
 			string attackDesc = (type.bombard > 0) ? $"{type.attack}({type.bombard})" : type.attack.ToString();
@@ -439,7 +439,7 @@ namespace C7GameData {
 						// TODO: Defender retreat behavior requires some more work. There's an issue for it here:
 						// https://github.com/C7-Game/Prototype/issues/274
 						Tile retreatDestination = defender.location.neighbors[attackerAttackDirection];
-						if ((retreatDestination != Tile.NONE) && defender.CanEnterTile(retreatDestination, TileProbe.MoveNonAggroProbe())) {
+						if ((retreatDestination != Tile.NONE) && defender.CanEnter(retreatDestination)) {
 							await defender.move(attackerAttackDirection, true);
 							result = CombatResult.DefenderRetreated;
 							break;
@@ -775,96 +775,144 @@ namespace C7GameData {
 			}
 		}
 
-		// Generalized check to see whether a given tile is accessible to the unit in a given context.
-		public bool CanEnterTile(Tile tile, TileProbe probe) {
+		public enum Intent {
+			Disabled,         // do nothing, don't move
+			MoveFreely,       // enter tile
+			Fight,            // move and fight an enemy unit, capture city/unit, pillage freely, etc
+			Load,             // load a unit on a friendly transport on this tile
+			Unload,           // unload a unit from a transport on this tile
+			NoticeUnit,       // a non-combat unit tries to move on another owner's unit tile
+			NoticeCity,       // a non-combat unit tries to move on another owner's city tile
+			NoticeAlliance,   // a combat unit tries to move on an ally's city/unit tile
+			WarDeclaration,   // a combat unit tries to move on another owner's city/unit tile (TODO: pillage non-enemy road/colony etc for example)
+		}
+
+		/// <summary>
+		/// Returns a unit's intent trying to move in on a tile.
+		/// </summary>
+		/// <param name="tile"></param>
+		/// <returns></returns>
+		// private Intent ResolveIntent(Tile tile, bool tset = false) {
+		private Intent ResolveIntent(Tile tile) {
+			if (!Tile.IsTileValid(tile))
+				return Intent.Disabled;
+
+			var unitOwner = this.owner;
+
 			// TODO: Perhaps this is not sufficient, but it is for now,
 			// since otherwise we can move air units on land and sea
 			if (this.IsAirUnit())
-				return false;
+				return Intent.Disabled;
 
-			if (this.owner.isHuman && !this.owner.HasExploredTile(tile))
-				return true;
+			if (unitOwner.isHuman && !unitOwner.HasExploredTile(tile))
+				return Intent.MoveFreely;
 
-			// TODO: Add sea/ocean restrictions for water units
-			// Check if the player has the appropriate tech or wonder to move freely.
-			// Civ3 seems to not allow to set a destination on sea/ocean without tech/wonder
-			// (even if you can actually go there using the keyboard keys)
-			// but it will go through it if it's just a shortcut to an allowed tile.
+			var hasOwnCity = HasOwnCity(tile, unitOwner);
 
 			// Keep land units on land and sea units on water
 			if (this.IsWaterUnit() && tile.IsLand()) {
-				if (tile.HasCity && tile.cityAtTile.owner == owner) {
-					return true;
-				}
-				return false;
+				if (hasOwnCity) return Intent.MoveFreely;
+
+				return Intent.Disabled;
 			}
 
-			if (CanBoardTransportOnTile(tile))
-				return true;
+			if (this.CanBoardTransportOnTile(tile))
+				return Intent.Load;
 
-			if (CanUnloadToTile(tile))
-				return true;
+			if (this.CanUnloadToTile(tile))
+				return Intent.Unload;
 
 			if (this.IsLandUnit() && !tile.IsLand())
-				return false;
+				return Intent.Disabled;
 
-			if (!this.HasRank()) {
-				if (HasHostileCity(tile, owner)) {
-					if (probe.RaiseNotice) {
-						new MsgShowTemporaryPopup($"Only combat units can capture cities and improvements.", location).send();
+			var hasOtherOwnersCity = HasOtherOwnersCity(tile, unitOwner);
+			var isHumanOwner = this.owner.isHuman;
+			var isActiveTile = this.owner.tileKnowledge.isActiveTile(tile);
+
+			if (isHumanOwner && !isActiveTile && hasOtherOwnersCity) {
+				return Intent.Disabled;
+			}
+
+			if (isHumanOwner && !isActiveTile) {
+				return Intent.MoveFreely;
+			}
+
+			var hasHostileUnits = HasHostileUnits(tile, unitOwner);
+			var hasOtherOwnersUnits = HasOtherOwnersUnits(tile, unitOwner);
+			var otherUnitsOwner = OtherUnitsOwner(tile);
+			var hasHostileCity = HasHostileCity(tile, unitOwner);
+			var cityOwner = tile.cityAtTile?.owner;
+			var hasBarbCamp = tile.hasBarbarianCamp;
+			var isCombatUnit = this.IsCombatUnit();
+			var distanceToTile = this.location.distanceTo(tile);
+
+			if (isHumanOwner && (hasOtherOwnersCity || hasHostileCity || hasOtherOwnersUnits || hasHostileUnits) && distanceToTile > 1) {
+				return Intent.Disabled;
+			}
+
+			if (!isCombatUnit) {
+				if (hasOtherOwnersUnits || hasHostileUnits) {
+					return Intent.NoticeUnit;
+				}
+				if (hasOtherOwnersCity || hasHostileCity || hasBarbCamp) {
+					return Intent.NoticeCity;
+				}
+			}
+
+			// TODO: add check for when we want to pillage something
+
+			if (isCombatUnit) {
+				if (hasHostileUnits || hasHostileCity) {
+					return Intent.Fight;
+				}
+				if (hasOtherOwnersUnits) {
+					if (distanceToTile == 1) {
+						if (EngineStorage.gameData.AreInLockedPeace(unitOwner, otherUnitsOwner)) {
+							return Intent.NoticeAlliance;
+						}
+						return Intent.WarDeclaration;
 					}
-					return false;
-				}
-				if (HasHostileUnits(tile, owner) || (tile.hasBarbarianCamp && !this.owner.isBarbarians)) {
-					if (probe.RaiseNotice) {
-						new MsgShowTemporaryPopup($"Non-combat units may not attack.", location).send();
-					}
-					return false;
-				}
-			}
 
-			var tileOwner = tile.OwningPlayer();
-
-			if (tile.HasCity && tileOwner != this.owner) {
-				if (EngineStorage.gameData.AreInLockedPeace(tileOwner, this.owner)) {
-					return false;
-				}
-			}
-
-			// If we allow declaring war on this move, then it doesn't matter if
-			// there are units belonging to another player on the tile.
-			// TODO: unbreakable alliances
-			if (probe.AllowWarDeclaration) {
-				return true;
-			}
-
-			// Allow AI to "see" human/other AI units even if they are in an unexplored or inactive tile
-			// from their perspective, but allow humans to set a course if the tile
-			// is unknown or not active, aka, the human player shouldn't know what's on the tile
-			// if the tile is not active, or they haven't  discovered it yet.
-			//
-			// If we don't want to have the AI have this advantage over the human player
-			// we can simply remove the !isHuman() condition. This can also be tied to
-			// AI difficulty level, or be made moddable somehow, etc...
-			if (!this.owner.isHuman || this.owner.tileKnowledge.isActiveTile(tile)) {
-				// Check for units belonging to other civs
-				foreach (MapUnit other in tile.unitsOnTile) {
-					if (other.owner != owner) {
-						if (!other.owner.IsAtPeaceWith(owner))
-							return probe.AllowCombat && unitType.attack > 0;
-						return false;
+					if (isActiveTile) {
+						return Intent.Disabled;
 					}
 				}
+				if (hasOtherOwnersCity) {
+					if (distanceToTile == 1) {
+						if (EngineStorage.gameData.AreInLockedPeace(unitOwner, cityOwner)) {
+							return Intent.NoticeAlliance;
+						}
+						return Intent.WarDeclaration;
+					}
+					return Intent.Disabled;
+				}
 			}
 
-			// Check for cities belonging to other civs.
-			if (tile.cityAtTile != null && tile.cityAtTile.owner != owner) {
-				if (!this.owner.isHuman || this.owner.tileKnowledge.isActiveTile(tile))
-					return probe.AllowCombat;
-				return false;
-			}
+			return Intent.MoveFreely;
+		}
 
-			return true;
+		public bool CanEnter(Tile tile) {
+			return CanEnter(tile, out _);
+		}
+		public bool CanEnter(Tile tile, out Intent intent) {
+			intent = this.ResolveIntent(tile);
+			return intent == Intent.MoveFreely || intent == Intent.Fight || intent == Intent.Load || intent == Intent.Unload;
+		}
+
+		public bool CanEnterPeacefully(Tile tile) {
+			return CanEnterPeacefully(tile, out _);
+		}
+		public bool CanEnterPeacefully(Tile tile, out Intent intent) {
+			intent = this.ResolveIntent(tile);
+			return intent == Intent.MoveFreely || intent == Intent.Load || intent == Intent.Unload;
+		}
+
+		public bool CanEnterForcefully(Tile tile) {
+			return CanEnterForcefully(tile, out _);
+		}
+		public bool CanEnterForcefully(Tile tile, out Intent intent) {
+			intent = this.ResolveIntent(tile);
+			return intent == Intent.MoveFreely || intent == Intent.Fight || intent == Intent.Load || intent == Intent.Unload || intent == Intent.WarDeclaration;
 		}
 
 		private bool CanBoardTransportOnTile(Tile tile) {
@@ -948,9 +996,26 @@ namespace C7GameData {
 			}
 			return false;
 		}
+		private static bool HasOtherOwnersUnits(Tile tile, Player player) {
+			foreach (MapUnit other in tile.unitsOnTile) {
+				if (player != other.owner)
+					return true;
+			}
+			return false;
+		}
+
+		private static Player OtherUnitsOwner(Tile tile) {
+			return tile.unitsOnTile.FirstOrDefault()?.owner;
+		}
 
 		private static bool HasHostileCity(Tile tile, Player player) {
 			return tile.HasCity && AtWar(player, tile.cityAtTile.owner);
+		}
+		private static bool HasOtherOwnersCity(Tile tile, Player player) {
+			return tile.HasCity && tile.cityAtTile.owner != player;
+		}
+		private static bool HasOwnCity(Tile tile, Player player) {
+			return tile.HasCity && tile.cityAtTile.owner == player;
 		}
 
 		/// <summary>
@@ -963,79 +1028,86 @@ namespace C7GameData {
 		/// <exception cref="Exception"></exception>
 		public async Task<bool> move(TileDirection dir, bool wait = false) {
 			(int dx, int dy) = dir.toCoordDiff();
+
 			Tile newLoc = EngineStorage.gameData.map.tileAt(dx + location.XCoordinate, dy + location.YCoordinate);
-			if ((newLoc != Tile.NONE) && CanEnterTile(newLoc, TileProbe.MoveAggroWithNoticeProbe()) && (movementPoints.canMove)) {
-				facingDirection = dir;
-				wake();
 
-				// Trigger combat if the tile we're moving into has an enemy  Or if this unit can't fight, do nothing.
-				MapUnit defender = newLoc.FindTopDefender(this);
-				if (defender != MapUnit.NONE && !owner.IsAtPeaceWith(defender.owner)) {
-					if (unitType.attack > 0) {
-						CombatResult combatResult = await fight(defender);
-						// If we were killed then of course there's nothing more to do. If the combat couldn't happen for whatever
-						// reason, just give up on trying to move.
-						if (combatResult == CombatResult.AttackerKilled) {
-							return false;
-						}
-						if (combatResult == CombatResult.Impossible) {
-							return true;
-						}
+			var canMove = (newLoc != Tile.NONE) && this.CanEnter(newLoc) && (movementPoints.canMove);
+			if (!canMove) return false;
 
-						// If the enemy was defeated, check if there is another enemy on the tile. If so we can't complete the move
-						// but still pay one movement point for the combat.
-						else if (combatResult == CombatResult.DefenderKilled || combatResult == CombatResult.DefenderRetreated) {
-							if (newLoc.FindTopDefender(this) != MapUnit.NONE) {
-								movementPoints.onUnitMove(1);
-								return true;
-							}
+			facingDirection = dir;
+			wake();
 
-							// Similarly if we retreated, pay one MP for the combat but don't move.
-						} else if (combatResult == CombatResult.AttackerRetreated) {
-							movementPoints.onUnitMove(1);
-							return true;
-						}
-					} else {
+			// Trigger combat if the tile we're moving into has an enemy  Or if this unit can't fight, do nothing.
+			MapUnit defender = newLoc.FindTopDefender(this);
+			if (defender != MapUnit.NONE && !owner.IsAtPeaceWith(defender.owner)) {
+				if (unitType.attack <= 0) {
+					return true;
+				}
+
+				CombatResult combatResult = await fight(defender);
+				this.path = TilePath.NONE;
+				// If we were killed then of course there's nothing more to do. If the combat couldn't happen for whatever
+				// reason, just give up on trying to move.
+				if (combatResult == CombatResult.AttackerKilled) {
+					return false;
+				}
+				if (combatResult == CombatResult.Impossible) {
+					return true;
+				}
+
+				// If the enemy was defeated, check if there is another enemy on the tile. If so we can't complete the move
+				// but still pay one movement point for the combat.
+				if (combatResult == CombatResult.DefenderKilled || combatResult == CombatResult.DefenderRetreated) {
+					this.movementPoints.onUnitMove(1);
+					if (newLoc.FindTopDefender(this) != MapUnit.NONE) {
+						this.facingDirection = this.facingDirection.reversed();
 						return true;
 					}
+
+					// Similarly if we retreated, pay one MP for the combat but don't move.
+				} else if (combatResult == CombatResult.AttackerRetreated) {
+					this.movementPoints.onUnitMove(1);
+					this.facingDirection = this.facingDirection.reversed();
+					return true;
 				}
-
-				facingDirection = dir;
-				float movementCost = TilePath.GetMovementCost(this.owner, location, dir, newLoc);
-
-				// Leave old tile
-				if (!location.unitsOnTile.Remove(this))
-					throw new System.Exception("Failed to remove unit from tile it's supposed to be on");
-
-				// Move transported units, too
-				if (CanTransport()) {
-					var transported = location.unitsOnTile
-						.Where(u => u.IsLoadedIn(this)).ToList();
-
-					foreach (var tu in transported) {
-						if (!location.unitsOnTile.Remove(tu))
-							throw new System.Exception("Failed to remove unit from tile during transport move");
-						newLoc.unitsOnTile.Add(tu);
-						tu.location = newLoc;
-					}
-				}
-
-				TryBoardingTransportOnTile(newLoc);
-				TryUnboardingTransportToTile(newLoc);
-
-				// Enter new tile
-				// Make sure the unit is on the new location before claiming we have entered the tile
-				newLoc.unitsOnTile.Add(this);
-				location = newLoc;
-				OnEnterTile(newLoc);
-
-				if (wait)
-					await animateAsync(MapUnit.AnimatedAction.RUN);
-				else
-					animate(MapUnit.AnimatedAction.RUN);
-
-				movementPoints.onUnitMove(movementCost);
 			}
+
+			facingDirection = dir;
+			float movementCost = TilePath.GetMovementCost(this.owner, location, dir, newLoc);
+
+			// Leave old tile
+			if (!location.unitsOnTile.Remove(this))
+				throw new System.Exception("Failed to remove unit from tile it's supposed to be on");
+
+			// Move transported units, too
+			if (CanTransport()) {
+				var transported = location.unitsOnTile
+					.Where(u => u.IsLoadedIn(this)).ToList();
+
+				foreach (var tu in transported) {
+					if (!location.unitsOnTile.Remove(tu))
+						throw new System.Exception("Failed to remove unit from tile during transport move");
+					newLoc.unitsOnTile.Add(tu);
+					tu.location = newLoc;
+				}
+			}
+
+			TryBoardingTransportOnTile(newLoc);
+			TryUnboardingTransportToTile(newLoc);
+
+			// Enter new tile
+			// Make sure the unit is on the new location before claiming we have entered the tile
+			newLoc.unitsOnTile.Add(this);
+			location = newLoc;
+			OnEnterTile(newLoc);
+
+			if (wait)
+				await animateAsync(MapUnit.AnimatedAction.RUN);
+			else
+				animate(MapUnit.AnimatedAction.RUN);
+
+			movementPoints.onUnitMove(movementCost);
+
 			return true;
 		}
 

--- a/EngineTests/AI/Pathing/AStarPathFindingTest.cs
+++ b/EngineTests/AI/Pathing/AStarPathFindingTest.cs
@@ -107,6 +107,8 @@ public sealed class AStarPathFindingWaterUnitTest : MapBase {
 		var north2 = AddNeighborsAndUpdateMap(north1, MakeCoastTile(), TileDirection.NORTH);
 
 		MapUnit unit = MakeWaterUnit();
+		unit.location = startTile;
+		startTile.unitsOnTile.Add(unit);
 
 		AStarAlgorithm aStarAlgorithm = PathingAlgorithmChooser.GetAlgorithm(unit) as AStarAlgorithm;
 		TilePath tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
@@ -150,6 +152,8 @@ public sealed class AStarPathFindingWaterUnitTest : MapBase {
 
 		MapUnit unit = MakeWaterUnit();
 		startTile.cityAtTile = new City(north1, unit.owner, "Canal City", ID.None(""));
+		unit.location = startTile;
+		startTile.unitsOnTile.Add(unit);
 
 		AStarAlgorithm aStarAlgorithm = PathingAlgorithmChooser.GetAlgorithm(unit) as AStarAlgorithm;
 		TilePath tilePath = aStarAlgorithm.PathFrom(startTile, north2, unit);
@@ -254,6 +258,8 @@ public sealed class AStarPathFindingWaterUnitTest : MapBase {
 		var north2 = AddNeighborsAndUpdateMap(north1, MakeCoastTile(), TileDirection.NORTH);
 
 		MapUnit unit = MakeWaterUnit();
+		unit.location = startTile;
+		startTile.unitsOnTile.Add(unit);
 
 		north1.cityAtTile = new City(north1, unit.owner, "Canal City", ID.None(""));
 
@@ -296,6 +302,8 @@ public sealed class AStarPathFindingWaterUnitTest : MapBase {
 		var lake4 = AddNeighborsAndUpdateMap(lake1, MakeLakeTile(), TileDirection.NORTH);
 
 		MapUnit unit = MakeWaterUnit();
+		unit.location = startTile;
+		startTile.unitsOnTile.Add(unit);
 
 		AStarAlgorithm aStarAlgorithm = PathingAlgorithmChooser.GetAlgorithm(unit) as AStarAlgorithm;
 		TilePath tilePath = aStarAlgorithm.PathFrom(startTile, lake4, unit);
@@ -377,6 +385,8 @@ public sealed class AStarPathFindingWaterUnitTest : MapBase {
 
 		MapUnit unit = MakeWaterUnit();
 		unit.owner.isHuman = true;
+		unit.location = startTile;
+		startTile.unitsOnTile.Add(unit);
 
 		// Test 1
 		// First we will try to path to the destination blind as a human


### PR DESCRIPTION
Introducing an intent behind movement to be able to determine movement better.
Various small fixes.

The `CanEnter()` method was getting progressively messier and it was hard to read, so I took a shot at refactoring the whole thing.

Another reason behind this commit, was to synchronise mouse based go-to movement and the keyboard key strokes movement. They behaved very differently, as the keyboard based movement was lacking half the functionality.

I didn't mean to remove the TileProbe class, but as the refactoring was progressing, it came as a natural thing to do.

The AI (in observer mode) seems to behave ok with this too, the can move, declare war, fight and take cities, at the same rate as before, so I don't think I broke someting.

I restored the correct tecch box pop up that was altered some time ago, and made the font smaller and not so "offensive". I don't know how well this will play in other resolutions, I can't test it to be honest.

Let me know what you think!