### PR TITLE
Unit bombardment improvements

### DIFF
--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -52,25 +52,36 @@ public class TileInfo {
 public class BombardInfo {
 	public MapUnit bombardingUnit;
 	public Tile mouseTile;
+	public MapUnit.BombardTarget bombardTarget = MapUnit.BombardTarget.None;
 
 	public BombardInfo(MapUnit bombardingUnit) {
 		this.bombardingUnit = bombardingUnit;
 	}
 
-	public bool requiresWarDeclaration(Tile tile, out Player player) {
+	public bool RequiresWarDeclaration(Tile tile, out Player player) {
 		player = null;
 
 		var bombarder = bombardingUnit.owner;
-		var foreignUnits = tile.unitsOnTile.Where(x => x.owner != bombarder).ToList();
-		if (!foreignUnits.Any())
+
+		if (bombardTarget == MapUnit.BombardTarget.None)
 			return false;
 
-		var targetPlayers = foreignUnits.Select(x => x.owner).Distinct();
-		var friendly= targetPlayers.Where(p => bombarder.IsAtPeaceWith(p)).ToList();
-		player = friendly.FirstOrDefault();
-		return friendly.Any();
+		if (bombardTarget == MapUnit.BombardTarget.City) {
+			player = tile.owningCity.owner;
+			return bombarder.IsAtPeaceWith(player);
+		}
 
-		// TODO: handle complex scenarios arising from multiple civs co-located on tile
+		if (bombardTarget == MapUnit.BombardTarget.Unit) {
+			player = tile.unitsOnTile.First().owner;
+			return bombarder.IsAtPeaceWith(player);
+		}
+
+		if (bombardTarget == MapUnit.BombardTarget.Improvement) {
+			player = tile.OwningPlayer();
+			return player != null && player != bombarder && bombarder.IsAtPeaceWith(player);
+		}
+
+		throw new NotImplementedException($"A case is missing here. {tile} | {player} | {bombardTarget}");
 	}
 };
 
@@ -598,10 +609,11 @@ public partial class Game : Node {
 			this.SetGotoMode(false);
 		} else if (bombardInfo != null) {
 			Tile tile = PositionToTile(eventMouseButton.Position);
-			if (bombardInfo.bombardingUnit.canBombardTile(tile)) {
+			if (bombardInfo.bombardingUnit.CanBombardTile(tile, out var bombardTarget)) {
+				bombardInfo.bombardTarget = bombardTarget;
 				HandleBombardClick(bombardInfo, tile);
-				setBombard(null);
 			}
+			setBombard(null);
 		} else {
 			// Select unit on tile at mouse location
 			HandleUnitSelectionTileClick(eventMouseButton);
@@ -667,8 +679,10 @@ public partial class Game : Node {
 
 		var activeTile = controller.tileKnowledge.isActiveTile(tile);
 
+		if (bombardInfo != null)
+			setBombard(null);
 		// Handle the shortcut of shift+right clicking a city to get the change production menu.
-		if (shiftDown && activeTile && tile.cityAtTile?.owner == controller)
+		else if (shiftDown && activeTile && tile.cityAtTile?.owner == controller)
 			new RightClickChooseProductionMenu(this, tile.cityAtTile).Open(eventMouseButton.Position);
 		else if (!shiftDown && activeTile && tile.unitsOnTile.Count > 0)
 			// There are units on this title, so open that menu.
@@ -676,8 +690,6 @@ public partial class Game : Node {
 		else if (!shiftDown && activeTile && tile.cityAtTile?.owner == controller)
 			// There are no units, but this is the player's city.
 			new RightClickCityMenu(this, tile).Open(eventMouseButton.Position);
-		else if (bombardInfo != null)
-			setBombard(null);
 		else
 			ShowTileInfo(tile);
 
@@ -947,7 +959,7 @@ public partial class Game : Node {
 		if (!IsMapUnitValid(CurrentlySelectedUnit)) return;
 
 		if (currentAction == C7Action.UnitHold) {
-			new ActionToEngineMsg(() => CurrentlySelectedUnit?.skipTurn()).send();
+			new ActionToEngineMsg(() => CurrentlySelectedUnit?.SkipTurn()).send();
 		}
 
 		if (currentAction == C7Action.UnitWait) {
@@ -979,11 +991,11 @@ public partial class Game : Node {
 		}
 
 		if (currentAction == C7Action.UnitExplore) {
-			new ActionToEngineMsg(() => CurrentlySelectedUnit.explore()).send();
+			new ActionToEngineMsg(() => CurrentlySelectedUnit.Explore()).send();
 		}
 
 		if (currentAction == C7Action.UnitAutomate) {
-			new ActionToEngineMsg(() => CurrentlySelectedUnit.automate()).send();
+			new ActionToEngineMsg(() => CurrentlySelectedUnit.Automate()).send();
 		}
 
 		if (currentAction == C7Action.UnitSentry) {
@@ -1006,7 +1018,7 @@ public partial class Game : Node {
 		}
 
 		if (currentAction == C7Action.UnitBombard) {
-			if (CurrentlySelectedUnit.canBombard()) {
+			if (CurrentlySelectedUnit.HasBombardAbility()) {
 				EngineStorage.ReadGameData((GameData gameData) => {
 					MapUnit currentUnit = gameData.GetUnit(CurrentlySelectedUnit.id);
 					setBombard(currentUnit);
@@ -1196,7 +1208,7 @@ public partial class Game : Node {
 		}
 
 		EngineStorage.ReadGameData((GameData gameData) => {
-			if (info.requiresWarDeclaration(tile, out var player)) {
+			if (info.RequiresWarDeclaration(tile, out var player)) {
 				MaybeDeclareWar(player, gameData.turn, () => {
 					new MsgBombard(CurrentlySelectedUnit.id, tile).send();
 				});

--- a/C7/Lua/civ3/ruleset.json
+++ b/C7/Lua/civ3/ruleset.json
@@ -2798,6 +2798,10 @@
         "Maya"
       ],
       "unproducible": false,
+      "flags": [
+        "lethalLandBombardment",
+        "lethalSeaBombardment"
+      ],
       "categories": [
         "Land"
       ],
@@ -3953,6 +3957,9 @@
         "Jet Fighter"
       ],
       "unproducible": false,
+      "flags": [
+        "lethalSeaBombardment"
+      ],
       "categories": [
         "Air"
       ],
@@ -4026,6 +4033,10 @@
         "Maya"
       ],
       "unproducible": false,
+      "flags": [
+        "lethalLandBombardment",
+        "lethalSeaBombardment"
+      ],
       "categories": [
         "Air"
       ],
@@ -4175,6 +4186,9 @@
         "Maya"
       ],
       "unproducible": false,
+      "flags": [
+        "lethalSeaBombardment"
+      ],
       "categories": [
         "Air"
       ],
@@ -4249,6 +4263,10 @@
         "Maya"
       ],
       "unproducible": false,
+      "flags": [
+        "lethalLandBombardment",
+        "lethalSeaBombardment"
+      ],
       "categories": [
         "Air"
       ],
@@ -4323,6 +4341,10 @@
         "Maya"
       ],
       "unproducible": false,
+      "flags": [
+        "lethalLandBombardment",
+        "lethalSeaBombardment"
+      ],
       "categories": [
         "Air"
       ],
@@ -5239,6 +5261,10 @@
         "America"
       ],
       "unproducible": false,
+      "flags": [
+        "lethalLandBombardment",
+        "lethalSeaBombardment"
+      ],
       "categories": [
         "Air"
       ],
@@ -5690,6 +5716,10 @@
         "Artillery"
       ],
       "unproducible": false,
+      "flags": [
+        "lethalLandBombardment",
+        "lethalSeaBombardment"
+      ],
       "categories": [
         "Land"
       ],
@@ -7425,6 +7455,9 @@
         "Caravel"
       ],
       "unproducible": false,
+      "flags": [
+        "lethalSeaBombardment"
+      ],
       "categories": [
         "Sea"
       ],

--- a/C7/Map/BombardLayer.cs
+++ b/C7/Map/BombardLayer.cs
@@ -41,7 +41,7 @@ public partial class BombardLayer : LooseLayer {
 		var unit = bombardInfo.bombardingUnit;
 		var range = unit.unitType.bombardRange;
 		var reachableTiles = GetTileSquare(tile, range);
-		var targetTiles = reachableTiles.Except([tile]).Where(t => unit.canBombardTile(t));
+		var targetTiles = reachableTiles.Where(t => unit.CanBombardTile(t));
 		var bombardTiles = targetTiles.ToHashSet();
 
 		// Choose one of two cursors depending on mouse tile hover

--- a/C7/UnitSelector.cs
+++ b/C7/UnitSelector.cs
@@ -107,7 +107,7 @@ public partial class UnitSelector : Node {
 
 		// Also emit the signal for a new unit being selected, so other areas such as Game Status and Unit Buttons can update
 		if (CurrentlySelectedUnit != MapUnit.NONE) {
-			unit.wake();
+			unit.Wake();
 			NoMoreAutoselectableUnitsEmitted = false;
 			ParameterWrapper<MapUnit> wrappedUnit = new(CurrentlySelectedUnit);
 			PreLoadUnitAnimationThumbnail(wrappedUnit.Value);

--- a/C7Engine/AI/BarbarianStrategy/BaseStrategy.cs
+++ b/C7Engine/AI/BarbarianStrategy/BaseStrategy.cs
@@ -19,7 +19,7 @@ internal abstract class BaseStrategy : IBarbarianStrategy {
 
 		// Wake up the unit if there's a reason to do so
 		if (ShouldWake(player, unit))
-			unit.wake();
+			unit.Wake();
 
 		// Skip units that didn't wake up
 		if (unit.isFortified)

--- a/C7Engine/AI/PlayerAI.cs
+++ b/C7Engine/AI/PlayerAI.cs
@@ -68,7 +68,7 @@ namespace C7Engine {
 				// Wake up any fortified units so our new strategy (if we have one)
 				// takes effect.
 				foreach (MapUnit u in player.units) {
-					u.wake();
+					u.Wake();
 				}
 			} else {
 				player.turnsUntilPriorityReevaluation--;
@@ -106,7 +106,7 @@ namespace C7Engine {
 			foreach (MapUnit u in player.units) {
 				if (u.currentAI is SettlerAI settlerAi && settlerAi.data.escort == null) {
 					foreach (MapUnit uu in u.location.unitsOnTile) {
-						uu.wake();
+						uu.Wake();
 					}
 				}
 			}

--- a/C7Engine/AI/UnitAI/DefenderAI.cs
+++ b/C7Engine/AI/UnitAI/DefenderAI.cs
@@ -47,7 +47,7 @@ namespace C7Engine.AI.UnitAI {
 		C7GameData.UnitAI.MoveResult C7GameData.UnitAI.PlayTurnImpl(Player player, MapUnit unit) {
 			if (data.destination == unit.location) {
 				if (!unit.isFortified) {
-					unit.fortify();
+					unit.Fortify();
 					log.Information("Fortifying " + unit + " at " + data.destination);
 				}
 				return C7GameData.UnitAI.Result.Done;

--- a/C7Engine/AI/UnitAiExtension.cs
+++ b/C7Engine/AI/UnitAiExtension.cs
@@ -30,7 +30,7 @@ namespace C7Engine {
 				return UnitAI.Result.InProgress;
 			}
 
-			Task<bool> moveTask = unit.move(unit.location.directionTo(nextTile));
+			Task<bool> moveTask = unit.Move(unit.location.directionTo(nextTile));
 
 			return MoveResult.MoveRequested(moveTask);
 		}

--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -130,22 +130,23 @@ namespace C7GameData {
 		}
 
 		// Players are in an active locked war (can't make peace)
-		private bool AreInLockedWar(Alliance one, Alliance other) {
+		private bool AreAlliancesInLockedWar(Alliance one, Alliance other) {
 			return allianceWars.Any(
 				kvp => (one != null && other != null) &&
 					((kvp.Key.name == one.name && kvp.Value.name == other.name)
 					|| (kvp.Key.name == other.name && kvp.Value.name == one.name)));
 		}
 		public bool AreInLockedWar(Player one, Player other) {
-			return AreInLockedWar(one.alliance, other.alliance);
+			return AreAlliancesInLockedWar(one.alliance, other.alliance) && one != other;
 		}
 
 		// Both players are part of the same alliance (can't declare war)
-		private bool AreInLockedPeace(Alliance one, Alliance other) {
+		// We exclude ourselves from this.
+		private bool AreInSameAlliance(Alliance one, Alliance other) {
 			return one != null && other != null && one == other;
 		}
 		public bool AreInLockedPeace(Player one, Player other) {
-			return AreInLockedPeace(one.alliance, other.alliance);
+			return AreInSameAlliance(one.alliance, other.alliance) && one != other;
 		}
 
 		public void UpdateTileOwners() {

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -1332,6 +1332,8 @@ namespace C7GameData {
 				if (prto.CanCarryFootUnitsOnly) prototype.flags.Add(SaveUnitPrototype.Flag.CanCarryFootUnitsOnly);
 				if (prto.CanCarryAircraft) prototype.flags.Add(SaveUnitPrototype.Flag.CanCarryAircraft);
 				if (prto.CanCarryTacticalMissiles) prototype.flags.Add(SaveUnitPrototype.Flag.CanCarryTacticalMissiles);
+				if (prto.LethalLandBombardment) prototype.flags.Add(SaveUnitPrototype.Flag.LethalLandBombardment);
+				if (prto.LethalSeaBombardment) prototype.flags.Add(SaveUnitPrototype.Flag.LethalSeaBombardment);
 
 				prototype.actions.UnionWith(GetUnitActions(prto));
 				prototype.terraformActions.UnionWith(GetUnitTerraforms(prto).Select(tfKey => terraformIdByCiv3Key[tfKey]));

--- a/C7Engine/C7GameData/MapUnit.cs
+++ b/C7Engine/C7GameData/MapUnit.cs
@@ -1,20 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using C7Engine;
+using Serilog;
 using static C7GameData.PlayerRelationship;
-using static C7GameData.Tile;
 
 namespace C7GameData {
-	using Serilog;
-	using System.Collections.Generic;
-	using System.Text.Json.Serialization;
-	using System.Linq;
-	using C7Engine;
-	using AIData;
-	using System;
-	using System.Threading.Tasks;
-
 	/**
 	 * A unit on the map.  Not to be confused with a unit prototype.
 	 **/
-	public class MapUnit {
+	public partial class MapUnit {
+		private static ILogger log = Log.ForContext<MapUnit>();
 		public ID id { get; internal set; }
 		public string name { get; internal set; }
 		public Civilization nationality { get; set; }
@@ -65,8 +63,10 @@ namespace C7GameData {
 
 		internal MapUnit() { }
 
+		public static MapUnit NONE = new MapUnit(ID.None("unit"));
+
 		public static bool IsMapUnitValid(MapUnit mapUnit) {
-			return mapUnit != null && mapUnit != MapUnit.NONE;
+			return mapUnit != null && mapUnit != NONE;
 		}
 
 		public bool IsBusy() {
@@ -116,7 +116,7 @@ namespace C7GameData {
 		}
 
 		public override string ToString() {
-			if (this != MapUnit.NONE) {
+			if (this != NONE) {
 				return $"{this.owner} {this.GetDisplayName()} at [{this.location.XCoordinate}, {this.location.YCoordinate}] " +
 					   $"with {this.movementPoints.getMixedNumber()} MP and {this.hitPointsRemaining} HP, id = {id}";
 			} else {
@@ -205,10 +205,6 @@ namespace C7GameData {
 			}
 		}
 
-		public static MapUnit NONE = new MapUnit(ID.None("unit"));
-
-		private static ILogger log = Log.ForContext<MapUnit>();
-
 		private const int JOB_PROGRESS_WORKER = 2;
 		private const int JOB_PROGRESS_SLAVE = 1;
 
@@ -255,16 +251,6 @@ namespace C7GameData {
 			if (!canMoveFreely) return false;
 
 			return true;
-		}
-
-		public void fortify() {
-			ResetFacingDirection();
-			isFortified = true;
-			animate(MapUnit.AnimatedAction.FORTIFY);
-		}
-
-		public void wake() {
-			isFortified = false;
 		}
 
 		public void ResetFacingDirection() {
@@ -348,7 +334,7 @@ namespace C7GameData {
 				promotionChance *= 2;
 			if (GameData.rng.NextDouble() < promotionChance) {
 				Promote();
-				animate(MapUnit.AnimatedAction.VICTORY);
+				animate(AnimatedAction.VICTORY);
 			}
 		}
 
@@ -373,334 +359,6 @@ namespace C7GameData {
 			return GetAttackAnimationDirection(attackDirection.reversed());
 		}
 
-		public async Task<CombatResult> fight(MapUnit defender) {
-			var attacker = this;
-
-			// Set combat animation facing. We'll restore the defender's original facing direction at the end of the battle.
-			TileDirection attackerAttackDirection = attacker.location.directionTo(defender.location);
-			TileDirection defenderDefenseDirection = attackerAttackDirection.reversed();
-			var defenderOriginalDirection = defender.facingDirection;
-			attacker.facingDirection = attacker.GetAttackAnimationDirection(attackerAttackDirection);
-			defender.facingDirection = defender.GetAttackAnimationDirection(defenderDefenseDirection);
-
-			IEnumerable<StrengthBonus> attackBonuses  = attacker.ListStrengthBonusesVersus(defender, CombatRole.Attack , attackerAttackDirection),
-								   defenseBonuses = defender.ListStrengthBonusesVersus(attacker, CombatRole.Defense, attackerAttackDirection);
-
-			double attackerStrength = attacker.unitType.attack  * StrengthBonus.ListToMultiplier(attackBonuses),
-			   defenderStrength = defender.unitType.defense * StrengthBonus.ListToMultiplier(defenseBonuses);
-
-			log.Information($"Combat log: {attacker} ({attackerStrength}) attacking {defender} ({defenderStrength})");
-			log.Information($"\tAttacker: {attacker.unitType.name}, base strength {attacker.unitType.BaseStrength(CombatRole.Attack)}");
-			foreach (StrengthBonus bonus in attackBonuses)
-				log.Information($"\t\t+{100.0 * bonus.amount}%\t{bonus.description}");
-			log.Information($"\tDefender: {defender.unitType.name}, base strength {defender.unitType.BaseStrength(CombatRole.Defense)}");
-			foreach (StrengthBonus bonus in defenseBonuses)
-				log.Information($"\t\t+{100.0 * bonus.amount}%\t{bonus.description}");
-
-			CombatResult result = CombatResult.Impossible;
-
-			double attackerOdds = attackerStrength / (attackerStrength + defenderStrength);
-			if (Double.IsNaN(attackerOdds))
-				return result;
-
-			// Defensive bombard
-			MapUnit defensiveBombarder = MapUnit.NONE;
-			double defensiveBombarderStrength = 0.0;
-			foreach (MapUnit candidate in defender.location.unitsOnTile.Where(u => u != defender && !u.owner.IsAtPeaceWith(attacker.owner) && u.defensiveBombardsRemaining > 0)) {
-				double strength = candidate.StrengthVersus(attacker, CombatRole.DefensiveBombard, defenderDefenseDirection);
-				if (strength > defensiveBombarderStrength) {
-					defensiveBombarder = candidate;
-					defensiveBombarderStrength = strength;
-				}
-			}
-			// In the original game, defensive bombard does not trigger against attackers with 1 HP. See:
-			// https://github.com/C7-Game/Prototype/pull/250#discussion_r893051111
-			if (defensiveBombarder != MapUnit.NONE && attacker.hitPointsRemaining > 1) {
-				var dBOriginalDirection = defensiveBombarder.facingDirection;
-				TileDirection defensiveBombardDirection = defenderDefenseDirection;
-				defensiveBombarder.facingDirection = defensiveBombarder.GetAttackAnimationDirection(defensiveBombardDirection);
-
-				await defensiveBombarder.animateAsync(MapUnit.AnimatedAction.ATTACK1);
-
-				// dADB = defense Against Defensive Bombard
-				double dADB = attacker.StrengthVersus(defensiveBombarder, CombatRole.DefensiveBombardDefense, defensiveBombardDirection);
-				if (GameData.rng.NextDouble() < defensiveBombarderStrength / (defensiveBombarderStrength + dADB))
-					attacker.hitPointsRemaining -= 1;
-
-				defensiveBombarder.defensiveBombardsRemaining -= 1;
-				defensiveBombarder.facingDirection = dBOriginalDirection;
-			}
-
-			bool defenderEligibleToRetreat = defender.hitPointsRemaining > 1 && ! defender.location.HasCity();
-
-			// Do combat rounds
-			while (true) {
-				defender.animate(MapUnit.AnimatedAction.ATTACK1);
-				await attacker.animateAsync(MapUnit.AnimatedAction.ATTACK1);
-				if (GameData.rng.NextDouble() < attackerOdds) {
-					if (defenderEligibleToRetreat &&
-						defender.hitPointsRemaining == 1 &&
-						GameData.rng.NextDouble() < defender.RetreatChance(attacker, false)) {
-						// TODO: Defender retreat behavior requires some more work. There's an issue for it here:
-						// https://github.com/C7-Game/Prototype/issues/274
-						Tile retreatDestination = defender.location.neighbors[attackerAttackDirection];
-						if ((retreatDestination != Tile.NONE) && defender.CanEnter(retreatDestination)) {
-							await defender.move(attackerAttackDirection, true);
-							result = CombatResult.DefenderRetreated;
-							break;
-						}
-					}
-					defender.hitPointsRemaining -= 1;
-					if (defender.hitPointsRemaining <= 0) {
-						result = CombatResult.DefenderKilled;
-						break;
-					}
-				} else {
-					if (attacker.hitPointsRemaining == 1 &&
-						GameData.rng.NextDouble() < attacker.RetreatChance(defender, true)) {
-						result = CombatResult.AttackerRetreated;
-						break;
-					}
-					attacker.hitPointsRemaining -= 1;
-					if (attacker.hitPointsRemaining <= 0) {
-						result = CombatResult.AttackerKilled;
-						break;
-					}
-				}
-			}
-
-			if ((result == CombatResult.AttackerKilled) || (result == CombatResult.DefenderKilled)) {
-				var (dead, alive) = (result == CombatResult.AttackerKilled) ? (attacker, defender) : (defender, attacker);
-				alive.RollToPromote(dead);
-				await dead.animateAsync(MapUnit.AnimatedAction.DEATH);
-				dead.RemoveFromPlay();
-			}
-
-			if (result.DefenderWon())
-				defender.facingDirection = defenderOriginalDirection;
-
-			return result;
-		}
-
-		public bool canBombard() {
-			return unitType.actions.Contains(UnitAction.Bombard);
-		}
-
-		public bool canBombardTile(Tile tile) {
-			if (unitType.bombard == 0)
-				return false;
-
-			if (tile.HasImprovements)
-				return true;
-
-			MapUnit target = tile.FindTopDefender(this);
-			if (target.owner == owner)
-				return false;
-
-			if (target != MapUnit.NONE)
-				return true;
-
-			if (tile.HasCity() && tile.cityAtTile.owner != owner)
-				return true;
-
-			return false;
-		}
-
-
-		public async Task bombard(Tile tile) {
-			// Could check canBombardTile(..) again, but no need really
-
-			MapUnit target = tile.FindTopDefender(this);
-
-			var hasTargetUnit = target != MapUnit.NONE && target.owner != owner;
-			var hasForeignCity = tile.HasCity() && tile.cityAtTile.owner != owner;
-			var hasCityWalls = hasForeignCity && tile.cityAtTile.GetBuildings().Any(b => b.building.providesWalls);
-			var hasTileImprovements = tile.HasImprovements;
-
-			if (!(hasTargetUnit || hasTileImprovements || hasForeignCity))
-				return; // Nothing to bombard
-
-			var unitOriginalOrientation = facingDirection;
-			facingDirection = location.directionTo(tile);
-
-			if (hasCityWalls)
-				await bombardCityWalls(tile);
-			else if (hasTargetUnit)
-				await bombardUnits(tile, target);
-			else if (hasForeignCity)
-				await bombardCity(tile);
-			else
-				await bombardTileImprovements(tile);
-
-			facingDirection = unitOriginalOrientation;
-		}
-
-		private async Task bombardUnits(Tile tile, MapUnit target) {
-			// TODO: Make configurable
-
-			var hitCount = 0;
-
-			foreach (var fire in Enumerable.Range(0, unitType.rateOfFire)) {
-				// TODO: Figure out the bombard defense that walls grant.
-				double bombardStrength  = StrengthVersus(target, CombatRole.Bombard, facingDirection);
-				double defenderStrength = target.StrengthVersus(this, CombatRole.BombardDefense, facingDirection);
-				double attackerOdds = bombardStrength / (bombardStrength + defenderStrength);
-				if (Double.IsNaN(attackerOdds))
-					return;
-
-				// TODO: Lethal/non-lethal bombardment
-				var isPotentiallyLethal = target.hitPointsRemaining == 1;
-
-				await animateAsync(MapUnit.AnimatedAction.ATTACK1);
-				movementPoints.onUnitMove(1);
-				if (GameData.rng.NextDouble() < attackerOdds && !isPotentiallyLethal) {
-					hitCount += 1;
-					target.hitPointsRemaining -= 1;
-					await tile.AnimateAsync(AnimatedEffect.Hit3);
-				} else
-					await tile.AnimateAsync(AnimatedEffect.Miss);
-
-				if (target.hitPointsRemaining <= 0) {
-					RollToPromote(target);
-					await target.animateAsync(MapUnit.AnimatedAction.DEATH);
-					target.RemoveFromPlay();
-					break; // Target destroyed, skip remaining fire -- TODO: Re-target?
-				}
-			}
-
-			if (owner.isHuman) {
-				if (hitCount > 0)
-					new MsgShowTemporaryPopup($"Artillery bombardment successful! Enemy units injured.", tile).send();
-				else
-					new MsgShowTemporaryPopup($"Artillery bombardment failed.", tile).send();
-			}
-		}
-
-		private async Task bombardCityWalls(Tile tile) {
-			// CF Civilopedia: City walls have a land bombardment defense of 8
-			// CF Civilopedia: Coastal defences have a land bombardment defense of 8
-			// Anecdotal: "City walls are hit first."
-			// TODO: Make configurable
-
-			const int wallDefence = 8;
-
-			var hitCount = 0;
-
-			var walls = tile.cityAtTile.GetBuildings().First(b => b.building.providesWalls);
-
-			foreach (var fire in Enumerable.Range(0, unitType.rateOfFire)) {
-				double bombardStrength  = StrengthVersus(null, CombatRole.Bombard, facingDirection);
-				double defenderStrength = wallDefence;
-				double attackerOdds = bombardStrength / (bombardStrength + defenderStrength);
-				if (Double.IsNaN(attackerOdds))
-					return;
-
-				await RunAnimatedBombard(tile, attackerOdds, () => {
-					hitCount += 1;
-					tile.cityAtTile.RemoveBuilding(walls);
-				});
-			}
-
-			if (owner.isHuman) {
-				if (hitCount > 0)
-					new MsgShowTemporaryPopup($"Artillery bombardment successful! Walls destroyed.", tile).send();
-				else
-					new MsgShowTemporaryPopup($"Artillery bombardment failed.", tile).send();
-			}
-		}
-
-		private async Task RunAnimatedBombard(Tile tile, double attackerOdds, Action callback) {
-			await animateAsync(MapUnit.AnimatedAction.ATTACK1);
-			movementPoints.onUnitMove(1);
-			if (GameData.rng.NextDouble() < attackerOdds) {
-				await tile.AnimateAsync(AnimatedEffect.Hit3);
-				callback();
-			} else
-				await tile.AnimateAsync(AnimatedEffect.Miss);
-		}
-
-		private async Task bombardCity(Tile tile) {
-			// Anecdotal: If there are no units left to hit, then citizens or buildings are hit, apparently with same probability.
-			// Anecdotal: "buildings (if I remember correctly) have a defense value of 16"
-			// Anecdotal: It seems population is killed off more quickly than buildings.
-			// TODO: Make configurable
-
-			const int buildingDefence = 16;
-			const int populationDefence = 12;
-			const float buildingOrPopulationOdds = 0.5f;
-
-			var targetBuildings = GameData.rng.NextDouble() <= buildingOrPopulationOdds;
-			var defence = targetBuildings ? buildingDefence : populationDefence;
-			var destroyMsg = targetBuildings ? "Destroyed city population." : "Destroyed a building.";
-			Action remover = targetBuildings
-				? () =>
-				{
-					var building = tile.cityAtTile.GetBuildings()
-						.OrderBy(x => GameData.rng.Next()).FirstOrDefault();
-					tile.cityAtTile.RemoveBuilding(building);
-				}
-			: () =>
-				{
-					tile.cityAtTile.RemoveRandomCitizen();
-				};
-
-			var hitCount = 0;
-
-			foreach (var fire in Enumerable.Range(0, unitType.rateOfFire)) {
-				double bombardStrength  = StrengthVersus(null, CombatRole.Bombard, facingDirection);
-				double defenderStrength = defence;
-				double attackerOdds = bombardStrength / (bombardStrength + defenderStrength);
-				if (Double.IsNaN(attackerOdds))
-					return;
-
-				await RunAnimatedBombard(tile, attackerOdds, () => {
-					hitCount += 1;
-					remover();
-				});
-			}
-
-			if (owner.isHuman) {
-				if (hitCount > 0)
-					new MsgShowTemporaryPopup($"Artillery bombardment successful! {destroyMsg}", tile).send();
-				else
-					new MsgShowTemporaryPopup($"Artillery bombardment failed.", tile).send();
-			}
-		}
-
-		private async Task bombardTileImprovements(Tile tile) {
-			// Anecdotal: "arty seems to wipe out improvement on 75% or more of the shots"
-			// ==> Artillery.bombard : 12 --> TileImprovement.Defense : 3
-			// TODO: Make configurable
-
-			const int tileImprovementDefence = 3;
-
-			var hitCount = 0;
-
-			var improvement = tile.overlays.GetImprovements()
-				.OrderBy(x => GameData.rng.Next()).FirstOrDefault();
-
-			foreach (var fire in Enumerable.Range(0, unitType.rateOfFire)) {
-				double bombardStrength  = StrengthVersus(null, CombatRole.Bombard, facingDirection);
-				double defenderStrength = tileImprovementDefence;
-				double attackerOdds = bombardStrength / (bombardStrength + defenderStrength);
-				if (Double.IsNaN(attackerOdds))
-					return;
-
-				await RunAnimatedBombard(tile, attackerOdds, () => {
-					hitCount += 1;
-					tile.overlays.Remove(improvement);
-					// TODO: Re-target?
-				});
-			}
-
-			if (owner.isHuman) {
-				if (hitCount > 0)
-					new MsgShowTemporaryPopup($"Artillery bombardment successful! Destroyed {improvement?.key}.", tile).send();
-				else
-					new MsgShowTemporaryPopup($"Artillery bombardment failed.", tile).send();
-			}
-		}
-
 		public int HealRateAt(Tile location) {
 			GameData gD = EngineStorage.gameData;
 			City city = location.cityAtTile;
@@ -711,73 +369,6 @@ namespace C7GameData {
 				return 0;
 			return gD.healRateInNeutralField;
 			// TODO: Consider friendly/neutral/enemy territory once that's implemented, barracks, the Red Cross
-		}
-
-		public void OnBeginTurn(bool skipTurn = false) {
-			int maxMP = unitType.movement;
-			if (movementPoints.remaining >= maxMP && !skipTurn) {
-				int maxHP = maxHitPoints;
-				if (hitPointsRemaining < maxHP)
-					hitPointsRemaining += HealRateAt(location);
-				if (hitPointsRemaining > maxHP)
-					hitPointsRemaining = maxHP;
-			}
-
-			if (skipTurn) {
-				movementPoints.skipTurn();
-			} else {
-				movementPoints.reset(maxMP);
-			}
-
-			defensiveBombardsRemaining = 1;
-		}
-
-		public void OnEnterTile(Tile tile) {
-			//Add to player knowledge of tiles
-			owner.tileKnowledge.AddTilesToKnown(tile);
-
-			// Disperse barb camp
-			if (tile.hasBarbarianCamp && !owner.isBarbarians) {
-				EngineStorage.gameData.map.barbarianCamps.Remove(tile);
-				tile.hasBarbarianCamp = false;
-				animate(MapUnit.AnimatedAction.VICTORY);
-
-				// TODO: make this configurable
-				owner.gold += 25;
-				if (owner.isHuman) {
-					new MsgShowMilitaryAdvisorPopup($"We cleared a barbarian encampment and earned 25 gold!", happy: true).send();
-				}
-			}
-
-			// Destroy the enemy city on the tile unless we're the barbarians,
-			// in which case we'll just take some gold.
-			if (tile.HasCity() && !owner.IsAtPeaceWith(tile.cityAtTile.owner)) {
-				if (owner.isBarbarians) {
-					// TODO: Add rules for how much gold is taken.
-					int goldTaken = tile.cityAtTile.owner.gold / 4;
-					tile.cityAtTile.owner.gold -= goldTaken;
-					this.RemoveFromPlay();
-					if (tile.cityAtTile.owner.isHuman) {
-						new MsgShowMilitaryAdvisorPopup($"Barbarians have stolen {goldTaken} gold from our cities!\nWe need a stronger military.", happy: false).send();
-					}
-				} else {
-					CityInteractions.DestroyCity(tile.XCoordinate, tile.YCoordinate);
-				}
-			}
-
-			// Check to see if we've discovered a new civ.
-			//
-			// TODO: this should really be based on interactions with our "visible"
-			// tiles. Also civ3 only counts border-based discovery from rank 1
-			// tiles, not rank 2+.
-			foreach (Tile t in tile.neighbors.Values) {
-				if (t.unitsOnTile.Count > 0 && owner != t.unitsOnTile[0].owner) {
-					owner.EnsureRelationshipExists(t.unitsOnTile[0].owner);
-				}
-				if (t.owningCity != null && owner != t.owningCity.owner) {
-					owner.EnsureRelationshipExists(t.owningCity.owner);
-				}
-			}
 		}
 
 		public enum Intent {
@@ -1025,159 +616,6 @@ namespace C7GameData {
 			return tile.HasCity() && tile.cityAtTile.owner == player;
 		}
 
-		/// <summary>
-		/// Moves the unit in the given direction
-		/// </summary>
-		/// <param name="unit"></param>
-		/// <param name="dir">Which direction to move, e.g. northeast, west, etc.</param>
-		/// <param name="wait">Whether the method should wait to return until animations complete</param>
-		/// <returns>True if the unit is alive after the movement, false otherwise</returns>
-		/// <exception cref="Exception"></exception>
-		public async Task<bool> move(TileDirection dir, bool wait = false) {
-			(int dx, int dy) = dir.toCoordDiff();
-
-			Tile newLoc = EngineStorage.gameData.map.tileAt(dx + location.XCoordinate, dy + location.YCoordinate);
-
-			var canMove = (newLoc != Tile.NONE) && this.CanEnter(newLoc) && (movementPoints.canMove);
-			if (!canMove) return false;
-
-			facingDirection = dir;
-			wake();
-
-			// Trigger combat if the tile we're moving into has an enemy  Or if this unit can't fight, do nothing.
-			MapUnit defender = newLoc.FindTopDefender(this);
-			if (defender != MapUnit.NONE && !owner.IsAtPeaceWith(defender.owner)) {
-				if (unitType.attack <= 0) {
-					return true;
-				}
-
-				CombatResult combatResult = await fight(defender);
-				this.path = TilePath.NONE;
-				// If we were killed then of course there's nothing more to do. If the combat couldn't happen for whatever
-				// reason, just give up on trying to move.
-				if (combatResult == CombatResult.AttackerKilled) {
-					return false;
-				}
-				if (combatResult == CombatResult.Impossible) {
-					return true;
-				}
-
-				// If the enemy was defeated, check if there is another enemy on the tile. If so we can't complete the move
-				// but still pay one movement point for the combat.
-				if (combatResult == CombatResult.DefenderKilled || combatResult == CombatResult.DefenderRetreated) {
-					this.movementPoints.onUnitMove(1);
-					if (newLoc.FindTopDefender(this) != MapUnit.NONE) {
-						this.facingDirection = this.facingDirection.reversed();
-						return true;
-					}
-
-					// Similarly if we retreated, pay one MP for the combat but don't move.
-				} else if (combatResult == CombatResult.AttackerRetreated) {
-					this.movementPoints.onUnitMove(1);
-					this.facingDirection = this.facingDirection.reversed();
-					return true;
-				}
-			}
-
-			facingDirection = dir;
-			float movementCost = TilePath.GetMovementCost(this.owner, location, dir, newLoc);
-
-			// Leave old tile
-			if (!location.unitsOnTile.Remove(this))
-				throw new System.Exception("Failed to remove unit from tile it's supposed to be on");
-
-			// Move transported units, too
-			if (CanTransport()) {
-				var transported = location.unitsOnTile
-					.Where(u => u.IsLoadedIn(this)).ToList();
-
-				foreach (var tu in transported) {
-					if (!location.unitsOnTile.Remove(tu))
-						throw new System.Exception("Failed to remove unit from tile during transport move");
-					newLoc.unitsOnTile.Add(tu);
-					tu.location = newLoc;
-				}
-			}
-
-			TryBoardingTransportOnTile(newLoc);
-			TryUnboardingTransportToTile(newLoc);
-
-			// Enter new tile
-			// Make sure the unit is on the new location before claiming we have entered the tile
-			newLoc.unitsOnTile.Add(this);
-			location = newLoc;
-			OnEnterTile(newLoc);
-
-			if (wait)
-				await animateAsync(MapUnit.AnimatedAction.RUN);
-			else
-				animate(MapUnit.AnimatedAction.RUN);
-
-			movementPoints.onUnitMove(movementCost);
-
-			return true;
-		}
-
-		public void TryBoardingTransportOnTile(Tile newLoc) {
-			var enteringCity = newLoc.HasCity() && newLoc != location;
-			if (enteringCity || !CanBoardTransportOnTile(newLoc))
-				return;
-
-			var t = SelectTransportToBoard(newLoc);
-			BoardTransport(t);
-		}
-
-		public void TryUnboardingTransportToTile(Tile newLoc) {
-			if (!CanUnboardTransportToTile(newLoc))
-				return;
-
-			var t = FindTransportToUnboard(this.location, this.loadedOnUnitId);
-			UnboardTransport(t);
-		}
-
-		public void BoardTransport(MapUnit t) {
-			if (t == null) {
-				// TODO: throw new System.Exception("Failed to find a transport to move to");
-				Log.Warning("Failed to find a transport to board");
-				return;
-			}
-			t.board(this);
-			isFortified = true;
-			ResetFacingDirection();
-			if (this.owner.isHuman)
-				new MsgUnitMoved(this).send();
-		}
-
-		public void UnboardTransport(MapUnit t) {
-			if (t == null) {
-				// TODO: throw new System.Exception("Failed to find the transport to unboard from");
-				Log.Warning("Failed to find a transport to unboard");
-				return;
-			}
-			t.unboard(this);
-			wake();
-			if (this.owner.isHuman)
-				new MsgUnitMoved(this).send();
-		}
-
-		/// <summary>
-		/// Boards unit into this transport
-		/// </summary>
-		/// <param name="mapUnit">The unit to load on a transport</param>
-		private void board(MapUnit mapUnit) {
-			mapUnit.loadedOnUnitId = this.id;
-			// TODO: consume moves?
-		}
-
-		/// <summary>
-		/// Unloads a unit from this transport
-		/// </summary>
-		/// <param name="mapUnit">The unit to unload from a transport</param>
-		private void unboard(MapUnit mapUnit) {
-			mapUnit.loadedOnUnitId = null;
-			// TODO: consume moves?
-		}
-
 		private float SumWorkerProgress(Tile tile, Terraform workerJob) {
 			float result = 0;
 			foreach (MapUnit unit in tile.unitsOnTile) {
@@ -1205,63 +643,6 @@ namespace C7GameData {
 			return (int)Math.Ceiling(remainingTerraformCost / combinedWorkerSpeed);
 		}
 
-		public async Task PerformBusyAction() {
-			if (isFortified) {
-				return;
-			}
-
-			if (path != null && path.PathLength() > 0) {
-				await moveAlongPath();
-				return;
-			}
-
-			if (isAutomated) {
-				// workers contribute their work at the end of the turn, not when assigned
-				if (this.unitType.isWorker && WorkerJob != null) {
-					return;
-				}
-				playAutomatedTurn();
-				return;
-			}
-		}
-
-		public async Task PerformEndOfTurnAction() {
-			// Busy Worker
-			if (WorkerJob != null) {
-				WorkerProgressTowardsJob += workerSpeed();
-				movementPoints.onConsumeAll();
-
-				// See if this worker finished the job.
-				if ((int)SumWorkerProgress(location, WorkerJob) >= GetWorkerJobCost(location, WorkerJob)) {
-					location.FinishWorkerJob(WorkerJob);
-				}
-			}
-		}
-
-		public async Task moveAlongPath() {
-			while (movementPoints.canMove && path?.PathLength() > 0) {
-				TileDirection dir = location.directionTo(path.Next());
-				await move(dir, true); //TODO: don't wait on last move animation?
-			}
-		}
-
-		public async Task setUnitPath(TilePath path) {
-			this.path = path;
-			await moveAlongPath();
-		}
-
-		public void skipTurn() {
-			movementPoints.skipTurn();
-		}
-
-		public async Task Disband() {
-			await EngineStorage.gameData.DisbandUnit(this);
-		}
-
-		public void RemoveFromPlay() {
-			EngineStorage.gameData.RemoveUnit(this);
-		}
-
 		public bool canBuildCity() {
 			if (!unitType.actions.Contains(UnitAction.BuildCity)) {
 				return false;
@@ -1270,22 +651,6 @@ namespace C7GameData {
 				return false;
 			}
 			return location.neighbors.Values.All(tile => !tile.HasCity());
-		}
-
-		public async Task<City?> buildCity(string cityName) {
-			if (!canBuildCity()) {
-				log.Warning($"can't build city at {location}");
-				return null;
-			}
-
-			await animateAsync(MapUnit.AnimatedAction.BUILD);
-
-			// TODO: Need to check somewhere that this unit is allowed to build a city on its current tile. Either do that here or in every caller
-			// (probably best to just do it here).
-			City city = CityInteractions.BuildCity(location, owner, cityName);
-			this.RemoveFromPlay();
-
-			return city;
 		}
 
 		public bool CanPerformTerraformAction(Terraform terraform) {
@@ -1299,32 +664,6 @@ namespace C7GameData {
 			return containsTerraform && meetsRequirements && !hasCity;
 		}
 
-		// entry point for "manual" job assignment
-		public void PerformTerraformAction(Terraform terraform) {
-			if (!CanPerformTerraformAction(terraform)) {
-				log.Warning($"can't perform {terraform.Name} by {this}");
-				return;
-			}
-			WorkerJob = terraform;
-
-			if (terraform.Animation is AnimatedAction animation)
-				animate(animation, AnimationEnding.Repeat);
-
-			movementPoints.onConsumeAll();
-
-			// See if this worker finished the job.
-			var terraformProgress = this.SumWorkerProgress(this.location, this.WorkerJob);
-			var turnProgress = this.location.GetCurrentUnaccountedJobProgress(terraform);
-			var totalCost = (float)GetWorkerJobCost(this.location, this.WorkerJob);
-
-			if (terraformProgress + turnProgress == totalCost) {
-				location.FinishWorkerJob(WorkerJob);
-			}
-
-			wake();
-			_ = PerformBusyAction();
-		}
-
 		public float workerSpeed() {
 			float progressPerTurn = this.IsCaptive() ? JOB_PROGRESS_SLAVE : JOB_PROGRESS_WORKER;
 			if (owner.civilization.traits.Contains(Civilization.Trait.Industrious)) {
@@ -1336,62 +675,15 @@ namespace C7GameData {
 		public void resetWorkerJob() {
 			WorkerJob = null;
 			WorkerProgressTowardsJob = 0;
-			animate(MapUnit.AnimatedAction.BLANK, AnimationEnding.Repeat);
+			animate(AnimatedAction.BLANK, AnimationEnding.Repeat);
 		}
 
 		public bool canAutomate() {
 			return unitType.actions.Contains(UnitAction.Automate);
 		}
 
-		public void automate() {
-			wake();
-			isAutomated = true;
-			WorkerAIData? maybeAiData = WorkerAI.MakeAiData(this, owner);
-			if (maybeAiData == null) {
-				log.Information($"Could not find anything to automate for {this} owned by {owner}");
-				isAutomated = false;
-				return;
-			}
-			currentAI = new WorkerAI(maybeAiData);
-			playAutomatedTurn();
-		}
-
 		public bool canExplore() {
 			return unitType.actions.Contains(UnitAction.Explore);
-		}
-
-		public void explore() {
-			wake();
-			isAutomated = true;
-			ExplorerAIData? maybeAiData = ExplorerAI.MaybeMakeAiData(this, owner);
-			if (maybeAiData == null) {
-				log.Information($"Could not find anything to explore for {this} owned by {owner}");
-				isAutomated = false;
-				return;
-			}
-			currentAI = new ExplorerAI(maybeAiData);
-			playAutomatedTurn();
-		}
-
-		public async void playAutomatedTurn() {
-			if (currentAI == null) {
-				// TODO: handle giving automated workers from loaded saves the
-				// proper unit ai.
-				isAutomated = false;
-				return;
-			}
-			UnitAI.Result result = await currentAI.PlayTurn(owner, this);
-			if (result == UnitAI.Result.Done) {
-				if (currentAI is WorkerAI) {
-					automate();
-				} else if (currentAI is ExplorerAI) {
-					explore();
-				}
-			}
-
-			// Do nothing after an error so control returns to the player, and
-			// nothing after an progress result, so that next turn continues the
-			// AI action.
 		}
 
 		public List<Terraform> GetAvailableTerraforms() {
@@ -1435,28 +727,6 @@ namespace C7GameData {
 			// unit.availableActions.Add("rename");
 
 			return result;
-		}
-	}
-
-	public struct TileProbe {
-		public bool AllowCombat { get; init; }
-		public bool AllowWarDeclaration { get; init; }
-		public bool RaiseNotice { get; init; }
-
-		public static TileProbe MoveNonAggroProbe() {
-			return new TileProbe();
-		}
-
-		public static TileProbe MoveAggroProbe() {
-			return new TileProbe() { AllowCombat = true };
-		}
-
-		public static TileProbe MoveAggroWithNoticeProbe() {
-			return new TileProbe() { AllowCombat = true, RaiseNotice = true };
-		}
-
-		public static TileProbe DeclareWarProbe() {
-			return new TileProbe() { AllowCombat = true, AllowWarDeclaration = true };
 		}
 	}
 }

--- a/C7Engine/C7GameData/MapUnit_Actions.cs
+++ b/C7Engine/C7GameData/MapUnit_Actions.cs
@@ -1,0 +1,495 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using C7Engine;
+using C7GameData.AIData;
+
+namespace C7GameData;
+
+public partial class MapUnit {
+	public void OnBeginTurn(bool skipTurn = false) {
+		int maxMP = unitType.movement;
+		if (movementPoints.remaining >= maxMP && !skipTurn) {
+			int maxHP = maxHitPoints;
+			if (hitPointsRemaining < maxHP)
+				hitPointsRemaining += HealRateAt(location);
+			if (hitPointsRemaining > maxHP)
+				hitPointsRemaining = maxHP;
+		}
+
+		if (skipTurn) {
+			movementPoints.skipTurn();
+		} else {
+			movementPoints.reset(maxMP);
+		}
+
+		defensiveBombardsRemaining = 1;
+	}
+
+	public void OnEnterTile(Tile tile) {
+		//Add to player knowledge of tiles
+		owner.tileKnowledge.AddTilesToKnown(tile);
+
+		// Disperse barb camp
+		if (tile.hasBarbarianCamp && !owner.isBarbarians) {
+			EngineStorage.gameData.map.barbarianCamps.Remove(tile);
+			tile.hasBarbarianCamp = false;
+			animate(MapUnit.AnimatedAction.VICTORY);
+
+			// TODO: make this configurable
+			owner.gold += 25;
+			if (owner.isHuman) {
+				new MsgShowMilitaryAdvisorPopup($"We cleared a barbarian encampment and earned 25 gold!", happy: true).send();
+			}
+		}
+
+		// Destroy the enemy city on the tile unless we're the barbarians,
+		// in which case we'll just take some gold.
+		if (tile.HasCity() && !owner.IsAtPeaceWith(tile.cityAtTile.owner)) {
+			if (owner.isBarbarians) {
+				// TODO: Add rules for how much gold is taken.
+				int goldTaken = tile.cityAtTile.owner.gold / 4;
+				tile.cityAtTile.owner.gold -= goldTaken;
+				this.RemoveFromPlay();
+				if (tile.cityAtTile.owner.isHuman) {
+					new MsgShowMilitaryAdvisorPopup($"Barbarians have stolen {goldTaken} gold from our cities!\nWe need a stronger military.", happy: false).send();
+				}
+			} else {
+				CityInteractions.DestroyCity(tile.XCoordinate, tile.YCoordinate);
+			}
+		}
+
+		// Check to see if we've discovered a new civ.
+		//
+		// TODO: this should really be based on interactions with our "visible"
+		// tiles. Also civ3 only counts border-based discovery from rank 1
+		// tiles, not rank 2+.
+		foreach (Tile t in tile.neighbors.Values) {
+			if (t.unitsOnTile.Count > 0 && owner != t.unitsOnTile[0].owner) {
+				owner.EnsureRelationshipExists(t.unitsOnTile[0].owner);
+			}
+			if (t.owningCity != null && owner != t.owningCity.owner) {
+				owner.EnsureRelationshipExists(t.owningCity.owner);
+			}
+		}
+	}
+
+	public void Fortify() {
+		ResetFacingDirection();
+		isFortified = true;
+		animate(MapUnit.AnimatedAction.FORTIFY);
+	}
+
+	public void Wake() {
+		isFortified = false;
+	}
+
+	public void Automate() {
+		Wake();
+		isAutomated = true;
+		WorkerAIData? maybeAiData = WorkerAI.MakeAiData(this, owner);
+		if (maybeAiData == null) {
+			log.Information($"Could not find anything to automate for {this} owned by {owner}");
+			isAutomated = false;
+			return;
+		}
+		currentAI = new WorkerAI(maybeAiData);
+		PlayAutomatedTurn();
+	}
+
+	public void Explore() {
+		Wake();
+		isAutomated = true;
+		ExplorerAIData? maybeAiData = ExplorerAI.MaybeMakeAiData(this, owner);
+		if (maybeAiData == null) {
+			log.Information($"Could not find anything to explore for {this} owned by {owner}");
+			isAutomated = false;
+			return;
+		}
+		currentAI = new ExplorerAI(maybeAiData);
+		PlayAutomatedTurn();
+	}
+
+	public void SkipTurn() {
+		movementPoints.skipTurn();
+	}
+
+	public async Task Disband() {
+		await EngineStorage.gameData.DisbandUnit(this);
+	}
+
+	public void RemoveFromPlay() {
+		EngineStorage.gameData.RemoveUnit(this);
+	}
+
+	public async Task MoveAlongPath() {
+		while (movementPoints.canMove && path?.PathLength() > 0) {
+			TileDirection dir = location.directionTo(path.Next());
+			await Move(dir, true); //TODO: don't wait on last move animation?
+		}
+	}
+
+	public async Task SetUnitPath(TilePath path) {
+		this.path = path;
+		await MoveAlongPath();
+	}
+
+	public async void PlayAutomatedTurn() {
+		if (currentAI == null) {
+			// TODO: handle giving automated workers from loaded saves the
+			// proper unit ai.
+			isAutomated = false;
+			return;
+		}
+		UnitAI.Result result = await currentAI.PlayTurn(owner, this);
+		if (result == UnitAI.Result.Done) {
+			if (currentAI is WorkerAI) {
+				Automate();
+			} else if (currentAI is ExplorerAI) {
+				Explore();
+			}
+		}
+
+		// Do nothing after an error so control returns to the player, and
+		// nothing after an progress result, so that next turn continues the
+		// AI action.
+	}
+
+	public async Task PerformBusyAction() {
+		if (isFortified) {
+			return;
+		}
+
+		if (path != null && path.PathLength() > 0) {
+			await MoveAlongPath();
+			return;
+		}
+
+		if (isAutomated) {
+			// workers contribute their work at the end of the turn, not when assigned
+			if (this.unitType.isWorker && WorkerJob != null) {
+				return;
+			}
+			PlayAutomatedTurn();
+			return;
+		}
+	}
+
+	public async Task PerformEndOfTurnAction() {
+		// Busy Worker
+		if (WorkerJob != null) {
+			WorkerProgressTowardsJob += workerSpeed();
+			movementPoints.onConsumeAll();
+
+			// See if this worker finished the job.
+			if ((int)SumWorkerProgress(location, WorkerJob) >= GetWorkerJobCost(location, WorkerJob)) {
+				location.FinishWorkerJob(WorkerJob);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Moves the unit in the given direction
+	/// </summary>
+	/// <param name="unit"></param>
+	/// <param name="dir">Which direction to move, e.g. northeast, west, etc.</param>
+	/// <param name="wait">Whether the method should wait to return until animations complete</param>
+	/// <returns>True if the unit is alive after the movement, false otherwise</returns>
+	/// <exception cref="Exception"></exception>
+	public async Task<bool> Move(TileDirection dir, bool wait = false) {
+		(int dx, int dy) = dir.toCoordDiff();
+
+		Tile newLoc = EngineStorage.gameData.map.tileAt(dx + location.XCoordinate, dy + location.YCoordinate);
+
+		var canMove = (newLoc != Tile.NONE) && this.CanEnter(newLoc) && (movementPoints.canMove);
+		if (!canMove) return false;
+
+		facingDirection = dir;
+		Wake();
+
+		// Trigger combat if the tile we're moving into has an enemy  Or if this unit can't fight, do nothing.
+		MapUnit defender = newLoc.FindTopDefender(this);
+		if (defender != MapUnit.NONE && !owner.IsAtPeaceWith(defender.owner)) {
+			if (unitType.attack <= 0) {
+				return true;
+			}
+
+			CombatResult combatResult = await Fight(defender);
+			this.path = TilePath.NONE;
+			// If we were killed then of course there's nothing more to do. If the combat couldn't happen for whatever
+			// reason, just give up on trying to move.
+			if (combatResult == CombatResult.AttackerKilled) {
+				return false;
+			}
+			if (combatResult == CombatResult.Impossible) {
+				return true;
+			}
+
+			// If the enemy was defeated, check if there is another enemy on the tile. If so we can't complete the move
+			// but still pay one movement point for the combat.
+			if (combatResult == CombatResult.DefenderKilled || combatResult == CombatResult.DefenderRetreated) {
+				this.movementPoints.onUnitMove(1);
+				if (newLoc.FindTopDefender(this) != MapUnit.NONE) {
+					this.facingDirection = this.facingDirection.reversed();
+					return true;
+				}
+
+				// Similarly if we retreated, pay one MP for the combat but don't move.
+			} else if (combatResult == CombatResult.AttackerRetreated) {
+				this.movementPoints.onUnitMove(1);
+				this.facingDirection = this.facingDirection.reversed();
+				return true;
+			}
+		}
+
+		facingDirection = dir;
+		float movementCost = TilePath.GetMovementCost(this.owner, location, dir, newLoc);
+
+		// Leave old tile
+		if (!location.unitsOnTile.Remove(this))
+			throw new System.Exception("Failed to remove unit from tile it's supposed to be on");
+
+		// Move transported units, too
+		if (CanTransport()) {
+			var transported = location.unitsOnTile
+					.Where(u => u.IsLoadedIn(this)).ToList();
+
+			foreach (var tu in transported) {
+				if (!location.unitsOnTile.Remove(tu))
+					throw new System.Exception("Failed to remove unit from tile during transport move");
+				newLoc.unitsOnTile.Add(tu);
+				tu.location = newLoc;
+			}
+		}
+
+		TryBoardingTransportOnTile(newLoc);
+		TryUnboardingTransportToTile(newLoc);
+
+		// Enter new tile
+		// Make sure the unit is on the new location before claiming we have entered the tile
+		newLoc.unitsOnTile.Add(this);
+		location = newLoc;
+		OnEnterTile(newLoc);
+
+		if (wait)
+			await animateAsync(MapUnit.AnimatedAction.RUN);
+		else
+			animate(MapUnit.AnimatedAction.RUN);
+
+		movementPoints.onUnitMove(movementCost);
+
+		return true;
+	}
+
+	public async Task<CombatResult> Fight(MapUnit defender) {
+		var attacker = this;
+
+		// Set combat animation facing. We'll restore the defender's original facing direction at the end of the battle.
+		TileDirection attackerAttackDirection = attacker.location.directionTo(defender.location);
+		TileDirection defenderDefenseDirection = attackerAttackDirection.reversed();
+		var defenderOriginalDirection = defender.facingDirection;
+		attacker.facingDirection = attacker.GetAttackAnimationDirection(attackerAttackDirection);
+		defender.facingDirection = defender.GetAttackAnimationDirection(defenderDefenseDirection);
+
+		IEnumerable<StrengthBonus> attackBonuses  = attacker.ListStrengthBonusesVersus(defender, CombatRole.Attack , attackerAttackDirection),
+								   defenseBonuses = defender.ListStrengthBonusesVersus(attacker, CombatRole.Defense, attackerAttackDirection);
+
+		double attackerStrength = attacker.unitType.attack  * StrengthBonus.ListToMultiplier(attackBonuses),
+			   defenderStrength = defender.unitType.defense * StrengthBonus.ListToMultiplier(defenseBonuses);
+
+		log.Information($"Combat log: {attacker} ({attackerStrength}) attacking {defender} ({defenderStrength})");
+		log.Information($"\tAttacker: {attacker.unitType.name}, base strength {attacker.unitType.BaseStrength(CombatRole.Attack)}");
+		foreach (StrengthBonus bonus in attackBonuses)
+			log.Information($"\t\t+{100.0 * bonus.amount}%\t{bonus.description}");
+		log.Information($"\tDefender: {defender.unitType.name}, base strength {defender.unitType.BaseStrength(CombatRole.Defense)}");
+		foreach (StrengthBonus bonus in defenseBonuses)
+			log.Information($"\t\t+{100.0 * bonus.amount}%\t{bonus.description}");
+
+		CombatResult result = CombatResult.Impossible;
+
+		double attackerOdds = attackerStrength / (attackerStrength + defenderStrength);
+		if (Double.IsNaN(attackerOdds))
+			return result;
+
+		// Defensive bombard
+		MapUnit defensiveBombarder = MapUnit.NONE;
+		double defensiveBombarderStrength = 0.0;
+		foreach (MapUnit candidate in defender.location.unitsOnTile.Where(u => u != defender && !u.owner.IsAtPeaceWith(attacker.owner) && u.defensiveBombardsRemaining > 0)) {
+			double strength = candidate.StrengthVersus(attacker, CombatRole.DefensiveBombard, defenderDefenseDirection);
+			if (strength > defensiveBombarderStrength) {
+				defensiveBombarder = candidate;
+				defensiveBombarderStrength = strength;
+			}
+		}
+		// In the original game, defensive bombard does not trigger against attackers with 1 HP. See:
+		// https://github.com/C7-Game/Prototype/pull/250#discussion_r893051111
+		if (defensiveBombarder != MapUnit.NONE && attacker.hitPointsRemaining > 1) {
+			var dBOriginalDirection = defensiveBombarder.facingDirection;
+			TileDirection defensiveBombardDirection = defenderDefenseDirection;
+			defensiveBombarder.facingDirection = defensiveBombarder.GetAttackAnimationDirection(defensiveBombardDirection);
+
+			await defensiveBombarder.animateAsync(MapUnit.AnimatedAction.ATTACK1);
+
+			// dADB = defense Against Defensive Bombard
+			double dADB = attacker.StrengthVersus(defensiveBombarder, CombatRole.DefensiveBombardDefense, defensiveBombardDirection);
+			if (GameData.rng.NextDouble() < defensiveBombarderStrength / (defensiveBombarderStrength + dADB))
+				attacker.hitPointsRemaining -= 1;
+
+			defensiveBombarder.defensiveBombardsRemaining -= 1;
+			defensiveBombarder.facingDirection = dBOriginalDirection;
+		}
+
+		bool defenderEligibleToRetreat = defender.hitPointsRemaining > 1 && ! defender.location.HasCity();
+
+		// Do combat rounds
+		while (true) {
+			defender.animate(MapUnit.AnimatedAction.ATTACK1);
+			await attacker.animateAsync(MapUnit.AnimatedAction.ATTACK1);
+			if (GameData.rng.NextDouble() < attackerOdds) {
+				if (defenderEligibleToRetreat &&
+					defender.hitPointsRemaining == 1 &&
+					GameData.rng.NextDouble() < defender.RetreatChance(attacker, false)) {
+					// TODO: Defender retreat behavior requires some more work. There's an issue for it here:
+					// https://github.com/C7-Game/Prototype/issues/274
+					Tile retreatDestination = defender.location.neighbors[attackerAttackDirection];
+					if ((retreatDestination != Tile.NONE) && defender.CanEnter(retreatDestination)) {
+						await defender.Move(attackerAttackDirection, true);
+						result = CombatResult.DefenderRetreated;
+						break;
+					}
+				}
+				defender.hitPointsRemaining -= 1;
+				if (defender.hitPointsRemaining <= 0) {
+					result = CombatResult.DefenderKilled;
+					break;
+				}
+			} else {
+				if (attacker.hitPointsRemaining == 1 &&
+					GameData.rng.NextDouble() < attacker.RetreatChance(defender, true)) {
+					result = CombatResult.AttackerRetreated;
+					break;
+				}
+				attacker.hitPointsRemaining -= 1;
+				if (attacker.hitPointsRemaining <= 0) {
+					result = CombatResult.AttackerKilled;
+					break;
+				}
+			}
+		}
+
+		if ((result == CombatResult.AttackerKilled) || (result == CombatResult.DefenderKilled)) {
+			var (dead, alive) = (result == CombatResult.AttackerKilled) ? (attacker, defender) : (defender, attacker);
+			alive.RollToPromote(dead);
+			await dead.animateAsync(MapUnit.AnimatedAction.DEATH);
+			dead.RemoveFromPlay();
+		}
+
+		if (result.DefenderWon())
+			defender.facingDirection = defenderOriginalDirection;
+
+		return result;
+	}
+
+	public async Task<City?> BuildCity(string cityName) {
+		if (!canBuildCity()) {
+			log.Warning($"can't build city at {location}");
+			return null;
+		}
+
+		await animateAsync(MapUnit.AnimatedAction.BUILD);
+
+		// TODO: Need to check somewhere that this unit is allowed to build a city on its current tile. Either do that here or in every caller
+		// (probably best to just do it here).
+		City city = CityInteractions.BuildCity(location, owner, cityName);
+		this.RemoveFromPlay();
+
+		return city;
+	}
+
+	// entry point for "manual" job assignment
+	public void PerformTerraformAction(Terraform terraform) {
+		if (!CanPerformTerraformAction(terraform)) {
+			log.Warning($"can't perform {terraform.Name} by {this}");
+			return;
+		}
+		WorkerJob = terraform;
+
+		if (terraform.Animation is AnimatedAction animation)
+			animate(animation, AnimationEnding.Repeat);
+
+		movementPoints.onConsumeAll();
+
+		// See if this worker finished the job.
+		var terraformProgress = this.SumWorkerProgress(this.location, this.WorkerJob);
+		var turnProgress = this.location.GetCurrentUnaccountedJobProgress(terraform);
+		var totalCost = (float)GetWorkerJobCost(this.location, this.WorkerJob);
+
+		if (terraformProgress + turnProgress == totalCost) {
+			location.FinishWorkerJob(WorkerJob);
+		}
+
+		Wake();
+		_ = PerformBusyAction();
+	}
+
+	public void BoardTransport(MapUnit t) {
+		if (t == null) {
+			// TODO: throw new System.Exception("Failed to find a transport to move to");
+			log.Warning("Failed to find a transport to board");
+			return;
+		}
+		t.Board(this);
+		isFortified = true;
+		ResetFacingDirection();
+		if (this.owner.isHuman)
+			new MsgUnitMoved(this).send();
+	}
+
+	public void UnboardTransport(MapUnit t) {
+		if (t == null) {
+			// TODO: throw new System.Exception("Failed to find the transport to unboard from");
+			log.Warning("Failed to find a transport to unboard");
+			return;
+		}
+		t.Unboard(this);
+		Wake();
+		if (this.owner.isHuman)
+			new MsgUnitMoved(this).send();
+	}
+
+	public void TryBoardingTransportOnTile(Tile newLoc) {
+		var enteringCity = newLoc.HasCity() && newLoc != location;
+		if (enteringCity || !CanBoardTransportOnTile(newLoc))
+			return;
+
+		var t = SelectTransportToBoard(newLoc);
+		BoardTransport(t);
+	}
+
+	public void TryUnboardingTransportToTile(Tile newLoc) {
+		if (!CanUnboardTransportToTile(newLoc))
+			return;
+
+		var t = FindTransportToUnboard(this.location, this.loadedOnUnitId);
+		UnboardTransport(t);
+	}
+
+	/// <summary>
+	/// Boards unit into this transport
+	/// </summary>
+	/// <param name="mapUnit">The unit to load on a transport</param>
+	private void Board(MapUnit mapUnit) {
+		mapUnit.loadedOnUnitId = this.id;
+		// TODO: consume moves?
+	}
+
+	/// <summary>
+	/// Unloads a unit from this transport
+	/// </summary>
+	/// <param name="mapUnit">The unit to unload from a transport</param>
+	private void Unboard(MapUnit mapUnit) {
+		mapUnit.loadedOnUnitId = null;
+		// TODO: consume moves?
+	}
+}

--- a/C7Engine/C7GameData/MapUnit_Bombard.cs
+++ b/C7Engine/C7GameData/MapUnit_Bombard.cs
@@ -1,0 +1,293 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using C7Engine;
+
+namespace C7GameData {
+	public partial class MapUnit {
+		private List<AnimatedEffect> hitList = [AnimatedEffect.Hit, AnimatedEffect.Hit2, AnimatedEffect.Hit3, AnimatedEffect.Hit5];
+
+		public enum BombardTarget {
+			None,
+			City,
+			Unit,
+			Improvement
+		}
+
+		public bool HasBombardAbility() {
+			return this.unitType.actions.Contains(UnitAction.Bombard);
+		}
+
+		public bool CanBombardTile(Tile tile) {
+			return CanBombardTile(tile, out _);
+		}
+
+		/// <summary>
+		/// Whether this unit can bombard a tile, regardless of status, except locked alliance, because nothing can break it.<br/>
+		/// Locked alliances are more protective of tiles/units etc, than even our own;<br/>
+		/// While we can pillage our own tiles, we can't pillage a tile belonging to a locked ally.
+		/// </summary>
+		/// <param name="tile"></param>
+		/// <param name="bombardTarget"></param>
+		/// <returns></returns>
+		public bool CanBombardTile(Tile tile, out BombardTarget bombardTarget) {
+			bombardTarget = BombardTarget.None;
+
+			if (this.location.distanceTo(tile) > this.unitType.bombardRange)
+				return false;
+
+			if (this.unitType.bombard == 0)
+				return false;
+
+			if (tile.HasCity() && tile.cityAtTile.owner == this.owner)
+				return false;
+
+			if (tile.HasCity() && EngineStorage.gameData.AreInLockedPeace(this.owner, tile.cityAtTile.owner))
+				return false;
+
+			if (tile.HasCity())
+				bombardTarget = BombardTarget.City;
+
+			MapUnit target = tile.FindTopDefenderForBombard(this);
+
+			// TODO: Consider colony on neutral tile (allies && potential enemies)
+
+			if (tile.HasImprovements) {
+				if (target == NONE) {
+					if (tile.OwningPlayer() != null && EngineStorage.gameData.AreInLockedPeace(this.owner, tile.OwningPlayer()))
+						return false;
+				}
+
+				if (target != NONE) {
+					bombardTarget = BombardTarget.Unit;
+					if (EngineStorage.gameData.AreInLockedPeace(this.owner, target.owner))
+						return false;
+
+					if (target.IsCombatUnit() && target.owner != this.owner) {
+						return true;
+					}
+				}
+
+				if (tile.OwningPlayer() != null && EngineStorage.gameData.AreInLockedPeace(this.owner, tile.OwningPlayer()))
+					return false;
+
+				bombardTarget = BombardTarget.Improvement;
+			} else {
+				if (target != NONE) {
+					if (!target.IsCombatUnit())
+						return false;
+					if (target.IsCombatUnit() && target.owner == this.owner)
+						return false;
+					if (EngineStorage.gameData.AreInLockedPeace(this.owner, target.owner))
+						return false;
+
+					bombardTarget = BombardTarget.Unit;
+				}
+			}
+
+			if (bombardTarget == BombardTarget.None)
+				return false;
+
+			return true;
+		}
+
+		public async Task Bombard(Tile tile) {
+			// Could check canBombardTile(..) again, but no need really
+
+			MapUnit target = tile.FindTopDefenderForBombard(this);
+
+			var hasTargetUnit = target != NONE && target.owner != owner;
+			var hasForeignCity = tile.HasCity() && tile.cityAtTile.owner != owner;
+			var hasCityWalls = hasForeignCity && tile.cityAtTile.GetBuildings().Any(b => b.building.providesWalls);
+			var hasTileImprovements = tile.HasImprovements;
+
+			if (!(hasTargetUnit || hasTileImprovements || hasForeignCity))
+				return; // Nothing to bombard
+
+			facingDirection = location.directionTo(tile);
+
+			if (hasCityWalls)
+				await BombardCityWalls(tile);
+			else if (hasTargetUnit)
+				await BombardUnits(tile, target);
+			else if (hasForeignCity)
+				await BombardCity(tile);
+			else
+				await BombardTileImprovements(tile);
+		}
+
+		private async Task BombardCityWalls(Tile tile) {
+			// CF Civilopedia: City walls have a land bombardment defense of 8
+			// CF Civilopedia: Coastal defences have a land bombardment defense of 8
+			// Anecdotal: "City walls are hit first."
+			// TODO: Make configurable
+
+			const int wallDefence = 8;
+
+			var hitCount = 0;
+
+			var walls = tile.cityAtTile.GetBuildings().First(b => b.building.providesWalls);
+
+			double bombardStrength  = StrengthVersus(null, CombatRole.Bombard, facingDirection);
+			double defenderStrength = wallDefence;
+			double attackerOdds = bombardStrength / (bombardStrength + defenderStrength);
+			if (Double.IsNaN(attackerOdds))
+				return;
+
+			if (tile.cityAtTile.GetBuildings().Contains(walls)) {
+				await RunAnimatedBombard(tile, attackerOdds, () => {
+					hitCount += 1;
+					tile.cityAtTile.RemoveBuilding(walls);
+				});
+			}
+
+			TriggerPopUp(hitCount, tile, $"The Walls of {tile.cityAtTile.name} have been destroyed.");
+		}
+
+		private async Task BombardUnits(Tile tile, MapUnit target) {
+			// TODO: Make configurable
+
+			movementPoints.onUnitMove(1); // TODO: UNDO THIS, JUST FOR TESTING
+			await animateAsync(AnimatedAction.ATTACK1);
+
+			// TODO: Figure out the bombard defense that walls grant.
+			double bombardStrength  = StrengthVersus(target, CombatRole.Bombard, facingDirection);
+			double defenderStrength = target.StrengthVersus(this, CombatRole.BombardDefense, facingDirection);
+			double attackerOdds = bombardStrength / (bombardStrength + defenderStrength);
+			if (Double.IsNaN(attackerOdds))
+				return;
+
+			var tries = 0;
+			var hitCount = 0;
+
+			while (tries < unitType.rateOfFire) {
+				tries++;
+				if (target.hitPointsRemaining - hitCount <= 1 && tile.IsLand() && !this.unitType.isLandBombardmentLethal)
+					break;
+				if (target.hitPointsRemaining - hitCount <= 1 && tile.IsWater() && !this.unitType.isSeaBombardmentLethal)
+					break;
+
+				var r = GameData.rng.NextDouble();
+				if (r < attackerOdds) {
+					hitCount++;
+				}
+			}
+
+			if (hitCount > 0) {
+				for (int i = 0; i < hitCount; ++i) {
+					target.hitPointsRemaining -= 1;
+					await tile.AnimateAsync(this.hitList[GameData.rng.Next(0, hitList.Count)]);
+				}
+
+			} else
+				await tile.AnimateAsync(tile.IsWater() ? AnimatedEffect.WaterMiss : AnimatedEffect.Miss);
+
+			if (target.hitPointsRemaining <= 0) {
+				RollToPromote(target);
+				await target.animateAsync(AnimatedAction.DEATH, AnimationEnding.Pause);
+				target.RemoveFromPlay();
+				// Target destroyed, skip remaining fire -- TODO: Re-target?
+			}
+
+			TriggerPopUp(hitCount, tile, "Artillery bombardment successful! Enemy units injured.");
+		}
+
+		private async Task BombardCity(Tile tile) {
+			// Anecdotal: If there are no units left to hit, then citizens or buildings are hit, apparently with same probability.
+			// Anecdotal: "buildings (if I remember correctly) have a defense value of 16"
+			// Anecdotal: It seems population is killed off more quickly than buildings.
+			// TODO: Make configurable
+
+			const int buildingDefence = 16;
+			const int populationDefence = 12;
+			const float buildingOrPopulationOdds = 0.5f;
+
+			// TODO: probably not canon to exclude palace
+			List<CityBuilding> eligibleBuildingsForBombardment = tile.cityAtTile.GetBuildings().Where(b => !b.building.isCenterOfEmpire).ToList();
+
+			var targetBuildings = GameData.rng.NextDouble() <= buildingOrPopulationOdds && eligibleBuildingsForBombardment.Count > 0;
+			var defence = targetBuildings ? buildingDefence : populationDefence;
+			var destroyMsg = string.Empty;
+			Action remover = targetBuildings
+				? () =>
+				{
+					var building = eligibleBuildingsForBombardment
+						.OrderBy(x => GameData.rng.Next()).First();
+					tile.cityAtTile.RemoveBuilding(building);
+					destroyMsg = $"The {building.building.name} of {tile.cityAtTile.name} has been destroyed!";
+				}
+			: () =>
+				{
+					tile.cityAtTile.RemoveRandomCitizen();
+					destroyMsg = $"Some of {tile.cityAtTile.name}'s citizens have been killed!";
+				};
+
+			var hitCount = 0;
+
+			double bombardStrength  = StrengthVersus(null, CombatRole.Bombard, facingDirection);
+			double defenderStrength = defence;
+			double attackerOdds = bombardStrength / (bombardStrength + defenderStrength);
+			if (Double.IsNaN(attackerOdds))
+				return;
+
+			await RunAnimatedBombard(tile, attackerOdds, () => {
+				hitCount += 1;
+				remover();
+			});
+
+			TriggerPopUp(hitCount, tile, destroyMsg);
+		}
+
+		private async Task BombardTileImprovements(Tile tile) {
+			// Anecdotal: "arty seems to wipe out improvement on 75% or more of the shots"
+			// ==> Artillery.bombard : 12 --> TileImprovement.Defense : 3
+			// TODO: Make configurable
+
+			const int tileImprovementDefence = 3;
+
+			var hitCount = 0;
+
+			var improvement = tile.overlays.GetImprovements()
+				.OrderBy(x => GameData.rng.Next()).FirstOrDefault();
+
+			// Anecdotal, just by observing the game; I think rate of fire doesn't apply to improvements
+			double bombardStrength  = StrengthVersus(null, CombatRole.Bombard, facingDirection);
+			double defenderStrength = tileImprovementDefence;
+			double attackerOdds = bombardStrength / (bombardStrength + defenderStrength);
+			if (Double.IsNaN(attackerOdds))
+				return;
+
+			await RunAnimatedBombard(tile, attackerOdds, () => {
+				hitCount += 1;
+				// Remove top improvement
+				tile.overlays.Remove(improvement);
+				// "Replace" with downgraded improvement if it exists
+				tile.overlays.Add(improvement?.upgradesFrom);
+				// TODO: Re-target?
+			});
+
+			TriggerPopUp(hitCount, tile, $"Artillery bombardment successful! Destroyed {improvement?.key}.");
+		}
+
+		private async Task RunAnimatedBombard(Tile tile, double attackerOdds, Action callback) {
+			await animateAsync(AnimatedAction.ATTACK1);
+			movementPoints.onUnitMove(1);
+			if (GameData.rng.NextDouble() < attackerOdds) {
+				await tile.AnimateAsync(this.hitList[GameData.rng.Next(0, hitList.Count)]);
+				callback();
+			} else
+				await tile.AnimateAsync(tile.IsWater() ? AnimatedEffect.WaterMiss : AnimatedEffect.Miss);
+		}
+
+		private void TriggerPopUp(int hitCount, Tile tile, string successMessage) {
+			if (owner.isHuman) {
+				if (hitCount > 0)
+					new MsgShowTemporaryPopup(successMessage, tile).send();
+				else
+					new MsgShowTemporaryPopup($"Artillery bombardment failed.", tile).send();
+			}
+		}
+
+	}
+}

--- a/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
+++ b/C7Engine/C7GameData/Save/SaveUnitPrototype.cs
@@ -7,7 +7,9 @@ namespace C7GameData.Save {
 			RotateBeforeAttack,
 			CanCarryFootUnitsOnly,
 			CanCarryAircraft,
-			CanCarryTacticalMissiles
+			CanCarryTacticalMissiles,
+			LethalLandBombardment,
+			LethalSeaBombardment,
 		}
 
 		public string name { get; set; }

--- a/C7Engine/C7GameData/Tile.cs
+++ b/C7Engine/C7GameData/Tile.cs
@@ -806,20 +806,47 @@ namespace C7GameData {
 			return result;
 		}
 
+		public MapUnit FindTopDefenderForBombard(MapUnit opponent) {
+			return FindTopDefenderForBombard(this, opponent);
+		}
+
+		public MapUnit FindTopDefenderForBombard(Tile tile, MapUnit opponent) {
+			MapUnit target;
+			var combatUnits = tile.unitsOnTile.Where(u => u.IsCombatUnit()).ToList();
+
+			if ((tile.IsLand() && opponent.unitType.isLandBombardmentLethal) || (tile.IsWater() && opponent.unitType.isSeaBombardmentLethal))
+				target = FindTopCombatUnit(opponent, combatUnits);
+			else
+				target = FindTopCombatUnit(opponent, combatUnits.Where(u => u.hitPointsRemaining > 1).ToList());
+
+			return target;
+		}
+
 		public MapUnit FindTopDefender(MapUnit opponent) {
-			if (unitsOnTile.Count > 0) {
-				IEnumerable<MapUnit> potentialDefenders = unitsOnTile.Where(u => u.CanDefendAgainst(opponent));
+			return FindTopDefender(opponent, unitsOnTile);
+		}
+
+		public MapUnit FindTopDefender(MapUnit opponent, List<MapUnit> units) {
+			if (units.Count > 0) {
+				List<MapUnit> potentialDefenders = units.Where(u => u.CanDefendAgainst(opponent)).ToList();
 				if (potentialDefenders.Count() == 0) {
 					return MapUnit.NONE;
 				}
 
-				MapUnit leadingCandidate = unitsOnTile[0];
-				foreach (MapUnit u in unitsOnTile)
-					if (u.HasPriorityAsDefender(leadingCandidate, opponent))
-						leadingCandidate = u;
-				return leadingCandidate;
-			} else
-				return MapUnit.NONE;
+				return FindTopCombatUnit(opponent, potentialDefenders);
+			}
+
+			return MapUnit.NONE;
+		}
+
+		public MapUnit FindTopCombatUnit(MapUnit opponent, List<MapUnit> units) {
+			if (units.Count < 1) return MapUnit.NONE;
+
+			MapUnit leadingCandidate = units[0];
+			foreach (MapUnit u in units)
+				if (u.HasPriorityAsDefender(leadingCandidate, opponent))
+					leadingCandidate = u;
+			return leadingCandidate;
 		}
 
 		/// <summary>
@@ -958,6 +985,9 @@ namespace C7GameData {
 		}
 
 		public void Add(TerrainImprovement improvement) {
+			if (improvement == null) {
+				return;
+			}
 			terrainImprovementByLayer.TryGetValue(improvement.layer, out TerrainImprovement replacedImprovement);
 
 			terrainImprovementByLayer[improvement.layer] = improvement;

--- a/C7Engine/C7GameData/UnitPrototype.cs
+++ b/C7Engine/C7GameData/UnitPrototype.cs
@@ -83,6 +83,27 @@ namespace C7GameData {
 			}
 		}
 
+		public bool isLandBombardmentLethal {
+			get => flags.Contains(SaveUnitPrototype.Flag.LethalLandBombardment);
+			set {
+				if (value) {
+					flags.Add(SaveUnitPrototype.Flag.LethalLandBombardment);
+				} else {
+					flags.Remove(SaveUnitPrototype.Flag.LethalLandBombardment);
+				}
+			}
+		}
+		public bool isSeaBombardmentLethal {
+			get => flags.Contains(SaveUnitPrototype.Flag.LethalSeaBombardment);
+			set {
+				if (value) {
+					flags.Add(SaveUnitPrototype.Flag.LethalSeaBombardment);
+				} else {
+					flags.Remove(SaveUnitPrototype.Flag.LethalSeaBombardment);
+				}
+			}
+		}
+
 		public HashSet<string> categories = new HashSet<string>();
 
 		public HashSet<UnitAction> actions = [];

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -37,9 +37,9 @@ namespace C7Engine {
 			// invalid actions at the server level but at the client level an invalid action received from the server indicates a desync.
 			if (unit != null) {
 				if (fortifyElseWake)
-					unit.fortify();
+					unit.Fortify();
 				else
-					unit.wake();
+					unit.Wake();
 			}
 		}
 	}
@@ -57,7 +57,7 @@ namespace C7Engine {
 			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
 			if (unit == null) return;
 
-			await unit.move(dir, true);
+			await unit.Move(dir, true);
 		}
 	}
 
@@ -74,7 +74,7 @@ namespace C7Engine {
 			MapUnit unit = EngineStorage.gameData.GetUnit(unitID);
 			if (unit == null) return;
 
-			await unit.setUnitPath(path);
+			await unit.SetUnitPath(path);
 		}
 	}
 
@@ -95,7 +95,7 @@ namespace C7Engine {
 			Tile tile = EngineStorage.gameData.map.tileAt(tileX, tileY);
 			if (unit == null || tile == null) return;
 
-			await unit.bombard(tile);
+			await unit.Bombard(tile);
 		}
 	}
 
@@ -433,7 +433,7 @@ namespace C7Engine {
 		}
 
 		public override async void process() {
-			City? city = await unit.buildCity(name);
+			City? city = await unit.BuildCity(name);
 			if (city != null) {
 				new MsgCityCreated(city).send();
 			}


### PR DESCRIPTION
1. Improved bombardment behaviour
2. Added lethal bombardment behaviour
3. Split MapUnit class to multiple files
4. Minor fixes/refactors

I took a stab at improving the bombardment mechanic. Now it should behave more like what we expect.

Also, the MapUnit class was getting too hard to navigate, I took the initiative and split it in 3 parts (could be more), one that contains the `is`, `has`, `can` stuff (mostly), one for moving, fighting, etc, and one for the bombard mechanic itself, as it was close to 300 lines of autonomous code.

Let me know what you think about this approach, we could certainly do something similar to `Tile` and other large classes.