### PR TITLE
Harmonise advisors

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -190,7 +190,7 @@ script = ExtResource("8_7a2mf")
 text = "S"
 tooltipText = "Spaceship"
 
-[node name="Advisor" type="CenterContainer" parent="CanvasLayer" node_paths=PackedStringArray("domesticAdvisor")]
+[node name="Advisor" type="CenterContainer" parent="CanvasLayer" node_paths=PackedStringArray("domesticAdvisor", "tradeAdvisor")]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -199,6 +199,7 @@ grow_vertical = 2
 theme = ExtResource("10")
 script = ExtResource("3")
 domesticAdvisor = NodePath("DomesticAdvisor")
+tradeAdvisor = NodePath("TradeAdvisor")
 
 [node name="DomesticAdvisor" parent="CanvasLayer/Advisor" instance=ExtResource("15")]
 visible = false

--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=20 format=3 uid="uid://cldl5nk4n61m2"]
+[gd_scene load_steps=21 format=3 uid="uid://cldl5nk4n61m2"]
 
 [ext_resource type="Script" uid="uid://yxhiwx46tety" path="res://Game.cs" id="1"]
 [ext_resource type="Script" uid="uid://cfenrvu7tnp40" path="res://DoubleClickHandler.cs" id="2_t735q"]
@@ -19,6 +19,7 @@
 [ext_resource type="Script" uid="uid://bmfpx37ovqnsx" path="res://UIElements/Diplomacy/Diplomacy.cs" id="14"]
 [ext_resource type="PackedScene" uid="uid://dkcu255o1qrt1" path="res://UIElements/PalaceScreen/palace_screen.tscn" id="14_ud8vi"]
 [ext_resource type="PackedScene" uid="uid://da7hbbufyfllg" path="res://UIElements/Advisors/domestic_advisor.tscn" id="15"]
+[ext_resource type="PackedScene" uid="uid://cucamooiqvddl" path="res://UIElements/Advisors/trade_advisor.tscn" id="15_4pqcd"]
 
 [node name="C7Game" type="Node" node_paths=PackedStringArray("Toolbar", "popupOverlay", "cityScreen", "advisor", "diplomacy", "palaceScene", "doubleClickHandler", "animationController", "unitSelector")]
 script = ExtResource("1")
@@ -200,6 +201,10 @@ script = ExtResource("3")
 domesticAdvisor = NodePath("DomesticAdvisor")
 
 [node name="DomesticAdvisor" parent="CanvasLayer/Advisor" instance=ExtResource("15")]
+visible = false
+layout_mode = 2
+
+[node name="TradeAdvisor" parent="CanvasLayer/Advisor" instance=ExtResource("15_4pqcd")]
 visible = false
 layout_mode = 2
 

--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=3 uid="uid://cldl5nk4n61m2"]
+[gd_scene load_steps=25 format=3 uid="uid://cldl5nk4n61m2"]
 
 [ext_resource type="Script" uid="uid://yxhiwx46tety" path="res://Game.cs" id="1"]
 [ext_resource type="Script" uid="uid://cfenrvu7tnp40" path="res://DoubleClickHandler.cs" id="2_t735q"]
@@ -20,6 +20,10 @@
 [ext_resource type="PackedScene" uid="uid://dkcu255o1qrt1" path="res://UIElements/PalaceScreen/palace_screen.tscn" id="14_ud8vi"]
 [ext_resource type="PackedScene" uid="uid://da7hbbufyfllg" path="res://UIElements/Advisors/domestic_advisor.tscn" id="15"]
 [ext_resource type="PackedScene" uid="uid://cucamooiqvddl" path="res://UIElements/Advisors/trade_advisor.tscn" id="15_4pqcd"]
+[ext_resource type="PackedScene" uid="uid://d0qk1h4jvf3i1" path="res://UIElements/Advisors/military_advisor.tscn" id="16_js1p2"]
+[ext_resource type="PackedScene" uid="uid://balpdexsjgl0b" path="res://UIElements/Advisors/foreign_advisor.tscn" id="18_alc04"]
+[ext_resource type="PackedScene" uid="uid://cla8cx1cxecu2" path="res://UIElements/Advisors/cultural_advisor.tscn" id="19_wqtcm"]
+[ext_resource type="PackedScene" uid="uid://c5qvjbhp6c3bv" path="res://UIElements/Advisors/science_advisor.tscn" id="20_v3pw1"]
 
 [node name="C7Game" type="Node" node_paths=PackedStringArray("Toolbar", "popupOverlay", "cityScreen", "advisor", "diplomacy", "palaceScene", "doubleClickHandler", "animationController", "unitSelector")]
 script = ExtResource("1")
@@ -190,7 +194,7 @@ script = ExtResource("8_7a2mf")
 text = "S"
 tooltipText = "Spaceship"
 
-[node name="Advisor" type="CenterContainer" parent="CanvasLayer" node_paths=PackedStringArray("domesticAdvisor", "tradeAdvisor")]
+[node name="Advisor" type="CenterContainer" parent="CanvasLayer" node_paths=PackedStringArray("domesticAdvisor", "tradeAdvisor", "militaryAdvisor", "foreignAdvisor", "culturalAdvisor", "scienceAdvisor")]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -200,12 +204,32 @@ theme = ExtResource("10")
 script = ExtResource("3")
 domesticAdvisor = NodePath("DomesticAdvisor")
 tradeAdvisor = NodePath("TradeAdvisor")
+militaryAdvisor = NodePath("MilitaryAdvisor")
+foreignAdvisor = NodePath("ForeignAdvisor")
+culturalAdvisor = NodePath("CulturalAdvisor")
+scienceAdvisor = NodePath("ScienceAdvisor")
 
 [node name="DomesticAdvisor" parent="CanvasLayer/Advisor" instance=ExtResource("15")]
 visible = false
 layout_mode = 2
 
 [node name="TradeAdvisor" parent="CanvasLayer/Advisor" instance=ExtResource("15_4pqcd")]
