### PR TITLE
Connect city to (rail)road network

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -944,6 +944,8 @@ public partial class Game : Node {
 			return;
 		}
 
+		if (!IsMapUnitValid(CurrentlySelectedUnit)) return;
+
 		if (currentAction == C7Action.UnitHold) {
 			new ActionToEngineMsg(() => CurrentlySelectedUnit?.skipTurn()).send();
 		}
@@ -958,10 +960,6 @@ public partial class Game : Node {
 		}
 
 		if (currentAction == C7Action.UnitDisband) {
-			if (CurrentlySelectedUnit == null || CurrentlySelectedUnit == MapUnit.NONE) {
-				log.Warning("Trying to disband null or NONE unit");
-				return;
-			}
 			popupOverlay.ShowPopup(
 				new ConfirmationPopup(
 					$"Disband {CurrentlySelectedUnit.name}? Pardon me but these are OUR people.\nDo you really want to disband them?",
@@ -980,12 +978,12 @@ public partial class Game : Node {
 			this.SetGotoMode(true);
 		}
 
-		if (currentAction == C7Action.UnitExplore && CurrentlySelectedUnit != MapUnit.NONE) {
-			new ActionToEngineMsg(() => CurrentlySelectedUnit?.explore()).send();
+		if (currentAction == C7Action.UnitExplore) {
+			new ActionToEngineMsg(() => CurrentlySelectedUnit.explore()).send();
 		}
 
-		if (currentAction == C7Action.UnitAutomate && CurrentlySelectedUnit != MapUnit.NONE) {
-			new ActionToEngineMsg(() => CurrentlySelectedUnit?.automate()).send();
+		if (currentAction == C7Action.UnitAutomate) {
+			new ActionToEngineMsg(() => CurrentlySelectedUnit.automate()).send();
 		}
 
 		if (currentAction == C7Action.UnitSentry) {
@@ -996,7 +994,7 @@ public partial class Game : Node {
 			// unimplemented
 		}
 
-		if (currentAction == C7Action.UnitBuildCity && CurrentlySelectedUnit != MapUnit.NONE && (CurrentlySelectedUnit?.canBuildCity() ?? false)) {
+		if (currentAction == C7Action.UnitBuildCity && CurrentlySelectedUnit.canBuildCity()) {
 			EngineStorage.ReadGameData((GameData gameData) => {
 				MapUnit currentUnit = gameData.GetUnit(CurrentlySelectedUnit.id);
 				log.Debug(currentUnit.Describe());
@@ -1008,7 +1006,7 @@ public partial class Game : Node {
 		}
 
 		if (currentAction == C7Action.UnitBombard) {
-			if (CurrentlySelectedUnit != MapUnit.NONE && (CurrentlySelectedUnit?.canBombard() ?? false)) {
+			if (CurrentlySelectedUnit.canBombard()) {
 				EngineStorage.ReadGameData((GameData gameData) => {
 					MapUnit currentUnit = gameData.GetUnit(CurrentlySelectedUnit.id);
 					setBombard(currentUnit);
@@ -1019,19 +1017,23 @@ public partial class Game : Node {
 
 		if (currentAction == C7Action.UnitLoad) {
 			// TODO: Which transport?
-			if (CurrentlySelectedUnit != MapUnit.NONE && CurrentlySelectedUnit != null)
-				new MsgLoadToTransport(CurrentlySelectedUnit.id).send();
+			new MsgLoadToTransport(CurrentlySelectedUnit.id).send();
 		}
 		if (currentAction == C7Action.UnitUnload) {
-			if (CurrentlySelectedUnit != MapUnit.NONE && CurrentlySelectedUnit != null) {
-				new MsgUnloadTransport(CurrentlySelectedUnit.id).send();
-			}
+			new MsgUnloadTransport(CurrentlySelectedUnit.id).send();
 		}
 
 		Terraform terraform = C7Action.ToTerraform(currentAction);
 
-		if (CurrentlySelectedUnit == MapUnit.NONE || CurrentlySelectedUnit == null
-			|| terraform == null || !CurrentlySelectedUnit.canPerformTerraformAction(terraform))
+		// the `r` key is mapped to the 'Build Road' action
+		// if there is a road we want to map this to 'Build Railroad' action
+		if (CurrentlySelectedUnit.location.HasRoad()
+			&& !CurrentlySelectedUnit.location.HasRailroad()
+			&& currentAction == C7Action.UnitBuildRoad) {
+			terraform = C7Action.ToTerraform(C7Action.UnitBuildRailroad);
+		}
+
+		if (terraform == null || !CurrentlySelectedUnit.CanPerformTerraformAction(terraform))
 			return;
 
 		TerrainImprovement replacementTarget = CurrentlySelectedUnit.location.overlays.GetReplacementTarget(terraform);

--- a/C7/Map/GotoLayer.cs
+++ b/C7/Map/GotoLayer.cs
@@ -78,7 +78,7 @@ public partial class GotoLayer : LooseLayer {
 	public override void drawObject(LooseView looseView, GameData gameData, Tile tile, Vector2 tileCenter) {
 		MapUnit unit = looseView.mapView.game.CurrentlySelectedUnit;
 		// When no unit is selected, at the end of a turn for example, we don't need to draw anything
-		if (looseView.mapView.game.gotoInfo == null || unit == MapUnit.NONE || unit == null) {
+		if (looseView.mapView.game.gotoInfo == null || !MapUnit.IsMapUnitValid(unit)) {
 			return;
 		}
 

--- a/C7/Map/TileOverlayLayer.cs
+++ b/C7/Map/TileOverlayLayer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using C7GameData;
 using Godot;
+using static C7GameData.TileOverlays;
 
 namespace C7.Map {
 	public partial class TileOverlayLayer : LooseLayer {
@@ -34,13 +35,13 @@ namespace C7.Map {
 
 			foreach (TerrainImprovement ti in tile.overlays.GetImprovements().OrderBy(ti => ti.zIndex)) {
 				switch (ti.key) {
-					case "irrigation":
+					case IRRIGATION:
 						drawIrrigaton(looseView, tile, screenTarget);
 						break;
-					case "road":
+					case ROAD:
 						drawRoad(looseView, tile, screenTarget);
 						break;
-					case "railroad":
+					case RAILROAD:
 						drawRailRoad(looseView, tile, screenTarget);
 						break;
 					default:
@@ -55,7 +56,8 @@ namespace C7.Map {
 			// this tile.
 			int irrigationIndex = 0;
 			foreach (KeyValuePair<TileDirection, Tile> dirToTile in tile.neighbors) {
-				if (hasIrrigation(dirToTile.Value)) {
+				var neighbour = dirToTile.Value;
+				if (neighbour.HasIrrigation()) {
 					irrigationIndex |= getIrrigationFlag(dirToTile.Key);
 				}
 			}
@@ -76,7 +78,8 @@ namespace C7.Map {
 		private void drawRoad(LooseView looseView, Tile tile, Rect2 screenTarget) {
 			int roadIndex = 0;
 			foreach (KeyValuePair<TileDirection, Tile> dirToTile in tile.neighbors) {
-				if (hasRoad(dirToTile.Value) || dirToTile.Value.HasCity || hasRailRoad((dirToTile.Value))) {
+				var neighbour = dirToTile.Value;
+				if (neighbour.HasRoad() || neighbour.HasRailroad()) {
 					roadIndex |= getRoadFlag(dirToTile.Key);
 				}
 			}
@@ -87,9 +90,10 @@ namespace C7.Map {
 			int roadIndex = 0;
 			int railroadIndex = 0;
 			foreach (KeyValuePair<TileDirection, Tile> dirToTile in tile.neighbors) {
-				if (hasRailRoad(dirToTile.Value) || dirToTile.Value.HasCity) {
+				var neighbour = dirToTile.Value;
+				if (neighbour.HasRailroad()) {
 					railroadIndex |= getRoadFlag(dirToTile.Key);
-				} else if (hasRoad(dirToTile.Value)) {
+				} else if (dirToTile.Value.HasRoad()) {
 					roadIndex |= getRoadFlag(dirToTile.Key);
 				}
 			}
@@ -153,18 +157,6 @@ namespace C7.Map {
 				TileDirection.NORTH => 0,
 				_ => throw new ArgumentOutOfRangeException("Invalid TileDirection")
 			};
-		}
-
-		private static bool hasRoad(Tile tile) {
-			return tile.overlays.ImprovementAtLayer(TerrainImprovement.Layer.Roads)?.key == "road";
-		}
-
-		private static bool hasRailRoad(Tile tile) {
-			return tile.overlays.ImprovementAtLayer(TerrainImprovement.Layer.Roads)?.key == "railroad";
-		}
-
-		private static bool hasIrrigation(Tile tile) {
-			return tile.overlays.ImprovementAtLayer(TerrainImprovement.Layer.ResourceDevelopment)?.key == "irrigation";
 		}
 	}
 }

--- a/C7/Map/UnitLayer.cs
+++ b/C7/Map/UnitLayer.cs
@@ -273,7 +273,7 @@ public partial class UnitLayer : LooseLayer {
 		Vector2 animOffset = new Vector2(appearance.offsetX, appearance.offsetY) * MapView.cellSize;
 
 		// If the unit we're about to draw is currently selected, draw the cursor first underneath it
-		if (unit != MapUnit.NONE && unit == looseView.mapView.game.CurrentlySelectedUnit) {
+		if ((unit != MapUnit.NONE) && (unit == looseView.mapView.game.CurrentlySelectedUnit)) {
 			drawCursor(looseView, tileCenter + animOffset);
 		}
 
@@ -320,7 +320,7 @@ public partial class UnitLayer : LooseLayer {
 		// TODO: Maybe add this is as a player configuration for a "harder" mode,
 		// where players can't see how many enemy units there are even in tiles that don't have a city.
 		// RightClickMenu functionality would need to be made configurable if this gets implemented in the future.
-		if (unit.location.HasCity && unit.owner != looseView.mapView.game.controller)
+		if (unit.location.HasCity() && unit.owner != looseView.mapView.game.controller)
 			return;
 
 		// Draw movement indicator for our units

--- a/C7/MapView.cs
+++ b/C7/MapView.cs
@@ -588,7 +588,7 @@ public partial class LooseView : Node2D {
 	}
 
 	public bool HasCityLabelToHideFromTileInfo(Tile tile) {
-		if (!tile.HasCity) return false;
+		if (!tile.HasCity()) return false;
 
 		var target = mapView.game.tileInfo;
 		if (target == null) return false;
@@ -887,7 +887,7 @@ public partial class MapView : Node2D {
 
 	public void OnCenterCameraOnUnit() {
 		MapUnit currentlySelectedUnit = game.CurrentlySelectedUnit;
-		if (currentlySelectedUnit == MapUnit.NONE || currentlySelectedUnit == null)
+		if (!MapUnit.IsMapUnitValid(currentlySelectedUnit))
 			return;
 		centerCameraOnTile(currentlySelectedUnit.location);
 	}

--- a/C7/UIElements/GameStatus/LowerRightInfoBox.cs
+++ b/C7/UIElements/GameStatus/LowerRightInfoBox.cs
@@ -188,7 +188,7 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 		bool showRank = false;
 
 		terrainType.Text = terrain.DisplayName;
-		if (unit.location.HasCity && unit.owner == unit.location.cityAtTile.owner) {
+		if (unit.location.HasCity() && unit.owner == unit.location.cityAtTile.owner) {
 			terrainType.Text = unit.location.cityAtTile.name;
 		}
 		if (unit.IsCombatUnit()) {
@@ -274,7 +274,7 @@ public partial class LowerRightInfoBox : Civ3TextureRect {
 		if (this.GetChildren().Contains(unitTintPlaceholder))
 			this.RemoveChild(unitTintPlaceholder);
 
-		if (unit == MapUnit.NONE || unit == null) {
+		if (!MapUnit.IsMapUnitValid(unit)) {
 			return;
 		}
 

--- a/C7/UIElements/GameStatus/TransportInfoBox.cs
+++ b/C7/UIElements/GameStatus/TransportInfoBox.cs
@@ -48,7 +48,7 @@ public partial class TransportInfoBox : Civ3TextureRect {
 
 		EngineStorage.ReadGameData((GameData gD) => {
 			var unit = _game.CurrentlySelectedUnit;
-			if (unit == null || unit == MapUnit.NONE || !unit.CanTransport()) {
+			if (!MapUnit.IsMapUnitValid(unit) || !unit.CanTransport()) {
 				Visible = false;
 				Reset();
 				return;
@@ -86,7 +86,7 @@ public partial class TransportInfoBox : Civ3TextureRect {
 	}
 
 	private void UpdateUnitGraphic(ICollection<MapUnit> units) {
-		if (!units.Any(u => u != MapUnit.NONE && u != null)) {
+		if (!units.Any(MapUnit.IsMapUnitValid)) {
 			return;
 		}
 

--- a/C7/UIElements/MiniMap/MiniMapLayers.cs
+++ b/C7/UIElements/MiniMap/MiniMapLayers.cs
@@ -59,7 +59,7 @@ public class PlayerColorMiniLayer : MiniMapLayer {
 
 public class CityMiniLayer : MiniMapLayer {
 	public override void DrawTile(Image mapImage, Tile tile, int x, int y) {
-		if (visible && tile.HasCity)
+		if (visible && tile.HasCity())
 			mapImage.SetPixel(x, y, Colors.White);
 	}
 }

--- a/C7Engine/AI/UnitAI/SettlerLocationAI.cs
+++ b/C7Engine/AI/UnitAI/SettlerLocationAI.cs
@@ -100,14 +100,14 @@ namespace C7Engine {
 		}
 
 		private static bool IsInvalidCityLocation(Tile tile) {
-			if (tile == Tile.NONE || tile.HasCity)
+			if (tile == Tile.NONE || tile.HasCity())
 				return true;
 			foreach (Tile neighbor in tile.neighbors.Values) {
-				if (neighbor.HasCity) {
+				if (neighbor.HasCity()) {
 					return true;
 				}
 				foreach (Tile neighborOfNeighbor in neighbor.neighbors.Values) {
-					if (neighborOfNeighbor.HasCity) {
+					if (neighborOfNeighbor.HasCity()) {
 						return true;
 					}
 				}

--- a/C7Engine/AI/UnitAI/WorkerAI.cs
+++ b/C7Engine/AI/UnitAI/WorkerAI.cs
@@ -87,7 +87,7 @@ namespace C7Engine {
 			}
 
 			HashSet<Terraform> accessibleTerraforms = EngineStorage.gameData.Terraforms
-													.Where(terr => unit.canPerformTerraformAction(terr, t))
+													.Where(terr => unit.CanPerformTerraformAction(terr, t))
 													.ToHashSet();
 
 			if (accessibleTerraforms.Count == 0) {
@@ -115,7 +115,7 @@ namespace C7Engine {
 		}
 
 		private UnitAI.Result PerformWorkerMove(MapUnit unit, Terraform workerMove) {
-			if (unit.canPerformTerraformAction(workerMove)) {
+			if (unit.CanPerformTerraformAction(workerMove)) {
 				unit.PerformTerraformAction(workerMove);
 				return UnitAI.Result.InProgress;
 			}

--- a/C7Engine/C7GameData/AIData/DefenderAIData.cs
+++ b/C7Engine/C7GameData/AIData/DefenderAIData.cs
@@ -18,7 +18,7 @@ namespace C7GameData.AIData {
 		public TilePath pathToDestination;
 
 		public override string ToString() {
-			string cityName = destination.HasCity ? destination.cityAtTile.name : " at " + destination.ToString();
+			string cityName = destination.HasCity() ? destination.cityAtTile.name : " at " + destination.ToString();
 			return goal + " " + cityName;
 		}
 	}

--- a/C7Engine/C7GameData/AIData/TilePath.cs
+++ b/C7Engine/C7GameData/AIData/TilePath.cs
@@ -108,7 +108,7 @@ namespace C7GameData {
 			// Special case: if we are a water unit, traveling from the water into
 			// a city, it doesn't matter if the city is on hills or on grassland,
 			// the cost should always be 1.
-			if (from.IsWater() && newLocation.HasCity) return 1;
+			if (from.IsWater() && newLocation.HasCity()) return 1;
 
 			// Movement costs of terrain improvements (roads and railroads)
 			float fromCost = from.overlays.MovementCost();

--- a/C7Engine/C7GameData/City.cs
+++ b/C7Engine/C7GameData/City.cs
@@ -80,6 +80,10 @@ namespace C7GameData {
 
 		public static City NONE = new City(Tile.NONE, null, "Dummy City", ID.None("city"));
 
+		public static bool IsValidCity(City city) {
+			return city != null && city != City.NONE;
+		}
+
 		public City(Tile location, Player owner, string name, ID id) {
 			this.id = id;
 			this.location = location;
@@ -740,7 +744,7 @@ namespace C7GameData {
 				}
 
 				// Skip tiles with cities on them.
-				if (t.HasCity) {
+				if (t.HasCity()) {
 					continue;
 				}
 

--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -216,7 +216,7 @@ namespace C7GameData {
 				// This clears out tile ownership due to Law VII or Law VIII.
 				// Regular tile ownership update will re-assign ownership where needed.
 				foreach (var fringeTile in tile.GetEdgeNeighbors().Where(x => !borderTileIds.Contains(x.Id))) {
-					if (fringeTile.HasCity) // skip encountered cities, just in case
+					if (fringeTile.HasCity()) // skip encountered cities, just in case
 						continue;
 
 					fringeTile.owningCity = null;
@@ -395,7 +395,7 @@ namespace C7GameData {
 			// the city tile is in, so a tile at rank 3, could well mean it's in the 2nd ring.
 			for (int r = aRank - 1; r <= aRank; r++) {
 				if (r <= 0) continue;
-				Tile winner = t.FindInRing(r, tile => tile.HasCity && (tile.cityAtTile == a || tile.cityAtTile == b), false);
+				Tile winner = t.FindInRing(r, tile => tile.HasCity() && (tile.cityAtTile == a || tile.cityAtTile == b), false);
 				if (winner == null) continue;
 				owner = winner.owningCity;
 				return true;

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -7,6 +7,7 @@ using QueryCiv3;
 using QueryCiv3.Biq;
 using C7GameData.Save;
 using System.Reflection;
+using static C7GameData.TileOverlays;
 
 /*
   This will read a Civ3 sav into C7 native format for immediate use or saving to native JSON save
@@ -165,16 +166,16 @@ namespace C7GameData {
 					tile.features.Add("riverNorthwest");
 				}
 				if (civ3Tile.Road) {
-					tile.overlays.Add("road");
+					tile.overlays.Add(ROAD);
 				}
 				if (civ3Tile.Railroad) {
-					tile.overlays.Add("railroad");
+					tile.overlays.Add(RAILROAD);
 				}
 				if (civ3Tile.Mine) {
-					tile.overlays.Add("mine");
+					tile.overlays.Add(MINE);
 				}
 				if (civ3Tile.Irrigation) {
-					tile.overlays.Add("irrigation");
+					tile.overlays.Add(IRRIGATION);
 				}
 				if (civ3Tile.ResourceID != -1) {
 					tile.resource = save.Resources[civ3Tile.ResourceID].Key;
@@ -274,16 +275,16 @@ namespace C7GameData {
 					tile.features.Add("riverNorthwest");
 				}
 				if (civ3Tile.Road) {
-					tile.overlays.Add("road");
+					tile.overlays.Add(ROAD);
 				}
 				if (civ3Tile.Railroad) {
-					tile.overlays.Add("railroad");
+					tile.overlays.Add(RAILROAD);
 				}
 				if (civ3Tile.Mine) {
-					tile.overlays.Add("mine");
+					tile.overlays.Add(MINE);
 				}
 				if (civ3Tile.Irrigation) {
-					tile.overlays.Add("irrigation");
+					tile.overlays.Add(IRRIGATION);
 				}
 				if (civ3Tile.Resource != -1) {
 					tile.resource = save.Resources[civ3Tile.Resource].Key;
@@ -1870,14 +1871,14 @@ namespace C7GameData {
 			}
 
 			if (terrainType.MiningBonus > 0) {
-				SetBonus("mine", Tile.YieldType.Production, terrainType.MiningBonus);
+				SetBonus(MINE, Tile.YieldType.Production, terrainType.MiningBonus);
 			}
 			if (terrainType.IrrigationBonus > 0) {
-				SetBonus("irrigation", Tile.YieldType.Food, terrainType.IrrigationBonus);
+				SetBonus(IRRIGATION, Tile.YieldType.Food, terrainType.IrrigationBonus);
 			}
 			if (terrainType.RoadBonus > 0) {
-				SetBonus("road", Tile.YieldType.Commerce, terrainType.RoadBonus);
-				SetBonus("railroad", Tile.YieldType.Commerce, terrainType.RoadBonus);
+				SetBonus(ROAD, Tile.YieldType.Commerce, terrainType.RoadBonus);
+				SetBonus(RAILROAD, Tile.YieldType.Commerce, terrainType.RoadBonus);
 			}
 		}
 

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -1289,10 +1289,7 @@ namespace C7GameData {
 		}
 
 		public bool CanPerformTerraformAction(Terraform terraform) {
-			var containsTerraform = unitType.terraformActions.Contains(terraform);
-			var meetsRequirements = terraform.MeetsRequirements(owner, location);
-			var hasCity = location.HasCity();
-			return containsTerraform && meetsRequirements && !hasCity;
+			return CanPerformTerraformAction(terraform, location);
 		}
 
 		public bool CanPerformTerraformAction(Terraform terraform, Tile tile) {

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -1,4 +1,5 @@
 using static C7GameData.PlayerRelationship;
+using static C7GameData.Tile;
 
 namespace C7GameData {
 	using Serilog;
@@ -63,6 +64,10 @@ namespace C7GameData {
 		}
 
 		internal MapUnit() { }
+
+		public static bool IsMapUnitValid(MapUnit mapUnit) {
+			return mapUnit != null && mapUnit != MapUnit.NONE;
+		}
 
 		public bool IsBusy() {
 			return isFortified || (path != null && path.PathLength() > 0) || WorkerJob != null || isAutomated;
@@ -231,7 +236,7 @@ namespace C7GameData {
 				new MsgUnitMoved(this).send();
 		}
 
-		public void animate(MapUnit.AnimatedAction action, AnimationEnding ending = AnimationEnding.Stop) {
+		public void animate(AnimatedAction action, AnimationEnding ending = AnimationEnding.Stop) {
 			_ = animateAsync(action, ending);
 		}
 
@@ -239,11 +244,11 @@ namespace C7GameData {
 			if (action != AnimatedAction.RUN) return false;
 
 			// as soon as we move, the tile we were just on becomes the previous tile
-			var isOnRailroad = Tile.IsTileValid(this.previousLocation) && this.previousLocation.overlays.HasRailroad();
+			var isOnRailroad = Tile.IsTileValid(this.previousLocation) && this.previousLocation.HasRailroad();
 			if (!isOnRailroad) return false;
 
 			// and the tile we are moving towards, becomes the current tile
-			var movingOnRailroad = Tile.IsTileValid(this.location) && this.location.overlays.HasRailroad();
+			var movingOnRailroad = Tile.IsTileValid(this.location) && this.location.HasRailroad();
 			if (!movingOnRailroad) return false;
 
 			var canMoveFreely = Player.CanMoveFreely(this.owner, this.previousLocation, this.location);
@@ -426,7 +431,7 @@ namespace C7GameData {
 				defensiveBombarder.facingDirection = dBOriginalDirection;
 			}
 
-			bool defenderEligibleToRetreat = defender.hitPointsRemaining > 1 && ! defender.location.HasCity;
+			bool defenderEligibleToRetreat = defender.hitPointsRemaining > 1 && ! defender.location.HasCity();
 
 			// Do combat rounds
 			while (true) {
@@ -495,7 +500,7 @@ namespace C7GameData {
 			if (target != MapUnit.NONE)
 				return true;
 
-			if (tile.HasCity && tile.cityAtTile.owner != owner)
+			if (tile.HasCity() && tile.cityAtTile.owner != owner)
 				return true;
 
 			return false;
@@ -508,7 +513,7 @@ namespace C7GameData {
 			MapUnit target = tile.FindTopDefender(this);
 
 			var hasTargetUnit = target != MapUnit.NONE && target.owner != owner;
-			var hasForeignCity = tile.HasCity && tile.cityAtTile.owner != owner;
+			var hasForeignCity = tile.HasCity() && tile.cityAtTile.owner != owner;
 			var hasCityWalls = hasForeignCity && tile.cityAtTile.GetBuildings().Any(b => b.building.providesWalls);
 			var hasTileImprovements = tile.HasImprovements;
 
@@ -746,7 +751,7 @@ namespace C7GameData {
 
 			// Destroy the enemy city on the tile unless we're the barbarians,
 			// in which case we'll just take some gold.
-			if (tile.HasCity && !owner.IsAtPeaceWith(tile.cityAtTile.owner)) {
+			if (tile.HasCity() && !owner.IsAtPeaceWith(tile.cityAtTile.owner)) {
 				if (owner.isBarbarians) {
 					// TODO: Add rules for how much gold is taken.
 					int goldTaken = tile.cityAtTile.owner.gold / 4;
@@ -1011,13 +1016,13 @@ namespace C7GameData {
 		}
 
 		private static bool HasHostileCity(Tile tile, Player player) {
-			return tile.HasCity && AtWar(player, tile.cityAtTile.owner);
+			return tile.HasCity() && AtWar(player, tile.cityAtTile.owner);
 		}
 		private static bool HasForeignCity(Tile tile, Player player) {
-			return tile.HasCity && tile.cityAtTile.owner != player;
+			return tile.HasCity() && tile.cityAtTile.owner != player;
 		}
 		private static bool HasOwnCity(Tile tile, Player player) {
-			return tile.HasCity && tile.cityAtTile.owner == player;
+			return tile.HasCity() && tile.cityAtTile.owner == player;
 		}
 
 		/// <summary>
@@ -1114,7 +1119,7 @@ namespace C7GameData {
 		}
 
 		public void TryBoardingTransportOnTile(Tile newLoc) {
-			var enteringCity = newLoc.HasCity && newLoc != location;
+			var enteringCity = newLoc.HasCity() && newLoc != location;
 			if (enteringCity || !CanBoardTransportOnTile(newLoc))
 				return;
 
@@ -1261,10 +1266,10 @@ namespace C7GameData {
 			if (!unitType.actions.Contains(UnitAction.BuildCity)) {
 				return false;
 			}
-			if (location.HasCity || !location.IsAllowCities()) {
+			if (location.HasCity() || !location.IsAllowCities()) {
 				return false;
 			}
-			return location.neighbors.Values.All(tile => !tile.HasCity);
+			return location.neighbors.Values.All(tile => !tile.HasCity());
 		}
 
 		public async Task<City?> buildCity(string cityName) {
@@ -1283,17 +1288,23 @@ namespace C7GameData {
 			return city;
 		}
 
-		public bool canPerformTerraformAction(Terraform terraform) {
-			return unitType.terraformActions.Contains(terraform) && terraform.MeetsRequirements(owner, location);
+		public bool CanPerformTerraformAction(Terraform terraform) {
+			var containsTerraform = unitType.terraformActions.Contains(terraform);
+			var meetsRequirements = terraform.MeetsRequirements(owner, location);
+			var hasCity = location.HasCity();
+			return containsTerraform && meetsRequirements && !hasCity;
 		}
 
-		public bool canPerformTerraformAction(Terraform terraform, Tile tile) {
-			return unitType.terraformActions.Contains(terraform) && terraform.MeetsRequirements(owner, tile);
+		public bool CanPerformTerraformAction(Terraform terraform, Tile tile) {
+			var containsTerraform = unitType.terraformActions.Contains(terraform);
+			var meetsRequirements = terraform.MeetsRequirements(owner, tile);
+			var hasCity = tile.HasCity();
+			return containsTerraform && meetsRequirements && !hasCity;
 		}
 
 		// entry point for "manual" job assignment
 		public void PerformTerraformAction(Terraform terraform) {
-			if (!canPerformTerraformAction(terraform)) {
+			if (!CanPerformTerraformAction(terraform)) {
 				log.Warning($"can't perform {terraform.Name} by {this}");
 				return;
 			}
@@ -1387,7 +1398,7 @@ namespace C7GameData {
 		}
 
 		public List<Terraform> GetAvailableTerraforms() {
-			return EngineStorage.gameData.Terraforms.Where(canPerformTerraformAction).ToList();
+			return EngineStorage.gameData.Terraforms.Where(CanPerformTerraformAction).ToList();
 		}
 
 		/**
@@ -1419,7 +1430,7 @@ namespace C7GameData {
 			if (CanBoardTransportOnTile(this.location) && this.loadedOnUnitId == null) {
 				result.Add(UnitAction.Load);
 			}
-			if (CanUnloadToTile(this.location) && this.location.HasCity) {
+			if (CanUnloadToTile(this.location) && this.location.HasCity()) {
 				result.Add(UnitAction.Unload);
 			}
 

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -869,10 +869,12 @@ namespace C7GameData {
 		}
 
 		private static void TechImprovementCallback(Player player, Tech tech) {
-			if (EngineStorage.gameData.Terraforms.Any(t => t.Improvement.layer == TerrainImprovement.Layer.Roads && t.RequiredTech == tech.id)) {
+			var terraforms = EngineStorage.gameData.Terraforms;
+			if (terraforms.Any(t => t.Improvement is { layer: TerrainImprovement.Layer.Roads } && t.RequiredTech == tech.id)) {
 				foreach (var city in player.cities) {
-					TryAddRoad(city.location, city.location.HasRoad(), city.location.HasRailroad());
-					TryAddRailroad(city.location, city.location.HasRailroad());
+					var cityLoc = city.location;
+					TryAddRoad(cityLoc, cityLoc.HasRoad(), cityLoc.HasRailroad());
+					TryAddRailroad(cityLoc, cityLoc.HasRailroad());
 				}
 			}
 		}

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -8,6 +8,7 @@ using Serilog;
 using static C7GameData.EraUtils;
 using static C7GameData.MultiTurnDeal;
 using static C7GameData.PlayerRelationship;
+using static C7GameData.Tile;
 
 namespace C7GameData {
 
@@ -852,6 +853,9 @@ namespace C7GameData {
 			}
 
 			knownTechs.Add(tech.id);
+			// trigger callback for techs that enable improvements to redraw map
+			TechImprovementCallback(this, tech);
+
 			SetCurrentlyResearchedTech(null);
 
 			// remove completed tech from the current research queue
@@ -861,6 +865,15 @@ namespace C7GameData {
 
 			if (CanAdvanceToNextEra(gameData)) {
 				eraCivilopediaName = GetNextEraNameByIndex(EraIndex());
+			}
+		}
+
+		private static void TechImprovementCallback(Player player, Tech tech) {
+			if (EngineStorage.gameData.Terraforms.Any(t => t.Improvement.layer == TerrainImprovement.Layer.Roads && t.RequiredTech == tech.id)) {
+				foreach (var city in player.cities) {
+					TryAddRoad(city.location, city.location.HasRoad(), city.location.HasRailroad());
+					TryAddRailroad(city.location, city.location.HasRailroad());
+				}
 			}
 		}
 

--- a/C7Engine/C7GameData/Player.cs
+++ b/C7Engine/C7GameData/Player.cs
@@ -642,11 +642,17 @@ namespace C7GameData {
 					continue;
 				}
 
-				if (g.prerequisiteTech == null || knownTechs.Contains(g.prerequisiteTech)) {
+				if (this.HasTech(g.prerequisiteTech)) {
+
 					result.Add(g);
 				}
 			}
 			return result;
+		}
+
+		public bool HasTech(ID techId) {
+			bool hasTech = techId == null || this.knownTechs.Contains(techId);
+			return hasTech;
 		}
 
 		// See https://forums.civfanatics.com/threads/everything-about-corruption-c3c-edition.76619/
@@ -1017,7 +1023,7 @@ namespace C7GameData {
 		// Returns a list of specialists that this player can use.
 		public List<CitizenType> GetKnownSpecialists(GameData gameData) {
 			return gameData.citizenTypes.FindAll(x => {
-				return !x.IsDefaultCitizen && (x.PrerequisiteTech == null || knownTechs.Contains(x.PrerequisiteTech));
+				return !x.IsDefaultCitizen && this.HasTech(x.PrerequisiteTech);
 			});
 		}
 

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -106,7 +106,9 @@ namespace C7GameData.Save {
 		private void populateGameDataTileUnitsAndCities(GameData data) {
 			foreach (Tile tile in data.map.tiles) {
 				tile.unitsOnTile = data.mapUnits.Where(unit => unit.location == tile).ToList();
-				tile.cityAtTile = data.cities.Find(city => city.location == tile);
+				var city = data.cities.Find(city => city.location == tile);
+				if (city != null)
+					tile.cityAtTile = city;
 			}
 		}
 
@@ -121,14 +123,17 @@ namespace C7GameData.Save {
 			// convert technologies earlier than the player data,
 			// because we need to fill in current research and research queues
 			ConvertTechnologies(data);
+			ConvertInflow(data);
+			ConvertStrengthBonuses(data);
+			ConvertHealRates(data);
+
+			EngineStorage.gameData = data;
+
 			ConvertMapAndPlayers(data);
 			ConvertBuildings(data);
 			ConvertUnits(data);
-			ConvertInflow(data);
 			ConvertCities(data);
 			ConvertBarbarianInfo(data);
-			ConvertStrengthBonuses(data);
-			ConvertHealRates(data);
 			ConvertCultureGroups(data);
 			ConvertAlliances(data);
 			ConvertAllianceWars(data);

--- a/C7Engine/C7GameData/Save/SaveTerraform.cs
+++ b/C7Engine/C7GameData/Save/SaveTerraform.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using C7Engine;
+using static C7GameData.TileOverlays;
 
 namespace C7GameData.Save;
 
@@ -73,12 +74,12 @@ public class SaveTerraform {
 
 	private static string TerraformKeyToTerrainImprovement(TerraformKey tfKey) {
 		return tfKey switch {
-			TerraformKey.BuildMine => "mine",
-			TerraformKey.Irrigate => "irrigation",
-			TerraformKey.BuildFortress => "fortress",
-			TerraformKey.BuildBarricade => "barricade",
-			TerraformKey.BuildRoad => "road",
-			TerraformKey.BuildRailroad => "railroad",
+			TerraformKey.BuildMine => MINE,
+			TerraformKey.Irrigate => IRRIGATION,
+			TerraformKey.BuildFortress => FORTRESS,
+			TerraformKey.BuildBarricade => BARRICADE,
+			TerraformKey.BuildRoad => ROAD,
+			TerraformKey.BuildRailroad => RAILROAD,
 			_ => null,
 		};
 	}

--- a/C7Engine/C7GameData/Save/SaveTerrainImprovement.cs
+++ b/C7Engine/C7GameData/Save/SaveTerrainImprovement.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using static C7GameData.TileOverlays;
 using Layer = C7GameData.TerrainImprovement.Layer;
 
 namespace C7GameData.Save;
@@ -7,30 +8,30 @@ public class SaveTerrainImprovement {
 	// The following method is used to generate terrain improvement
 	// data when loading a CIV3 SAV or BIQ file
 	public static IEnumerable<SaveTerrainImprovement> Civ3Improvements() {
-		yield return new("irrigation", Layer.ResourceDevelopment, zIndex: 0);
-		yield return new("mine", Layer.ResourceDevelopment, zIndex: 2);
+		yield return new(IRRIGATION, Layer.ResourceDevelopment, zIndex: 0);
+		yield return new(MINE, Layer.ResourceDevelopment, zIndex: 2);
 
-		yield return new("road", Layer.Roads, movementCost: 1.0f / 3, zIndex: 1);
+		yield return new(ROAD, Layer.Roads, movementCost: 1.0f / 3, zIndex: 1);
 		yield return new(
-			"railroad",
+			RAILROAD,
 			Layer.Roads,
-			upgradesFrom: "road",
+			upgradesFrom: ROAD,
 			movementCost: 0,
 			zIndex: 1,
 			tileModifier: "terrain_improvements.railroad.tile_modifier"
 		);
 
 		yield return new(
-			"fortress",
+			FORTRESS,
 			Layer.Holdings,
-			defenseBonus: new("fortress", 0.5),
+			defenseBonus: new(FORTRESS, 0.5),
 			zIndex: 3
 		);
 		yield return new(
-			"barricade",
+			BARRICADE,
 			Layer.Holdings,
-			upgradesFrom: "fortress",
-			defenseBonus: new("barricade", 1),
+			upgradesFrom: FORTRESS,
+			defenseBonus: new(BARRICADE, 1),
 			zIndex: 3
 		);
 

--- a/C7Engine/C7GameData/Terraform.cs
+++ b/C7Engine/C7GameData/Terraform.cs
@@ -73,13 +73,13 @@ public class Terraform {
 	}
 
 	public bool MeetsRequirements(Player player, Tile tile) {
-		bool hasTech = RequiredTech == null || player.knownTechs.Contains(RequiredTech);
+		var hasTech = player.HasTech(RequiredTech);
 
 		bool hasResources = RequiredResources.All(
 			res => EngineStorage.gameData.GetTradeNetwork().HasTradeAccess(tile, player, res)
 		);
 
-		bool canAddImprovement = Improvement == null || tile.overlays.CanAdd(Improvement);
+		bool canAddImprovement = Improvement == null || tile.overlays.CanAdd(tile, Improvement);
 
 		return hasTech && hasResources
 				&& canAddImprovement && ActionValidators.All(func => func(new(player, tile, this)));
@@ -89,9 +89,15 @@ public class Terraform {
 		Effect?.Invoke(new(player, tile, this));
 
 		if (Improvement != null) {
-			if (!tile.overlays.CanAdd(Improvement))
+			if (!tile.overlays.CanAdd(tile, Improvement))
 				throw new InvalidOperationException($"Cannot add {Improvement.key} to the tile {tile}");
 			tile.overlays.Add(Improvement);
+
+			var cityTile = tile.neighbors.FirstOrDefault(n => n.Value.HasCity()).Value;
+			if (Improvement.layer == TerrainImprovement.Layer.Roads && cityTile != null) {
+				if (this.MeetsRequirements(cityTile.cityAtTile.owner, cityTile))
+					cityTile.overlays.Add(Improvement);
+			}
 		}
 	}
 

--- a/C7Engine/C7GameData/TerrainImprovement.cs
+++ b/C7Engine/C7GameData/TerrainImprovement.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using C7Engine.Lua;
 using C7GameData.Save;
 using System;
+using System.Linq;
+using C7Engine;
 
 namespace C7GameData {
 	public class TerrainImprovement {
@@ -90,6 +92,10 @@ namespace C7GameData {
 			if (this.upgradesFrom == replacement) return false;  // railroad upgrades from road so road cannot replace railroad
 			if (replacement.upgradesFrom == this) return true;   // railroad upgrades from road so railroad can replace road
 			return this.layer == replacement.layer;              // irrigation can replace mine and vice versa, an outpost a radar tower, etc
+		}
+
+		public static Terraform? ToTerraform(string improvement) {
+			return EngineStorage.gameData?.Terraforms.FirstOrDefault(tf => tf.Improvement.key.ToLower() == improvement.ToLower());
 		}
 	}
 }

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -1,13 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using C7Engine;
+using C7GameData.Save;
 using Serilog;
+using static C7GameData.City;
+using static C7GameData.TerrainImprovement;
+using static C7GameData.TileOverlays;
 
 namespace C7GameData {
-	using System;
-	using System.Collections.Generic;
-	using System.Linq;
-	using C7GameData.Save;
-	using C7Engine;
-	using System.Threading.Tasks;
-
 	public class Tile {
 		public enum YieldType {
 			Commerce,
@@ -86,17 +88,59 @@ namespace C7GameData {
 
 		private City _cityAtTile;
 		public City cityAtTile {
-			get { return _cityAtTile; }
+			get => _cityAtTile;
 			set {
 				_cityAtTile = value;
 				if (value != null) {
+					BuildCityCallback();
+				}
+				// Abandon/Destroy city
+				else {
 					ClearTerrainOverlay();
 					overlays.Clear();
+					// TODO: spawn ruins
 				}
 			}
 		}
 
-		public bool HasCity => cityAtTile != null && cityAtTile != City.NONE;
+		private void BuildCityCallback() {
+			var hasRoad = this.HasRoad();
+			var hasRailroad = this.HasRailroad();
+
+			// remove stuff like a forest, jungle etc (whatever can be cleared by a worker action), but not hills/mountains etc
+			if (this.overlayTerrainType.allowedFoliageAction != TerrainType.Civ3FoliageAction.None)
+				ClearTerrainOverlay();
+
+			overlays.Clear();
+
+			// Auto connect cities to adjacent road/railroad network
+			if ((!hasRoad && !hasRailroad && this.neighbors.Any(p => p.Value.HasRoad()) || hasRoad)) {
+				var roadTerraform = ToTerraform(ROAD);
+				if (roadTerraform != null && _cityAtTile.owner.HasTech(roadTerraform.RequiredTech)) {
+					this.overlays.Add(roadTerraform.Improvement);
+				}
+			}
+			if ((!hasRailroad && this.neighbors.Any(p => p.Value.HasRailroad()) || hasRailroad)) {
+				var railroadTerraform = ToTerraform(RAILROAD);
+				if (railroadTerraform != null && _cityAtTile.owner.HasTech(railroadTerraform.RequiredTech)) {
+					this.overlays.Add(railroadTerraform.Improvement);
+				}
+			}
+		}
+
+		public bool HasCity(out City city) {
+			city = null;
+			if (IsValidCity(cityAtTile)) {
+				city = cityAtTile;
+				return true;
+			}
+
+			return false;
+		}
+		public bool HasCity() {
+			return HasCity(out _);
+		}
+
 		public CityResident personWorkingTile = null;   //allows us to see if another city is working this tile
 		public bool hasBarbarianCamp = false;
 		//One thing to decide is do we want to have a tile have a list of units on it,
@@ -253,12 +297,39 @@ namespace C7GameData {
 		}
 
 		public bool IsRoaded() {
-			return this.overlays.HasRoad() || this.overlays.HasRailroad();
+			return this.HasRoad() || this.HasRailroad();
+		}
+
+		public bool HasRoad() {
+			if (this.HasRailroad())
+				return true;
+
+			if (this.overlays.terrainImprovementByLayer.TryGetValue(Layer.Roads, out var value)) {
+				if (this.overlays.ImprovementAtLayer(value.layer).key == ROAD)
+					return true;
+			}
+			return false;
+		}
+
+		public bool HasRailroad() {
+			if (this.overlays.terrainImprovementByLayer.TryGetValue(Layer.Roads, out var value)) {
+				if (this.overlays.ImprovementAtLayer(value.layer).key == RAILROAD)
+					return true;
+			}
+			return false;
+		}
+
+		public bool HasIrrigation() {
+			if (this.overlays.terrainImprovementByLayer.TryGetValue(Layer.ResourceDevelopment, out var value)) {
+				if (this.overlays.ImprovementAtLayer(value.layer).key == IRRIGATION)
+					return true;
+			}
+			return false;
 		}
 
 		public TileDirection directionTo(Tile other) {
 			if ((this == NONE) || (other == NONE))
-				throw new System.Exception("Can't get direction toward NONE Tile since it doesn't have a meaningful location");
+				throw new Exception("Can't get direction toward NONE Tile since it doesn't have a meaningful location");
 
 			// We have to use the map helper functions to handle edge wrapping
 			// correctly.
@@ -311,7 +382,7 @@ namespace C7GameData {
 				yield += this.Resource.FoodBonus;
 			}
 
-			if (HasCity) {
+			if (HasCity()) {
 				// All city centers have a food yield of 2, regardless of bonus
 				// food. See https://wiki.civforum.de/wiki/Stadtfeldertrag_(Civ3).
 				yield = 2;
@@ -343,7 +414,7 @@ namespace C7GameData {
 				yield++;
 			}
 
-			if (HasCity) {
+			if (HasCity()) {
 				// City centers always have 1 shield prior to any bonuses
 				// resources, regardless of the terrain.
 				// See https://wiki.civforum.de/wiki/Stadtfeldertrag_(Civ3).
@@ -389,12 +460,15 @@ namespace C7GameData {
 			if (this.Resource != Resource.NONE && player.KnowsAboutResource(Resource)) {
 				yield += this.Resource.CommerceBonus;
 			}
-			if (BordersRiver()) {
+
+			bool borderRiver = this.BordersRiver();
+
+			if (borderRiver) {
 				yield += 1;
 			}
 
 			// See https://wiki.civforum.de/wiki/Stadtfeldertrag_(Civ3)
-			if (HasCity) {
+			if (HasCity()) {
 				int regularCityYield;
 				if (cityAtTile.residents.Count <= EngineStorage.gameData.rules.MaximumLevel1CitySize) {
 					regularCityYield = 1;
@@ -403,7 +477,7 @@ namespace C7GameData {
 				} else {
 					regularCityYield = 3;
 				}
-				if (BordersRiver()) {
+				if (borderRiver) {
 					regularCityYield += 1;
 				}
 				if (this.Resource != Resource.NONE && player.KnowsAboutResource(Resource)) {
@@ -446,14 +520,14 @@ namespace C7GameData {
 		public bool CanBeIrrigated(TerrainImprovement irrigation, Player player) {
 			// Irrigation can't be done if there is no irrigation bonus for the
 			// tile or if there's already an improvement or city on the tile.
-			if (!overlays.CanAdd(irrigation) ||
+			if (!overlays.CanAdd(this, irrigation) ||
 				irrigation.GetYieldBonus(overlayTerrainType, YieldType.Food) <= 0 ||
 				cityAtTile != null) {
 				return false;
 			}
 
 			// If a tile borders a river or fresh water, it has fresh water access.
-			if (BordersRiver() || NeighborsFreshWater()) {
+			if (this.BordersRiver() || this.NeighborsFreshWater()) {
 				return true;
 			}
 
@@ -860,8 +934,15 @@ namespace C7GameData {
 	}
 
 	public class TileOverlays {
+		public const string ROAD = "road";
+		public const string RAILROAD = "railroad";
+		public const string IRRIGATION = "irrigation";
+		public const string MINE = "mine";
+		public const string FORTRESS = "fortress";
+		public const string BARRICADE = "barricade";
+
 		private readonly Tile tile;
-		private Dictionary<TerrainImprovement.Layer, TerrainImprovement> terrainImprovementByLayer = [];
+		public Dictionary<Layer, TerrainImprovement> terrainImprovementByLayer { get; private set; } = [];
 
 		public TileOverlays(Tile tile) {
 			this.tile = tile;
@@ -883,8 +964,8 @@ namespace C7GameData {
 		}
 
 		private static void ApplyTerrainImprovementChange(TerrainImprovement oldImprovement, TerrainImprovement newImprovement) {
-			var roadCreated = oldImprovement == null && newImprovement?.layer == TerrainImprovement.Layer.Roads;
-			var roadRemoved = oldImprovement?.layer == TerrainImprovement.Layer.Roads && newImprovement == null;
+			var roadCreated = oldImprovement == null && newImprovement?.layer == Layer.Roads;
+			var roadRemoved = oldImprovement?.layer == Layer.Roads && newImprovement == null;
 
 			// If there's a change in road coverage, invalidate the cached trade network
 			if (roadCreated || roadRemoved) {
@@ -893,7 +974,7 @@ namespace C7GameData {
 			}
 		}
 
-		public TerrainImprovement ImprovementAtLayer(TerrainImprovement.Layer layer) {
+		public TerrainImprovement ImprovementAtLayer(Layer layer) {
 			terrainImprovementByLayer.TryGetValue(layer, out TerrainImprovement ti);
 			return ti;
 		}
@@ -921,8 +1002,13 @@ namespace C7GameData {
 			return terrainImprovementByLayer.Values;
 		}
 
-		public bool CanAdd(TerrainImprovement improvement) {
-			if (tile.HasCity)
+		public bool CanAdd(Tile targetTile, TerrainImprovement improvement) {
+			var hasCity = targetTile.HasCity();
+
+			if (hasCity && improvement.layer == Layer.Roads)
+				return true;
+
+			if (hasCity)
 				return false;
 
 			if (!terrainImprovementByLayer.TryGetValue(improvement.layer, out var current))
@@ -931,30 +1017,17 @@ namespace C7GameData {
 			return current.CanBeReplacedBy(improvement);
 		}
 
-		public bool HasRoad() {
-			if (terrainImprovementByLayer.TryGetValue(TerrainImprovement.Layer.Roads, out var value)) {
-				if (ImprovementAtLayer(value.layer).key == "road")
-					return true;
-			} else if (tile.HasCity)
-				return true;
-			return false;
-		}
-		public bool HasRailroad() {
-			if (terrainImprovementByLayer.TryGetValue(TerrainImprovement.Layer.Roads, out var value)) {
-				if (ImprovementAtLayer(value.layer).key == "railroad")
-					return true;
-			} else if (tile.HasCity)
-				return true;
-			return false;
-		}
-
 		// Will return a -1 if the tile movement cost is unaffected by the improvements
 		public float MovementCost() {
-			if (terrainImprovementByLayer.TryGetValue(TerrainImprovement.Layer.Roads, out TerrainImprovement road)) {
+			if (terrainImprovementByLayer.TryGetValue(Layer.Roads, out TerrainImprovement road)) {
 				return road.movementCost;
 			}
 
-			if (tile.HasCity) {
+			// since we added roads & railroads on city tiles, this is probably not needed
+			// I am only leaving this here, because it doesn't seem to affect the game
+			// and it's also related to the tile path algorithm, and I think I want to favourite 
+			// going through cities if possible, for better defense.
+			if (tile.HasCity()) {
 				return 0;
 			}
 

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -114,16 +114,25 @@ namespace C7GameData {
 			overlays.Clear();
 
 			// Auto connect cities to adjacent road/railroad network
-			if ((!hasRoad && !hasRailroad && this.neighbors.Any(p => p.Value.HasRoad()) || hasRoad)) {
+			TryAddRoad(this, hasRoad, hasRailroad);
+			TryAddRailroad(this, hasRailroad);
+		}
+
+		public static void TryAddRoad(Tile tile, bool hasRoad, bool hasRailroad) {
+			var shouldConnectToToNetwork = !hasRailroad && tile.neighbors.Any(p => p.Value.HasRoad());
+			if (shouldConnectToToNetwork || hasRoad) {
 				var roadTerraform = ToTerraform(ROAD);
-				if (roadTerraform != null && _cityAtTile.owner.HasTech(roadTerraform.RequiredTech)) {
-					this.overlays.Add(roadTerraform.Improvement);
+				if (roadTerraform != null && tile.cityAtTile.owner.HasTech(roadTerraform.RequiredTech)) {
+					tile.overlays.Add(roadTerraform.Improvement);
 				}
 			}
-			if ((!hasRailroad && this.neighbors.Any(p => p.Value.HasRailroad()) || hasRailroad)) {
+		}
+		public static void TryAddRailroad(Tile tile, bool hasRailroad) {
+			var shouldConnectToToNetwork = !hasRailroad && tile.neighbors.Any(p => p.Value.HasRailroad());
+			if (shouldConnectToToNetwork || hasRailroad) {
 				var railroadTerraform = ToTerraform(RAILROAD);
-				if (railroadTerraform != null && _cityAtTile.owner.HasTech(railroadTerraform.RequiredTech)) {
-					this.overlays.Add(railroadTerraform.Improvement);
+				if (railroadTerraform != null && tile.cityAtTile.owner.HasTech(railroadTerraform.RequiredTech)) {
+					tile.overlays.Add(railroadTerraform.Improvement);
 				}
 			}
 		}
@@ -1005,16 +1014,20 @@ namespace C7GameData {
 		public bool CanAdd(Tile targetTile, TerrainImprovement improvement) {
 			var hasCity = targetTile.HasCity();
 
-			if (hasCity && improvement.layer == Layer.Roads)
-				return true;
-
-			if (hasCity)
+			// we can't ever add anything on a city tile, except roading
+			if (hasCity && improvement.layer != Layer.Roads)
 				return false;
 
-			if (!terrainImprovementByLayer.TryGetValue(improvement.layer, out var current))
+			var hasImprovement = terrainImprovementByLayer.TryGetValue(improvement.layer, out var current);
+			var canBeReplaced = hasImprovement && current.CanBeReplacedBy(improvement);
+
+			if (hasCity && improvement.layer == Layer.Roads && canBeReplaced)
+				return true;
+
+			if (!hasImprovement)
 				return improvement.upgradesFrom == null;
 
-			return current.CanBeReplacedBy(improvement);
+			return canBeReplaced;
 		}
 
 		// Will return a -1 if the tile movement cost is unaffected by the improvements


### PR DESCRIPTION
1. Connect city tiles to (rail)road network if an adjacenet neighbour has a (rail)road.
2. Enable railroad worker action with hotkey when a road is alreay present. 
3. Break up initialization of game data, to convert ruleset data first and then some gameplay data, because for example a gampley city/tile needs to know the what terraforms are available. 
4. Small refactors/fixes

These fixes enable us to add a (rail)road terrain improvement on the actual tile, instead of faking it with `HasCity` etc..

The only thing I don't really like is how I initialize the `EngineStorage.gamedata`, I may come up with something better.

Again, I will share a .biq file on Discord (https://discord.com/channels/909680526498082837/909857733388406844/1523044397170692288) to test this out.