### PR TITLE
Engine messages not going through

### DIFF
--- a/C7/UnitSelector.cs
+++ b/C7/UnitSelector.cs
@@ -35,6 +35,7 @@ public partial class UnitSelector : Node {
 
 	public override void _Process(double delta) {
 		if (game.CurrentState != GameState.PlayerTurn) return;
+		if (NoMoreAutoselectableUnitsEmitted) return;
 		if (EngineStorage.HasPendingAnimations()) return;
 
 		// If no unit is selected, move to the next one

--- a/C7Engine/EntryPoints/MessageToEngine.cs
+++ b/C7Engine/EntryPoints/MessageToEngine.cs
@@ -337,12 +337,6 @@ namespace C7Engine {
 				player.taxRate++;
 			}
 
-			// Update citizen moods in all cities, as changing the sliders can
-			// change moods.
-			foreach (City city in player.cities) {
-				city.RecalculateCitizenMoods(EngineStorage.gameData);
-			}
-
 			// Update the ui to reflect our changes.
 			new MsgUpdateUiAfterDomesticChange().send();
 		}


### PR DESCRIPTION
This PR fixes a bug where, if you load a game where there are no more selectable (not busy) units, and you try for example to update the Domestic advisors' slider values ( I noticed the bug while working on #979), this will either lag a lot, or simply not go through at all.

I am not 100% sure why this is happening when a game is loaded like that, but not when we are in game and have no more selectable units, but I could see the engine sending a lot of `MsgPerformUnitAction` messages when the player is expected to simply end their turn.

So the main fix is to exit early from the `UnitSelector`'s process when the blinker signal has been emitted.

If you want to reproduce it, load a game (I tried `.SAV`) where you have finished you turn and the blinker is on, and try to update the Domestic advisor's slider values.

Another thing I noticed was that we update the citizens' moods back to back, one in the `MsgChangeSliders` after updating the values, and then right after we send a new `MsgUpdateUiAfterDomesticChange` message wihch does the exact same thing and seems redundant, so I removed it.