+visible = false
+layout_mode = 2
+
+[node name="MilitaryAdvisor" parent="CanvasLayer/Advisor" instance=ExtResource("16_js1p2")]
+visible = false
+layout_mode = 2
+
+[node name="ForeignAdvisor" parent="CanvasLayer/Advisor" instance=ExtResource("18_alc04")]
+visible = false
+layout_mode = 2
+
+[node name="CulturalAdvisor" parent="CanvasLayer/Advisor" instance=ExtResource("19_wqtcm")]
+visible = false
+layout_mode = 2
+
+[node name="ScienceAdvisor" parent="CanvasLayer/Advisor" instance=ExtResource("20_v3pw1")]
 visible = false
 layout_mode = 2
 

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -743,6 +743,9 @@ public partial class Game : Node {
 		if (eventKeyDown.Keycode == Godot.Key.F1) {
 			EmitSignal(SignalName.ShowSpecificAdvisor, "F1");
 		}
+		if (eventKeyDown.Keycode == Godot.Key.F2) {
+			EmitSignal(SignalName.ShowSpecificAdvisor, C7Action.ShowTradeAdvisor);
+		}
 		if (eventKeyDown.Keycode == Godot.Key.F3) {
 			EmitSignal(SignalName.ShowSpecificAdvisor, "F3");
 		}

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -522,7 +522,7 @@ public partial class Game : Node {
 
 	public override void _UnhandledInput(InputEvent @event) {
 		// Don't handle mouse actions if UI elements are visible, or it's the AI's turn
-		if (popupOverlay.Visible || cityScreen.Visible || advisor.Visible || diplomacy.Visible || palaceScene.Visible || CurrentState == GameState.ComputerTurn) {
+		if (popupOverlay.Visible || cityScreen.Visible || diplomacy.Visible || palaceScene.Visible || CurrentState == GameState.ComputerTurn) {
 			IsMovingCamera = false;
 			return;
 		}
@@ -741,16 +741,22 @@ public partial class Game : Node {
 			ToggleObserverMode();
 		}
 		if (eventKeyDown.Keycode == Godot.Key.F1) {
-			EmitSignal(SignalName.ShowSpecificAdvisor, "F1");
+			EmitSignal(SignalName.ShowSpecificAdvisor, C7Action.ShowDomesticAdvisor);
 		}
 		if (eventKeyDown.Keycode == Godot.Key.F2) {
 			EmitSignal(SignalName.ShowSpecificAdvisor, C7Action.ShowTradeAdvisor);
 		}
 		if (eventKeyDown.Keycode == Godot.Key.F3) {
-			EmitSignal(SignalName.ShowSpecificAdvisor, "F3");
+			EmitSignal(SignalName.ShowSpecificAdvisor, C7Action.ShowMilitaryAdvisor);
+		}
+		if (eventKeyDown.Keycode == Godot.Key.F4) {
+			EmitSignal(SignalName.ShowSpecificAdvisor, C7Action.ShowForeignAdvisor);
+		}
+		if (eventKeyDown.Keycode == Godot.Key.F5) {
+			EmitSignal(SignalName.ShowSpecificAdvisor, C7Action.ShowCulturalAdvisor);
 		}
 		if (eventKeyDown.Keycode == Godot.Key.F6) {
-			EmitSignal(SignalName.ShowSpecificAdvisor, "F6");
+			EmitSignal(SignalName.ShowSpecificAdvisor, C7Action.ShowScienceAdvisor);
 		}
 		if (eventKeyDown.Keycode == Godot.Key.F9) {
 			palaceScene.Show();

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -308,26 +308,20 @@ public partial class Game : Node {
 				break;
 			case MsgShowMilitaryAdvisorPopup mSMAP:
 				if (!popupOverlay.Visible) {
-					popupOverlay.ShowPopup(
-						new InformationalPopup(mSMAP.message, AdvisorHead.Advisor.Military, mSMAP.happy ? AdvisorHead.Mood.Happy : AdvisorHead.Mood.Angry),
-						PopupOverlay.PopupCategory.Advisor);
+					var mood = mSMAP.happy ? AdvisorHead.Mood.Happy : AdvisorHead.Mood.Angry;
+					var pop = new InformationalPopup(mSMAP.message, AdvisorHead.Advisor.Military, mood);
+					popupOverlay.ShowPopup(pop, PopupOverlay.PopupCategory.Advisor);
 				}
 				break;
 			case MsgShowScienceAdvisor mSSA:
-				// F6 is the science advisor.
-				// TODO: Move the F* key strings to a set of constants/enum.
-				EmitSignal(SignalName.ShowSpecificAdvisor, "F6");
+				EmitSignal(SignalName.ShowSpecificAdvisor, C7Action.ShowScienceAdvisor);
 				break;
 			case MsgUpdateUiAfterDomesticChange mUUASC:
-				// F1 is the domestic advisor.
-				// TODO: Move the F* key strings to a set of constants/enum.
-
-				// Ensure the citizen moods are correct before displaying
-				// them.
+				// Ensure the citizen moods are correct before displaying them.
 				foreach (City c in controller.cities) {
 					c.RecalculateCitizenMoods(gameData);
 				}
-				EmitSignal(SignalName.ShowSpecificAdvisor, "F1");
+				EmitSignal(SignalName.ShowSpecificAdvisor, C7Action.ShowDomesticAdvisor);
 				break;
 			case MsgShowTradeOffer mSTO:
 				diplomacy.ShowDealScreenForPlayer(

--- a/C7/Lua/civ3/textures.lua
+++ b/C7/Lua/civ3/textures.lua
@@ -1,4 +1,5 @@
 -- Base paths
+local ROOT = "Art/"
 local ADVISORS = "Art/Advisors/"
 
 local BUTTONS = "Art/buttonsFINAL.pcx"
@@ -17,6 +18,7 @@ local CITY_ICONS = "Art/Cities/city icons.pcx"
 
 local CREDITS = "Art/Credits/"
 local PALACE = "Art/PalaceView/"
+local SPACE_RACE = "Art/SpaceShip/"
 
 local POPUP_BORDERS = "Art/popupborders.pcx"
 
@@ -101,12 +103,27 @@ textures.advisors = {
 }
 
 textures.screens = {
+  wonders = {
+    background = ADVISORS .. "wonders.pcx",
+  },
+  standing = {
+    victory_status = {
+      background = ROOT .. "histograph-win5_final.pcx",
+    },
+    histogram = {
+      background = ROOT .. "histograph-top5_final.pcx",
+    }
+  },
+  space_race = {
+    background = SPACE_RACE .. "SHIPbackground.pcx",
+  },
+  palace = {
+    background = PALACE .. "bkgr.pcx",
+  },
   demographics = {
     background = ADVISORS .. "demographics.pcx",
   },
-  wonders = {
-    background = ADVISORS .. "wonders.pcx",
-  }
+
 }
 
 textures.ui = {
@@ -375,10 +392,6 @@ textures.city_screen = {
     },
   },
   production_queue = CITY_SCREEN .. "ProductionQueueBox.pcx",
-}
-
-textures.palace = {
-  background = PALACE .. "bkgr.pcx",
 }
 
 textures.world_setup = require "textures.world_setup"

--- a/C7/Lua/civ3/textures.lua
+++ b/C7/Lua/civ3/textures.lua
@@ -79,6 +79,34 @@ textures.advisors = {
       },
     },
   },
+  trade = {
+    background = ADVISORS .. "trade.pcx",
+  },
+  foreign = {
+    background = ADVISORS .. "foreign.pcx",
+    navigation = {
+      trade = {
+        path = ADVISORS .. "foreignTAB.pcx",
+        crop_region = { 0, 0, 224, 237 },
+      },
+      treaty = {
+        path = ADVISORS .. "foreignTAB.pcx",
+        crop_region = { 225, 0, 448, 237 },
+      }
+    }
+  },
+  culture = {
+    background = ADVISORS .. "culture.pcx",
+  }
+}
+
+textures.screens = {
+  demographics = {
+    background = ADVISORS .. "demographics.pcx",
+  },
+  wonders = {
+    background = ADVISORS .. "wonders.pcx",
+  }
 }
 
 textures.ui = {
@@ -275,6 +303,10 @@ textures.icons = {
   minus = {
     path = ADVISORS .. "domestic_icons_aux.pcx",
     crop_region = { 51, 1, 22, 22 },
+  },
+  maintenance = {
+    path = ADVISORS .. "domestic_icons_aux.pcx",
+    crop_region = { 1, 1, 19, 34 },
   },
   capital_star = {
     path = CITY_ICONS,

--- a/C7/Lua/civ3/textures.lua
+++ b/C7/Lua/civ3/textures.lua
@@ -104,7 +104,7 @@ textures.advisors = {
 
 textures.screens = {
   wonders = {
-    background = ADVISORS .. "wonders.pcx",
+    background = ADVISORS .. "wonders_background.pcx",
   },
   standing = {
     victory_status = {

--- a/C7/Lua/civ3/textures.lua
+++ b/C7/Lua/civ3/textures.lua
@@ -87,13 +87,17 @@ textures.advisors = {
   foreign = {
     background = ADVISORS .. "foreign.pcx",
     navigation = {
-      trade = {
+      treaties = {
         path = ADVISORS .. "foreignTAB.pcx",
-        crop_region = { 0, 0, 224, 237 },
+        crop_region = { 1, 1, 223, 236 },
       },
-      treaty = {
+      trades = {
         path = ADVISORS .. "foreignTAB.pcx",
-        crop_region = { 225, 0, 448, 237 },
+        crop_region = { 225, 1, 223, 236 },
+      },
+      details = {
+        path = ADVISORS .. "foreignTAB.pcx",
+        crop_region = { 449, 1, 223, 236 },
       }
     }
   },

--- a/C7/Lua/standalone/textures.lua
+++ b/C7/Lua/standalone/textures.lua
@@ -101,7 +101,15 @@ local c7_texture_list = {
   "Art/city screen/buildings-small.png",
   "Art/city screen/buildings-large.png",
   "Art/Cursor.png",
-  "Art/interface/box trans color.png"
+  "Art/interface/box trans color.png",
+  "Art/SpaceShip/SHIPbackground.png",
+  "Art/Advisors/trade.png",
+  "Art/Advisors/foreign.png",
+  "Art/Advisors/foreignTAB.png",
+  "Art/Advisors/culture.png",
+  "Art/Advisors/wonders_background.png",
+  "Art/histograph-win5_final.png",
+  "Art/histograph-top5_final.png",
 }
 
 --- For ease of editing, we define the civ colors as hex codes, not 1x1 px images

--- a/C7/UIElements/Advisors/AdvisorUtils.cs
+++ b/C7/UIElements/Advisors/AdvisorUtils.cs
@@ -41,8 +41,7 @@ public static class AdvisorUtils {
 		return (dialogBox, dialogBoxLabel);
 	}
 
-	public static void CreateAdvisorTitle(Control parent, float containerWidth, string advisorTitleString)
-	{
+	public static void CreateAdvisorTitle(Control parent, float containerWidth, string advisorTitleString) {
 		int bigFontSize = 26;
 		// int middleFontSize = 20;
 		int bigFontGlyphSpacing = 14;

--- a/C7/UIElements/Advisors/AdvisorUtils.cs
+++ b/C7/UIElements/Advisors/AdvisorUtils.cs
@@ -1,0 +1,97 @@
+using Godot;
+
+public static class AdvisorUtils {
+	public static TextureButton CreateExitButton(Control parent, Vector2? position = null) {
+		Vector2 buttonPosition = position ?? new Vector2(952, 720);
+
+		TextureButton btn = new();
+		TextureLoader.SetButtonTextures(btn, "ui.exit");
+		btn.SetPosition(buttonPosition);
+		parent.AddChild(btn);
+		return btn;
+	}
+
+	public static TextureRect CreateAdvisorHead(Control parent, AdvisorHead.Advisor advisor, Vector2? position = null) {
+		Vector2 headPosition = position ?? new Vector2(851, 0);
+
+		TextureRect advisorHead = new();
+		advisorHead.Texture = AdvisorHead.GetPopupImage(advisor, AdvisorHead.Mood.Happy, eraIndex: 0);
+		advisorHead.SetPosition(headPosition);
+		parent.AddChild(advisorHead);
+
+		return advisorHead;
+	}
+
+	public static (TextureButton box, Label label) CreateAdvisorDialogBox(Control parent, Vector2? position = null) {
+		Vector2 boxPosition = position ?? new Vector2(806, 110);
+		Vector2 labelPosition = boxPosition + new Vector2(9, 9);
+
+		ImageTexture dialogBoxTexture = TextureLoader.Load("advisors.dialog_box");
+		TextureButton dialogBox = new TextureButton();
+		dialogBox.TextureNormal = dialogBoxTexture;
+		dialogBox.SetPosition(boxPosition);
+		parent.AddChild(dialogBox);
+
+		//TODO: Multi-line capabilities
+		Label dialogBoxLabel = new();
+		dialogBoxLabel.Text = "You are running OpenCiv3!";
+		dialogBoxLabel.SetPosition(labelPosition);
+		parent.AddChild(dialogBoxLabel);
+
+		return (dialogBox, dialogBoxLabel);
+	}
+
+	public static void CreateAdvisorTitle(Control parent, float containerWidth, string advisorTitleString)
+	{
+		int bigFontSize = 26;
+		// int middleFontSize = 20;
+		int bigFontGlyphSpacing = 14;
+		int bigFontGlyphSpaceSpacing = 22;
+
+		FontFile regularFont = ResourceLoader.Load<FontFile>("res://Fonts/NotoSans-Regular.ttf");
+		Theme regularBigFontTheme = new();
+		regularBigFontTheme.DefaultFont = regularFont;
+		regularBigFontTheme.SetFontSize("font_size", "Label", bigFontSize);
+
+		FontVariation fontVariation = new FontVariation
+		{
+			BaseFont = regularFont,
+			SpacingGlyph = bigFontGlyphSpacing,
+			SpacingSpace = bigFontGlyphSpaceSpacing,
+		};
+
+		Theme regularThemeWithCustomSpacing = new Theme();
+		regularThemeWithCustomSpacing.SetFont("font", "Label", fontVariation);
+		regularThemeWithCustomSpacing.SetFontSize("font_size", "Label", bigFontSize);
+
+		float advisorTitleStringWidth = GetStringSizeWithCustomSpacing(regularFont, advisorTitleString, bigFontSize,
+			bigFontGlyphSpacing, bigFontGlyphSpaceSpacing).X;
+
+		float advisorTitleOffsetLeft = (containerWidth / 2.0f) - (advisorTitleStringWidth) / 2.0f;
+
+		Label advisorTitle = new() {
+			Text = advisorTitleString,
+			OffsetLeft = advisorTitleOffsetLeft,
+			OffsetTop = 15,
+			Theme = regularThemeWithCustomSpacing,
+		};
+		parent.AddChild(advisorTitle);
+	}
+
+	private static Vector2 GetStringSizeWithCustomSpacing(Font font, string input, int fontSize = 16, int glyphSpacing = 0, int glyphSpaceSpacing = 0) {
+
+		float extraSpacing = 0.0f;
+		for (int i = 0; i < input.Length; i++) {
+			if (i < input.Length - 1) {
+				if (char.IsWhiteSpace(input[i]) && glyphSpaceSpacing > 0) {
+					extraSpacing += glyphSpaceSpacing;
+				} else {
+					extraSpacing += glyphSpacing;
+				}
+			}
+		}
+
+		Vector2 originalSize = font.GetStringSize(input, fontSize: fontSize);
+		return new Vector2(originalSize.X + extraSpacing, originalSize.Y);
+	}
+}

--- a/C7/UIElements/Advisors/AdvisorUtils.cs.uid
+++ b/C7/UIElements/Advisors/AdvisorUtils.cs.uid
@@ -1,0 +1,1 @@
+uid://c4cuwfhrupdr1

--- a/C7/UIElements/Advisors/Advisors.cs
+++ b/C7/UIElements/Advisors/Advisors.cs
@@ -1,7 +1,5 @@
 using Godot;
-using System;
 using Serilog;
-using System.Collections.Generic;
 using C7Engine;
 
 /**
@@ -12,69 +10,63 @@ using C7Engine;
 public partial class Advisors : CenterContainer {
 	private ILogger log = LogManager.ForContext<Advisors>();
 
+	private string latest = C7Action.ShowDomesticAdvisor;
+
 	[Export] public DomesticAdvisor domesticAdvisor;
 	[Export] public TradeAdvisor tradeAdvisor;
-	private MilitaryAdvisor militaryAdvisor;
-	private ScienceAdvisor scienceAdvisor;
+	[Export] public MilitaryAdvisor militaryAdvisor;
+	[Export] public ForeignAdvisor foreignAdvisor;
+	[Export] public CulturalAdvisor culturalAdvisor;
+	[Export] public ScienceAdvisor scienceAdvisor;
 
-	// A list of all the non-null advisors, so we can hide them whenever we
-	// draw a different advisor.
-	private List<TextureRect> advisors = new();
-
-	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
-		//Center the advisor container.  Following directions at https://docs.godotengine.org/en/stable/tutorials/gui/size_and_anchors.html?highlight=anchor
-		//Also taking advantage of it being 1024x768, as the directions didn't really work.  This is not 100% ideal (would be great for a general-purpose solution to work),
-		//but does work with the current graphics independent of resolution.
-		this.Hide();
+		Hide();
 	}
 
 	private void ShowLatestAdvisor() {
-		log.Debug("Received request to show latest advisor");
-
-		OnShowSpecificAdvisor("F1");
-		this.Show();
+		OnShowSpecificAdvisor(latest);
 	}
 
 	private void OnShowSpecificAdvisor(string advisorType) {
-		// Hide any existing advisors so we can draw the requested one.
-		foreach (TextureRect tr in advisors) {
-			tr.Hide();
+		latest = advisorType;
+
+		HideAdvisors();
+
+		switch (advisorType)
+		{
+			case C7Action.ShowDomesticAdvisor:
+				domesticAdvisor.ShowAdvisor();
+				break;
+			case C7Action.ShowTradeAdvisor:
+				tradeAdvisor.ShowAdvisor();
+				break;
+			case C7Action.ShowForeignAdvisor:
+				foreignAdvisor.ShowAdvisor();
+				break;
+			case C7Action.ShowMilitaryAdvisor:
+				militaryAdvisor.ShowAdvisor();
+				break;
+			case C7Action.ShowCulturalAdvisor:
+				culturalAdvisor.ShowAdvisor();
+				break;
+			case C7Action.ShowScienceAdvisor:
+				scienceAdvisor.ShowAdvisor();
+				break;
+			default:
+				log.Warning("Unknown advisor type: " + advisorType);
+				break;
 		}
+
+		Show();
+	}
+
+	private void HideAdvisors()
+	{
 		domesticAdvisor.Hide();
 		tradeAdvisor.Hide();
-
-		if (advisorType.Equals("F1")) {
-			domesticAdvisor.ShowAdvisor();
-			this.Show();
-		}
-		if (advisorType.Equals(C7Action.ShowTradeAdvisor)) {
-			tradeAdvisor.ShowAdvisor();
-			this.Show();
-		}
-		if (advisorType.Equals("F3")) {
-			if (militaryAdvisor != null) {
-				RemoveChild(militaryAdvisor);
-				militaryAdvisor = null;
-			}
-
-			militaryAdvisor = new MilitaryAdvisor();
-			advisors.Add(militaryAdvisor);
-			AddChild(militaryAdvisor);
-			this.Show();
-		}
-		if (advisorType.Equals("F6")) {
-			// TODO: What's the best way to refresh the tech tree UI without
-			// adding too many children?
-			if (scienceAdvisor != null) {
-				RemoveChild(scienceAdvisor);
-				scienceAdvisor = null;
-			}
-
-			scienceAdvisor = new ScienceAdvisor();
-			advisors.Add(scienceAdvisor);
-			AddChild(scienceAdvisor);
-			this.Show();
-		}
+		militaryAdvisor.Hide();
+		foreignAdvisor.Hide();
+		culturalAdvisor.Hide();
+		scienceAdvisor.Hide();
 	}
 }

--- a/C7/UIElements/Advisors/Advisors.cs
+++ b/C7/UIElements/Advisors/Advisors.cs
@@ -2,6 +2,7 @@ using Godot;
 using System;
 using Serilog;
 using System.Collections.Generic;
+using C7Engine;
 
 /**
  * Handles managing the advisor screens.
@@ -12,6 +13,7 @@ public partial class Advisors : CenterContainer {
 	private ILogger log = LogManager.ForContext<Advisors>();
 
 	[Export] public DomesticAdvisor domesticAdvisor;
+	[Export] public TradeAdvisor tradeAdvisor;
 	private MilitaryAdvisor militaryAdvisor;
 	private ScienceAdvisor scienceAdvisor;
 
@@ -43,6 +45,10 @@ public partial class Advisors : CenterContainer {
 
 		if (advisorType.Equals("F1")) {
 			domesticAdvisor.ShowAdvisor();
+			this.Show();
+		}
+		if (advisorType.Equals(C7Action.ShowTradeAdvisor)) {
+			tradeAdvisor.ShowAdvisor();
 			this.Show();
 		}
 		if (advisorType.Equals("F3")) {

--- a/C7/UIElements/Advisors/Advisors.cs
+++ b/C7/UIElements/Advisors/Advisors.cs
@@ -28,9 +28,10 @@ public partial class Advisors : CenterContainer {
 	}
 
 	private void OnShowSpecificAdvisor(string advisorType) {
-		latest = advisorType;
-
-		HideAdvisors();
+		if (advisorType != latest) {
+			latest = advisorType;
+			HideAdvisors();
+		}
 
 		switch (advisorType) {
 			case C7Action.ShowDomesticAdvisor:

--- a/C7/UIElements/Advisors/Advisors.cs
+++ b/C7/UIElements/Advisors/Advisors.cs
@@ -42,6 +42,7 @@ public partial class Advisors : CenterContainer {
 			tr.Hide();
 		}
 		domesticAdvisor.Hide();
+		tradeAdvisor.Hide();
 
 		if (advisorType.Equals("F1")) {
 			domesticAdvisor.ShowAdvisor();

--- a/C7/UIElements/Advisors/Advisors.cs
+++ b/C7/UIElements/Advisors/Advisors.cs
@@ -32,8 +32,7 @@ public partial class Advisors : CenterContainer {
 
 		HideAdvisors();
 
-		switch (advisorType)
-		{
+		switch (advisorType) {
 			case C7Action.ShowDomesticAdvisor:
 				domesticAdvisor.ShowAdvisor();
 				break;
@@ -60,8 +59,7 @@ public partial class Advisors : CenterContainer {
 		Show();
 	}
 
-	private void HideAdvisors()
-	{
+	private void HideAdvisors() {
 		domesticAdvisor.Hide();
 		tradeAdvisor.Hide();
 		militaryAdvisor.Hide();

--- a/C7/UIElements/Advisors/CulturalAdvisor.cs
+++ b/C7/UIElements/Advisors/CulturalAdvisor.cs
@@ -5,7 +5,7 @@ using Godot;
 
 [GlobalClass]
 [Tool]
-public partial class TradeAdvisor : Control  {
+public partial class CulturalAdvisor : Control  {
 
 	[Export] public TextureRect background;
 
@@ -19,14 +19,12 @@ public partial class TradeAdvisor : Control  {
 	}
 
 	private void CreateUI() {
-		background.Texture = TextureLoader.Load("advisors.trade.background");
+		background.Texture = TextureLoader.Load("advisors.culture.background");
 
-		_advisorHead = AdvisorUtils.CreateAdvisorHead(background, AdvisorHead.Advisor.Trade);
+		_advisorHead = AdvisorUtils.CreateAdvisorHead(background, AdvisorHead.Advisor.Culture);
 		_close = AdvisorUtils.CreateExitButton(background);
 		_close.Pressed += () => {  this.GetParent<Advisors>().Hide(); };
 		(_dialogBox, _dialogBoxLabel) = AdvisorUtils.CreateAdvisorDialogBox(background);
-
-		AdvisorUtils.CreateAdvisorTitle(background, background.Texture.GetWidth(), "TRADE ADVISOR");
 	}
 
 	public void ShowAdvisor() {
@@ -36,7 +34,7 @@ public partial class TradeAdvisor : Control  {
 			Player player = gameData.GetFirstHumanPlayer();
 
 			// TODO: Choose advisor head
-			_advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Trade, AdvisorHead.Mood.Happy, player.EraIndex());
+			_advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Culture, AdvisorHead.Mood.Happy, player.EraIndex());
 		});
 	}
 }

--- a/C7/UIElements/Advisors/CulturalAdvisor.cs
+++ b/C7/UIElements/Advisors/CulturalAdvisor.cs
@@ -5,7 +5,7 @@ using Godot;
 
 [GlobalClass]
 [Tool]
-public partial class CulturalAdvisor : Control  {
+public partial class CulturalAdvisor : Control {
 
 	[Export] public TextureRect background;
 
@@ -23,8 +23,10 @@ public partial class CulturalAdvisor : Control  {
 
 		_advisorHead = AdvisorUtils.CreateAdvisorHead(background, AdvisorHead.Advisor.Culture);
 		_close = AdvisorUtils.CreateExitButton(background);
-		_close.Pressed += () => {  this.GetParent<Advisors>().Hide(); };
+		_close.Pressed += () => { this.GetParent<Advisors>().Hide(); };
 		(_dialogBox, _dialogBoxLabel) = AdvisorUtils.CreateAdvisorDialogBox(background);
+
+		AdvisorUtils.CreateAdvisorTitle(background, background.Texture.GetWidth(), "CULTURAL ADVISOR");
 	}
 
 	public void ShowAdvisor() {

--- a/C7/UIElements/Advisors/CulturalAdvisor.cs
+++ b/C7/UIElements/Advisors/CulturalAdvisor.cs
@@ -14,6 +14,10 @@ public partial class CulturalAdvisor : Control {
 	private TextureButton _dialogBox;
 	private Label _dialogBoxLabel;
 
+	public CulturalAdvisor() {
+		MouseFilter = MouseFilterEnum.Stop;
+	}
+
 	public override void _Ready() {
 		this.CreateUI();
 	}

--- a/C7/UIElements/Advisors/CulturalAdvisor.cs.uid
+++ b/C7/UIElements/Advisors/CulturalAdvisor.cs.uid
@@ -1,0 +1,1 @@
+uid://3ypsgev3rsg7

--- a/C7/UIElements/Advisors/DomesticAdvisor.cs
+++ b/C7/UIElements/Advisors/DomesticAdvisor.cs
@@ -44,6 +44,10 @@ public partial class DomesticAdvisor : Control {
 	private int scienceSliderY = 84;
 	private int luxurySliderY = 130;
 
+	public DomesticAdvisor() {
+		MouseFilter = MouseFilterEnum.Stop;
+	}
+
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
 		this.CreateUI();

--- a/C7/UIElements/Advisors/DomesticAdvisor.cs
+++ b/C7/UIElements/Advisors/DomesticAdvisor.cs
@@ -53,6 +53,8 @@ public partial class DomesticAdvisor : Control {
 		ImageTexture DomesticBackground = TextureLoader.Load("advisors.domestic.background");
 		background.Texture = DomesticBackground;
 
+		AdvisorUtils.CreateAdvisorTitle(background, background.Texture.GetWidth(), "DOMESTIC ADVISOR");
+
 		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Domestic, AdvisorHead.Mood.Happy, eraIndex: 0);
 		advisorHead.SetPosition(new Vector2(851, 0));
 		background.AddChild(advisorHead);

--- a/C7/UIElements/Advisors/ForeignAdvisor.cs
+++ b/C7/UIElements/Advisors/ForeignAdvisor.cs
@@ -5,7 +5,7 @@ using Godot;
 
 [GlobalClass]
 [Tool]
-public partial class TradeAdvisor : Control  {
+public partial class ForeignAdvisor : Control  {
 
 	[Export] public TextureRect background;
 
@@ -19,14 +19,12 @@ public partial class TradeAdvisor : Control  {
 	}
 
 	private void CreateUI() {
-		background.Texture = TextureLoader.Load("advisors.trade.background");
+		background.Texture = TextureLoader.Load("advisors.foreign.background");
 
-		_advisorHead = AdvisorUtils.CreateAdvisorHead(background, AdvisorHead.Advisor.Trade);
+		_advisorHead = AdvisorUtils.CreateAdvisorHead(background, AdvisorHead.Advisor.Foreign);
 		_close = AdvisorUtils.CreateExitButton(background);
 		_close.Pressed += () => {  this.GetParent<Advisors>().Hide(); };
 		(_dialogBox, _dialogBoxLabel) = AdvisorUtils.CreateAdvisorDialogBox(background);
-
-		AdvisorUtils.CreateAdvisorTitle(background, background.Texture.GetWidth(), "TRADE ADVISOR");
 	}
 
 	public void ShowAdvisor() {
@@ -36,7 +34,7 @@ public partial class TradeAdvisor : Control  {
 			Player player = gameData.GetFirstHumanPlayer();
 
 			// TODO: Choose advisor head
-			_advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Trade, AdvisorHead.Mood.Happy, player.EraIndex());
+			_advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Foreign, AdvisorHead.Mood.Happy, player.EraIndex());
 		});
 	}
 }

--- a/C7/UIElements/Advisors/ForeignAdvisor.cs
+++ b/C7/UIElements/Advisors/ForeignAdvisor.cs
@@ -5,7 +5,7 @@ using Godot;
 
 [GlobalClass]
 [Tool]
-public partial class ForeignAdvisor : Control  {
+public partial class ForeignAdvisor : Control {
 
 	[Export] public TextureRect background;
 
@@ -23,8 +23,10 @@ public partial class ForeignAdvisor : Control  {
 
 		_advisorHead = AdvisorUtils.CreateAdvisorHead(background, AdvisorHead.Advisor.Foreign);
 		_close = AdvisorUtils.CreateExitButton(background);
-		_close.Pressed += () => {  this.GetParent<Advisors>().Hide(); };
+		_close.Pressed += () => { this.GetParent<Advisors>().Hide(); };
 		(_dialogBox, _dialogBoxLabel) = AdvisorUtils.CreateAdvisorDialogBox(background);
+
+		AdvisorUtils.CreateAdvisorTitle(background, background.Texture.GetWidth(), "FOREIGN ADVISOR");
 	}
 
 	public void ShowAdvisor() {

--- a/C7/UIElements/Advisors/ForeignAdvisor.cs
+++ b/C7/UIElements/Advisors/ForeignAdvisor.cs
@@ -2,12 +2,20 @@ using System.Numerics;
 using C7Engine;
 using C7GameData;
 using Godot;
+using Vector2 = Godot.Vector2;
 
 [GlobalClass]
 [Tool]
 public partial class ForeignAdvisor : Control {
 
 	[Export] public TextureRect background;
+
+	[Export] public TextureRect treaties = new();
+	[Export] public TextureButton treatiesButton = new();
+	[Export] public TextureRect trades = new();
+	[Export] public TextureButton tradesButton = new();
+	[Export] public TextureRect details = new();
+	[Export] public TextureButton detailsButton = new();
 
 	private TextureButton _close;
 	private TextureRect _advisorHead;
@@ -30,7 +38,50 @@ public partial class ForeignAdvisor : Control {
 		_close.Pressed += () => { this.GetParent<Advisors>().Hide(); };
 		(_dialogBox, _dialogBoxLabel) = AdvisorUtils.CreateAdvisorDialogBox(background);
 
+		// Tabs
+		Vector2 tabsPosition = new(740, 300);
+		CreateTabs(tabsPosition);
+		CreateTabHeaders(tabsPosition);
+
 		AdvisorUtils.CreateAdvisorTitle(background, background.Texture.GetWidth(), "FOREIGN ADVISOR");
+	}
+
+	private void CreateTabs(Vector2 tabsPosition) {
+		treaties.Texture = TextureLoader.Load("advisors.foreign.navigation.treaties");
+		treaties.SetPosition(tabsPosition);
+		background.AddChild(treaties);
+
+		trades.Texture = TextureLoader.Load("advisors.foreign.navigation.trades");
+		trades.SetPosition(tabsPosition);
+		background.AddChild(trades);
+
+		details.Texture = TextureLoader.Load("advisors.foreign.navigation.details");
+		details.SetPosition(tabsPosition);
+		background.AddChild(details);
+
+		treaties.Show();
+		trades.Hide();
+		details.Hide();
+	}
+
+	private void CreateTabHeaders(Vector2 tabsPosition) {
+		Vector2 buttonSize = new(74, 18);
+		Vector2 xShift = new(buttonSize.X + 3, 0);
+
+		treatiesButton.SetSize(buttonSize);
+		treatiesButton.Pressed += () => { treaties.Show(); trades.Hide(); details.Hide(); };
+		treatiesButton.SetPosition(tabsPosition);
+		background.AddChild(treatiesButton);
+
+		tradesButton.SetSize(buttonSize);
+		tradesButton.Pressed += () => { treaties.Hide(); trades.Show(); details.Hide(); };
+		tradesButton.SetPosition(tabsPosition + xShift);
+		background.AddChild(tradesButton);
+
+		detailsButton.SetSize(buttonSize);
+		detailsButton.Pressed += () => { treaties.Hide(); trades.Hide(); details.Show(); };
+		detailsButton.SetPosition(tabsPosition + xShift + xShift);
+		background.AddChild(detailsButton);
 	}
 
 	public void ShowAdvisor() {

--- a/C7/UIElements/Advisors/ForeignAdvisor.cs
+++ b/C7/UIElements/Advisors/ForeignAdvisor.cs
@@ -14,6 +14,10 @@ public partial class ForeignAdvisor : Control {
 	private TextureButton _dialogBox;
 	private Label _dialogBoxLabel;
 
+	public ForeignAdvisor() {
+		MouseFilter = MouseFilterEnum.Stop;
+	}
+
 	public override void _Ready() {
 		this.CreateUI();
 	}

--- a/C7/UIElements/Advisors/ForeignAdvisor.cs.uid
+++ b/C7/UIElements/Advisors/ForeignAdvisor.cs.uid
@@ -1,0 +1,1 @@
+uid://bf2a0oynkd2b2

--- a/C7/UIElements/Advisors/MilitaryAdvisor.cs
+++ b/C7/UIElements/Advisors/MilitaryAdvisor.cs
@@ -18,6 +18,10 @@ public partial class MilitaryAdvisor : Control {
 	private Label _allowedUnitsLabel = new();
 	private Label _unitSupportCostLabel = new();
 
+	public MilitaryAdvisor() {
+		MouseFilter = MouseFilterEnum.Stop;
+	}
+
 	public override void _Ready() {
 		this.CreateUI();
 	}

--- a/C7/UIElements/Advisors/MilitaryAdvisor.cs
+++ b/C7/UIElements/Advisors/MilitaryAdvisor.cs
@@ -3,66 +3,58 @@ using C7GameData;
 using Godot;
 using System;
 
-public partial class MilitaryAdvisor : TextureRect {
-	Label totalUnitsLabel = new();
-	Label allowedUnitsLabel = new();
-	Label unitSupportCostLabel = new();
+[GlobalClass]
+[Tool]
+public partial class MilitaryAdvisor : Control {
+
+	[Export] public TextureRect background;
+
+	private TextureButton _close;
+	private TextureRect _advisorHead;
+	private TextureButton _dialogBox;
+	private Label _dialogBoxLabel;
+
+	private Label _totalUnitsLabel = new();
+	private Label _allowedUnitsLabel = new();
+	private Label _unitSupportCostLabel = new();
 
 	public override void _Ready() {
 		this.CreateUI();
 	}
 
 	private void CreateUI() {
-		this.Texture = TextureLoader.Load("advisors.military.background");
+		background.Texture = TextureLoader.Load("advisors.military.background");
 
-		ImageTexture DialogBoxTexture = TextureLoader.Load("advisors.dialog_box");
-		TextureButton DialogBox = new TextureButton();
-		DialogBox.TextureNormal = DialogBoxTexture;
-		DialogBox.SetPosition(new Vector2(806, 110));
-		AddChild(DialogBox);
+		_advisorHead = AdvisorUtils.CreateAdvisorHead(background, AdvisorHead.Advisor.Military);
+		_close = AdvisorUtils.CreateExitButton(background);
+		_close.Pressed += () => {  this.GetParent<Advisors>().Hide(); };
+		(_dialogBox, _dialogBoxLabel) = AdvisorUtils.CreateAdvisorDialogBox(background);
 
-		//TODO: Multi-line capabilities
-		Label DialogBoxAdvise = new Label();
-		DialogBoxAdvise.Text = "You are running OpenCiv3!";
-		DialogBoxAdvise.SetPosition(new Vector2(815, 119));
-		AddChild(DialogBoxAdvise);
+		background.AddChild(_totalUnitsLabel);
 
-		ImageTexture GoBackTexture = TextureLoader.Load("ui.exit.normal");
-		TextureButton GoBackButton = new TextureButton();
-		GoBackButton.TextureNormal = GoBackTexture;
-		GoBackButton.SetPosition(new Vector2(952, 720));
-		AddChild(GoBackButton);
-		GoBackButton.Pressed += ReturnToMenu;
+		background.AddChild(_allowedUnitsLabel);
+		_allowedUnitsLabel.SetPosition(new Vector2(-50, 139));
+
+		background.AddChild(_unitSupportCostLabel);
+		_unitSupportCostLabel.SetPosition(new Vector2(-50, 188));
+	}
+
+	public void ShowAdvisor() {
+		Show();
 
 		EngineStorage.ReadGameData((GameData gameData) => {
 			Player player = gameData.GetFirstHumanPlayer();
 			var (totalUnits, allowedUnits, unitSupportCost) = player.TotalUnitsAllowedUnitsAndSupportCost();
 
-			AddChild(totalUnitsLabel);
-			totalUnitsLabel.SetPosition(new Vector2(0, 90));
-			totalUnitsLabel.SetTextAndCenterLabel($"Total Units\n{totalUnits}");
-			totalUnitsLabel.Position += new Vector2(-50, 0);
+			var headlineFiguresOffset = -75;
+			_totalUnitsLabel.SetTextAndCenterLabel($"Total Units\n{totalUnits}");
+			_totalUnitsLabel.SetPosition(new Vector2(headlineFiguresOffset, 90));
 
-			AddChild(allowedUnitsLabel);
-			allowedUnitsLabel.SetPosition(new Vector2(0, 139));
-			allowedUnitsLabel.SetTextAndCenterLabel($"Allowed Units\n{allowedUnits}");
-			allowedUnitsLabel.Position += new Vector2(-50, 0);
+			_allowedUnitsLabel.SetTextAndCenterLabel($"Allowed Units\n{allowedUnits}");
+			_unitSupportCostLabel.SetTextAndCenterLabel($"Unit Support Cost\n{unitSupportCost} gold/turn");
 
-			AddChild(unitSupportCostLabel);
-			unitSupportCostLabel.SetPosition(new Vector2(0, 188));
-			unitSupportCostLabel.SetTextAndCenterLabel($"Unit Support Cost\n{unitSupportCost} gold/turn");
-			unitSupportCostLabel.Position += new Vector2(-50, 0);
-
-			TextureRect advisorHead = new();
-			//TODO: Randomize or set logically
-			advisorHead.Texture =
+			_advisorHead.Texture =
 				AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Military, AdvisorHead.Mood.Happy, player.EraIndex());
-			advisorHead.SetPosition(new Vector2(851, 0));
-			AddChild(advisorHead);
 		});
-	}
-
-	private void ReturnToMenu() {
-		GetParent<Advisors>().Hide();
 	}
 }

--- a/C7/UIElements/Advisors/MilitaryAdvisor.cs
+++ b/C7/UIElements/Advisors/MilitaryAdvisor.cs
@@ -27,16 +27,17 @@ public partial class MilitaryAdvisor : Control {
 
 		_advisorHead = AdvisorUtils.CreateAdvisorHead(background, AdvisorHead.Advisor.Military);
 		_close = AdvisorUtils.CreateExitButton(background);
-		_close.Pressed += () => {  this.GetParent<Advisors>().Hide(); };
+		_close.Pressed += () => { this.GetParent<Advisors>().Hide(); };
 		(_dialogBox, _dialogBoxLabel) = AdvisorUtils.CreateAdvisorDialogBox(background);
 
+		AdvisorUtils.CreateAdvisorTitle(background, background.Texture.GetWidth(), "MILITARY ADVISOR");
+
 		background.AddChild(_totalUnitsLabel);
-
+		_totalUnitsLabel.SetPosition(new Vector2(0, 90));
 		background.AddChild(_allowedUnitsLabel);
-		_allowedUnitsLabel.SetPosition(new Vector2(-50, 139));
-
+		_allowedUnitsLabel.SetPosition(new Vector2(0, 139));
 		background.AddChild(_unitSupportCostLabel);
-		_unitSupportCostLabel.SetPosition(new Vector2(-50, 188));
+		_unitSupportCostLabel.SetPosition(new Vector2(0, 188));
 	}
 
 	public void ShowAdvisor() {
@@ -46,12 +47,12 @@ public partial class MilitaryAdvisor : Control {
 			Player player = gameData.GetFirstHumanPlayer();
 			var (totalUnits, allowedUnits, unitSupportCost) = player.TotalUnitsAllowedUnitsAndSupportCost();
 
-			var headlineFiguresOffset = -75;
 			_totalUnitsLabel.SetTextAndCenterLabel($"Total Units\n{totalUnits}");
-			_totalUnitsLabel.SetPosition(new Vector2(headlineFiguresOffset, 90));
-
+			_totalUnitsLabel.Position += new Vector2(-50, 0);
 			_allowedUnitsLabel.SetTextAndCenterLabel($"Allowed Units\n{allowedUnits}");
+			_allowedUnitsLabel.Position += new Vector2(-50, 0);
 			_unitSupportCostLabel.SetTextAndCenterLabel($"Unit Support Cost\n{unitSupportCost} gold/turn");
+			_unitSupportCostLabel.Position += new Vector2(-50, 0);
 
 			_advisorHead.Texture =
 				AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Military, AdvisorHead.Mood.Happy, player.EraIndex());

--- a/C7/UIElements/Advisors/ScienceAdvisor.cs
+++ b/C7/UIElements/Advisors/ScienceAdvisor.cs
@@ -36,7 +36,6 @@ public partial class ScienceAdvisor : Control {
 		MouseFilter = MouseFilterEnum.Stop;
 	}
 
-	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
 		this.CreateUI();
 	}
@@ -56,7 +55,11 @@ public partial class ScienceAdvisor : Control {
 
 		AdvisorUtils.CreateAdvisorTitle(background, AncientBackground.GetWidth(), "SCIENCE ADVISOR");
 
+		CreatePreviousEraButton();
+		CreateNextEraButton();
+	}
 
+	private void CreatePreviousEraButton() {
 		previousEra = new();
 		TextureLoader.SetButtonTextures(previousEra, "advisors.science.navigation.button");
 		previousEra.SetPosition(new Vector2(512 - 128 - 100, 720));
@@ -73,7 +76,9 @@ public partial class ScienceAdvisor : Control {
 		previousEra.AddChild(previousEraLabel);
 		previousEraLabel.SetTextAndCenterLabel("Previous Era");
 		previousEraLabel.Position += new Vector2(0, 7);
+	}
 
+	private void CreateNextEraButton() {
 		nextEra = new();
 		TextureLoader.SetButtonTextures(nextEra, "advisors.science.navigation.button");
 		nextEra.SetPosition(new Vector2(512 + 100, 720));
@@ -91,7 +96,6 @@ public partial class ScienceAdvisor : Control {
 		nextEraLabel.SetTextAndCenterLabel("Next Era");
 		nextEraLabel.Position += new Vector2(0, 7);
 	}
-
 
 	private void LoadTechTree() {
 		EngineStorage.ReadGameData((GameData gameData) => {
@@ -158,7 +162,7 @@ public partial class ScienceAdvisor : Control {
 
 	private void ChangeEraAndDrawTree(int delta) {
 		foreach (TechBox tb in techBoxes) {
-			RemoveChild(tb);
+			background.RemoveChild(tb);
 			tb.QueueFree();
 		}
 		techBoxes.Clear();
@@ -172,11 +176,6 @@ public partial class ScienceAdvisor : Control {
 			DrawTechTree(eraName, player, allTechs, player.GetAvailableTechsToResearch(allTechs));
 		});
 	}
-
-	private void ReturnToMenu() {
-		GetParent<Advisors>().Hide();
-	}
-
 
 
 	public void ShowAdvisor() {

--- a/C7/UIElements/Advisors/ScienceAdvisor.cs
+++ b/C7/UIElements/Advisors/ScienceAdvisor.cs
@@ -6,7 +6,12 @@ using System.Linq;
 using static C7Engine.MsgChooseResearch;
 using static C7GameData.EraUtils;
 
-public partial class ScienceAdvisor : TextureRect {
+[GlobalClass]
+[Tool]
+public partial class ScienceAdvisor : Control {
+
+	[Export] public TextureRect background;
+
 	private ImageTexture AncientBackground;
 	private ImageTexture MiddleBackground;
 	private ImageTexture IndustrialBackground;
@@ -22,35 +27,14 @@ public partial class ScienceAdvisor : TextureRect {
 	// store the last opened era window so next time we open the advisor, it opens at the same era window
 	private static string lastOpenedEra = string.Empty;
 
-	private string advisorTitleString = "SCIENCE ADVISOR";
-
-	private FontFile regularFont = new();
-	private Theme regularBigFontTheme = new();
-
-	private int bigFontSize = 26;
-	// private int middleFontSize = 20;
-
-	private int bigFontGlyphSpacing = 14;
-	private int bigFontGlyphSpaceSpacing = 22;
-
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
 		this.CreateUI();
 
-		EngineStorage.ReadGameData((GameData gameData) => {
-			List<Tech> allTechs = gameData.techs;
-			Player player = gameData.GetFirstHumanPlayer();
-			eraName = string.IsNullOrEmpty(lastOpenedEra) ? player.eraCivilopediaName : lastOpenedEra;
-			this.DrawTechTree(eraName, player, allTechs, player.GetAvailableTechsToResearch(allTechs));
-		});
+
 	}
 
 	private void CreateUI() {
-
-		regularFont = ResourceLoader.Load<FontFile>("res://Fonts/NotoSans-Regular.ttf");
-		regularBigFontTheme.DefaultFont = regularFont;
-		regularBigFontTheme.SetFontSize("font_size", "Label", bigFontSize);
-
 		// science_industrial_new is used as the industrial tech tree is
 		// different from vanilla civ3.
 		AncientBackground = TextureLoader.Load("advisors.science.background.ancient");
@@ -60,58 +44,33 @@ public partial class ScienceAdvisor : TextureRect {
 
 		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Science, AdvisorHead.Mood.Happy, eraIndex: 0);
 		advisorHead.SetPosition(new Vector2(851, 0));
-		AddChild(advisorHead);
+		background.AddChild(advisorHead);
 
-		FontVariation fontVariation = new FontVariation
-		{
-			BaseFont = regularFont,
-			SpacingGlyph = bigFontGlyphSpacing,
-			SpacingSpace = bigFontGlyphSpaceSpacing,
-		};
-
-		Theme regularThemeWithCustomSpacing = new Theme();
-		regularThemeWithCustomSpacing.SetFont("font", "Label", fontVariation);
-		regularThemeWithCustomSpacing.SetFontSize("font_size", "Label", bigFontSize);
-
-		float containerWidth = AncientBackground.GetWidth();
-
-		float advisorTitleStringWidth = GetStringSizeWithCustomSpacing(regularFont, advisorTitleString, bigFontSize,
-			bigFontGlyphSpacing, bigFontGlyphSpaceSpacing).X;
-
-		float advisorTitleOffsetLeft = (containerWidth / 2.0f) - (advisorTitleStringWidth) / 2.0f;
-
-		Label advisorTitle = new() {
-			Text = advisorTitleString,
-			OffsetLeft = advisorTitleOffsetLeft,
-			OffsetTop = 15,
-			Theme = regularThemeWithCustomSpacing,
-		};
-		AddChild(advisorTitle);
-
+		AdvisorUtils.CreateAdvisorTitle(background, AncientBackground.GetWidth(), "SCIENCE ADVISOR");
 
 		ImageTexture DialogBoxTexture = TextureLoader.Load("advisors.dialog_box");
 		TextureButton DialogBox = new TextureButton();
 		DialogBox.TextureNormal = DialogBoxTexture;
 		DialogBox.SetPosition(new Vector2(806, 110));
-		AddChild(DialogBox);
+		background.AddChild(DialogBox);
 
 		//TODO: Multi-line capabilities
 		Label DialogBoxAdvise = new Label();
 		DialogBoxAdvise.Text = "You are running OpenCiv3!";
 		DialogBoxAdvise.SetPosition(new Vector2(815, 119));
-		AddChild(DialogBoxAdvise);
+		background.AddChild(DialogBoxAdvise);
 
 		ImageTexture GoBackTexture = TextureLoader.Load("ui.exit.normal");
 		TextureButton GoBackButton = new TextureButton();
 		GoBackButton.TextureNormal = GoBackTexture;
 		GoBackButton.SetPosition(new Vector2(952, 720));
-		AddChild(GoBackButton);
+		background.AddChild(GoBackButton);
 		GoBackButton.Pressed += ReturnToMenu;
 
 		previousEra = new();
 		TextureLoader.SetButtonTextures(previousEra, "advisors.science.navigation.button");
 		previousEra.SetPosition(new Vector2(512 - 128 - 100, 720));
-		AddChild(previousEra);
+		background.AddChild(previousEra);
 		previousEra.Pressed += () => { ChangeEraAndDrawTree(-1); };
 
 		TextureRect leftArrow = new() {
@@ -128,7 +87,7 @@ public partial class ScienceAdvisor : TextureRect {
 		nextEra = new();
 		TextureLoader.SetButtonTextures(nextEra, "advisors.science.navigation.button");
 		nextEra.SetPosition(new Vector2(512 + 100, 720));
-		AddChild(nextEra);
+		background.AddChild(nextEra);
 		nextEra.Pressed += () => { ChangeEraAndDrawTree(1); };
 
 		TextureRect rightArrow = new() {
@@ -143,6 +102,17 @@ public partial class ScienceAdvisor : TextureRect {
 		nextEraLabel.Position += new Vector2(0, 7);
 	}
 
+
+	private void LoadTechTree()
+	{
+		EngineStorage.ReadGameData((GameData gameData) => {
+			List<Tech> allTechs = gameData.techs;
+			Player player = gameData.GetFirstHumanPlayer();
+			eraName = string.IsNullOrEmpty(lastOpenedEra) ? player.eraCivilopediaName : lastOpenedEra;
+			this.DrawTechTree(eraName, player, allTechs, player.GetAvailableTechsToResearch(allTechs));
+		});
+	}
+
 	void DrawTechTree(string eraName, Player player, List<Tech> allTechs, HashSet<Tech> availableTechsToResearch) {
 		HashSet<ID> knownTechs = player.knownTechs;
 		previousEra.Show();
@@ -155,13 +125,13 @@ public partial class ScienceAdvisor : TextureRect {
 		// Set the tech background based on the player's era.
 		if (eraName == ANCIENT_TIMES_CVLPD) {
 			previousEra.Hide();
-			this.Texture = AncientBackground;
+			background.Texture = AncientBackground;
 		} else if (eraName == MIDDLE_AGES_CVLPD) {
-			this.Texture = MiddleBackground;
+			background.Texture = MiddleBackground;
 		} else if (eraName == INDUSTRIAL_AGE_CVLPD) {
-			this.Texture = IndustrialBackground;
+			background.Texture = IndustrialBackground;
 		} else if (eraName == MODERN_ERA_CVLPD) {
-			this.Texture = ModernBackground;
+			background.Texture = ModernBackground;
 			nextEra.Hide();
 		}
 		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Science, AdvisorHead.Mood.Happy, player.EraIndex());
@@ -192,7 +162,7 @@ public partial class ScienceAdvisor : TextureRect {
 				SelectionMode selection = Input.IsKeyPressed(Key.Shift) ? SelectionMode.Multi : SelectionMode.Single;
 				new MsgChooseResearch(tech, AdvisorState.Show, selection).send();
 			};
-			AddChild(techButton);
+			background.AddChild(techButton);
 			techBoxes.Add(techButton);
 		}
 	}
@@ -218,20 +188,18 @@ public partial class ScienceAdvisor : TextureRect {
 		GetParent<Advisors>().Hide();
 	}
 
-	private Vector2 GetStringSizeWithCustomSpacing(Font font, string input, int fontSize = 16, int glyphSpacing = 0, int glyphSpaceSpacing = 0) {
 
-		float extraSpacing = 0.0f;
-		for (int i = 0; i < input.Length; i++) {
-			if (i < input.Length - 1) {
-				if (char.IsWhiteSpace(input[i]) && glyphSpaceSpacing > 0) {
-					extraSpacing += glyphSpaceSpacing;
-				} else {
-					extraSpacing += glyphSpacing;
-				}
-			}
-		}
 
-		Vector2 originalSize = font.GetStringSize(input, fontSize: fontSize);
-		return new Vector2(originalSize.X + extraSpacing, originalSize.Y);
+	public void ShowAdvisor() {
+		LoadTechTree();
+
+		Show();
+
+		EngineStorage.ReadGameData((GameData gameData) => {
+			Player player = gameData.GetFirstHumanPlayer();
+
+			// TODO: Choose advisor head
+			// _advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Science, AdvisorHead.Mood.Happy, player.EraIndex());
+		});
 	}
 }

--- a/C7/UIElements/Advisors/ScienceAdvisor.cs
+++ b/C7/UIElements/Advisors/ScienceAdvisor.cs
@@ -32,11 +32,13 @@ public partial class ScienceAdvisor : Control {
 	// store the last opened era window so next time we open the advisor, it opens at the same era window
 	private static string lastOpenedEra = string.Empty;
 
+	public ScienceAdvisor() {
+		MouseFilter = MouseFilterEnum.Stop;
+	}
+
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
 		this.CreateUI();
-
-
 	}
 
 	private void CreateUI() {

--- a/C7/UIElements/Advisors/ScienceAdvisor.cs
+++ b/C7/UIElements/Advisors/ScienceAdvisor.cs
@@ -16,10 +16,15 @@ public partial class ScienceAdvisor : Control {
 	private ImageTexture MiddleBackground;
 	private ImageTexture IndustrialBackground;
 	private ImageTexture ModernBackground;
+
+	private TextureButton _close;
+	private TextureRect _advisorHead;
+	private TextureButton _dialogBox;
+	private Label _dialogBoxLabel;
+
 	private TextureButton nextEra;
 	private TextureButton previousEra;
 	private List<TechBox> techBoxes = new();
-	private TextureRect advisorHead = new();
 
 	// Stored separately so we can modify this without mutating the player.
 	private string eraName;
@@ -42,30 +47,13 @@ public partial class ScienceAdvisor : Control {
 		IndustrialBackground = TextureLoader.Load("advisors.science.background.industrial");
 		ModernBackground = TextureLoader.Load("advisors.science.background.modern");
 
-		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Science, AdvisorHead.Mood.Happy, eraIndex: 0);
-		advisorHead.SetPosition(new Vector2(851, 0));
-		background.AddChild(advisorHead);
+		_advisorHead = AdvisorUtils.CreateAdvisorHead(background, AdvisorHead.Advisor.Science);
+		_close = AdvisorUtils.CreateExitButton(background);
+		_close.Pressed += () => { this.GetParent<Advisors>().Hide(); };
+		(_dialogBox, _dialogBoxLabel) = AdvisorUtils.CreateAdvisorDialogBox(background);
 
 		AdvisorUtils.CreateAdvisorTitle(background, AncientBackground.GetWidth(), "SCIENCE ADVISOR");
 
-		ImageTexture DialogBoxTexture = TextureLoader.Load("advisors.dialog_box");
-		TextureButton DialogBox = new TextureButton();
-		DialogBox.TextureNormal = DialogBoxTexture;
-		DialogBox.SetPosition(new Vector2(806, 110));
-		background.AddChild(DialogBox);
-
-		//TODO: Multi-line capabilities
-		Label DialogBoxAdvise = new Label();
-		DialogBoxAdvise.Text = "You are running OpenCiv3!";
-		DialogBoxAdvise.SetPosition(new Vector2(815, 119));
-		background.AddChild(DialogBoxAdvise);
-
-		ImageTexture GoBackTexture = TextureLoader.Load("ui.exit.normal");
-		TextureButton GoBackButton = new TextureButton();
-		GoBackButton.TextureNormal = GoBackTexture;
-		GoBackButton.SetPosition(new Vector2(952, 720));
-		background.AddChild(GoBackButton);
-		GoBackButton.Pressed += ReturnToMenu;
 
 		previousEra = new();
 		TextureLoader.SetButtonTextures(previousEra, "advisors.science.navigation.button");
@@ -103,8 +91,7 @@ public partial class ScienceAdvisor : Control {
 	}
 
 
-	private void LoadTechTree()
-	{
+	private void LoadTechTree() {
 		EngineStorage.ReadGameData((GameData gameData) => {
 			List<Tech> allTechs = gameData.techs;
 			Player player = gameData.GetFirstHumanPlayer();
@@ -134,7 +121,7 @@ public partial class ScienceAdvisor : Control {
 			background.Texture = ModernBackground;
 			nextEra.Hide();
 		}
-		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Science, AdvisorHead.Mood.Happy, player.EraIndex());
+		_advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Science, AdvisorHead.Mood.Happy, player.EraIndex());
 
 		foreach (Tech tech in allTechs) {
 			if (tech.EraCivilopediaName != eraName) {

--- a/C7/UIElements/Advisors/TradeAdvisor.cs
+++ b/C7/UIElements/Advisors/TradeAdvisor.cs
@@ -2,20 +2,25 @@ using C7Engine;
 using C7GameData;
 using Godot;
 
+public interface IAdvisor {
+	void ShowAdvisor();
+}
+
 [GlobalClass]
 [Tool]
-public partial class TradeAdvisor : Control {
-	[Export] TextureRect background;
-	[Export] TextureButton close;
+public partial class TradeAdvisor : Control, IAdvisor  {
 
-	TextureRect advisorHead = new();
-	Label DialogBoxAdvise = new();
+	[Export] public TextureRect background;
+	[Export] public TextureButton close;
+
+	private TextureRect advisorHead = new();
+	private Label DialogBoxAdvise = new();
 
 	public override void _Ready() {
 		this.CreateUI();
 	}
 
-	private void CreateUI() {
+	protected void CreateUI() {
 		background.Texture = TextureLoader.Load("advisors.trade.background");
 
 		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Domestic, AdvisorHead.Mood.Happy, eraIndex: 0);

--- a/C7/UIElements/Advisors/TradeAdvisor.cs
+++ b/C7/UIElements/Advisors/TradeAdvisor.cs
@@ -5,7 +5,7 @@ using Godot;
 
 [GlobalClass]
 [Tool]
-public partial class TradeAdvisor : Control  {
+public partial class TradeAdvisor : Control {
 
 	[Export] public TextureRect background;
 
@@ -23,7 +23,7 @@ public partial class TradeAdvisor : Control  {
 
 		_advisorHead = AdvisorUtils.CreateAdvisorHead(background, AdvisorHead.Advisor.Trade);
 		_close = AdvisorUtils.CreateExitButton(background);
-		_close.Pressed += () => {  this.GetParent<Advisors>().Hide(); };
+		_close.Pressed += () => { this.GetParent<Advisors>().Hide(); };
 		(_dialogBox, _dialogBoxLabel) = AdvisorUtils.CreateAdvisorDialogBox(background);
 
 		AdvisorUtils.CreateAdvisorTitle(background, background.Texture.GetWidth(), "TRADE ADVISOR");

--- a/C7/UIElements/Advisors/TradeAdvisor.cs
+++ b/C7/UIElements/Advisors/TradeAdvisor.cs
@@ -1,0 +1,52 @@
+using C7Engine;
+using C7GameData;
+using Godot;
+
+[GlobalClass]
+[Tool]
+public partial class TradeAdvisor : Control {
+	[Export] TextureRect background;
+	[Export] TextureButton close;
+
+	TextureRect advisorHead = new();
+	Label DialogBoxAdvise = new();
+
+	public override void _Ready() {
+		this.CreateUI();
+	}
+
+	private void CreateUI() {
+		background.Texture = TextureLoader.Load("advisors.trade.background");
+
+		advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Domestic, AdvisorHead.Mood.Happy, eraIndex: 0);
+		advisorHead.SetPosition(new Vector2(851, 0));
+		background.AddChild(advisorHead);
+
+		ImageTexture DialogBoxTexture = TextureLoader.Load("advisors.dialog_box");
+		TextureButton DialogBox = new TextureButton();
+		DialogBox.TextureNormal = DialogBoxTexture;
+		DialogBox.SetPosition(new Vector2(806, 110));
+		background.AddChild(DialogBox);
+
+		//TODO: Multi-line capabilities
+		DialogBoxAdvise.Text = "You are running OpenCiv3!";
+		DialogBoxAdvise.SetPosition(new Vector2(815, 119));
+		background.AddChild(DialogBoxAdvise);
+
+		TextureLoader.SetButtonTextures(close, "ui.exit");
+		close.Pressed += () => {
+			GetParent<Advisors>().Hide();
+		};
+	}
+
+	public void ShowAdvisor() {
+		Show();
+
+		EngineStorage.ReadGameData((GameData gameData) => {
+			Player player = gameData.GetFirstHumanPlayer();
+
+			// TODO: Choose advisor head
+			advisorHead.Texture = AdvisorHead.GetPopupImage(AdvisorHead.Advisor.Trade, AdvisorHead.Mood.Happy, player.EraIndex());
+		});
+	}
+}

--- a/C7/UIElements/Advisors/TradeAdvisor.cs
+++ b/C7/UIElements/Advisors/TradeAdvisor.cs
@@ -14,6 +14,10 @@ public partial class TradeAdvisor : Control {
 	private TextureButton _dialogBox;
 	private Label _dialogBoxLabel;
 
+	public TradeAdvisor() {
+		MouseFilter = MouseFilterEnum.Stop;
+	}
+
 	public override void _Ready() {
 		this.CreateUI();
 	}

--- a/C7/UIElements/Advisors/TradeAdvisor.cs.uid
+++ b/C7/UIElements/Advisors/TradeAdvisor.cs.uid
@@ -1,0 +1,1 @@
+uid://bqrqi50q5303p

--- a/C7/UIElements/Advisors/cultural_advisor.tscn
+++ b/C7/UIElements/Advisors/cultural_advisor.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=3 format=3 uid="uid://cla8cx1cxecu2"]
+
+[ext_resource type="Script" uid="uid://3ypsgev3rsg7" path="res://UIElements/Advisors/CulturalAdvisor.cs" id="1_c1awi"]
+[ext_resource type="Script" uid="uid://doqipc4rnaotx" path="res://UIElements/Civ3TextureRect.cs" id="1_mght3"]
+
+[node name="CulturalAdvisor" type="CenterContainer" node_paths=PackedStringArray("background")]
+script = ExtResource("1_c1awi")
+background = NodePath("CulturalAdvisorBG")
+
+[node name="CulturalAdvisorBG" type="TextureRect" parent="."]
+layout_mode = 2
+script = ExtResource("1_mght3")
+metadata/_custom_type_script = "uid://doqipc4rnaotx"

--- a/C7/UIElements/Advisors/foreign_advisor.tscn
+++ b/C7/UIElements/Advisors/foreign_advisor.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=3 format=3 uid="uid://balpdexsjgl0b"]
+
+[ext_resource type="Script" uid="uid://doqipc4rnaotx" path="res://UIElements/Civ3TextureRect.cs" id="1_1v6yt"]
+[ext_resource type="Script" uid="uid://bf2a0oynkd2b2" path="res://UIElements/Advisors/ForeignAdvisor.cs" id="1_wq635"]
+
+[node name="ForeignAdvisor" type="CenterContainer" node_paths=PackedStringArray("background")]
+script = ExtResource("1_wq635")
+background = NodePath("ForeingAdvisorBG")
+
+[node name="ForeingAdvisorBG" type="TextureRect" parent="."]
+layout_mode = 2
+script = ExtResource("1_1v6yt")
+metadata/_custom_type_script = "uid://doqipc4rnaotx"

--- a/C7/UIElements/Advisors/military_advisor.tscn
+++ b/C7/UIElements/Advisors/military_advisor.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=3 format=3 uid="uid://d0qk1h4jvf3i1"]
+
+[ext_resource type="Script" uid="uid://b4s6vurld6x3b" path="res://UIElements/Advisors/MilitaryAdvisor.cs" id="1_plxsm"]
+[ext_resource type="Script" uid="uid://doqipc4rnaotx" path="res://UIElements/Civ3TextureRect.cs" id="2_plxsm"]
+
+[node name="MilitaryAdvisor" type="CenterContainer" node_paths=PackedStringArray("background")]
+script = ExtResource("1_plxsm")
+background = NodePath("MilitaryAdvisorBG")
+
+[node name="MilitaryAdvisorBG" type="TextureRect" parent="."]
+layout_mode = 2
+script = ExtResource("2_plxsm")
+metadata/_custom_type_script = "uid://doqipc4rnaotx"

--- a/C7/UIElements/Advisors/science_advisor.tscn
+++ b/C7/UIElements/Advisors/science_advisor.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=3 format=3 uid="uid://c5qvjbhp6c3bv"]
+
+[ext_resource type="Script" uid="uid://doqipc4rnaotx" path="res://UIElements/Civ3TextureRect.cs" id="1_hrpi3"]
+[ext_resource type="Script" uid="uid://goye21dxmgpf" path="res://UIElements/Advisors/ScienceAdvisor.cs" id="1_iqyvj"]
+
+[node name="ScienceAdvisor" type="CenterContainer" node_paths=PackedStringArray("background")]
+script = ExtResource("1_iqyvj")
+background = NodePath("ScienceAdvisorBG")
+
+[node name="ScienceAdvisorBG" type="TextureRect" parent="."]
+layout_mode = 2
+script = ExtResource("1_hrpi3")
+metadata/_custom_type_script = "uid://doqipc4rnaotx"

--- a/C7/UIElements/Advisors/trade_advisor.tscn
+++ b/C7/UIElements/Advisors/trade_advisor.tscn
@@ -1,27 +1,17 @@
-[gd_scene load_steps=4 format=3 uid="uid://cucamooiqvddl"]
+[gd_scene load_steps=3 format=3 uid="uid://cucamooiqvddl"]
 
 [ext_resource type="Script" uid="uid://bqrqi50q5303p" path="res://UIElements/Advisors/TradeAdvisor.cs" id="1_cr3pi"]
 [ext_resource type="Script" uid="uid://doqipc4rnaotx" path="res://UIElements/Civ3TextureRect.cs" id="2_nbt20"]
-[ext_resource type="Script" uid="uid://dcrdcjop64t6t" path="res://UIElements/Civ3TextureButton.cs" id="3_mxdqt"]
 
-[node name="TradeAdvisor" type="CenterContainer" node_paths=PackedStringArray("background", "close")]
+[node name="TradeAdvisor" type="CenterContainer" node_paths=PackedStringArray("background")]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_cr3pi")
-background = NodePath("TradeAdvisorBackground")
-close = NodePath("TradeAdvisorBackground/Close")
+background = NodePath("TradeAdvisorBG")
 
-[node name="TradeAdvisorBackground" type="TextureRect" parent="."]
+[node name="TradeAdvisorBG" type="TextureRect" parent="."]
 layout_mode = 2
 script = ExtResource("2_nbt20")
-
-[node name="Close" type="TextureButton" parent="TradeAdvisorBackground"]
-layout_mode = 0
-offset_left = 952.0
-offset_top = 720.0
-offset_right = 1024.0
-offset_bottom = 768.0
-script = ExtResource("3_mxdqt")

--- a/C7/UIElements/Advisors/trade_advisor.tscn
+++ b/C7/UIElements/Advisors/trade_advisor.tscn
@@ -1,21 +1,23 @@
-[gd_scene load_steps=4 format=3 uid="uid://cucamooiqvddl"]
+[gd_scene load_steps=2 format=3 uid="uid://cucamooiqvddl"]
 
 [ext_resource type="Script" uid="uid://bqrqi50q5303p" path="res://UIElements/Advisors/TradeAdvisor.cs" id="1_cr3pi"]
-[ext_resource type="Script" uid="uid://doqipc4rnaotx" path="res://UIElements/Civ3TextureRect.cs" id="2_nbt20"]
-[ext_resource type="Script" uid="uid://dcrdcjop64t6t" path="res://UIElements/Civ3TextureButton.cs" id="3_mxdqt"]
 
-[node name="TradeAdvisor" type="CenterContainer"]
+[node name="TradeAdvisor" type="CenterContainer" node_paths=PackedStringArray("background", "close")]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_cr3pi")
+background = NodePath("Background")
+close = NodePath("Background/Close")
 
 [node name="Background" type="TextureRect" parent="."]
 layout_mode = 2
-script = ExtResource("2_nbt20")
 
 [node name="Close" type="TextureButton" parent="Background"]
-layout_mode = 2
-script = ExtResource("3_mxdqt")
+layout_mode = 0
+offset_left = 952.0
+offset_top = 720.0
+offset_right = 1024.0
+offset_bottom = 768.0

--- a/C7/UIElements/Advisors/trade_advisor.tscn
+++ b/C7/UIElements/Advisors/trade_advisor.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=4 format=3 uid="uid://cucamooiqvddl"]
+
+[ext_resource type="Script" uid="uid://bqrqi50q5303p" path="res://UIElements/Advisors/TradeAdvisor.cs" id="1_cr3pi"]
+[ext_resource type="Script" uid="uid://doqipc4rnaotx" path="res://UIElements/Civ3TextureRect.cs" id="2_nbt20"]
+[ext_resource type="Script" uid="uid://dcrdcjop64t6t" path="res://UIElements/Civ3TextureButton.cs" id="3_mxdqt"]
+
+[node name="TradeAdvisor" type="CenterContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_cr3pi")
+
+[node name="Background" type="TextureRect" parent="."]
+layout_mode = 2
+script = ExtResource("2_nbt20")
+
+[node name="Close" type="TextureButton" parent="Background"]
+layout_mode = 2
+script = ExtResource("3_mxdqt")

--- a/C7/UIElements/Advisors/trade_advisor.tscn
+++ b/C7/UIElements/Advisors/trade_advisor.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=2 format=3 uid="uid://cucamooiqvddl"]
+[gd_scene load_steps=4 format=3 uid="uid://cucamooiqvddl"]
 
 [ext_resource type="Script" uid="uid://bqrqi50q5303p" path="res://UIElements/Advisors/TradeAdvisor.cs" id="1_cr3pi"]
+[ext_resource type="Script" uid="uid://doqipc4rnaotx" path="res://UIElements/Civ3TextureRect.cs" id="2_nbt20"]
+[ext_resource type="Script" uid="uid://dcrdcjop64t6t" path="res://UIElements/Civ3TextureButton.cs" id="3_mxdqt"]
 
 [node name="TradeAdvisor" type="CenterContainer" node_paths=PackedStringArray("background", "close")]
 anchors_preset = 15
@@ -9,15 +11,17 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_cr3pi")
-background = NodePath("Background")
-close = NodePath("Background/Close")
+background = NodePath("TradeAdvisorBackground")
+close = NodePath("TradeAdvisorBackground/Close")
 
-[node name="Background" type="TextureRect" parent="."]
+[node name="TradeAdvisorBackground" type="TextureRect" parent="."]
 layout_mode = 2
+script = ExtResource("2_nbt20")
 
-[node name="Close" type="TextureButton" parent="Background"]
+[node name="Close" type="TextureButton" parent="TradeAdvisorBackground"]
 layout_mode = 0
 offset_left = 952.0
 offset_top = 720.0
 offset_right = 1024.0
 offset_bottom = 768.0
+script = ExtResource("3_mxdqt")

--- a/C7/UIElements/PalaceScreen/palace_screen.tscn
+++ b/C7/UIElements/PalaceScreen/palace_screen.tscn
@@ -10,7 +10,7 @@
 layout_mode = 2
 script = ExtResource("2_kp65c")
 switchButtonContainer = NodePath("SwitchButtonContainer")
-textureConfigKey = "palace.background"
+textureConfigKey = "screens.palace.background"
 
 [node name="Close" type="TextureButton" parent="HBoxContainer/PalaceScreen" index="0"]
 layout_mode = 0

--- a/C7/project.godot
+++ b/C7/project.godot
@@ -219,11 +219,32 @@ unit_unload={
 }
 show_domestic_advisor={
 "deadzone": 0.5,
-"events": []
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194332,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
 }
 show_trade_advisor={
 "deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194333,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+show_military_advisor={
+"deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194334,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+show_foreign_advisor={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194335,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+show_cultural_advisor={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194336,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+show_science_advisor={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194337,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/C7/project.godot
+++ b/C7/project.godot
@@ -217,6 +217,15 @@ unit_unload={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":85,"key_label":0,"unicode":117,"location":0,"echo":false,"script":null)
 ]
 }
+show_domestic_advisor={
+"deadzone": 0.5,
+"events": []
+}
+show_trade_advisor={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194334,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [mono]
 

--- a/C7Engine/Actions.cs
+++ b/C7Engine/Actions.cs
@@ -8,6 +8,7 @@ namespace C7Engine;
 public static class C7Action {
 	public const string EndTurn = "end_turn";
 	public const string Escape = "escape";
+
 	public const string MoveUnitSouthwest = "move_unit_southwest";
 	public const string MoveUnitSouth = "move_unit_south";
 	public const string MoveUnitSoutheast = "move_unit_southeast";
@@ -16,11 +17,20 @@ public static class C7Action {
 	public const string MoveUnitNorthwest = "move_unit_northwest";
 	public const string MoveUnitNorth = "move_unit_north";
 	public const string MoveUnitNortheast = "move_unit_northeast";
+
 	public const string ToggleAnimations = "toggle_animations";
 	public const string EnableTempAnimations = "enable_temp_animations";
 	public const string ToggleGrid = "toggle_grid";
 	public const string ToggleCoordinates = "toggle_coordinates";
 	public const string ToggleZoom = "toggle_zoom";
+
+	public const string ShowDomesticAdvisor = "show_domestic_advisor";
+	public const string ShowTradeAdvisor = "show_trade_advisor";
+	public const string ShowMilitaryAdvisor = "show_military_advisor";
+	public const string ShowForeignAdvisor = "show_foreign_advisor";
+	public const string ShowCulturalAdvisor = "show_cultural_advisor";
+	public const string ShowScienceAdvisor = "show_science_advisor";
+
 	public const string UnitBombard = "unit_bombard";
 	public const string UnitBuildCity = "unit_build_city";
 	public const string UnitBuildRoad = "unit_build_road";


### PR DESCRIPTION
- Add barebones trade, cultural, and foreign advisors
- Harmonise new and existing advisors, so they all function broadly the same from a UI perspective
- Fix popup logic, so one can now quickly switch between advisors
- Replace function key references with dedicated actions, and wire these to Godot InputMap
- Bring in a bunch of custom assets for advisor backgrounds, etc.

There's probably a way to reduce repetition in advisors even further, but one step at a time.

New assets here: https://github.com/C7-Game/Assets/pull/8