### PR TITLE
Seed persistance

### DIFF
--- a/C7Engine/C7GameData/GameData.cs
+++ b/C7Engine/C7GameData/GameData.cs
@@ -78,14 +78,17 @@ namespace C7GameData {
 		// An action called after initialization of EngineStorage
 		internal Action onGameCreation;
 
-		public GameData() {
+		public GameData(int customSeed = -1) {
 			map = new GameMap();
+			seed = customSeed;
+			// this will probably never happen, leaving it as a fallback
 			if (seed == -1) {
+				log.Information("Random seed was not set, generating...");
 				rng = new Random();
 				seed = rng.Next(int.MaxValue);
-				log.Information("Random seed is " + seed);
 			}
 			rng = new Random(seed);
+			log.Information($"Seed is {seed}");
 		}
 
 		// Returns the first human player in the set of players, or the first

--- a/C7Engine/C7GameData/ImportCiv3.cs
+++ b/C7Engine/C7GameData/ImportCiv3.cs
@@ -97,6 +97,7 @@ namespace C7GameData {
 			biq = savData.Bic;
 			pediaIcons = new(getPediaIconsPath(biq.Game[0].ScenarioSearchFolders));
 			save.TurnNumber = savData.Game.TurnNumber;
+			save.Seed = savData.Wrld.WorldSeed;
 
 			ImportSharedBiqData();
 			ImportSavLeaders();
@@ -209,6 +210,7 @@ namespace C7GameData {
 			biq = BiqData.LoadFile(biqPath);
 			defaultBiq = BiqData.LoadFile(defaultBiqPath);
 			pediaIcons = new(getPediaIconsPath(biq.Game[0].ScenarioSearchFolders));
+			save.Seed = biq.Wmap[0].MapSeed;
 
 			ImportSharedBiqData();
 			ImportBicLeaders();

--- a/C7Engine/C7GameData/Save/SaveGame.cs
+++ b/C7Engine/C7GameData/Save/SaveGame.cs
@@ -176,8 +176,7 @@ namespace C7GameData.Save {
 
 		private GameData InitializeGameData() {
 			// copy data without references
-			return new GameData {
-				seed = Seed,
+			var data = new GameData(Seed) {
 				turn = TurnNumber,
 				terrainTypes = TerrainTypes,
 				Resources = Resources,
@@ -196,6 +195,8 @@ namespace C7GameData.Save {
 				timeOptions = TimeOptions,
 				GreatWondersBuilt = GreatWondersBuilt,
 			};
+
+			return data;
 		}
 
 		private void ConvertTerraforms(GameData data) {

--- a/C7Engine/MapGenerator.cs
+++ b/C7Engine/MapGenerator.cs
@@ -77,6 +77,7 @@ namespace C7Engine {
 		// The entry point to the overall map generation process.
 		public static GameMap GenerateMap(WorldCharacteristics wc) {
 			if (wc.mapSeed == -1) {
+				log.Information("Random seed is not specified, generating...");
 				wc.mapSeed = new Random().Next(int.MaxValue);
 			}
 			log.Information("Seed: " + wc.mapSeed);

--- a/EngineTests/GameData/GameDataTest.cs
+++ b/EngineTests/GameData/GameDataTest.cs
@@ -1,0 +1,73 @@
+using System;
+using C7Engine;
+using C7Engine.Lua;
+using C7GameData.Save;
+using EngineTests.Utils;
+using Xunit;
+
+namespace EngineTests.GameData;
+
+public class GameDataTest : RemoteSaveLoader, IClassFixture<SaveGameFixture> {
+	private const string SAVES_FOLDER = "saves/game-data";
+	C7GameData.GameData gameData;
+	private BehaviorEngine behaviorEngine;
+
+	public GameDataTest(SaveGameFixture fixture) {
+		this.behaviorEngine = fixture.behaviors;
+		gameData = fixture.saveGame.ToGameData(fixture.behaviors);
+
+		EngineStorage.InitializeGameDataForTests(gameData);
+	}
+
+	[SkippableFact]
+	public async void SeedInGameData_SAV() {
+		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
+			return;
+		}
+
+		string saveName = "Conquests 16 Players.SAV";
+		string uri = "https://www.dropbox.com/scl/fi/gmxbx1mtrammzfc6vly1g/Conquests-16-Players.SAV?rlkey=2z1es5aetqva4ymv59qduq1at&st=d0udmb3w&dl=1";
+
+		(SaveGame game, Exception ex, string savePath) = await LoadGameAndData(saveName, SAVES_FOLDER, uri);
+
+		C7GameData.GameData gd = game.ToGameData(behaviorEngine);
+		EngineStorage.InitializeGameDataForTests(gd);
+
+		Assert.Equal(33127520, game.Seed);
+		Assert.Equal(33127520, gd.seed);
+	}
+
+	[SkippableFact]
+	public async void SeedInGameData_JSON() {
+		if (Civ3TestData.ShouldSkipCiv3DependentTests()) {
+			return;
+		}
+
+		string saveName = "Conquests 16 Players.json";
+		string uri = "https://www.dropbox.com/scl/fi/g1qxuvc6xptg1l6hx9s21/Conquests-16-Players.json?rlkey=bkq158od7469pibhtw44g04if&st=tqax1064&dl=1";
+
+		(SaveGame game, Exception ex, string savePath) = await LoadGameAndData(saveName, SAVES_FOLDER, uri);
+
+		C7GameData.GameData gd = game.ToGameData(behaviorEngine);
+		EngineStorage.InitializeGameDataForTests(gd);
+
+		Assert.Equal(-1, game.Seed);
+		Assert.NotEqual(-1, gd.seed);
+	}
+
+	[Fact]
+	public void SeedInGameData_Default() {
+		C7GameData.GameData gd = new C7GameData.GameData();
+		EngineStorage.InitializeGameDataForTests(gd);
+
+		Assert.NotEqual(-1, gd.seed);
+	}
+
+	[Fact]
+	public void SeedInGameData_Custom() {
+		C7GameData.GameData gd = new C7GameData.GameData(654972132);
+		EngineStorage.InitializeGameDataForTests(gd);
+
+		Assert.Equal(654972132, gd.seed);
+	}
+}

--- a/EngineTests/GameData/SaveTest.cs
+++ b/EngineTests/GameData/SaveTest.cs
@@ -497,6 +497,7 @@ public class SaveTests : IClassFixture<SaveGameFixture> {
 			Assert.True(ex == null, name + ":" + ex?.ToString());
 			Assert.NotNull(game);
 			Assert.NotNull(gd);
+			Assert.NotEqual(-1, gd.seed);
 
 			CheckPlayableCivs(name, game);
 			CheckAlliances(name, gd);


### PR DESCRIPTION
Read and use seeds from .biq and .sav files.
Persist seed numbers across save files.
Added some unit tests.

I wanted to push this by itself just so we have a clean point of reference if it goes wrong.

I chose not to add any variation to the .biq and .sav file seeds, like adding a magic number at the end (just so it's not the same) because then I would have to check for overflows/underflows etc.
At the end of the day these numbers from the original game don't mean much to us anyway.